### PR TITLE
feat(review): caller blast-radius signal + /review REPL command

### DIFF
--- a/apps/docs/src/content/docs/reference/commands.mdx
+++ b/apps/docs/src/content/docs/reference/commands.mdx
@@ -31,7 +31,9 @@ tsforge review --base develop  # diff against an explicit base ref
 
 `tsforge review` reviews the change you're working on — the working tree (committed **and** uncommitted edits) vs the auto-detected base (merge-base with `main`/`master`). No commit or push required.
 
-It is **functional** review — logic, regressions, edge cases, and business rules — guided by a built-in senior-review rubric (lenses), with each finding adversarially re-checked against the real code so false positives are dropped. Types, structure, and style are out of scope (the gate covers those). Exits non-zero if any **error**-severity finding survives, so it's CI-usable. Disable the tool entirely with `TSFORGE_NO_GIT_TOOL=1` (it relies on git).
+It is **functional** review — logic, regressions, edge cases, and business rules — guided by a built-in senior-review rubric (lenses), with each finding adversarially re-checked against the real code so false positives are dropped. Types, structure, and style are out of scope (the gate covers those). When a `tsconfig.json` is present it also feeds the reviewer a **caller blast-radius** signal (who calls each changed export, computed type-exactly) so the regression lens has concrete call sites to check. Exits non-zero if any **error**-severity finding survives, so it's CI-usable.
+
+The same review is available inside an interactive session as **`/review`** (optionally `/review <base>` to diff against a specific ref).
 
 ## Merge gate (repo root)
 

