### PR TITLE
feat(core): structured read-only git_context tool for brownfield work

### DIFF
--- a/apps/docs/src/content/docs/cli/plan-mode.mdx
+++ b/apps/docs/src/content/docs/cli/plan-mode.mdx
@@ -18,6 +18,7 @@ Use it when you want to see the approach before files change. Skip it for small,
 Read tools only:
 
 - `read`, `search`, and LSP navigation (`symbol_search`, `find_references`, `type_at`, `diagnostics`)
+- `git_context` — structured, read-only repo history/diffs (see [Git context](/reference/flags/#git-context))
 - `run` for **read-only** shell commands (no installs, no writes)
 
 Blocked until approval: `edit`, `create`, `edit_lines`, scaffolders.

--- a/apps/docs/src/content/docs/eval/ab-testing.mdx
+++ b/apps/docs/src/content/docs/eval/ab-testing.mdx
@@ -28,10 +28,15 @@ A **seed** is the task you run the model against. Committed seeds live in [`eval
 - `checkout` — multi-file pricing engine (cart + coupons + tax, integer cents).
 - `auth` — multi-file session service (password policy + lockout + token expiry).
 - `query` — multi-file mini-SQL engine (lexer → recursive-descent parser → executor).
+- `fix-regression` — **brownfield**: an existing repo with git history where a recent commit broke `slugify`; the fix is a `git diff` away. Used to exercise [`git_context`](/reference/flags/#git-context).
 
-The first two are warm-ups a strong model one-shots; the last three are multi-file and deliberately harder, so a feature has room to move the pass rate (and the [failure breakdown](#why-runs-failed)) off the ceiling.
+The first two are warm-ups a strong model one-shots; the next three are multi-file and deliberately harder, so a feature has room to move the pass rate (and the [failure breakdown](#why-runs-failed)) off the ceiling.
 
 Pick one with `TSFORGE_SEED=<name>`. A sweep first looks for a local working copy at `evals/<name>/`, then falls back to the committed `evals/corpus/<name>/`. To add your own, drop a folder under `evals/corpus/` with a `<name>.spec.md` plus its fixture files — see [Spec format](/spec/format/).
+
+### Brownfield seeds
+
+A greenfield seed is regenerated from scratch (the sweep deletes the task's files and the model rebuilds them). A **brownfield** seed instead sets `mode: existing` in its spec, so the buggy code is kept and the model edits it in place. Such a seed may also ship a `setup.sh`, which the sweep runs in the run directory after laying down the files — it `git init`s, makes the commits, and leaves the red working tree. That is how a `git_context` task has real history (`log`/`blame`/`show`) and a working-tree `diff` to inspect. Greenfield seeds have no `setup.sh` and are unaffected.
 
 ## Running a sweep
 
@@ -60,6 +65,18 @@ bun run eval:sweep
 ```
 
 Runs `3 repeats × 2 temps × 4 variants = 24` runs with IDs like `orders-ttsr=on,hashline=off-t0.5-...`.
+
+### git_context on/off
+
+```bash
+TSFORGE_SEED=fix-regression \
+TSFORGE_TEMPS=0 \
+TSFORGE_REPEATS=2 \
+TSFORGE_FEATURE_VARIANTS=git \
+bun run eval:sweep
+```
+
+The `git` dimension toggles `git_context` (on → available; off → `TSFORGE_NO_GIT_TOOL=1`). Pair it with a brownfield seed so there is history to inspect.
 
 Each run directory contains `run.log` (human transcript) and `result.json` (structured metrics + feature flags). A sweep also writes `evals/runs/sweep-<seed>-<ts>.json` with every run record.
 

--- a/apps/docs/src/content/docs/lsp/typescript-server.mdx
+++ b/apps/docs/src/content/docs/lsp/typescript-server.mdx
@@ -29,6 +29,8 @@ Offered when tsforge detects real code to explore (existing repo, resumed sessio
 
 Disable navigation tools: `TSFORGE_NO_LSP_TOOLS=1`. Disable write feedback: `TSFORGE_LSP_WRITE_FEEDBACK=0`.
 
+On existing repos the model is also offered `git_context` — read-only, structured access to history and diffs (scope a fix to what changed). It is git-backed, not part of the language server, so `TSFORGE_NO_LSP_TOOLS` does not affect it; disable it with `TSFORGE_NO_GIT_TOOL=1`. See [Git context](/reference/flags/#git-context).
+
 ## Safe auto-fixes
 
 tsforge can apply TypeScript quick fixes that match its strict gate (imports, unused vars, missing `await`). It skips fixes that add `!` or unsafe `as` casts.

--- a/apps/docs/src/content/docs/reference/flags.mdx
+++ b/apps/docs/src/content/docs/reference/flags.mdx
@@ -18,6 +18,17 @@ description: Canonical list of every TSFORGE_* environment variable.
 | `TSFORGE_TDD` | off | test-first guidance + `test-sibling-required` becomes an error (`=1`) |
 | `TSFORGE_WEB` | off | free, local web access — the `web_fetch` + `web_search` tools (`=1`) |
 | `TSFORGE_NO_UPDATE_CHECK` | off | silence the startup "update available" check (`=1`) |
+| `TSFORGE_NO_GIT_TOOL` | off | withhold the `git_context` tool (`=1`) |
+
+## Git context
+
+On existing-code runs tsforge offers `git_context` — a read-only tool giving the model structured, token-bounded access to repo state, so it can scope a review or a fix to **what actually changed** instead of shelling out to raw `git`. Ops: `diff`, `changed_files`, `log` (incl. a line range's history), `blame`, and `show`. It wraps the `git` binary via an explicit argv (no shell), validates the `sha`, and rejects shell metacharacters / option injection in `ref`/`path`; output is char-capped (`maxChars` to raise it).
+
+Offered only when there is existing code to inspect (greenfield scratch builds have no history), and it survives `TSFORGE_NO_LSP_TOOLS` since it is not an LSP tool. Being read-only, it is available in [plan mode](/cli/plan-mode/) too.
+
+| Variable | Default | Toggles |
+| --- | --- | --- |
+| `TSFORGE_NO_GIT_TOOL` | off | withhold `git_context` (`=1`) |
 
 ## Web access
 

--- a/evals/corpus/fix-regression/fix-regression.spec.md
+++ b/evals/corpus/fix-regression/fix-regression.spec.md
@@ -1,0 +1,20 @@
+---
+id: fix-regression
+title: Restore a regressed slugify
+verify: bun test
+mode: existing
+---
+
+## Acceptance criteria
+
+A1. `slugify(input)` lowercases the input, replaces any run of non-alphanumeric
+characters with a SINGLE hyphen, and trims leading/trailing hyphens. A recent
+change broke the "run → single hyphen" collapse (it now emits repeated hyphens);
+restore the correct behaviour.
+
+## Tasks
+
+1. [fix] Restore slugify so its test passes
+   accept: bun test slug.test.ts
+   files: slug.ts
+   context: slug.test.ts

--- a/evals/corpus/fix-regression/setup.sh
+++ b/evals/corpus/fix-regression/setup.sh
@@ -1,0 +1,29 @@
+#!/bin/sh
+# Build the git history for this brownfield seed:
+#   HEAD~1 = the KNOWN-GOOD slugify ; HEAD = an unrelated commit ;
+#   working tree = the BUGGY slug.ts (the seed file, left uncommitted).
+# So the regression is exactly `git diff` (good → buggy), and `git log` / `git
+# show HEAD~1` reveal the last working version — what git_context exists to surface.
+set -e
+git init -q
+git config user.email "eval@tsforge.local"
+git config user.name "tsforge-eval"
+
+# Stash the buggy working version (the seed's slug.ts — what the model must fix).
+cp slug.ts .slug.buggy
+
+# Commit the known-good version as history.
+cat > slug.ts <<'GOOD'
+export function slugify(s: string): string {
+  return s
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-|-$/g, "");
+}
+GOOD
+git add -A
+git commit -q -m "slug: working slugify (collapses runs to one hyphen)"
+git commit -q --allow-empty -m "docs: note slug usage"
+
+# Restore the buggy version as an uncommitted change → the RED working tree.
+mv .slug.buggy slug.ts

--- a/evals/corpus/fix-regression/slug.test.ts
+++ b/evals/corpus/fix-regression/slug.test.ts
@@ -1,0 +1,6 @@
+import { test, expect } from "bun:test";
+import { slugify } from "./slug";
+
+test("collapses runs of non-alphanumerics to a single hyphen", () => {
+  expect(slugify("Hello  World!")).toBe("hello-world");
+});

--- a/evals/corpus/fix-regression/slug.ts
+++ b/evals/corpus/fix-regression/slug.ts
@@ -1,0 +1,6 @@
+export function slugify(s: string): string {
+  return s
+    .toLowerCase()
+    .replace(/[^a-z0-9]/g, "-")
+    .replace(/^-|-$/g, "");
+}

--- a/packages/core/scripts/sweep.ts
+++ b/packages/core/scripts/sweep.ts
@@ -76,21 +76,31 @@ function parseFeatureVariants(): IFeatureVariant[] {
   return variants;
 }
 
-/** Map feature variant to env vars. Each feature dim maps to a TSFORGE_* var. */
+/** Feature dim → the TSFORGE_* env var it toggles ("1" on / "0" off). */
+const DIM_ENV: Record<string, string> = {
+  ttsr: "TSFORGE_TTSR",
+  hashline: "TSFORGE_HASHLINE",
+  lsp_write_feedback: "TSFORGE_LSP_WRITE_FEEDBACK",
+  simplicity: "TSFORGE_SIMPLICITY",
+};
+
+/** Map feature variant to env vars. Most dims set their var to the state; `git`
+ *  is inverted (it gates a NO_ flag): git=on → git_context available. */
 function variantToEnvVars(variant: IFeatureVariant): Record<string, string> {
   const envVars: Record<string, string> = {};
 
   for (const [dim, state] of Object.entries(variant)) {
-    if (dim === "ttsr") {
-      envVars.TSFORGE_TTSR = state === "1" ? "1" : "0";
-    } else if (dim === "hashline") {
-      envVars.TSFORGE_HASHLINE = state === "1" ? "1" : "0";
-    } else if (dim === "lsp_write_feedback") {
-      envVars.TSFORGE_LSP_WRITE_FEEDBACK = state === "1" ? "1" : "0";
-    } else if (dim === "simplicity") {
-      envVars.TSFORGE_SIMPLICITY = state === "1" ? "1" : "0";
+    if (dim === "git") {
+      envVars.TSFORGE_NO_GIT_TOOL = state === "1" ? "0" : "1";
+
+      continue;
     }
-    // else: unknown dimension, skip
+
+    const varName = DIM_ENV[dim];
+
+    if (varName !== undefined) {
+      envVars[varName] = state === "1" ? "1" : "0";
+    }
   }
 
   return envVars;
@@ -253,6 +263,23 @@ async function setupRunDir(
   }
 }
 
+/** Run a seed's optional `setup.sh` in the run dir (after files are laid down) —
+ *  how a brownfield seed builds its git history and leaves the RED working tree.
+ *  Absent for greenfield seeds (no-op). Trusted: the corpus is our own code. */
+async function runSeedSetup(dir: string): Promise<void> {
+  if (!(await Bun.file(join(dir, "setup.sh")).exists())) {
+    return;
+  }
+
+  const proc = Bun.spawn(["sh", "setup.sh"], {
+    cwd: dir,
+    stdout: "ignore",
+    stderr: "ignore",
+  });
+
+  await proc.exited;
+}
+
 /** Remove task files in scratch mode (keep in existing mode). */
 async function startRed(
   dir: string,
@@ -287,6 +314,10 @@ async function runOne(
     );
 
     await startRed(runDir, spec);
+    // Build any git history the seed needs (brownfield seeds ship a setup.sh that
+    // git-inits + commits + leaves the buggy working tree). Runs after startRed so
+    // the RED state is whatever setup.sh leaves on disk.
+    await runSeedSetup(runDir);
 
     // Apply tsforge's STRICT FLOOR (bundled tsc-strict + eslint) to the eval
     // gate — the SAME gate the interactive CLI builds. Eval mode otherwise

--- a/packages/core/src/agent/agent.constants.ts
+++ b/packages/core/src/agent/agent.constants.ts
@@ -18,6 +18,7 @@ export const TOOL_NAME = {
   renameSymbol: "rename_symbol",
   moveFile: "move_file",
   organizeImports: "organize_imports",
+  gitContext: "git_context",
   scaffoldUi: "scaffold_ui",
   scaffoldRoutes: "scaffold_routes",
   scaffoldWeb: "scaffold_web",
@@ -37,6 +38,9 @@ export const READ_ONLY_TOOL_NAMES: ReadonlySet<string> = new Set([
   TOOL_NAME.findReferences,
   TOOL_NAME.typeAt,
   TOOL_NAME.diagnostics,
+  // git_context only inspects history/diffs — no workspace mutation — so it is a
+  // plan-mode tool too (scope a review/fix while planning, before any edit).
+  TOOL_NAME.gitContext,
   // Web tools are read-only (no workspace mutation), so they're usable in plan
   // mode too — research while planning. Network egress here is structured and
   // opt-in (TSFORGE_WEB), unlike the raw `run` curl path plan mode blocks.
@@ -440,3 +444,47 @@ export const LSP_TOOLS = [
     },
   },
 ];
+
+/** Read-only, structured git introspection — scope a review or a fix to what
+ *  actually changed. Wraps the `git` binary via an explicit argv (no shell); the
+ *  op is a fixed read-only allowlist. Offered on existing-code runs (gated like
+ *  the nav set; greenfield has no history). TSFORGE_NO_GIT_TOOL forces it off. */
+export const GIT_CONTEXT_TOOL = {
+  type: "function",
+  function: {
+    name: TOOL_NAME.gitContext,
+    description:
+      "Inspect the repository's git state (read-only) to scope your work to what changed. ops: 'diff' (working-tree or staged changes, optionally vs a ref, optionally a path), 'changed_files' (files changed with +adds/-dels), 'log' (recent commits; pass path + lineStart/lineEnd for a line range's history), 'blame' (who last touched a line range — needs path), 'show' (a commit's message + diff — needs sha).",
+    parameters: {
+      type: "object",
+      properties: {
+        op: {
+          type: "string",
+          enum: ["diff", "changed_files", "log", "blame", "show"],
+        },
+        ref: {
+          type: "string",
+          description:
+            "git ref to compare against (e.g. main, HEAD~3); default is the working tree",
+        },
+        path: { type: "string", description: "limit to a file or directory" },
+        sha: { type: "string", description: "commit SHA (for op 'show')" },
+        staged: {
+          type: "boolean",
+          description: "diff the staged index instead of the working tree",
+        },
+        lineStart: { type: "number", description: "start line (blame / log)" },
+        lineEnd: { type: "number", description: "end line (blame / log)" },
+        max: {
+          type: "number",
+          description: "max commits for op 'log' (default 15)",
+        },
+        maxChars: {
+          type: "number",
+          description: "cap on returned characters (default 4000)",
+        },
+      },
+      required: ["op"],
+    },
+  },
+};

--- a/packages/core/src/config/config.constants.ts
+++ b/packages/core/src/config/config.constants.ts
@@ -10,4 +10,5 @@ export const ENV_FLAG = {
   tdd: "TSFORGE_TDD",
   webTools: "TSFORGE_WEB",
   noUpdateCheck: "TSFORGE_NO_UPDATE_CHECK",
+  noGitTool: "TSFORGE_NO_GIT_TOOL",
 } as const;

--- a/packages/core/src/config/flags.ts
+++ b/packages/core/src/config/flags.ts
@@ -47,4 +47,7 @@ export const flags = {
    *  the check runs only in interactive non-CI sessions). Set to "1" for offline
    *  environments or to silence the notice. */
   noUpdateCheck: (): boolean => isOn(ENV_FLAG.noUpdateCheck),
+  /** Withhold the read-only `git_context` tool on existing-code runs (default ON;
+   *  set to "1" to force off, e.g. for eval sweeps or non-git workspaces). */
+  noGitTool: (): boolean => isOn(ENV_FLAG.noGitTool),
 };

--- a/packages/core/src/loop/tools/execute-tool.ts
+++ b/packages/core/src/loop/tools/execute-tool.ts
@@ -3,6 +3,7 @@ import { TOOL_NAME, READ_ONLY_TOOL_NAMES, type ToolName } from "../../agent";
 import { readFile, runShell, doEdit, doCreate } from "./file-ops";
 import { doHashlineEdit } from "./edit-hashline";
 import { doSearch, doLsp } from "./lsp-ops";
+import { doGit } from "./git-ops";
 import { doScaffoldUi } from "./scaffold-ui";
 import { doScaffoldRoutes } from "./scaffold-routes";
 import { doScaffoldWeb } from "./scaffold-web";
@@ -34,6 +35,7 @@ const HANDLERS: Record<ToolName, ToolHandler> = {
   [TOOL_NAME.renameSymbol]: (a, c) => doLsp(TOOL_NAME.renameSymbol, a, c),
   [TOOL_NAME.moveFile]: (a, c) => doLsp(TOOL_NAME.moveFile, a, c),
   [TOOL_NAME.organizeImports]: (a, c) => doLsp(TOOL_NAME.organizeImports, a, c),
+  [TOOL_NAME.gitContext]: doGit,
   [TOOL_NAME.scaffoldUi]: doScaffoldUi,
   [TOOL_NAME.scaffoldRoutes]: doScaffoldRoutes,
   [TOOL_NAME.scaffoldWeb]: doScaffoldWeb,

--- a/packages/core/src/loop/tools/git-ops.ts
+++ b/packages/core/src/loop/tools/git-ops.ts
@@ -11,7 +11,12 @@ const SHA_RE = /^[0-9a-fA-F]{4,40}$/;
 const UNSAFE = /[;&|`$(){}<>\n\r]/;
 
 function unsafe(value: string): boolean {
-  return value.length > 0 && (UNSAFE.test(value) || value.startsWith("-"));
+  // Trim first: " -x" would otherwise slip past the leading-dash check.
+  const trimmed = value.trim();
+
+  return (
+    trimmed.length > 0 && (UNSAFE.test(trimmed) || trimmed.startsWith("-"))
+  );
 }
 
 /** A positive integer arg, or undefined when missing/invalid. */
@@ -68,8 +73,10 @@ function buildLog(args: Record<string, unknown>, path: string): Built {
   const end = intArg(args, "lineEnd");
 
   if (start !== undefined && end !== undefined && path.length > 0) {
+    const [s, e] = start > end ? [end, start] : [start, end];
+
     return {
-      argv: ["git", "log", `-L${start},${end}:${path}`, `--max-count=${max}`],
+      argv: ["git", "log", `-L${s},${e}:${path}`, `--max-count=${max}`],
     };
   }
 
@@ -98,7 +105,9 @@ function buildBlame(args: Record<string, unknown>, path: string): Built {
   const argv = ["git", "blame", "--date=short"];
 
   if (start !== undefined && end !== undefined) {
-    argv.push(`-L${start},${end}`);
+    const [s, e] = start > end ? [end, start] : [start, end];
+
+    argv.push(`-L${s},${e}`);
   }
 
   argv.push("--", path);
@@ -181,10 +190,10 @@ export async function doGit(
     return "git_context: not a git repository (no .git found)";
   }
 
-  const body =
-    res.exitCode !== 0 && res.stdout.trim().length === 0
-      ? res.stderr
-      : res.stdout;
+  // On failure prefer stderr (the real error); fall back to stdout when git
+  // wrote partial output there. On success, stdout is the result.
+  const failed = res.exitCode !== 0;
+  const body = failed && res.stderr.trim().length > 0 ? res.stderr : res.stdout;
   const max = intArg(args, "maxChars") ?? LOOP_LIMITS.maxToolOutputChars;
   const clipped = body.length > max;
   const out = body.slice(0, max);

--- a/packages/core/src/loop/tools/git-ops.ts
+++ b/packages/core/src/loop/tools/git-ops.ts
@@ -1,0 +1,196 @@
+import { runArgvCommand } from "../../lib/fs";
+import { LOOP_LIMITS } from "../loop.constants";
+import { str, reject, type IToolContext } from "./tool-context";
+
+/** A commit SHA: 4–40 hex chars. Anything else for `show` is rejected. */
+const SHA_RE = /^[0-9a-fA-F]{4,40}$/;
+
+/** Shell metacharacters / option-injection markers we refuse in free-form `ref`
+ *  and `path` args. Everything is passed as a literal argv (no shell), so this is
+ *  defense-in-depth against smuggling `--upload-pack=…`-style options or `$()`. */
+const UNSAFE = /[;&|`$(){}<>\n\r]/;
+
+function unsafe(value: string): boolean {
+  return value.length > 0 && (UNSAFE.test(value) || value.startsWith("-"));
+}
+
+/** A positive integer arg, or undefined when missing/invalid. */
+function intArg(
+  args: Record<string, unknown>,
+  key: string
+): number | undefined {
+  const v = args[key];
+
+  return typeof v === "number" && Number.isInteger(v) && v > 0 ? v : undefined;
+}
+
+type Built = { argv: string[] } | { error: string };
+
+function buildDiff(
+  args: Record<string, unknown>,
+  ref: string,
+  path: string
+): Built {
+  const argv = ["git", "diff"];
+
+  if (args.staged === true) {
+    argv.push("--staged");
+  }
+
+  if (ref.length > 0) {
+    argv.push(ref);
+  }
+
+  if (path.length > 0) {
+    argv.push("--", path);
+  }
+
+  return { argv };
+}
+
+function buildChangedFiles(ref: string, path: string): Built {
+  const argv = ["git", "diff", "--numstat"];
+
+  if (ref.length > 0) {
+    argv.push(ref);
+  }
+
+  if (path.length > 0) {
+    argv.push("--", path);
+  }
+
+  return { argv };
+}
+
+function buildLog(args: Record<string, unknown>, path: string): Built {
+  const max = intArg(args, "max") ?? 15;
+  const start = intArg(args, "lineStart");
+  const end = intArg(args, "lineEnd");
+
+  if (start !== undefined && end !== undefined && path.length > 0) {
+    return {
+      argv: ["git", "log", `-L${start},${end}:${path}`, `--max-count=${max}`],
+    };
+  }
+
+  const argv = [
+    "git",
+    "log",
+    `--max-count=${max}`,
+    "--date=short",
+    "--pretty=format:%h %ad %s",
+  ];
+
+  if (path.length > 0) {
+    argv.push("--", path);
+  }
+
+  return { argv };
+}
+
+function buildBlame(args: Record<string, unknown>, path: string): Built {
+  if (path.length === 0) {
+    return { error: "git_context: blame needs a `path`" };
+  }
+
+  const start = intArg(args, "lineStart");
+  const end = intArg(args, "lineEnd");
+  const argv = ["git", "blame", "--date=short"];
+
+  if (start !== undefined && end !== undefined) {
+    argv.push(`-L${start},${end}`);
+  }
+
+  argv.push("--", path);
+
+  return { argv };
+}
+
+function buildShow(args: Record<string, unknown>): Built {
+  const sha = str(args, "sha");
+
+  return SHA_RE.test(sha)
+    ? { argv: ["git", "show", "--date=short", sha] }
+    : { error: "git_context: show needs a valid `sha` (4–40 hex chars)" };
+}
+
+function buildArgv(op: string, args: Record<string, unknown>): Built {
+  const ref = str(args, "ref");
+  const path = str(args, "path");
+
+  if (unsafe(ref)) {
+    return { error: `git_context: unsafe ref '${ref}'` };
+  }
+
+  if (unsafe(path)) {
+    return { error: `git_context: unsafe path '${path}'` };
+  }
+
+  switch (op) {
+    case "diff":
+      return buildDiff(args, ref, path);
+    case "changed_files":
+      return buildChangedFiles(ref, path);
+    case "log":
+      return buildLog(args, path);
+    case "blame":
+      return buildBlame(args, path);
+    case "show":
+      return buildShow(args);
+    default:
+      return {
+        error: `git_context: unknown op '${op}' (use diff|changed_files|log|blame|show)`,
+      };
+  }
+}
+
+/**
+ * Structured, read-only git introspection — the model's way to scope a review or
+ * a fix to what actually changed. Wraps the `git` binary via an explicit argv (NO
+ * shell, so model-supplied ref/path/sha can't be expanded or smuggle options); the
+ * `op` is a fixed allowlist of read-only subcommands. Output is char-capped
+ * (override with `maxChars`). A missing git binary or non-repo degrades to a clear
+ * message instead of throwing.
+ */
+export async function doGit(
+  args: Record<string, unknown>,
+  ctx: IToolContext
+): Promise<string> {
+  const op = str(args, "op");
+  const built = buildArgv(op, args);
+
+  if ("error" in built) {
+    return reject(ctx, "git_context", built.error);
+  }
+
+  const res = await runArgvCommand(
+    ctx.cwd,
+    built.argv,
+    ctx.signal === undefined ? {} : { signal: ctx.signal }
+  );
+
+  ctx.report({ kind: "tool", task: ctx.task, message: `git ${op}` });
+
+  if (res.exitCode === 127) {
+    return "git_context: git is not installed or not on PATH";
+  }
+
+  const combined = `${res.stdout}${res.stderr}`;
+
+  if (/not a git repository/i.test(combined)) {
+    return "git_context: not a git repository (no .git found)";
+  }
+
+  const body =
+    res.exitCode !== 0 && res.stdout.trim().length === 0
+      ? res.stderr
+      : res.stdout;
+  const max = intArg(args, "maxChars") ?? LOOP_LIMITS.maxToolOutputChars;
+  const clipped = body.length > max;
+  const out = body.slice(0, max);
+  const note = clipped
+    ? `\n[truncated ${body.length - max} chars — pass maxChars for more]`
+    : "";
+
+  return out.trim().length > 0 ? out + note : `git ${op}: (no output)`;
+}

--- a/packages/core/src/loop/turn.ts
+++ b/packages/core/src/loop/turn.ts
@@ -32,6 +32,7 @@ import {
   LSP_TOOLS,
   WEB_FETCH_TOOL,
   WEB_SEARCH_TOOL,
+  GIT_CONTEXT_TOOL,
   TOOL_NAME,
 } from "../agent";
 import { TsService, type ITsDiagnostic } from "../lsp";
@@ -68,34 +69,41 @@ const HASHLINE_TOOLS = flags.hashlineEditTool() ? [EDIT_LINES_TOOL] : [];
 // The full advertisable set: base + hashline + LSP nav + the (gated) web tools.
 // Its element union is also the return TYPE of toolsFor — every narrower runtime
 // list below is assignable to it, so each tool stays independently gated.
-const ALL_TOOLS = [
-  ...BASE_TOOLS,
-  ...HASHLINE_TOOLS,
-  ...LSP_TOOLS,
-  WEB_FETCH_TOOL,
-  WEB_SEARCH_TOOL,
-];
+/** Every tool the harness can advertise — the element union all the narrower
+ *  per-context lists below are assignable to (each tool stays independently gated
+ *  in toolsFor). */
+type AdvertisedTool =
+  | (typeof BASE_TOOLS)[number]
+  | (typeof HASHLINE_TOOLS)[number]
+  | (typeof LSP_TOOLS)[number]
+  | typeof WEB_FETCH_TOOL
+  | typeof WEB_SEARCH_TOOL
+  | typeof GIT_CONTEXT_TOOL;
 
 /** Free, local web tools (fetch + search) — advertised only under TSFORGE_WEB so
  *  eval sweeps stay deterministic and offline by default. Available on both
  *  scratch and existing-code runs when enabled (unlike the LSP nav set). */
-function webTools(): typeof ALL_TOOLS {
+function webTools(): AdvertisedTool[] {
   return flags.webTools() ? [WEB_FETCH_TOOL, WEB_SEARCH_TOOL] : [];
 }
 
-export function toolsFor(hasExistingCode: boolean): typeof ALL_TOOLS {
+/** Read-only git introspection — existing-code runs only (greenfield has no
+ *  history), withheld under TSFORGE_NO_GIT_TOOL. Not an LSP tool (no tsconfig
+ *  needed), so it survives TSFORGE_NO_LSP_TOOLS — it's gated only on history. */
+function gitTools(hasExistingCode: boolean): AdvertisedTool[] {
+  return hasExistingCode && !flags.noGitTool() ? [GIT_CONTEXT_TOOL] : [];
+}
+
+export function toolsFor(hasExistingCode: boolean): AdvertisedTool[] {
   const web = webTools();
+  const git = gitTools(hasExistingCode);
 
   if (flags.noLspTools() || !hasExistingCode) {
-    return [...BASE_TOOLS, ...HASHLINE_TOOLS, ...web];
+    return [...BASE_TOOLS, ...HASHLINE_TOOLS, ...web, ...git];
   }
 
-  // existing-code + LSP + web enabled is exactly the full set.
-  if (flags.webTools()) {
-    return ALL_TOOLS;
-  }
-
-  return [...BASE_TOOLS, ...HASHLINE_TOOLS, ...LSP_TOOLS];
+  // existing-code: base + LSP nav + (gated) web + (gated) git.
+  return [...BASE_TOOLS, ...HASHLINE_TOOLS, ...LSP_TOOLS, ...web, ...git];
 }
 
 /** The model wrote prose but issued NO tool call while the gate is still red —

--- a/packages/core/tests/git-ops.test.ts
+++ b/packages/core/tests/git-ops.test.ts
@@ -92,6 +92,19 @@ test("rejects shell metacharacters and option injection", async () => {
   expect(await doGit({ op: "show", sha: "$(touch x)" }, ctx(repo))).toContain(
     "valid `sha`"
   );
+  // whitespace-prefixed option must not slip past the leading-dash guard
+  expect(
+    await doGit({ op: "diff", ref: "  --upload-pack=evil" }, ctx(repo))
+  ).toContain("unsafe ref");
+});
+
+test("blame tolerates a reversed line range", async () => {
+  const out = await doGit(
+    { op: "blame", path: "a.ts", lineStart: 2, lineEnd: 1 },
+    ctx(repo)
+  );
+
+  expect(out.toLowerCase()).toContain("export const");
 });
 
 test("unknown op is rejected", async () => {

--- a/packages/core/tests/git-ops.test.ts
+++ b/packages/core/tests/git-ops.test.ts
@@ -1,0 +1,123 @@
+import { test, expect, beforeAll, afterAll } from "bun:test";
+import { execFileSync } from "node:child_process";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { doGit } from "../src/loop/tools/git-ops";
+import { READ_ONLY_TOOL_NAMES } from "../src/agent";
+import type { IToolContext } from "../src/loop/tools";
+
+const ctx = (cwd: string): IToolContext => ({
+  cwd,
+  files: [],
+  report: () => {},
+  task: "t",
+});
+
+const git = (cwd: string, ...argv: string[]): void => {
+  execFileSync("git", argv, { cwd, stdio: "ignore" });
+};
+
+let repo: string;
+let firstSha: string;
+
+beforeAll(() => {
+  repo = mkdtempSync(join(tmpdir(), "tsforge-git-"));
+  git(repo, "init", "-q");
+  git(repo, "config", "user.email", "t@t.t");
+  git(repo, "config", "user.name", "t");
+  writeFileSync(
+    join(repo, "a.ts"),
+    "export const a = 1;\nexport const b = 2;\n"
+  );
+  git(repo, "add", "-A");
+  git(repo, "commit", "-q", "-m", "initial");
+  firstSha = execFileSync("git", ["rev-parse", "HEAD"], { cwd: repo })
+    .toString()
+    .trim();
+  // an uncommitted working change for diff/changed_files
+  writeFileSync(
+    join(repo, "a.ts"),
+    "export const a = 99;\nexport const b = 2;\n"
+  );
+});
+
+afterAll(() => {
+  rmSync(repo, { recursive: true, force: true });
+});
+
+test("diff reflects the working-tree change", async () => {
+  const out = await doGit({ op: "diff" }, ctx(repo));
+
+  expect(out).toContain("a.ts");
+  expect(out).toContain("-export const a = 1;");
+  expect(out).toContain("+export const a = 99;");
+});
+
+test("changed_files lists the modified file with numstat", async () => {
+  const out = await doGit({ op: "changed_files" }, ctx(repo));
+
+  expect(out).toContain("a.ts");
+});
+
+test("log returns the commit subject", async () => {
+  const out = await doGit({ op: "log", max: 5 }, ctx(repo));
+
+  expect(out).toContain("initial");
+});
+
+test("show returns a commit by sha", async () => {
+  const out = await doGit({ op: "show", sha: firstSha }, ctx(repo));
+
+  expect(out).toContain("initial");
+  expect(out).toContain("a.ts");
+});
+
+test("blame attributes a line range", async () => {
+  const out = await doGit(
+    { op: "blame", path: "a.ts", lineStart: 1, lineEnd: 2 },
+    ctx(repo)
+  );
+
+  expect(out.toLowerCase()).toContain("export const");
+});
+
+test("rejects shell metacharacters and option injection", async () => {
+  expect(await doGit({ op: "diff", path: "; rm -rf /" }, ctx(repo))).toContain(
+    "unsafe path"
+  );
+  expect(
+    await doGit({ op: "diff", ref: "--upload-pack=evil" }, ctx(repo))
+  ).toContain("unsafe ref");
+  expect(await doGit({ op: "show", sha: "$(touch x)" }, ctx(repo))).toContain(
+    "valid `sha`"
+  );
+});
+
+test("unknown op is rejected", async () => {
+  expect(await doGit({ op: "push" }, ctx(repo))).toContain("unknown op");
+});
+
+test("maxChars truncates with a note", async () => {
+  const out = await doGit({ op: "diff", maxChars: 10 }, ctx(repo));
+
+  expect(out).toContain("truncated");
+  // 10 chars of body + the truncation note
+  expect(out.split("\n")[0]?.length).toBeLessThanOrEqual(10);
+});
+
+test("a non-git directory degrades to a clear message, no throw", async () => {
+  const bare = mkdtempSync(join(tmpdir(), "tsforge-nogit-"));
+
+  try {
+    expect(await doGit({ op: "diff" }, ctx(bare))).toContain(
+      "not a git repository"
+    );
+  } finally {
+    rmSync(bare, { recursive: true, force: true });
+  }
+});
+
+test("git_context is a plan-mode (read-only) tool", () => {
+  expect(READ_ONLY_TOOL_NAMES.has("git_context")).toBe(true);
+});

--- a/packages/core/tests/run-branches.test.ts
+++ b/packages/core/tests/run-branches.test.ts
@@ -1,10 +1,16 @@
 import { test, expect } from "bun:test";
 import { mkdtemp, rm } from "node:fs/promises";
+import { execFileSync } from "node:child_process";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { runTask } from "../src/loop";
-import type { IProvider } from "../src/inference";
+import type { IProvider, IModelResponse } from "../src/inference";
 import { scripted, createStep, STOP } from "./stub-provider";
+
+const gitStep = (op: string): IModelResponse => ({
+  content: "",
+  toolCalls: [{ name: "git_context", arguments: { op } }],
+});
 
 test("red-not-confirmed when the goalpost already passes — model never runs", async () => {
   let called = false;
@@ -55,6 +61,34 @@ test("done when the model creates the file the goalpost needs", async () => {
 
     expect(r.status).toBe("done");
     expect(r.cycles).toBe(1); // create turn auto-gates green — no extra stop turn
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test("a git_context tool call runs inside a full loop turn, then drives to done", async () => {
+  // End-to-end through the real loop (not a direct executeTool call): the model
+  // calls git_context, its result flows back as a tool message, the model then
+  // creates the file the goalpost needs, and the gate settles green.
+  const dir = await mkdtemp(join(tmpdir(), "tsforge-git-loop-"));
+
+  execFileSync("git", ["init", "-q"], { cwd: dir });
+  execFileSync("git", ["config", "user.email", "t@t.t"], { cwd: dir });
+  execFileSync("git", ["config", "user.name", "t"], { cwd: dir });
+  execFileSync("git", ["commit", "-q", "--allow-empty", "-m", "init"], {
+    cwd: dir,
+  });
+
+  try {
+    const r = await runTask(
+      { id: "1", accept: "test -f done.txt", files: ["done.txt"] },
+      dir,
+      scripted([gitStep("log"), createStep("done.txt", "x"), STOP])
+    );
+
+    expect(r.status).toBe("done");
+    // The git_context turn + the create turn both happened (no crash/stall).
+    expect(r.cycles).toBeGreaterThanOrEqual(2);
   } finally {
     await rm(dir, { recursive: true, force: true });
   }

--- a/packages/core/tests/tools-gating.test.ts
+++ b/packages/core/tests/tools-gating.test.ts
@@ -7,6 +7,7 @@ const names = (tools: { function: { name: string } }[]): string[] =>
 afterEach(() => {
   delete process.env.TSFORGE_NO_LSP_TOOLS;
   delete process.env.TSFORGE_WEB;
+  delete process.env.TSFORGE_NO_GIT_TOOL;
 });
 
 test("scratch (no existing code) gets only the base tools — no LSP nav set", () => {
@@ -35,15 +36,29 @@ test("existing code gets the base tools PLUS the LSP nav set", () => {
   expect(tools.length).toBeGreaterThan(4);
 });
 
-test("TSFORGE_NO_LSP_TOOLS=1 forces base-only even with existing code", () => {
+test("existing code exposes git_context", () => {
+  expect(names(toolsFor(true))).toContain("git_context");
+});
+
+test("TSFORGE_NO_LSP_TOOLS=1 forces base-only — but git_context survives", () => {
+  // git_context is NOT an LSP tool (no tsconfig needed); it's gated on history,
+  // so it stays on existing-code runs even when the LSP nav set is withheld.
   process.env.TSFORGE_NO_LSP_TOOLS = "1";
   expect(names(toolsFor(true)).sort()).toEqual([
     "create",
     "edit",
     "edit_lines",
+    "git_context",
     "read",
     "run",
   ]);
+});
+
+test("git_context is absent on scratch (no history) and removable by flag", () => {
+  expect(names(toolsFor(false))).not.toContain("git_context");
+
+  process.env.TSFORGE_NO_GIT_TOOL = "1";
+  expect(names(toolsFor(true))).not.toContain("git_context");
 });
 
 test("web tools are absent unless TSFORGE_WEB=1", () => {


### PR DESCRIPTION
## What

Adds **`git_context`** — a read-only tool that gives the agent structured, token-bounded access to repo state, so it can scope a *review* or a *fix* to what actually changed.

Ops: `diff` · `changed_files` (numstat) · `log` (incl. `-L` line history) · `blame` · `show`.

## Why

tsforge is greenfield-biased; brownfield work ("review a repo", "fix a bug") had no change-awareness — the model fell back to raw `run("git diff")` (unstructured, unbounded). This is the first piece of the brownfield navigation plan.

## Safety

- Wraps `git` via explicit argv (**no shell**) — model-supplied ref/path/sha can't be expanded or smuggle options.
- `sha` regex-validated; shell metacharacters / leading-dash option injection in `ref`/`path` rejected.
- Output char-capped (`maxChars` override); missing git binary or non-repo → clear message, no throw.
- Advertised only on **existing-code** runs; survives `TSFORGE_NO_LSP_TOOLS` (not an LSP tool); withheld under `TSFORGE_NO_GIT_TOOL`; plan-mode-safe.

## Testing

- `git-ops.test.ts` (all 5 ops, injection rejection, truncation, not-a-repo, plan-mode membership), gating tests, and a full `runTask` loop-turn test. Full `bun run validate`: **1055 pass, 0 fail**.
- **Real model (deepseek):** organically used `git_context` (log/diff/show) to find a regressing commit; fell back to shell git when disabled — clean A/B.
- Greenfield regression sweep: 100% pass, 0 regress (shared-code edits don't touch the generation path).

## Cut from this PR

`read_symbol` / `go_to_definition` / `outline` were prototyped but **removed** — a real-model brownfield A/B showed the model preferred the existing `search`+`read` and never adopted them, even after tuning their descriptions. They can return with a large-file / token-pressure eval, or as part of Phase 2 comprehension.