### PR TITLE
feat(cli): tsforge review — functional review of the change you're on

### DIFF
--- a/apps/docs/src/content/docs/reference/commands.mdx
+++ b/apps/docs/src/content/docs/reference/commands.mdx
@@ -21,6 +21,18 @@ bun run tsforge
 
 Environment variables: [Environment variables](/reference/flags/). Interactive usage: [Interactive CLI](/cli/interactive/).
 
+## Review the change you're on
+
+```bash
+tsforge review                 # functional review of the current diff
+tsforge review --staged        # only staged changes (pre-commit)
+tsforge review --base develop  # diff against an explicit base ref
+```
+
+`tsforge review` reviews the change you're working on — the working tree (committed **and** uncommitted edits) vs the auto-detected base (merge-base with `main`/`master`). No commit or push required.
+
+It is **functional** review — logic, regressions, edge cases, and business rules — guided by a built-in senior-review rubric (lenses), with each finding adversarially re-checked against the real code so false positives are dropped. Types, structure, and style are out of scope (the gate covers those). Exits non-zero if any **error**-severity finding survives, so it's CI-usable. Disable the tool entirely with `TSFORGE_NO_GIT_TOOL=1` (it relies on git).
+
 ## Merge gate (repo root)
 
 Commands for people working on the tsforge repository itself:

