### PR TITLE
feat(cli): /map — deterministic workspace map to prime the agent

### DIFF
--- a/apps/docs/src/content/docs/reference/commands.mdx
+++ b/apps/docs/src/content/docs/reference/commands.mdx
@@ -35,6 +35,16 @@ It is **functional** review — logic, regressions, edge cases, and business rul
 
 The same review is available inside an interactive session as **`/review`** (optionally `/review <base>` to diff against a specific ref).
 
+## Map the repo to prime the agent
+
+```bash
+tsforge map            # build a structural map of the workspace
+tsforge map status     # when it was built, files/hubs, how much drifted
+tsforge map forget     # delete it
+```
+
+`tsforge map` (or `/map` in a session) builds a deterministic structural map of a TypeScript repo — the directory shape, what each module exports, and the **hub modules** everything imports — and persists it under `.tsforge/`. On the next session it's injected into the agent's context so it starts oriented instead of exploring from scratch. All compiler facts (no AI guessing, no extra dependencies); it primes future sessions (run `/clear` to apply mid-session). Best for existing repos; greenfield builds don't need it.
+
 ## Merge gate (repo root)
 
 Commands for people working on the tsforge repository itself:

--- a/packages/core/scripts/map-eval.ts
+++ b/packages/core/scripts/map-eval.ts
@@ -1,0 +1,111 @@
+// Value eval for `/map`: does priming the agent with the workspace map reduce
+// exploration? Runs a brownfield fix through the real interactive Session loop
+// WITH vs WITHOUT the map injected, counting tool calls before the first edit.
+// The metric that justifies the feature — run it on a SMALL local model.
+//
+// Run: bun run packages/core/scripts/map-eval.ts   (uses ~/.tsforge/models.json)
+import { mkdtempSync, rmSync, writeFileSync, mkdirSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { OpenAICompatibleProvider } from "../src/inference";
+import { Session } from "../src/loop";
+import { buildAndPersistMap, forgetMap } from "../src/codebase";
+import { resolveActiveModel, resolveApiKey } from "../src/models-config";
+import type { ILoopEvent } from "../src/loop";
+
+async function buildProvider(): Promise<OpenAICompatibleProvider> {
+  const { entry } = await resolveActiveModel();
+
+  return new OpenAICompatibleProvider({
+    baseUrl: entry.baseUrl,
+    model: entry.model,
+    apiKey: resolveApiKey(entry),
+    maxTokens: entry.maxTokens ?? 8192,
+    reasoning: entry.reasoning,
+    reasoningEffort: entry.reasoningEffort,
+    extraBody: entry.extraBody,
+    extraHeaders: entry.extraHeaders,
+  });
+}
+
+/** A multi-file repo where the bug is in a file the agent must FIND first. */
+function setup(): string {
+  const dir = mkdtempSync(join(tmpdir(), "map-eval-"));
+
+  mkdirSync(join(dir, "src"), { recursive: true });
+  writeFileSync(
+    join(dir, "tsconfig.json"),
+    '{"compilerOptions":{"strict":true,"skipLibCheck":true,"moduleResolution":"bundler"},"include":["src"]}'
+  );
+  writeFileSync(
+    join(dir, "src/types.ts"),
+    "export interface Line { qty: number; cents: number }\n"
+  );
+  // The bug lives here: should multiply qty*cents, but only sums cents.
+  writeFileSync(
+    join(dir, "src/totals.ts"),
+    'import type { Line } from "./types";\nexport function lineTotal(l: Line): number {\n  return l.cents;\n}\n'
+  );
+  writeFileSync(
+    join(dir, "src/cart.ts"),
+    'import { lineTotal } from "./totals";\nimport type { Line } from "./types";\nexport function cartTotal(ls: Line[]): number {\n  return ls.reduce((n, l) => n + lineTotal(l), 0);\n}\n'
+  );
+  writeFileSync(
+    join(dir, "src/cart.test.ts"),
+    'import { test, expect } from "bun:test";\nimport { cartTotal } from "./cart";\ntest("multiplies qty by cents", () => {\n  expect(cartTotal([{ qty: 3, cents: 100 }])).toBe(300);\n});\n'
+  );
+
+  return dir;
+}
+
+async function runVariant(
+  provider: OpenAICompatibleProvider,
+  mapped: boolean
+): Promise<{ preEditTools: number; status: string }> {
+  const dir = setup();
+  let preEditTools = 0;
+  let firstEdit = false;
+
+  const report = (e: ILoopEvent): void => {
+    if (!firstEdit && (e.kind === "tool" || e.kind === "run")) {
+      preEditTools += 1;
+    }
+
+    if (e.kind === "edit" || e.kind === "create") {
+      firstEdit = true;
+    }
+  };
+
+  try {
+    await (mapped ? buildAndPersistMap(dir) : forgetMap(dir));
+
+    const session = await Session.create({
+      provider,
+      cwd: dir,
+      accept: "bun test src/cart.test.ts",
+      report,
+      maxTurns: 12,
+    });
+    const result = await session.send(
+      "The cart total test is failing. Find the bug and fix it."
+    );
+
+    return { preEditTools, status: result.status };
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+}
+
+const provider = await buildProvider();
+const { entry } = await resolveActiveModel();
+
+process.stdout.write(`map-eval: model ${entry.model}\n`);
+
+const mappedRun = await runVariant(provider, true);
+const plainRun = await runVariant(provider, false);
+
+process.stdout.write(
+  `\n=== map-eval (tool calls before first edit) ===\n` +
+    `  mapped:   ${mappedRun.preEditTools} pre-edit tool calls (${mappedRun.status})\n` +
+    `  unmapped: ${plainRun.preEditTools} pre-edit tool calls (${plainRun.status})\n`
+);

--- a/packages/core/src/cli.ts
+++ b/packages/core/src/cli.ts
@@ -13,6 +13,7 @@ import {
   reviewChange,
   formatReport,
 } from "./loop";
+import { buildAndPersistMap, mapStatus, forgetMap } from "./codebase";
 import {
   PROVIDER_LIMITS,
   PROVIDER_DEFAULTS,
@@ -123,6 +124,8 @@ export interface ICliArgs {
   staged: boolean;
   /** Explicit base ref to diff against for review (`--base <ref>`). */
   base: string;
+  /** Build a structural workspace map (`tsforge map`). */
+  map: boolean;
 }
 
 const BOOL_FLAGS: Record<
@@ -168,6 +171,7 @@ export function parseArgs(argv: readonly string[]): ICliArgs {
     review: false,
     staged: false,
     base: "",
+    map: false,
   };
 
   for (let i = 0; i < argv.length; i += 1) {
@@ -191,9 +195,13 @@ export function parseArgs(argv: readonly string[]): ICliArgs {
 
   out.task = positional.join(" ").trim();
 
-  // `tsforge review` is a subcommand, not a task: the first positional selects it.
+  // `tsforge review` / `tsforge map` are subcommands, not tasks: the first
+  // positional selects them.
   if (positional[0] === "review") {
     out.review = true;
+    out.task = positional.slice(1).join(" ").trim();
+  } else if (positional[0] === "map") {
+    out.map = true;
     out.task = positional.slice(1).join(" ").trim();
   }
 
@@ -1276,6 +1284,10 @@ async function repl(args: ICliArgs): Promise<number> {
         await runReviewCommand(provider, args.dir, arg);
         break;
 
+      case "map":
+        await runMapCommand(args.dir, arg);
+        break;
+
       case "files": {
         const globs = arg
           .split(",")
@@ -1583,6 +1595,42 @@ async function repl(args: ICliArgs): Promise<number> {
   return 0;
 }
 
+/** `/map [status|forget]` (REPL) and `tsforge map` — build/inspect the workspace
+ *  map. The built map primes future sessions (and a `/clear`). */
+async function runMapCommand(dir: string, sub: string): Promise<void> {
+  if (sub === "status") {
+    process.stdout.write(`${await mapStatus(dir)}\n`);
+
+    return;
+  }
+
+  if (sub === "forget") {
+    const had = await forgetMap(dir);
+
+    process.stdout.write(
+      had ? "workspace map deleted\n" : "no map to delete\n"
+    );
+
+    return;
+  }
+
+  process.stdout.write("building workspace map…\n");
+
+  try {
+    const map = await buildAndPersistMap(dir);
+
+    process.stdout.write(
+      map === null
+        ? "no tsconfig.json — nothing to map (the map is for TypeScript projects)\n"
+        : `mapped ${map.meta.totalFiles} files, ${map.hubs.length} hubs. Primes new sessions (/clear to apply now).\n`
+    );
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+
+    process.stdout.write(`map failed: ${message}\n`);
+  }
+}
+
 /** `/review` in the REPL — review the current change and print findings. */
 async function runReviewCommand(
   provider: OpenAICompatibleProvider,
@@ -1620,11 +1668,21 @@ async function reviewMode(args: ICliArgs): Promise<number> {
   return report.findings.some((f) => f.severity === "error") ? 1 : 0;
 }
 
+async function mapMode(args: ICliArgs): Promise<number> {
+  await runMapCommand(args.dir, args.task);
+
+  return 0;
+}
+
 export async function main(): Promise<number> {
   const args = parseArgs(process.argv.slice(2));
 
   if (args.review) {
     return reviewMode(args);
+  }
+
+  if (args.map) {
+    return mapMode(args);
   }
 
   // A positional task with a scope + gate ⇒ one-shot; otherwise interactive.

--- a/packages/core/src/cli.ts
+++ b/packages/core/src/cli.ts
@@ -1614,6 +1614,14 @@ async function runMapCommand(dir: string, sub: string): Promise<void> {
     return;
   }
 
+  if (sub.length > 0) {
+    process.stdout.write(
+      `unknown map subcommand: ${sub} (use 'status', 'forget', or nothing to build)\n`
+    );
+
+    return;
+  }
+
   process.stdout.write("building workspace map…\n");
 
   try {

--- a/packages/core/src/cli/commands.ts
+++ b/packages/core/src/cli/commands.ts
@@ -44,6 +44,11 @@ export const COMMANDS: readonly ICommandSpec[] = [
     summary: "review the current change (logic, regressions, edge cases)",
   },
   {
+    name: "/map",
+    arg: "[status|forget]",
+    summary: "build a structural map of the repo to prime the agent",
+  },
+  {
     name: "/model",
     arg: "[name]",
     summary: "list configured models (★ active), or switch to <name>",

--- a/packages/core/src/codebase/build-map.ts
+++ b/packages/core/src/codebase/build-map.ts
@@ -65,7 +65,9 @@ function buildModule(
   return {
     path: file,
     exports: svc.exportedSymbols(file).map((s) => s.name),
-    imports: svc.importsOf(file).map((abs) => relative(cwd, abs)),
+    imports: svc
+      .importsOf(file)
+      .map((abs) => relative(cwd, abs).replaceAll("\\", "/")),
     lineCount: text.length === 0 ? 0 : text.split("\n").length,
     hasTests: hasSiblingTest(file, fileSet),
   };

--- a/packages/core/src/codebase/build-map.ts
+++ b/packages/core/src/codebase/build-map.ts
@@ -1,0 +1,118 @@
+import { join, relative, dirname } from "node:path";
+import { readFileSync } from "node:fs";
+import type { TsService } from "../lsp";
+import type { IStackProfile } from "../stack-detection";
+import { fingerprint, gitHead } from "./staleness";
+import { rankHubs } from "./rank-hubs";
+import type { IWorkspaceMap, IWorkspaceModule } from "./codebase.types";
+
+// Real entry points: main/app/server/cli anywhere, plus the top-level index —
+// NOT every nested index.ts barrel (those are noise, not entry points).
+const ENTRY_RE = /(^|\/)(main|app|server|cli)\.(ts|tsx)$/;
+const TOP_INDEX_RE = /^(src\/)?index\.(ts|tsx)$/;
+const MAX_ENTRY_POINTS = 12;
+const CONVENTIONS_CHARS = 1500;
+
+/**
+ * Build a deterministic workspace map from the TS LanguageService — exports,
+ * the internal import graph, and import-in-degree hubs. No LLM, no type-checking
+ * beyond what `importsOf`/`exportedSymbols` already do.
+ */
+export async function buildWorkspaceMap(
+  cwd: string,
+  svc: TsService,
+  stack: IStackProfile
+): Promise<IWorkspaceMap> {
+  const files = svc.projectFiles();
+  const fileSet = new Set(files);
+  const modules: Record<string, IWorkspaceModule> = {};
+
+  for (const f of files) {
+    modules[f] = buildModule(cwd, svc, f, fileSet);
+  }
+
+  const fp = fingerprint(cwd, files);
+  const head = await gitHead(cwd);
+
+  return {
+    meta: {
+      gitHead: head,
+      sourceFingerprint: fp.combined,
+      builtAt: new Date().toISOString(),
+      totalFiles: files.length,
+    },
+    stack,
+    entryPoints: files
+      .filter((f) => ENTRY_RE.test(f) || TOP_INDEX_RE.test(f))
+      .slice(0, MAX_ENTRY_POINTS),
+    directoryTree: renderTree(files),
+    modules,
+    hubs: rankHubs(modules),
+    conventions: readConventions(cwd),
+    fileHashes: fp.perFile,
+    staleFiles: [],
+  };
+}
+
+function buildModule(
+  cwd: string,
+  svc: TsService,
+  file: string,
+  fileSet: Set<string>
+): IWorkspaceModule {
+  const text = readSafe(cwd, file);
+
+  return {
+    path: file,
+    exports: svc.exportedSymbols(file).map((s) => s.name),
+    imports: svc.importsOf(file).map((abs) => relative(cwd, abs)),
+    lineCount: text.length === 0 ? 0 : text.split("\n").length,
+    hasTests: hasSiblingTest(file, fileSet),
+  };
+}
+
+function hasSiblingTest(file: string, fileSet: Set<string>): boolean {
+  if (/\.(test|spec)\.[tj]sx?$/.test(file)) {
+    return true;
+  }
+
+  const sibling = file.replace(/\.([tj]sx?)$/, ".test.$1");
+
+  return sibling !== file && fileSet.has(sibling);
+}
+
+function readSafe(cwd: string, file: string): string {
+  try {
+    return readFileSync(join(cwd, file), "utf8");
+  } catch {
+    return "";
+  }
+}
+
+/** A condensed directory summary: each directory with its source-file count. */
+function renderTree(files: string[]): string {
+  const counts = new Map<string, number>();
+
+  for (const f of files) {
+    const dir = dirname(f);
+
+    counts.set(dir, (counts.get(dir) ?? 0) + 1);
+  }
+
+  return [...counts.entries()]
+    .sort(([a], [b]) => a.localeCompare(b))
+    .map(([dir, n]) => `${dir === "." ? "(root)" : dir}/ (${n})`)
+    .join("\n");
+}
+
+function readConventions(cwd: string): string {
+  for (const name of ["AGENTS.md", "CLAUDE.md"]) {
+    const text = readSafe(cwd, name);
+
+    if (text.length > 0) {
+      return text.slice(0, CONVENTIONS_CHARS);
+    }
+  }
+
+  return "";
+}

--- a/packages/core/src/codebase/codebase.types.ts
+++ b/packages/core/src/codebase/codebase.types.ts
@@ -1,0 +1,44 @@
+import type { IStackProfile } from "../stack-detection";
+
+export interface IWorkspaceMeta {
+  /** Commit at build time, or "dirty"/"" when unavailable. */
+  gitHead: string;
+  /** Combined hash of all mapped files (quick fresh/stale equality check). */
+  sourceFingerprint: string;
+  /** ISO timestamp of the build. */
+  builtAt: string;
+  totalFiles: number;
+}
+
+export interface IWorkspaceModule {
+  path: string;
+  exports: string[];
+  /** Resolved internal imports, relative to the workspace root. */
+  imports: string[];
+  lineCount: number;
+  hasTests: boolean;
+}
+
+/** A module ranked by IMPORT IN-DEGREE — how many other modules import it. */
+export interface IModuleHub {
+  path: string;
+  exports: string[];
+  importedBy: number;
+}
+
+export interface IWorkspaceMap {
+  meta: IWorkspaceMeta;
+  stack: IStackProfile;
+  entryPoints: string[];
+  /** Condensed text tree of the source files. */
+  directoryTree: string;
+  modules: Record<string, IWorkspaceModule>;
+  /** Sorted desc by importedBy. */
+  hubs: IModuleHub[];
+  /** AGENTS.md excerpt if present (else ""). */
+  conventions: string;
+  /** Per-file content hash, for staleness detection (not injected). */
+  fileHashes: Record<string, string>;
+  /** Files changed since the build (filled at recall, not persisted). */
+  staleFiles: string[];
+}

--- a/packages/core/src/codebase/index.ts
+++ b/packages/core/src/codebase/index.ts
@@ -1,0 +1,125 @@
+import { join } from "node:path";
+import { existsSync } from "node:fs";
+import { TsService } from "../lsp";
+import { detectStack } from "../stack-detection";
+import { buildWorkspaceMap } from "./build-map";
+import { serializeMapBlock } from "./serialize";
+import { staleFiles } from "./staleness";
+import type { IWorkspaceMap } from "./codebase.types";
+
+export type { IWorkspaceMap, IModuleHub } from "./codebase.types";
+export { serializeMapBlock } from "./serialize";
+
+const MAP_DIR = ".tsforge";
+const MAP_FILE = "workspace-map.json";
+
+function mapPath(cwd: string): string {
+  return join(cwd, MAP_DIR, MAP_FILE);
+}
+
+/** Build the workspace map and persist it under `.tsforge/`. Returns null when
+ *  the project has no tsconfig (nothing to map deterministically). */
+export async function buildAndPersistMap(
+  cwd: string
+): Promise<IWorkspaceMap | null> {
+  if (!existsSync(join(cwd, "tsconfig.json"))) {
+    return null;
+  }
+
+  const stack = await detectStack(cwd);
+  const map = await buildWorkspaceMap(cwd, new TsService(cwd), stack);
+
+  await Bun.write(mapPath(cwd), `${JSON.stringify(map, null, 2)}\n`);
+  await ensureIgnored(cwd);
+
+  return map;
+}
+
+/** Read the persisted map, or null if none / unreadable. */
+export async function loadMap(cwd: string): Promise<IWorkspaceMap | null> {
+  const file = Bun.file(mapPath(cwd));
+
+  if (!(await file.exists())) {
+    return null;
+  }
+
+  try {
+    const parsed: unknown = JSON.parse(await file.text());
+
+    return isWorkspaceMap(parsed) ? parsed : null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * The system-prompt block for a session: load the persisted map, mark which
+ * files drifted since it was built (cheap; no rebuild — keeps session start
+ * fast), and serialize. Returns "" when the workspace was never mapped.
+ */
+export async function recallMapBlock(cwd: string): Promise<string> {
+  const map = await loadMap(cwd);
+
+  if (map === null) {
+    return "";
+  }
+
+  map.staleFiles = staleFiles(cwd, map);
+
+  return serializeMapBlock(map);
+}
+
+/** One-line status for `/map status`. */
+export async function mapStatus(cwd: string): Promise<string> {
+  const map = await loadMap(cwd);
+
+  if (map === null) {
+    return "no workspace map — run /map to build one";
+  }
+
+  const stale = staleFiles(cwd, map);
+  const head = map.meta.gitHead.length > 0 ? map.meta.gitHead.slice(0, 7) : "?";
+
+  return (
+    `map: ${map.meta.totalFiles} files, ${map.hubs.length} hubs, ` +
+    `built ${map.meta.builtAt} @ ${head}, ${stale.length} changed since`
+  );
+}
+
+/** Delete the persisted map. */
+export async function forgetMap(cwd: string): Promise<boolean> {
+  const file = Bun.file(mapPath(cwd));
+
+  if (!(await file.exists())) {
+    return false;
+  }
+
+  await file.delete();
+
+  return true;
+}
+
+function isWorkspaceMap(value: unknown): value is IWorkspaceMap {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    "meta" in value &&
+    "modules" in value &&
+    "hubs" in value
+  );
+}
+
+/** Append the map artifact to `.tsforge/.gitignore` (machine-specific). */
+async function ensureIgnored(cwd: string): Promise<void> {
+  const file = Bun.file(join(cwd, MAP_DIR, ".gitignore"));
+  const current = (await file.exists()) ? await file.text() : "";
+
+  if (current.split("\n").includes(MAP_FILE)) {
+    return;
+  }
+
+  await Bun.write(
+    join(cwd, MAP_DIR, ".gitignore"),
+    `${current.replace(/\n*$/u, current.length > 0 ? "\n" : "")}${MAP_FILE}\n`
+  );
+}

--- a/packages/core/src/codebase/index.ts
+++ b/packages/core/src/codebase/index.ts
@@ -114,7 +114,13 @@ async function ensureIgnored(cwd: string): Promise<void> {
   const file = Bun.file(join(cwd, MAP_DIR, ".gitignore"));
   const current = (await file.exists()) ? await file.text() : "";
 
-  if (current.split("\n").includes(MAP_FILE)) {
+  // Split on \r?\n so a CRLF .gitignore doesn't leave "\r" and re-append forever.
+  if (
+    current
+      .split(/\r?\n/)
+      .map((l) => l.trim())
+      .includes(MAP_FILE)
+  ) {
     return;
   }
 

--- a/packages/core/src/codebase/rank-hubs.ts
+++ b/packages/core/src/codebase/rank-hubs.ts
@@ -1,0 +1,27 @@
+import type { IWorkspaceModule, IModuleHub } from "./codebase.types";
+
+/**
+ * Rank modules by IMPORT IN-DEGREE — how many other modules import each one.
+ * Computed by inverting the import graph (free; no per-symbol reference walks).
+ * The most-imported modules are the hubs the agent should know about first.
+ */
+export function rankHubs(
+  modules: Record<string, IWorkspaceModule>
+): IModuleHub[] {
+  const inDegree = new Map<string, number>();
+
+  for (const m of Object.values(modules)) {
+    for (const imp of m.imports) {
+      inDegree.set(imp, (inDegree.get(imp) ?? 0) + 1);
+    }
+  }
+
+  return Object.values(modules)
+    .map((m) => ({
+      path: m.path,
+      exports: m.exports,
+      importedBy: inDegree.get(m.path) ?? 0,
+    }))
+    .filter((h) => h.importedBy > 0)
+    .sort((a, b) => b.importedBy - a.importedBy);
+}

--- a/packages/core/src/codebase/serialize.ts
+++ b/packages/core/src/codebase/serialize.ts
@@ -1,0 +1,90 @@
+import type { IWorkspaceMap, IModuleHub } from "./codebase.types";
+
+const MAX_HUBS = 15;
+const MAX_HUB_EXPORTS = 8;
+const MODULE_BUDGET_CHARS = 6000;
+const MAX_CONVENTIONS = 800;
+
+/**
+ * Render the workspace map as the single block injected into the system prompt.
+ * Budget-trimmed: hubs and a module list ordered by import in-degree, dropping
+ * the least-imported modules first so a small model's context isn't starved.
+ */
+export function serializeMapBlock(map: IWorkspaceMap): string {
+  const lines = [
+    "WORKSPACE_MAP:",
+    `stack: ${map.stack.name} (${map.stack.confidence})`,
+  ];
+
+  if (map.entryPoints.length > 0) {
+    lines.push(`entry points: ${map.entryPoints.join(", ")}`);
+  }
+
+  lines.push("", "directories:", map.directoryTree);
+
+  if (map.hubs.length > 0) {
+    lines.push("", "hubs (most-imported modules):");
+
+    for (const h of map.hubs.slice(0, MAX_HUBS)) {
+      lines.push(
+        `  ${h.path} ←${h.importedBy} — exports: ${h.exports.slice(0, MAX_HUB_EXPORTS).join(", ")}`
+      );
+    }
+  }
+
+  const modules = renderModules(map);
+
+  if (modules.length > 0) {
+    lines.push("", "modules:", modules);
+  }
+
+  if (map.conventions.length > 0) {
+    lines.push("", "conventions:", map.conventions.slice(0, MAX_CONVENTIONS));
+  }
+
+  lines.push("", staleNote(map));
+
+  return lines.join("\n");
+}
+
+/** Module lines ordered by in-degree, accumulated until the char budget. */
+function renderModules(map: IWorkspaceMap): string {
+  const rank = new Map<string, number>(
+    map.hubs.map((h: IModuleHub) => [h.path, h.importedBy])
+  );
+  const ordered = Object.values(map.modules).sort(
+    (a, b) => (rank.get(b.path) ?? 0) - (rank.get(a.path) ?? 0)
+  );
+
+  const out: string[] = [];
+  let used = 0;
+  let dropped = 0;
+
+  for (const m of ordered) {
+    const line =
+      m.exports.length > 0
+        ? `  ${m.path} (${m.lineCount}) — exports: ${m.exports.join(", ")}`
+        : `  ${m.path} (${m.lineCount})`;
+
+    if (used + line.length > MODULE_BUDGET_CHARS) {
+      dropped += 1;
+      continue;
+    }
+
+    out.push(line);
+    used += line.length + 1;
+  }
+
+  if (dropped > 0) {
+    out.push(`  … ${dropped} more module(s) — use search / read on demand`);
+  }
+
+  return out.join("\n");
+}
+
+function staleNote(map: IWorkspaceMap): string {
+  const n = map.staleFiles.length;
+  const drift = n > 0 ? `${n} file(s) changed since` : "no changes since";
+
+  return `Map built ${map.meta.builtAt}; ${drift}. For live symbols/refs use symbol_search / find_references.`;
+}

--- a/packages/core/src/codebase/serialize.ts
+++ b/packages/core/src/codebase/serialize.ts
@@ -61,9 +61,13 @@ function renderModules(map: IWorkspaceMap): string {
   let dropped = 0;
 
   for (const m of ordered) {
+    // Cap exports per module so a barrel/types file can't blow the budget on one line.
+    const shown = m.exports.slice(0, MAX_HUB_EXPORTS).join(", ");
+    const exportsText =
+      m.exports.length > MAX_HUB_EXPORTS ? `${shown}, …` : shown;
     const line =
       m.exports.length > 0
-        ? `  ${m.path} (${m.lineCount}) — exports: ${m.exports.join(", ")}`
+        ? `  ${m.path} (${m.lineCount}) — exports: ${exportsText}`
         : `  ${m.path} (${m.lineCount})`;
 
     if (used + line.length > MODULE_BUDGET_CHARS) {

--- a/packages/core/src/codebase/staleness.ts
+++ b/packages/core/src/codebase/staleness.ts
@@ -1,0 +1,50 @@
+import { join } from "node:path";
+import { readFileSync } from "node:fs";
+import { computeFileHash } from "../files/hashline-format";
+import { runArgvCommand } from "../lib/fs";
+import type { IWorkspaceMap } from "./codebase.types";
+
+/** Per-file content hashes + a combined fingerprint over the given files. */
+export function fingerprint(
+  cwd: string,
+  files: string[]
+): { combined: string; perFile: Record<string, string> } {
+  const perFile: Record<string, string> = {};
+
+  for (const f of files) {
+    perFile[f] = hashFile(cwd, f);
+  }
+
+  // Combine into one hash: stable order, path + hash per file.
+  const combined = computeFileHash(
+    Object.keys(perFile)
+      .sort()
+      .map((f) => `${f}:${perFile[f] ?? ""}`)
+      .join("\n")
+  );
+
+  return { combined, perFile };
+}
+
+function hashFile(cwd: string, file: string): string {
+  try {
+    return computeFileHash(readFileSync(join(cwd, file), "utf8"));
+  } catch {
+    return "";
+  }
+}
+
+/** Current git HEAD sha, or "" when not a repo / git absent. */
+export async function gitHead(cwd: string): Promise<string> {
+  const res = await runArgvCommand(cwd, ["git", "rev-parse", "HEAD"]);
+
+  return res.exitCode === 0 ? res.stdout.trim() : "";
+}
+
+/** Mapped files whose content changed since the map was built. */
+export function staleFiles(cwd: string, map: IWorkspaceMap): string[] {
+  const files = Object.keys(map.fileHashes);
+  const { perFile } = fingerprint(cwd, files);
+
+  return files.filter((f) => perFile[f] !== map.fileHashes[f]);
+}

--- a/packages/core/src/loop/session.ts
+++ b/packages/core/src/loop/session.ts
@@ -21,6 +21,7 @@ import { readFiles } from "../lib/fs";
 import { WEB_VENDORED_PATTERNS } from "../lib/scope";
 import { validate, type ErrorParser } from "../validate";
 import { detectStack } from "../stack-detection";
+import { recallMapBlock } from "../codebase";
 import {
   loadTsforgeConfig,
   normalizeRuleOverrides,
@@ -323,8 +324,10 @@ const MALFORMED_CALL_NUDGE =
   "malformed, so NO tool ran and nothing happened. Do not write tool syntax " +
   "in prose. Re-issue that action as a real tool call now.";
 
-/** CHAT_SYSTEM + a short orientation to the workspace and (optional) gate. */
-function systemPrompt(cfg: ISessionConfig): string {
+/** CHAT_SYSTEM + the (optional) workspace map + a short orientation to the
+ *  workspace and gate. The map block, when present, is injected right after
+ *  CHAT_SYSTEM so the agent is oriented before the task-specific lines. */
+function systemPrompt(cfg: ISessionConfig, workspaceMap: string): string {
   const lines = [`Workspace: ${cfg.cwd}`];
   const files = cfg.files ?? [];
   const wholeRepo = files.length === 0 || files.includes("**/*");
@@ -347,7 +350,9 @@ function systemPrompt(cfg: ISessionConfig): string {
     lines.push(cfg.guidance);
   }
 
-  return `${CHAT_SYSTEM}\n\n${lines.join("\n")}`;
+  const prefix = workspaceMap.length > 0 ? `${workspaceMap}\n\n` : "";
+
+  return `${CHAT_SYSTEM}\n\n${prefix}${lines.join("\n")}`;
 }
 
 export class Session {
@@ -522,6 +527,10 @@ export class Session {
             report({ kind: "tool", task: SESSION_ID, message });
           });
 
+    // Persisted workspace map (from `/map`), if any — primes the agent with the
+    // repo's structure. Cheap: loads + marks drift, never rebuilds here.
+    const workspaceMap = await recallMapBlock(cfg.cwd);
+
     const isWebScaffold = cfg.scaffoldWeb === true || cfg.scaffoldUi === true;
     const ctx: ILoopCtx = {
       task,
@@ -537,7 +546,7 @@ export class Session {
       messages:
         cfg.history !== undefined && cfg.history.length > 0
           ? [...cfg.history]
-          : [{ role: "system", content: systemPrompt(cfg) }],
+          : [{ role: "system", content: systemPrompt(cfg, workspaceMap) }],
       // Stream the gate's output live (the interactive CLI), so a slow gate
       // (vite build + chromium) shows progress instead of running silently.
       onGateChunk: (text) => {

--- a/packages/core/src/lsp/service.ts
+++ b/packages/core/src/lsp/service.ts
@@ -1,4 +1,4 @@
-import { join, isAbsolute, dirname } from "node:path";
+import { join, isAbsolute, dirname, relative } from "node:path";
 import { mkdirSync, rmSync } from "node:fs";
 import ts from "typescript";
 import type {
@@ -38,6 +38,7 @@ export class TsService {
   private readonly service: ts.LanguageService;
   private readonly versions = new Map<string, number>();
   private readonly files: string[];
+  private readonly options: ts.CompilerOptions;
 
   constructor(private readonly dir: string) {
     const configPath = join(dir, "tsconfig.json");
@@ -49,6 +50,7 @@ export class TsService {
     );
 
     this.files = [...parsed.fileNames];
+    this.options = parsed.options;
 
     const host: ts.LanguageServiceHost = {
       getScriptFileNames: () => this.files,
@@ -316,6 +318,39 @@ export class TsService {
     return sf === undefined ? [] : collectExports(sf);
   }
 
+  /** Internal project files that `file` imports (resolved via TS module
+   *  resolution) — the edges of the workspace import graph. Excludes
+   *  node_modules and unresolved/external specifiers. Absolute paths. */
+  importsOf(file: string): string[] {
+    const abs = this.toAbs(file);
+    const sf = this.service.getProgram()?.getSourceFile(abs);
+
+    if (sf === undefined) {
+      return [];
+    }
+
+    const out = new Set<string>();
+
+    for (const spec of importSpecifiers(sf)) {
+      const resolved = ts.resolveModuleName(spec, abs, this.options, ts.sys)
+        .resolvedModule?.resolvedFileName;
+
+      if (resolved !== undefined && !resolved.includes("node_modules")) {
+        out.add(resolved);
+      }
+    }
+
+    return [...out];
+  }
+
+  /** Non-declaration source files in the project, relative to the root —
+   *  the set a workspace map iterates over. */
+  projectFiles(): string[] {
+    return this.files
+      .filter((f) => !f.endsWith(".d.ts") && !f.includes("node_modules"))
+      .map((f) => relative(this.dir, f));
+  }
+
   /** Start offsets of `file`'s exported declarations — file-level blast-radius. */
   private exportedPositions(abs: string): number[] {
     const sf = this.service.getProgram()?.getSourceFile(abs);
@@ -538,6 +573,23 @@ export class TsService {
   private toAbs(file: string): string {
     return isAbsolute(file) ? file : join(this.dir, file);
   }
+}
+
+/** Module specifiers of a file's top-level `import`/`export … from` statements. */
+function importSpecifiers(sf: ts.SourceFile): string[] {
+  const specs: string[] = [];
+
+  sf.forEachChild((node) => {
+    if (
+      (ts.isImportDeclaration(node) || ts.isExportDeclaration(node)) &&
+      node.moduleSpecifier !== undefined &&
+      ts.isStringLiteral(node.moduleSpecifier)
+    ) {
+      specs.push(node.moduleSpecifier.text);
+    }
+  });
+
+  return specs;
 }
 
 /** Top-level exported declarations of a source file as {name, start offset}. */

--- a/packages/core/src/lsp/service.ts
+++ b/packages/core/src/lsp/service.ts
@@ -348,7 +348,7 @@ export class TsService {
   projectFiles(): string[] {
     return this.files
       .filter((f) => !f.endsWith(".d.ts") && !f.includes("node_modules"))
-      .map((f) => relative(this.dir, f));
+      .map((f) => relative(this.dir, f).replaceAll("\\", "/"));
   }
 
   /** Start offsets of `file`'s exported declarations — file-level blast-radius. */

--- a/packages/core/tests/codebase.test.ts
+++ b/packages/core/tests/codebase.test.ts
@@ -1,0 +1,98 @@
+import { test, expect, beforeEach, afterEach } from "bun:test";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  buildAndPersistMap,
+  loadMap,
+  recallMapBlock,
+  serializeMapBlock,
+  forgetMap,
+} from "../src/codebase";
+
+let dir: string;
+
+beforeEach(() => {
+  dir = mkdtempSync(join(tmpdir(), "tsforge-map-"));
+  writeFileSync(
+    join(dir, "tsconfig.json"),
+    '{"compilerOptions":{"strict":true,"skipLibCheck":true,"moduleResolution":"bundler"},"include":["*.ts"]}'
+  );
+  // a.ts is the hub: imported by both b.ts and c.ts.
+  writeFileSync(
+    join(dir, "a.ts"),
+    "export const foo = 1;\nexport function bar(): number {\n  return foo;\n}\n"
+  );
+  writeFileSync(
+    join(dir, "b.ts"),
+    'import { foo } from "./a";\nexport const x = foo;\n'
+  );
+  writeFileSync(
+    join(dir, "c.ts"),
+    'import { bar } from "./a";\nexport const y = bar();\n'
+  );
+});
+
+afterEach(() => {
+  rmSync(dir, { recursive: true, force: true });
+});
+
+test("builds an import graph and ranks hubs by in-degree", async () => {
+  const map = await buildAndPersistMap(dir);
+
+  expect(map).not.toBeNull();
+  expect(map?.modules["a.ts"]?.exports).toEqual(["foo", "bar"]);
+  expect(map?.modules["b.ts"]?.imports).toContain("a.ts");
+  // a.ts is imported by b.ts and c.ts → top hub with in-degree 2.
+  expect(map?.hubs[0]?.path).toBe("a.ts");
+  expect(map?.hubs[0]?.importedBy).toBe(2);
+});
+
+test("serializes a prompt block with hubs and a staleness note", async () => {
+  const map = await buildAndPersistMap(dir);
+  const block = serializeMapBlock(map!);
+
+  expect(block).toContain("WORKSPACE_MAP:");
+  expect(block).toContain("a.ts");
+  expect(block).toContain("hubs");
+  expect(block).toContain("Map built");
+});
+
+test("recall returns the block, and flags drift after an edit", async () => {
+  await buildAndPersistMap(dir);
+
+  const fresh = await recallMapBlock(dir);
+
+  expect(fresh).toContain("WORKSPACE_MAP:");
+  expect(fresh).toContain("no changes since");
+
+  writeFileSync(join(dir, "a.ts"), "export const foo = 2;\n"); // drift
+  const stale = await recallMapBlock(dir);
+
+  expect(stale).toContain("1 file(s) changed since");
+});
+
+test("persisted map is gitignored under .tsforge", async () => {
+  await buildAndPersistMap(dir);
+  const ignore = await Bun.file(join(dir, ".tsforge", ".gitignore")).text();
+
+  expect(ignore).toContain("workspace-map.json");
+});
+
+test("no tsconfig → null (nothing to map); no map → empty recall", async () => {
+  const bare = mkdtempSync(join(tmpdir(), "tsforge-bare-"));
+
+  try {
+    expect(await buildAndPersistMap(bare)).toBeNull();
+    expect(await recallMapBlock(bare)).toBe("");
+  } finally {
+    rmSync(bare, { recursive: true, force: true });
+  }
+});
+
+test("forget deletes the persisted map", async () => {
+  await buildAndPersistMap(dir);
+  expect(await loadMap(dir)).not.toBeNull();
+  expect(await forgetMap(dir)).toBe(true);
+  expect(await loadMap(dir)).toBeNull();
+});


### PR DESCRIPTION
## What

`/map` (REPL) and `tsforge map` build a **deterministic structural map** of a TypeScript repo and persist it under `.tsforge/`; the next session injects it so the agent starts oriented instead of re-exploring. For existing repos — most valuable for the small local models this harness targets.

## How it works (no AI, no new deps)
- New `TsService.importsOf` (import graph via TS module resolution) + `projectFiles`.
- `codebase/`: build the map (each module's exports + internal imports), rank **hubs by import in-degree** (cheap — no per-symbol `references()` walks), serialize one budget-trimmed block, staleness via `computeFileHash` + git HEAD.
- `Session.create` injects the map block after `CHAT_SYSTEM`; recall **loads + flags drift, never rebuilds** (session start stays fast). Built on the AST `exportedSymbols`, not regex.
- CLI `/map [status|forget]` + `tsforge map`; artifacts gitignored.

## Tested
- 6 unit tests (import graph, in-degree hubs, serialize, staleness/drift, gitignore, null cases). Full `bun run validate`: **1070 pass, 0 fail**; docs build green.
- **Perf:** mapped this repo (488 files) in ~1.25s — the in-degree path avoids the slow per-symbol walks.
- **`map-eval.ts`** (the value metric — pre-edit tool calls, mapped vs unmapped): deepseek directional run gave **6 vs 9**. n=1 on a strong model (one run went `stuck`), so it's directional, not a verdict — the script exists to be run on a **small local model**, which is where the value should show.

## Honest notes
- Opt-in and low-risk: no map = no injection (default behavior unchanged); you run `/map` to build one.
- Staleness is a non-blocking note (don't rebuild on session start); incremental auto-rebuild + post-commit hooks are deferred.