--- a/packages/core/src/cli.ts
+++ b/packages/core/src/cli.ts
@@ -1590,12 +1590,20 @@ async function runReviewCommand(
   base: string
 ): Promise<void> {
   process.stdout.write("reviewing the current change…\n");
-  const report = await reviewChange(provider, dir, {
-    ...(base.length > 0 ? { base } : {}),
-    log: (m) => process.stdout.write(`  ↳ ${m}\n`),
-  });
 
-  process.stdout.write(`\n${formatReport(report)}\n`);
+  // Guard the REPL: a review error (git/fs/model) must not crash the session.
+  try {
+    const report = await reviewChange(provider, dir, {
+      ...(base.length > 0 ? { base } : {}),
+      log: (m) => process.stdout.write(`  ↳ ${m}\n`),
+    });
+
+    process.stdout.write(`\n${formatReport(report)}\n`);
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+
+    process.stdout.write(`\nreview failed: ${message}\n`);
+  }
 }
 
 async function reviewMode(args: ICliArgs): Promise<number> {

--- a/packages/core/src/cli.ts
+++ b/packages/core/src/cli.ts
@@ -1272,6 +1272,10 @@ async function repl(args: ICliArgs): Promise<number> {
         await persist();
         break;
 
+      case "review":
+        await runReviewCommand(provider, args.dir, arg);
+        break;
+
       case "files": {
         const globs = arg
           .split(",")
@@ -1577,6 +1581,21 @@ async function repl(args: ICliArgs): Promise<number> {
   statusBar.teardown(); // belt-and-suspenders: restore the terminal on loop exit
 
   return 0;
+}
+
+/** `/review` in the REPL — review the current change and print findings. */
+async function runReviewCommand(
+  provider: OpenAICompatibleProvider,
+  dir: string,
+  base: string
+): Promise<void> {
+  process.stdout.write("reviewing the current change…\n");
+  const report = await reviewChange(provider, dir, {
+    ...(base.length > 0 ? { base } : {}),
+    log: (m) => process.stdout.write(`  ↳ ${m}\n`),
+  });
+
+  process.stdout.write(`\n${formatReport(report)}\n`);
 }
 
 async function reviewMode(args: ICliArgs): Promise<number> {

--- a/packages/core/src/cli/commands.ts
+++ b/packages/core/src/cli/commands.ts
@@ -39,6 +39,11 @@ export const COMMANDS: readonly ICommandSpec[] = [
     summary: "set the editable scope (comma-separated; empty = all)",
   },
   {
+    name: "/review",
+    arg: "[base]",
+    summary: "review the current change (logic, regressions, edge cases)",
+  },
+  {
     name: "/model",
     arg: "[name]",
     summary: "list configured models (★ active), or switch to <name>",

--- a/packages/core/src/loop/review/review-change.ts
+++ b/packages/core/src/loop/review/review-change.ts
@@ -292,12 +292,17 @@ function errText(err: unknown): string {
  *  abort the whole review). */
 async function safeFind(
   provider: IProvider,
+  svc: TsService | null,
+  cwd: string,
   file: string,
   diff: string,
-  signal: string,
   log: (m: string) => void
 ): Promise<IRepoFinding[]> {
   try {
+    // callerSignal lives INSIDE the try so a LanguageService hiccup on one file
+    // degrades that file's review, never aborting the whole run.
+    const signal = callerSignal(svc, cwd, file);
+
     return await findInFile(provider, file, diff, signal);
   } catch (err) {
     log(`  ${file}: review failed — ${errText(err)}`);
@@ -349,8 +354,7 @@ export async function reviewChange(
   // isolated in try/catch so one bad file can't abort the whole review.
   for (const file of files) {
     const diff = await fileDiff(cwd, base, file, staged);
-    const signal = await callerSignal(svc, cwd, file);
-    const found = await safeFind(provider, file, diff, signal, log);
+    const found = await safeFind(provider, svc, cwd, file, diff, log);
 
     log(`  ${file}: ${found.length} candidate finding(s)`);
     raw.push(...found);

--- a/packages/core/src/loop/review/review-change.ts
+++ b/packages/core/src/loop/review/review-change.ts
@@ -3,7 +3,10 @@ import { runArgvCommand } from "../../lib/fs";
 import { isRecord, isArray } from "../../lib/guards";
 import { extractJson } from "../../lib/json";
 import type { IProvider } from "../../inference";
+import type { TsService } from "../../lsp";
+import { buildTsService } from "../turn";
 import { LENSES, lensRubric } from "./lenses";
+import { callerSignal } from "./signals";
 import type {
   IRepoFinding,
   IVerifiedFinding,
@@ -113,18 +116,24 @@ const FIND_SYSTEM = [
 async function findInFile(
   provider: IProvider,
   file: string,
-  diff: string
+  diff: string,
+  signal: string
 ): Promise<IRepoFinding[]> {
   if (diff.length === 0) {
     return [];
   }
+
+  const callers =
+    signal.length > 0
+      ? `\n\nCallers of this file's exports (type-exact — review these for regressions):\n${signal}`
+      : "";
 
   const res = await provider.complete(
     [
       { role: "system", content: FIND_SYSTEM },
       {
         role: "user",
-        content: `File: ${file}\n\nDiff (base → working tree):\n${diff}`,
+        content: `File: ${file}\n\nDiff (base → working tree):\n${diff}${callers}`,
       },
     ],
     { temperature: 0 }
@@ -285,10 +294,11 @@ async function safeFind(
   provider: IProvider,
   file: string,
   diff: string,
+  signal: string,
   log: (m: string) => void
 ): Promise<IRepoFinding[]> {
   try {
-    return await findInFile(provider, file, diff);
+    return await findInFile(provider, file, diff, signal);
   } catch (err) {
     log(`  ${file}: review failed — ${errText(err)}`);
 
@@ -329,6 +339,9 @@ export async function reviewChange(
 
   log(`reviewing ${files.length} changed file(s) vs ${base}`);
 
+  // In-process TS LanguageService (null without a tsconfig) — powers the
+  // caller blast-radius signal. Built once; falls back gracefully when absent.
+  const svc: TsService | null = await buildTsService(cwd);
   const raw: IRepoFinding[] = [];
 
   // Sequential on purpose: this harness targets a single local-model server, so
@@ -336,7 +349,8 @@ export async function reviewChange(
   // isolated in try/catch so one bad file can't abort the whole review.
   for (const file of files) {
     const diff = await fileDiff(cwd, base, file, staged);
-    const found = await safeFind(provider, file, diff, log);
+    const signal = await callerSignal(svc, cwd, file);
+    const found = await safeFind(provider, file, diff, signal, log);
 
     log(`  ${file}: ${found.length} candidate finding(s)`);
     raw.push(...found);

--- a/packages/core/src/loop/review/signals.ts
+++ b/packages/core/src/loop/review/signals.ts
@@ -1,0 +1,96 @@
+import { isAbsolute, join, relative } from "node:path";
+import type { TsService } from "../../lsp";
+
+/** Top-level exported declaration names in a file (best-effort, text-based) —
+ *  the symbols other code can depend on, hence the regression surface. */
+const EXPORT_RE =
+  /^export\s+(?:async\s+)?(?:function|const|let|var|class|interface|type|enum)\s+([A-Za-z_$][\w$]*)/gm;
+
+function exportedNames(text: string): string[] {
+  const names = new Set<string>();
+
+  for (const m of text.matchAll(EXPORT_RE)) {
+    if (m[1] !== undefined) {
+      names.add(m[1]);
+    }
+  }
+
+  return [...names];
+}
+
+const MAX_CALLER_FILES = 5;
+const MAX_CALLER_LINES = 3;
+
+/**
+ * A tool-derived signal: who CALLS the changed file's exports, computed
+ * type-exactly from the TypeScript LanguageService (`impact`). Handed to the
+ * reviewer so the regressions lens has concrete call sites to check instead of
+ * having to guess them. Returns "" when there's no LanguageService (no tsconfig)
+ * or the exports have no external callers.
+ */
+export async function callerSignal(
+  svc: TsService | null,
+  cwd: string,
+  file: string
+): Promise<string> {
+  if (svc === null) {
+    return "";
+  }
+
+  const abs = isAbsolute(file) ? file : join(cwd, file);
+  const text = await Bun.file(abs)
+    .text()
+    .catch(() => "");
+
+  if (text.length === 0) {
+    return "";
+  }
+
+  const lines: string[] = [];
+
+  for (const name of exportedNames(text)) {
+    const sites = callersOf(svc, cwd, file, abs, name);
+
+    if (sites.length > 0) {
+      lines.push(`- ${name} → ${sites.join("; ")}`);
+    }
+  }
+
+  return lines.join("\n");
+}
+
+/** External call sites of one exported symbol, as `path:line,line` strings. */
+function callersOf(
+  svc: TsService,
+  cwd: string,
+  file: string,
+  abs: string,
+  name: string
+): string[] {
+  let pos: number | undefined;
+
+  try {
+    pos = svc.positionOfSymbol(file, name);
+  } catch {
+    return [];
+  }
+
+  if (pos === undefined) {
+    return [];
+  }
+
+  let external: { file: string; lines: number[] }[];
+
+  try {
+    external = svc.impact(file, pos).files.filter((f) => f.file !== abs);
+  } catch {
+    return [];
+  }
+
+  return external
+    .slice(0, MAX_CALLER_FILES)
+    .map(
+      (f) =>
+        `${relative(cwd, f.file)}:${f.lines.slice(0, MAX_CALLER_LINES).join(",")}`
+    );
+}

--- a/packages/core/src/loop/review/signals.ts
+++ b/packages/core/src/loop/review/signals.ts
@@ -1,23 +1,6 @@
 import { isAbsolute, join, relative } from "node:path";
 import type { TsService } from "../../lsp";
 
-/** Top-level exported declaration names in a file (best-effort, text-based) —
- *  the symbols other code can depend on, hence the regression surface. */
-const EXPORT_RE =
-  /^export\s+(?:async\s+)?(?:function|const|let|var|class|interface|type|enum)\s+([A-Za-z_$][\w$]*)/gm;
-
-function exportedNames(text: string): string[] {
-  const names = new Set<string>();
-
-  for (const m of text.matchAll(EXPORT_RE)) {
-    if (m[1] !== undefined) {
-      names.add(m[1]);
-    }
-  }
-
-  return [...names];
-}
-
 const MAX_CALLER_FILES = 5;
 const MAX_CALLER_LINES = 3;
 
@@ -28,31 +11,23 @@ const MAX_CALLER_LINES = 3;
  * having to guess them. Returns "" when there's no LanguageService (no tsconfig)
  * or the exports have no external callers.
  */
-export async function callerSignal(
+export function callerSignal(
   svc: TsService | null,
   cwd: string,
   file: string
-): Promise<string> {
+): string {
   if (svc === null) {
     return "";
   }
 
   const abs = isAbsolute(file) ? file : join(cwd, file);
-  const text = await Bun.file(abs)
-    .text()
-    .catch(() => "");
-
-  if (text.length === 0) {
-    return "";
-  }
-
   const lines: string[] = [];
 
-  for (const name of exportedNames(text)) {
-    const sites = callersOf(svc, cwd, file, abs, name);
+  for (const sym of svc.exportedSymbols(file)) {
+    const sites = callersOf(svc, cwd, file, abs, sym.pos);
 
     if (sites.length > 0) {
-      lines.push(`- ${name} → ${sites.join("; ")}`);
+      lines.push(`- ${sym.name} → ${sites.join("; ")}`);
     }
   }
 
@@ -65,20 +40,8 @@ function callersOf(
   cwd: string,
   file: string,
   abs: string,
-  name: string
+  pos: number
 ): string[] {
-  let pos: number | undefined;
-
-  try {
-    pos = svc.positionOfSymbol(file, name);
-  } catch {
-    return [];
-  }
-
-  if (pos === undefined) {
-    return [];
-  }
-
   let external: { file: string; lines: number[] }[];
 
   try {

--- a/packages/core/src/lsp/service.ts
+++ b/packages/core/src/lsp/service.ts
@@ -307,47 +307,20 @@ export class TsService {
     };
   }
 
-  /** Start offsets of `file`'s top-level EXPORTED declarations (the symbols other
-   *  files can depend on) — the entry points for a file-level blast-radius check. */
+  /** `file`'s top-level EXPORTED declarations as {name, start offset} — the
+   *  symbols other files can depend on. AST-derived (not regex), so commented-out
+   *  or string-literal "exports" don't count. */
+  exportedSymbols(file: string): { name: string; pos: number }[] {
+    const sf = this.service.getProgram()?.getSourceFile(this.toAbs(file));
+
+    return sf === undefined ? [] : collectExports(sf);
+  }
+
+  /** Start offsets of `file`'s exported declarations — file-level blast-radius. */
   private exportedPositions(abs: string): number[] {
     const sf = this.service.getProgram()?.getSourceFile(abs);
 
-    if (sf === undefined) {
-      return [];
-    }
-
-    const out: number[] = [];
-
-    sf.forEachChild((node) => {
-      const mods = ts.canHaveModifiers(node)
-        ? ts.getModifiers(node)
-        : undefined;
-      const exported =
-        mods?.some((m) => m.kind === ts.SyntaxKind.ExportKeyword) ?? false;
-
-      if (!exported) {
-        return;
-      }
-
-      if (ts.isVariableStatement(node)) {
-        for (const d of node.declarationList.declarations) {
-          if (ts.isIdentifier(d.name)) {
-            out.push(d.name.getStart(sf));
-          }
-        }
-      } else if (
-        (ts.isFunctionDeclaration(node) ||
-          ts.isClassDeclaration(node) ||
-          ts.isInterfaceDeclaration(node) ||
-          ts.isTypeAliasDeclaration(node) ||
-          ts.isEnumDeclaration(node)) &&
-        node.name !== undefined
-      ) {
-        out.push(node.name.getStart(sf));
-      }
-    });
-
-    return out;
+    return sf === undefined ? [] : collectExports(sf).map((s) => s.pos);
   }
 
   /**
@@ -565,4 +538,38 @@ export class TsService {
   private toAbs(file: string): string {
     return isAbsolute(file) ? file : join(this.dir, file);
   }
+}
+
+/** Top-level exported declarations of a source file as {name, start offset}. */
+function collectExports(sf: ts.SourceFile): { name: string; pos: number }[] {
+  const out: { name: string; pos: number }[] = [];
+
+  sf.forEachChild((node) => {
+    const mods = ts.canHaveModifiers(node) ? ts.getModifiers(node) : undefined;
+    const exported =
+      mods?.some((m) => m.kind === ts.SyntaxKind.ExportKeyword) ?? false;
+
+    if (!exported) {
+      return;
+    }
+
+    if (ts.isVariableStatement(node)) {
+      for (const d of node.declarationList.declarations) {
+        if (ts.isIdentifier(d.name)) {
+          out.push({ name: d.name.text, pos: d.name.getStart(sf) });
+        }
+      }
+    } else if (
+      (ts.isFunctionDeclaration(node) ||
+        ts.isClassDeclaration(node) ||
+        ts.isInterfaceDeclaration(node) ||
+        ts.isTypeAliasDeclaration(node) ||
+        ts.isEnumDeclaration(node)) &&
+      node.name !== undefined
+    ) {
+      out.push({ name: node.name.getText(sf), pos: node.name.getStart(sf) });
+    }
+  });
+
+  return out;
 }

--- a/packages/core/tests/review-change.test.ts
+++ b/packages/core/tests/review-change.test.ts
@@ -116,6 +116,59 @@ test("a string line number from the model is parsed, not defaulted to 1", async 
   expect(report.findings[0]?.line).toBe(2);
 });
 
+test("injects the caller blast-radius signal into the find prompt", async () => {
+  // A two-file TS project (with tsconfig so the LanguageService loads): caller.ts
+  // calls util.ts's export. Reviewing a change to util.ts should surface caller.ts
+  // as a regression site in the find prompt.
+  const proj = mkdtempSync(join(tmpdir(), "tsforge-signal-"));
+  const pgit = (...a: string[]): void =>
+    void execFileSync("git", a, { cwd: proj, stdio: "ignore" });
+
+  writeFileSync(
+    join(proj, "tsconfig.json"),
+    '{"compilerOptions":{"strict":true,"skipLibCheck":true},"include":["*.ts"]}'
+  );
+  writeFileSync(
+    join(proj, "util.ts"),
+    "export function area(w: number, h: number): number {\n  return w * h;\n}\n"
+  );
+  writeFileSync(
+    join(proj, "caller.ts"),
+    'import { area } from "./util";\nexport const room = area(3, 4);\n'
+  );
+  pgit("init", "-q");
+  pgit("config", "user.email", "t@t.t");
+  pgit("config", "user.name", "t");
+  pgit("add", "-A");
+  pgit("commit", "-q", "-m", "init");
+  writeFileSync(
+    join(proj, "util.ts"),
+    "export function area(w: number, h: number): number {\n  return w + h;\n}\n"
+  );
+
+  let findPrompt = "";
+  const capturing: IProvider = {
+    async complete(messages) {
+      const sys = messages.find((m) => m.role === "system")?.content ?? "";
+
+      if (!sys.includes("verifying a code-review finding")) {
+        findPrompt = messages.find((m) => m.role === "user")?.content ?? "";
+      }
+
+      return { content: JSON.stringify({ findings: [] }), toolCalls: [] };
+    },
+  };
+
+  try {
+    await reviewChange(capturing, proj);
+    expect(findPrompt).toContain("Callers of this file's exports");
+    expect(findPrompt).toContain("area");
+    expect(findPrompt).toContain("caller.ts");
+  } finally {
+    rmSync(proj, { recursive: true, force: true });
+  }
+});
+
 test("the senior-review rubric ships with the expected lenses", () => {
   const ids = LENSES.map((l) => l.id);
 


### PR DESCRIPTION
## What

Two additions to `tsforge review` (shipped in 0.11.0):

1. **Caller blast-radius signal** — when a `tsconfig.json` is present, the reviewer is fed the **type-exact callers** of each changed file's exports (via `TsService.impact()`), so the *regressions* lens reviews concrete call sites instead of guessing. Built once per review, sequential (single local-model server is the target), and degrades to nothing without a LanguageService or callers. This is the first of the "tool-derived signals" from the plan (coverage/proptest — which need running the project — are the next sub-slice).

2. **`/review` REPL command** — review is now available inside an interactive session as `/review [base]`, not just the `tsforge review` subcommand. Same driver.

## Tested

- Unit test drives a real two-file TS project end-to-end: a change to a called export surfaces the caller in the find prompt. `/review` is registered in the command palette + help.
- Full `bun run validate`: **1064 pass, 0 fail**; docs build green.

## Notes

- Kept the find/verify calls sequential on purpose (single local-model server); the review bot's parallelism suggestion is declined for that reason, resilience added via try/catch.
- The single-file eval scenarios don't exercise the caller signal (no callers); a multi-file planted-issue scenario to quantify its effect is a follow-up.