--- a/packages/core/scripts/review-eval.ts
+++ b/packages/core/scripts/review-eval.ts
@@ -1,0 +1,183 @@
+// Eval for `tsforge review`: run the reviewer against repos with PLANTED bugs
+// (known ground truth) and measure recall (did it find the plant?) and false
+// positives (did it invent issues?), A/B'ing the adversarial-verify pass on/off.
+// Review can't be test-graded (a test leaks the answer), so we grade against
+// planted defects instead. Writes a record to evals/runs/.
+//
+// Run: bun run packages/core/scripts/review-eval.ts   (uses ~/.tsforge/models.json)
+import { mkdtempSync, rmSync, writeFileSync, mkdirSync } from "node:fs";
+import { execFileSync } from "node:child_process";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { OpenAICompatibleProvider } from "../src/inference";
+import { reviewChange } from "../src/loop/review";
+import { resolveActiveModel, resolveApiKey } from "../src/models-config";
+
+interface IScenario {
+  id: string;
+  file: string;
+  /** The 1-based line the planted bug sits on. */
+  line: number;
+  /** Committed (correct) version. */
+  good: string;
+  /** Working-tree (buggy) version — the change under review. */
+  bad: string;
+}
+
+const SCENARIOS: IScenario[] = [
+  {
+    id: "correctness-reversed-subtraction",
+    file: "discount.ts",
+    line: 2,
+    good: "export function discount(price: number, off: number): number {\n  return price - off;\n}\n",
+    bad: "export function discount(price: number, off: number): number {\n  return off - price;\n}\n",
+  },
+  {
+    id: "edge-case-unguarded-index",
+    file: "host.ts",
+    line: 2,
+    good: 'export function host(url: string): string {\n  return url.split("//")[1] ?? "";\n}\n',
+    bad: 'export function host(url: string): string {\n  return url.split("//")[1].split("/")[0];\n}\n',
+  },
+  {
+    id: "business-logic-missing-rounding",
+    file: "tax.ts",
+    line: 2,
+    good: "export function withTax(cents: number): number {\n  return Math.round(cents * 1.2);\n}\n",
+    bad: "export function withTax(cents: number): number {\n  return cents * 1.2;\n}\n",
+  },
+];
+
+async function buildProvider(): Promise<OpenAICompatibleProvider> {
+  const { entry } = await resolveActiveModel();
+
+  return new OpenAICompatibleProvider({
+    baseUrl: entry.baseUrl,
+    model: entry.model,
+    apiKey: resolveApiKey(entry),
+    maxTokens: entry.maxTokens ?? 8192,
+    reasoning: entry.reasoning,
+    reasoningEffort: entry.reasoningEffort,
+    extraBody: entry.extraBody,
+    extraHeaders: entry.extraHeaders,
+  });
+}
+
+function setup(s: IScenario): string {
+  const dir = mkdtempSync(join(tmpdir(), `review-${s.id}-`));
+  const git = (...a: string[]): void =>
+    void execFileSync("git", a, { cwd: dir, stdio: "ignore" });
+
+  writeFileSync(
+    join(dir, "tsconfig.json"),
+    '{"compilerOptions":{"strict":true,"skipLibCheck":true},"include":["*.ts"]}'
+  );
+  writeFileSync(join(dir, s.file), s.good);
+  git("init", "-q");
+  git("config", "user.email", "e@e.e");
+  git("config", "user.name", "e");
+  git("add", "-A");
+  git("commit", "-q", "-m", "baseline");
+  writeFileSync(join(dir, s.file), s.bad); // the buggy change under review
+
+  return dir;
+}
+
+interface IScore {
+  found: boolean;
+  falsePositives: number;
+  verified: number;
+  rejected: number;
+}
+
+const NEAR = 3;
+
+async function score(
+  provider: OpenAICompatibleProvider,
+  s: IScenario,
+  verify: boolean
+): Promise<IScore> {
+  const dir = setup(s);
+
+  try {
+    const report = await reviewChange(provider, dir, { verify });
+    const onPlant = (line: number): boolean => Math.abs(line - s.line) <= NEAR;
+    const hits = report.findings.filter(
+      (f) => f.file === s.file && onPlant(f.line)
+    );
+    const fp = report.findings.filter(
+      (f) => !(f.file === s.file && onPlant(f.line))
+    );
+
+    return {
+      found: hits.length > 0,
+      falsePositives: fp.length,
+      verified: report.findings.length,
+      rejected: report.rejected,
+    };
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+}
+
+interface IVariantAgg {
+  variant: string;
+  recall: number;
+  avgFalsePositives: number;
+  scores: { id: string; score: IScore }[];
+}
+
+async function runVariant(
+  provider: OpenAICompatibleProvider,
+  verify: boolean
+): Promise<IVariantAgg> {
+  const scores: { id: string; score: IScore }[] = [];
+
+  for (const s of SCENARIOS) {
+    const sc = await score(provider, s, verify);
+
+    scores.push({ id: s.id, score: sc });
+    process.stdout.write(
+      `  [${verify ? "verify=on " : "verify=off"}] ${s.id}: found=${sc.found ? "yes" : "no"} fp=${sc.falsePositives}\n`
+    );
+  }
+
+  const found = scores.filter((x) => x.score.found).length;
+  const fpTotal = scores.reduce((n, x) => n + x.score.falsePositives, 0);
+
+  return {
+    variant: verify ? "verify=on" : "verify=off",
+    recall: found / scores.length,
+    avgFalsePositives: fpTotal / scores.length,
+    scores,
+  };
+}
+
+const provider = await buildProvider();
+const { entry } = await resolveActiveModel();
+
+process.stdout.write(`review-eval: model ${entry.model}\n`);
+
+const variants = [
+  await runVariant(provider, true),
+  await runVariant(provider, false),
+];
+
+process.stdout.write("\n=== review-eval summary ===\n");
+
+for (const v of variants) {
+  process.stdout.write(
+    `${v.variant}: recall ${(v.recall * 100).toFixed(0)}%  avg false-positives ${v.avgFalsePositives.toFixed(2)}\n`
+  );
+}
+
+const stamp = new Date().toISOString().replace(/[:.]/g, "-");
+const runsDir = join(import.meta.dir, "..", "..", "..", "evals", "runs");
+const out = join(runsDir, `review-eval-${stamp}.json`);
+
+mkdirSync(runsDir, { recursive: true });
+writeFileSync(
+  out,
+  `${JSON.stringify({ model: entry.model, variants }, null, 2)}\n`
+);
+process.stdout.write(`\nsaved ${out}\n`);

--- a/packages/core/src/cli.ts
+++ b/packages/core/src/cli.ts
@@ -5,7 +5,14 @@ import { createInterface } from "node:readline/promises";
 import { emitKeypressEvents } from "node:readline";
 import { formatHelp, takesArg } from "./cli/commands";
 import { pickCommand } from "./render/command-menu";
-import { runTask, RUN_STATUS, Session, PLAN_APPROVED_NOTE } from "./loop";
+import {
+  runTask,
+  RUN_STATUS,
+  Session,
+  PLAN_APPROVED_NOTE,
+  reviewChange,
+  formatReport,
+} from "./loop";
 import {
   PROVIDER_LIMITS,
   PROVIDER_DEFAULTS,
@@ -110,11 +117,17 @@ export interface ICliArgs {
    *  project's discovered tests (`--strict-floor-only`). By default the auto-gate
    *  also runs the project's tests, so "green" means floor + tests pass. */
   strictFloorOnly: boolean;
+  /** Review the change you're on (functional review of the diff) (`tsforge review`). */
+  review: boolean;
+  /** Review only staged changes (`--staged`). */
+  staged: boolean;
+  /** Explicit base ref to diff against for review (`--base <ref>`). */
+  base: string;
 }
 
 const BOOL_FLAGS: Record<
   string,
-  "continue" | "noGate" | "web" | "log" | "plan" | "strictFloorOnly"
+  "continue" | "noGate" | "web" | "log" | "plan" | "strictFloorOnly" | "staged"
 > = {
   "--continue": "continue",
   "-c": "continue",
@@ -123,6 +136,7 @@ const BOOL_FLAGS: Record<
   "--log": "log",
   "--plan": "plan",
   "--strict-floor-only": "strictFloorOnly",
+  "--staged": "staged",
 };
 
 const VALUE_FLAGS = new Set([
@@ -132,6 +146,7 @@ const VALUE_FLAGS = new Set([
   "--gate",
   "--browser",
   "--resume",
+  "--base",
 ]);
 
 /** Parse argv (without the tsforge binary name). Always succeeds — mode is decided in main. */
@@ -150,6 +165,9 @@ export function parseArgs(argv: readonly string[]): ICliArgs {
     log: false,
     plan: false,
     strictFloorOnly: false,
+    review: false,
+    staged: false,
+    base: "",
   };
 
   for (let i = 0; i < argv.length; i += 1) {
@@ -172,6 +190,13 @@ export function parseArgs(argv: readonly string[]): ICliArgs {
   }
 
   out.task = positional.join(" ").trim();
+
+  // `tsforge review` is a subcommand, not a task: the first positional selects it.
+  if (positional[0] === "review") {
+    out.review = true;
+    out.task = positional.slice(1).join(" ").trim();
+  }
+
   out.dir = isAbsolute(out.dir) ? out.dir : join(process.cwd(), out.dir);
 
   return out;
@@ -190,6 +215,8 @@ function applyValueFlag(flag: string, value: string, out: ICliArgs): void {
     out.browser = value;
   } else if (flag === "--resume") {
     out.resumeId = value;
+  } else if (flag === "--base") {
+    out.base = value;
   } else {
     out.accept = value; // --accept / --gate
   }
@@ -1552,8 +1579,26 @@ async function repl(args: ICliArgs): Promise<number> {
   return 0;
 }
 
+async function reviewMode(args: ICliArgs): Promise<number> {
+  const { entry } = await resolveActiveModel();
+  const report = await reviewChange(makeProvider(entry), args.dir, {
+    ...(args.base.length > 0 ? { base: args.base } : {}),
+    staged: args.staged,
+    log: (m) => process.stdout.write(`  ↳ ${m}\n`),
+  });
+
+  process.stdout.write(`\n${formatReport(report)}\n`);
+
+  // Exit non-zero when there are error-severity findings, so it's CI-usable.
+  return report.findings.some((f) => f.severity === "error") ? 1 : 0;
+}
+
 export async function main(): Promise<number> {
   const args = parseArgs(process.argv.slice(2));
+
+  if (args.review) {
+    return reviewMode(args);
+  }
 
   // A positional task with a scope + gate ⇒ one-shot; otherwise interactive.
   return isOneShot(args) ? runOnce(args) : repl(args);

--- a/packages/core/src/loop/index.ts
+++ b/packages/core/src/loop/index.ts
@@ -17,3 +17,11 @@ export {
   type ISessionConfig,
   type ISendResult,
 } from "./session";
+export {
+  reviewChange,
+  formatReport,
+  LENSES,
+  type IReviewOptions,
+  type IReviewReport,
+  type IVerifiedFinding,
+} from "./review";

--- a/packages/core/src/loop/review/index.ts
+++ b/packages/core/src/loop/review/index.ts
@@ -1,0 +1,13 @@
+export {
+  reviewChange,
+  formatReport,
+  type IReviewOptions,
+} from "./review-change";
+export { LENSES } from "./lenses";
+export type {
+  ILens,
+  IRepoFinding,
+  IVerifiedFinding,
+  IReviewReport,
+  Severity,
+} from "./review.types";

--- a/packages/core/src/loop/review/lenses.ts
+++ b/packages/core/src/loop/review/lenses.ts
@@ -1,0 +1,99 @@
+import type { ILens } from "./review.types";
+
+/**
+ * The built-in senior-review rubric. This is the knowledge that makes `tsforge
+ * review` more than "ask the model to review a diff": each lens tells the model
+ * exactly what to focus on, with the questions a senior reviewer actually asks
+ * and a concrete example of the kind of bug it catches. Fed to the model so a
+ * SMALL local model reviews like a senior engineer.
+ *
+ * Deliberately scoped to FUNCTIONAL review (logic, behaviour, regressions) — the
+ * gate (tsc + rule packs + meta-rules) already covers types, structure, style.
+ * Fixed in the harness for now; structured so it can become project-configurable
+ * later (like rule packs).
+ */
+export const LENSES: readonly ILens[] = [
+  {
+    id: "correctness",
+    title: "Logic correctness",
+    focus:
+      "Does the code actually do what the surrounding names, comments, and call sites imply it should?",
+    questions: [
+      "Are any conditions inverted, or operators wrong (< vs <=, && vs ||, + vs -)?",
+      "Off-by-one in loops/indexing/slicing?",
+      "Does every branch return/assign the value it's supposed to?",
+    ],
+    example:
+      "A `getDiscount` that returns the price instead of the discount because the subtraction is reversed.",
+  },
+  {
+    id: "regressions",
+    title: "Regressions & contract changes",
+    focus:
+      "Does this change break existing callers or alter behaviour they depend on?",
+    questions: [
+      "Did a function signature, return shape, thrown error, or default value change?",
+      "Will an existing caller now get a different result for the same input?",
+      "Was a previously handled case silently dropped?",
+    ],
+    example:
+      "Changing a function to return `null` instead of `[]`, so every caller that does `.map` now throws.",
+  },
+  {
+    id: "edge-cases",
+    title: "Edge cases & error paths",
+    focus: "What happens at the boundaries and on the unhappy path?",
+    questions: [
+      "Empty / null / undefined / zero / negative / very large inputs?",
+      "Are errors and rejected promises handled, or do they escape?",
+      "Is there an unawaited async call, or a missing await before using a result?",
+    ],
+    example:
+      "Splitting a string and indexing `[1]` without checking the split produced two parts.",
+  },
+  {
+    id: "business-logic",
+    title: "Business rules",
+    focus:
+      "Does the change honour the domain rules the code is responsible for?",
+    questions: [
+      "Money: integer-cents vs float, correct rounding, currency mixing?",
+      "Auth/permissions: is every privileged path actually gated?",
+      "State machines: are invalid transitions prevented; are invariants kept?",
+    ],
+    example:
+      "An order total computed with floating-point dollars, losing a cent on rounding.",
+  },
+  {
+    id: "data-concurrency",
+    title: "Data & concurrency",
+    focus: "Can two things racing, or a partial failure, corrupt state?",
+    questions: [
+      "Read-modify-write without atomicity; check-then-act races?",
+      "A multi-step write that can fail halfway and leave inconsistent data?",
+      "Shared mutable state touched from concurrent handlers?",
+    ],
+    example:
+      "Incrementing a counter via read → +1 → write, losing updates under concurrency.",
+  },
+  {
+    id: "api-contract",
+    title: "API & external contracts",
+    focus:
+      "Does the change keep faith with what consumers and external systems expect?",
+    questions: [
+      "Breaking an HTTP route's response shape, status code, or required field?",
+      "Changing serialized/persisted formats without migration?",
+      "Sending more/less data than the consumer expects (over- or under-fetching)?",
+    ],
+    example:
+      "Renaming a JSON response field, breaking every client that reads the old name.",
+  },
+];
+
+/** Compact rubric text for a single lens, injected into the find prompt. */
+export function lensRubric(lens: ILens): string {
+  const qs = lens.questions.map((q) => `  - ${q}`).join("\n");
+
+  return `### ${lens.title} (lens id: ${lens.id})\n${lens.focus}\nAsk:\n${qs}\nExample bug: ${lens.example}`;
+}

--- a/packages/core/src/loop/review/review-change.ts
+++ b/packages/core/src/loop/review/review-change.ts
@@ -72,9 +72,10 @@ async function changedFiles(
   base: string,
   staged: boolean
 ): Promise<string[]> {
+  // --diff-filter=d drops deleted files — no point reviewing a file that's gone.
   const argv = staged
-    ? ["diff", "--name-only", "--staged"]
-    : ["diff", "--name-only", base];
+    ? ["diff", "--name-only", "--diff-filter=d", "--staged"]
+    : ["diff", "--name-only", "--diff-filter=d", base];
   const out = await gitText(cwd, argv);
 
   return out
@@ -140,6 +141,23 @@ function toSeverity(value: unknown): Severity {
   return "info";
 }
 
+/** A 1-based line, accepting a number OR a numeric string (models emit both). */
+function toLine(value: unknown): number {
+  if (typeof value === "number" && value > 0) {
+    return value;
+  }
+
+  if (typeof value === "string") {
+    const n = Number.parseInt(value, 10);
+
+    if (Number.isFinite(n) && n > 0) {
+      return n;
+    }
+  }
+
+  return 1;
+}
+
 function parseFindings(content: string, file: string): IRepoFinding[] {
   let data: unknown;
 
@@ -170,7 +188,7 @@ function parseFindings(content: string, file: string): IRepoFinding[] {
 
     out.push({
       file,
-      line: typeof line === "number" && line > 0 ? line : 1,
+      line: toLine(line),
       severity: toSeverity(entry.severity),
       lens:
         typeof lens === "string" && LENS_IDS.has(lens) ? lens : "correctness",
@@ -257,6 +275,43 @@ async function verifyFinding(
   return { ...finding, verified: real, verdict };
 }
 
+function errText(err: unknown): string {
+  return err instanceof Error ? err.message : String(err);
+}
+
+/** findInFile, but a thrown error degrades to no findings (one bad file can't
+ *  abort the whole review). */
+async function safeFind(
+  provider: IProvider,
+  file: string,
+  diff: string,
+  log: (m: string) => void
+): Promise<IRepoFinding[]> {
+  try {
+    return await findInFile(provider, file, diff);
+  } catch (err) {
+    log(`  ${file}: review failed — ${errText(err)}`);
+
+    return [];
+  }
+}
+
+/** verifyFinding, but a thrown error drops the finding (fail closed on error). */
+async function safeVerify(
+  provider: IProvider,
+  cwd: string,
+  finding: IRepoFinding,
+  log: (m: string) => void
+): Promise<IVerifiedFinding> {
+  try {
+    return await verifyFinding(provider, cwd, finding);
+  } catch (err) {
+    log(`  verify failed at ${finding.file}:${finding.line} — ${errText(err)}`);
+
+    return { ...finding, verified: false, verdict: "verification error" };
+  }
+}
+
 /**
  * Review the change you're on (working tree vs the auto-detected base, including
  * uncommitted edits). Per-file find pass guided by the senior-review lenses, then
@@ -276,9 +331,12 @@ export async function reviewChange(
 
   const raw: IRepoFinding[] = [];
 
+  // Sequential on purpose: this harness targets a single local-model server, so
+  // we don't fan out concurrent requests that would swamp it. Each file is
+  // isolated in try/catch so one bad file can't abort the whole review.
   for (const file of files) {
     const diff = await fileDiff(cwd, base, file, staged);
-    const found = await findInFile(provider, file, diff);
+    const found = await safeFind(provider, file, diff, log);
 
     log(`  ${file}: ${found.length} candidate finding(s)`);
     raw.push(...found);
@@ -290,7 +348,7 @@ export async function reviewChange(
 
   for (const finding of raw) {
     const result = doVerify
-      ? await verifyFinding(provider, cwd, finding)
+      ? await safeVerify(provider, cwd, finding, log)
       : { ...finding, verified: true, verdict: "(unverified)" };
 
     if (result.verified) {

--- a/packages/core/src/loop/review/review-change.ts
+++ b/packages/core/src/loop/review/review-change.ts
@@ -1,0 +1,338 @@
+import { isAbsolute, join } from "node:path";
+import { runArgvCommand } from "../../lib/fs";
+import { isRecord, isArray } from "../../lib/guards";
+import { extractJson } from "../../lib/json";
+import type { IProvider } from "../../inference";
+import { LENSES, lensRubric } from "./lenses";
+import type {
+  IRepoFinding,
+  IVerifiedFinding,
+  IReviewReport,
+  Severity,
+} from "./review.types";
+
+const MAX_FILES = 25;
+const DIFF_CHARS = 6000;
+const WINDOW = 8;
+const LENS_IDS = new Set<string>(LENSES.map((l) => l.id));
+
+export interface IReviewOptions {
+  /** Explicit base ref; default = auto-detected (merge-base with the default branch). */
+  base?: string;
+  /** Review only staged changes (pre-commit). */
+  staged?: boolean;
+  /** Run the adversarial-verify pass (default true). Off = raw findings pass
+   *  through unverified — for A/B measuring verify's effect on precision. */
+  verify?: boolean;
+  /** Progress callback (one line per step). */
+  log?: (message: string) => void;
+}
+
+/** Run `git` with an explicit argv (no shell); return trimmed stdout, "" on error. */
+async function gitText(cwd: string, argv: string[]): Promise<string> {
+  const res = await runArgvCommand(cwd, ["git", ...argv]);
+
+  return res.exitCode === 0 ? res.stdout.trim() : "";
+}
+
+/** The ref to diff the working tree against: explicit override, else the
+ *  merge-base with the default branch, else HEAD (already on the default branch). */
+async function detectBase(cwd: string, override?: string): Promise<string> {
+  if (override !== undefined && override.length > 0) {
+    return override;
+  }
+
+  const branch = await gitText(cwd, ["rev-parse", "--abbrev-ref", "HEAD"]);
+
+  for (const candidate of ["main", "master"]) {
+    const exists = await gitText(cwd, [
+      "rev-parse",
+      "--verify",
+      "--quiet",
+      candidate,
+    ]);
+
+    if (exists.length === 0 || branch === candidate) {
+      continue;
+    }
+
+    const mergeBase = await gitText(cwd, ["merge-base", "HEAD", candidate]);
+
+    if (mergeBase.length > 0) {
+      return mergeBase;
+    }
+  }
+
+  return "HEAD";
+}
+
+/** Changed source files in the working tree vs `base` (or staged-only). */
+async function changedFiles(
+  cwd: string,
+  base: string,
+  staged: boolean
+): Promise<string[]> {
+  const argv = staged
+    ? ["diff", "--name-only", "--staged"]
+    : ["diff", "--name-only", base];
+  const out = await gitText(cwd, argv);
+
+  return out
+    .split("\n")
+    .map((f) => f.trim())
+    .filter((f) => /\.(ts|tsx|js|jsx|mts|cts)$/.test(f))
+    .slice(0, MAX_FILES);
+}
+
+async function fileDiff(
+  cwd: string,
+  base: string,
+  file: string,
+  staged: boolean
+): Promise<string> {
+  const argv = staged
+    ? ["diff", "--staged", "--", file]
+    : ["diff", base, "--", file];
+  const out = await gitText(cwd, argv);
+
+  return out.slice(0, DIFF_CHARS);
+}
+
+const FIND_SYSTEM = [
+  "You are a senior engineer reviewing a code change for FUNCTIONAL problems: logic errors, regressions, missed edge cases, and broken business rules.",
+  "A separate automated gate already covers types, structure, and style — do NOT report those. Only functional/behavioural issues.",
+  "Review the change THROUGH these lenses:",
+  LENSES.map(lensRubric).join("\n\n"),
+  "Rules: report ONLY concrete problems you can tie to a specific changed line. If the change looks correct, return an empty list. Never speculate — prefer silence over a guess.",
+  'Respond with ONLY JSON: {"findings":[{"line":<number>,"severity":"error|warning|info","lens":"<lens id>","claim":"<what is wrong>","reason":"<why>"}]}.',
+].join("\n\n");
+
+/** One find pass over a single changed file's diff (per-file decomposition keeps
+ *  a small model in its reliable zone). */
+async function findInFile(
+  provider: IProvider,
+  file: string,
+  diff: string
+): Promise<IRepoFinding[]> {
+  if (diff.length === 0) {
+    return [];
+  }
+
+  const res = await provider.complete(
+    [
+      { role: "system", content: FIND_SYSTEM },
+      {
+        role: "user",
+        content: `File: ${file}\n\nDiff (base → working tree):\n${diff}`,
+      },
+    ],
+    { temperature: 0 }
+  );
+
+  return parseFindings(res.content, file);
+}
+
+function toSeverity(value: unknown): Severity {
+  if (value === "error" || value === "warning" || value === "info") {
+    return value;
+  }
+
+  return "info";
+}
+
+function parseFindings(content: string, file: string): IRepoFinding[] {
+  let data: unknown;
+
+  try {
+    data = JSON.parse(extractJson(content));
+  } catch {
+    return [];
+  }
+
+  const raw = isRecord(data) ? data.findings : undefined;
+
+  if (!isArray(raw)) {
+    return [];
+  }
+
+  const out: IRepoFinding[] = [];
+
+  for (const entry of raw) {
+    if (!isRecord(entry)) {
+      continue;
+    }
+
+    const { line, lens, claim, reason } = entry;
+
+    if (typeof claim !== "string" || claim.length === 0) {
+      continue;
+    }
+
+    out.push({
+      file,
+      line: typeof line === "number" && line > 0 ? line : 1,
+      severity: toSeverity(entry.severity),
+      lens:
+        typeof lens === "string" && LENS_IDS.has(lens) ? lens : "correctness",
+      claim,
+      reason: typeof reason === "string" ? reason : "",
+    });
+  }
+
+  return out;
+}
+
+/** A numbered window of the real file around `line` (the evidence the verifier
+ *  judges against — a finding that the actual code doesn't confirm is dropped). */
+async function codeWindow(
+  cwd: string,
+  file: string,
+  line: number
+): Promise<string> {
+  const abs = isAbsolute(file) ? file : join(cwd, file);
+  const text = await Bun.file(abs)
+    .text()
+    .catch(() => "");
+
+  if (text.length === 0) {
+    return "";
+  }
+
+  const lines = text.split("\n");
+  const from = Math.max(0, line - 1 - WINDOW);
+  const to = Math.min(lines.length, line + WINDOW);
+
+  return lines
+    .slice(from, to)
+    .map((l, i) => `${from + i + 1}: ${l}`)
+    .join("\n");
+}
+
+const VERIFY_SYSTEM = [
+  "You are verifying a code-review finding. Be skeptical: a finding survives ONLY if the actual code shown clearly confirms a real functional problem.",
+  "Default to rejecting — if the evidence is ambiguous, not present, or the claim is speculative, mark it not real.",
+  'Respond with ONLY JSON: {"real":true|false,"verdict":"<one short sentence>"}.',
+].join("\n");
+
+/** Adversarially re-check one finding against the real code. */
+async function verifyFinding(
+  provider: IProvider,
+  cwd: string,
+  finding: IRepoFinding
+): Promise<IVerifiedFinding> {
+  const window = await codeWindow(cwd, finding.file, finding.line);
+  const drop = (verdict: string): IVerifiedFinding => ({
+    ...finding,
+    verified: false,
+    verdict,
+  });
+
+  if (window.length === 0) {
+    return drop("no code at the cited location");
+  }
+
+  const res = await provider.complete(
+    [
+      { role: "system", content: VERIFY_SYSTEM },
+      {
+        role: "user",
+        content: `Finding [${finding.lens}] at ${finding.file}:${finding.line}\nClaim: ${finding.claim}\nReason: ${finding.reason}\n\nActual code:\n${window}\n\nIs this a real functional problem?`,
+      },
+    ],
+    { temperature: 0 }
+  );
+
+  let data: unknown;
+
+  try {
+    data = JSON.parse(extractJson(res.content));
+  } catch {
+    return drop("unverifiable (unparseable verdict)");
+  }
+
+  const real = isRecord(data) && data.real === true;
+  const verdict =
+    isRecord(data) && typeof data.verdict === "string" ? data.verdict : "";
+
+  return { ...finding, verified: real, verdict };
+}
+
+/**
+ * Review the change you're on (working tree vs the auto-detected base, including
+ * uncommitted edits). Per-file find pass guided by the senior-review lenses, then
+ * an adversarial-verify pass that drops findings the real code doesn't confirm.
+ */
+export async function reviewChange(
+  provider: IProvider,
+  cwd: string,
+  opts: IReviewOptions = {}
+): Promise<IReviewReport> {
+  const log = opts.log ?? ((): void => undefined);
+  const staged = opts.staged ?? false;
+  const base = await detectBase(cwd, opts.base);
+  const files = await changedFiles(cwd, base, staged);
+
+  log(`reviewing ${files.length} changed file(s) vs ${base}`);
+
+  const raw: IRepoFinding[] = [];
+
+  for (const file of files) {
+    const diff = await fileDiff(cwd, base, file, staged);
+    const found = await findInFile(provider, file, diff);
+
+    log(`  ${file}: ${found.length} candidate finding(s)`);
+    raw.push(...found);
+  }
+
+  const doVerify = opts.verify ?? true;
+  const verified: IVerifiedFinding[] = [];
+  let rejected = 0;
+
+  for (const finding of raw) {
+    const result = doVerify
+      ? await verifyFinding(provider, cwd, finding)
+      : { ...finding, verified: true, verdict: "(unverified)" };
+
+    if (result.verified) {
+      verified.push(result);
+    } else {
+      rejected += 1;
+    }
+  }
+
+  log(`verified ${verified.length} finding(s), rejected ${rejected}`);
+
+  return { base, changedFiles: files, findings: verified, rejected };
+}
+
+const SEVERITY_RANK: Record<Severity, number> = {
+  error: 0,
+  warning: 1,
+  info: 2,
+};
+
+/** Render a report as plain text for the CLI. */
+export function formatReport(report: IReviewReport): string {
+  if (report.changedFiles.length === 0) {
+    return "No changed source files to review.";
+  }
+
+  if (report.findings.length === 0) {
+    return `No functional issues found across ${report.changedFiles.length} changed file(s) (${report.rejected} candidate(s) rejected on verification).`;
+  }
+
+  const sorted = [...report.findings].sort(
+    (a, b) => SEVERITY_RANK[a.severity] - SEVERITY_RANK[b.severity]
+  );
+  const lines = sorted.map(
+    (f) =>
+      `${f.severity.toUpperCase()} ${f.file}:${f.line} [${f.lens}]\n  ${f.claim}\n  → ${f.reason}`
+  );
+
+  return [
+    `Review of ${report.changedFiles.length} changed file(s) vs ${report.base}:`,
+    `${report.findings.length} verified finding(s), ${report.rejected} rejected.`,
+    "",
+    ...lines,
+  ].join("\n");
+}

--- a/packages/core/src/loop/review/review.types.ts
+++ b/packages/core/src/loop/review/review.types.ts
@@ -1,0 +1,49 @@
+/** Review findings are about FUNCTIONALITY (logic, regressions, edge cases,
+ *  business rules) — not types/structure/style, which the gate already covers. */
+
+export type Severity = "error" | "warning" | "info";
+
+/** One reviewing perspective (a senior-engineer "lens"), fed to the model as its
+ *  rubric so a small local model reviews systematically instead of skimming. */
+export interface ILens {
+  /** Stable id used as the finding's `lens` tag. */
+  id: string;
+  title: string;
+  /** What this lens looks for. */
+  focus: string;
+  /** Concrete "ask yourself" prompts. */
+  questions: string[];
+  /** A one-line concrete example of a real problem this lens catches. */
+  example: string;
+}
+
+/** A raw finding from the find pass (before verification). */
+export interface IRepoFinding {
+  file: string;
+  line: number;
+  severity: Severity;
+  /** The lens id it came from. */
+  lens: string;
+  /** The problem, stated concretely. */
+  claim: string;
+  /** Why it's a problem. */
+  reason: string;
+}
+
+/** A finding after the adversarial-verify pass. */
+export interface IVerifiedFinding extends IRepoFinding {
+  /** Survived verification (the cited code confirms the problem). */
+  verified: boolean;
+  /** The verifier's one-line judgement. */
+  verdict: string;
+}
+
+export interface IReviewReport {
+  /** The ref the working tree was diffed against (the auto-detected base). */
+  base: string;
+  changedFiles: string[];
+  /** Verified survivors only (the report shown to the user). */
+  findings: IVerifiedFinding[];
+  /** How many raw findings the verify pass rejected (precision signal). */
+  rejected: number;
+}

--- a/packages/core/tests/review-change.test.ts
+++ b/packages/core/tests/review-change.test.ts
@@ -1,0 +1,111 @@
+import { test, expect, beforeEach, afterEach } from "bun:test";
+import { execFileSync } from "node:child_process";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { IProvider } from "../src/inference";
+import { reviewChange, formatReport, LENSES } from "../src/loop/review";
+
+/** A provider that answers the find pass and the verify pass differently,
+ *  keyed on the system prompt (so call order doesn't matter). */
+function stub(findings: string, verifyReal: boolean): IProvider {
+  return {
+    async complete(messages) {
+      const sys = messages.find((m) => m.role === "system")?.content ?? "";
+      const body = sys.includes("verifying a code-review finding")
+        ? JSON.stringify({ real: verifyReal, verdict: "judged" })
+        : findings;
+
+      return { content: body, toolCalls: [] };
+    },
+  };
+}
+
+const FINDINGS = JSON.stringify({
+  findings: [
+    {
+      line: 2,
+      severity: "error",
+      lens: "correctness",
+      claim: "subtraction is reversed",
+      reason: "returns a negative discount",
+    },
+  ],
+});
+
+let repo: string;
+const git = (...a: string[]): void =>
+  void execFileSync("git", a, { cwd: repo, stdio: "ignore" });
+
+beforeEach(() => {
+  repo = mkdtempSync(join(tmpdir(), "tsforge-review-"));
+  git("init", "-q");
+  git("config", "user.email", "t@t.t");
+  git("config", "user.name", "t");
+  writeFileSync(
+    join(repo, "discount.ts"),
+    "export function discount(price: number, off: number): number {\n  return price - off;\n}\n"
+  );
+  git("add", "-A");
+  git("commit", "-q", "-m", "init");
+  // a working-tree change (uncommitted) — the thing under review
+  writeFileSync(
+    join(repo, "discount.ts"),
+    "export function discount(price: number, off: number): number {\n  return off - price;\n}\n"
+  );
+});
+
+afterEach(() => {
+  rmSync(repo, { recursive: true, force: true });
+});
+
+test("reviews the uncommitted change and keeps a verified finding", async () => {
+  const report = await reviewChange(stub(FINDINGS, true), repo);
+
+  expect(report.changedFiles).toContain("discount.ts");
+  expect(report.findings).toHaveLength(1);
+  expect(report.findings[0]?.lens).toBe("correctness");
+  expect(report.rejected).toBe(0);
+});
+
+test("adversarial verify drops a finding the code doesn't confirm", async () => {
+  const report = await reviewChange(stub(FINDINGS, false), repo);
+
+  expect(report.findings).toHaveLength(0);
+  expect(report.rejected).toBe(1);
+});
+
+test("no changed source files → nothing to review", async () => {
+  git("add", "-A");
+  git("commit", "-q", "-m", "commit the change");
+  const report = await reviewChange(stub(FINDINGS, true), repo);
+
+  expect(report.changedFiles).toHaveLength(0);
+  expect(formatReport(report)).toContain("No changed source files");
+});
+
+test("malformed model output yields no findings (no throw)", async () => {
+  const report = await reviewChange(stub("not json", true), repo);
+
+  expect(report.findings).toHaveLength(0);
+});
+
+test("formatReport surfaces a verified finding with file:line and lens", async () => {
+  const report = await reviewChange(stub(FINDINGS, true), repo);
+  const text = formatReport(report);
+
+  expect(text).toContain("discount.ts:2");
+  expect(text).toContain("[correctness]");
+  expect(text).toContain("subtraction is reversed");
+});
+
+test("the senior-review rubric ships with the expected lenses", () => {
+  const ids = LENSES.map((l) => l.id);
+
+  expect(ids).toContain("correctness");
+  expect(ids).toContain("regressions");
+  expect(ids).toContain("business-logic");
+  expect(
+    LENSES.every((l) => l.questions.length > 0 && l.example.length > 0)
+  ).toBe(true);
+});

--- a/packages/core/tests/review-change.test.ts
+++ b/packages/core/tests/review-change.test.ts
@@ -99,6 +99,23 @@ test("formatReport surfaces a verified finding with file:line and lens", async (
   expect(text).toContain("subtraction is reversed");
 });
 
+test("a string line number from the model is parsed, not defaulted to 1", async () => {
+  const stringLine = JSON.stringify({
+    findings: [
+      {
+        line: "2",
+        severity: "error",
+        lens: "correctness",
+        claim: "subtraction is reversed",
+        reason: "x",
+      },
+    ],
+  });
+  const report = await reviewChange(stub(stringLine, true), repo);
+
+  expect(report.findings[0]?.line).toBe(2);
+});
+
 test("the senior-review rubric ships with the expected lenses", () => {
   const ids = LENSES.map((l) => l.id);
 


### PR DESCRIPTION
## What

`tsforge review` — reviews the change you're working on (working tree, committed **and** uncommitted, vs the auto-detected base = merge-base with `main`/`master`). No commit/push needed. `--staged` and `--base <ref>` override scope.

## The core value (not a generic wrapper)

This is **functional** review — logic, regressions, edge cases, business rules — *not* types/structure/style (the gate owns those). Two things make it more than "ask the model to review a diff", which matters most for the **small local models** this harness targets:

1. **Built-in senior-review rubric (lenses)** — correctness, regressions, edge cases, business logic, data/concurrency, API/contract — fed to the model with concrete heuristics + examples, per-file, so a small model reviews *systematically* instead of skimming.
2. **Adversarial verify** — every finding is re-checked against the real code and dropped unless the code confirms it. Kills the false positives that are the #1 failure of small-model review.

## Layout

- `loop/review/`: `lenses.ts` (the rubric), `review-change.ts` (scope → find per file → adversarial verify → report), `review.types.ts`.
- `cli.ts`: `tsforge review` subcommand; non-zero exit on surviving error findings (CI-usable).
- `scripts/review-eval.ts`: planted-bug eval — ground-truth recall + false positives, verify on/off A/B, writes to `evals/runs/`.
- docs: `reference/commands.mdx`.

## Tested

- Unit (stub provider): 6 tests — find/verify/scope/format/rubric. Full `bun run validate`: **1062 pass, 0 fail**; docs build green.
- **Eval (deepseek, planted bugs):** 100% recall, 0 false positives across correctness / edge-case / business-logic plants.
- **Live CLI** on a richer diff: verify kept 1 of 3 candidate findings (dropped 2 over-reports) — the precision pass working.

## Honest caveats

- The verify A/B doesn't yet *separate* on/off on the toy eval scenarios (too clean to induce false positives); the live run shows the effect, but a noisier planted-issue corpus is the follow-up to quantify it.
- Tool-derived signals (caller blast-radius via `impact()`, changed-line coverage, proptest) are designed in the plan but not in this PR — next slice.
- Whole-repo review (vs diff-scoped) reuses this machinery with a walked surface — later phase.