### PR TITLE
feat(gate): TDD enforcement on by default, scoped to changed files + broadened

### DIFF
--- a/apps/docs/src/content/docs/reference/flags.mdx
+++ b/apps/docs/src/content/docs/reference/flags.mdx
@@ -15,7 +15,7 @@ description: Canonical list of every TSFORGE_* environment variable.
 | `TSFORGE_NO_ASTGREP` | off | disable ast-grep rewrite (`=1`) |
 | `TSFORGE_FORCE_TOOLS` | off | force tool_choice required (`=1`) |
 | `TSFORGE_SIMPLICITY` | off | shortest-solution guidance, scratch non-web (`=1`) |
-| `TSFORGE_TDD` | off | test-first guidance + `test-sibling-required` becomes an error (`=1`) |
+| `TSFORGE_TDD` | ON (`≠ "0"`) | test-first guidance + `test-sibling-required` is an error on changed logic files (`=0` to opt out) |
 | `TSFORGE_WEB` | off | free, local web access — the `web_fetch` + `web_search` tools (`=1`) |
 | `TSFORGE_NO_UPDATE_CHECK` | off | silence the startup "update available" check (`=1`) |
 | `TSFORGE_NO_GIT_TOOL` | off | withhold the `git_context` tool (`=1`) |

--- a/packages/core/RULES.md
+++ b/packages/core/RULES.md
@@ -175,7 +175,7 @@ Meta-rules enforce project structure and configuration invariants that ESLint ca
 
 ### testing
 
-- **test-sibling-required** [WARN]: Logic modules (*.service.ts, *.utils.ts, etc.) should have a co-located *.test.ts sibling.
+- **test-sibling-required** [WARN]: A logic file (one that exports a function or class) the agent changes must have a test — co-located (*.test.ts) or mirrored under tests/.
 
 ### stack-layout
 

--- a/packages/core/src/config/flags.ts
+++ b/packages/core/src/config/flags.ts
@@ -34,10 +34,12 @@ export const flags = {
    *  default OFF until a sweep validates it). */
   simplicity: (): boolean => isOn(ENV_FLAG.simplicity),
   /** TDD-first mode: appends test-first guidance to the build prompt AND elevates
-   *  the `test-sibling-required` meta-rule to an ERROR — so a logic module without
-   *  a co-located test fails the gate (the harness obsesses over tests, not just
-   *  suggests them). Default OFF. */
-  tdd: (): boolean => isOn(ENV_FLAG.tdd),
+   *  the `test-sibling-required` meta-rule to an ERROR — so a logic file the agent
+   *  TOUCHES without a test fails the gate (the harness obsesses over tests, not
+   *  just suggests them). Quality + strictness out of the box, so DEFAULT ON; set
+   *  TSFORGE_TDD=0 to opt out. The error is scoped to changed files (see the rule),
+   *  so it never blocks on a repo's pre-existing untested code. */
+  tdd: (): boolean => process.env.TSFORGE_TDD !== "0",
   /** Free, local web access (web_fetch + web_search) — opt-in (default OFF) so
    *  eval sweeps stay deterministic and offline. No key, no paid service:
    *  web_fetch extracts locally; web_search uses DuckDuckGo (or a self-hosted

--- a/packages/core/src/loop/turn.ts
+++ b/packages/core/src/loop/turn.ts
@@ -11,7 +11,7 @@ import {
   type IErrorItem,
 } from "../validate";
 import { isInScope } from "../lib/scope";
-import { fileExists, resolveScopeFiles } from "../lib/fs";
+import { fileExists, resolveScopeFiles, runArgvCommand } from "../lib/fs";
 import { RUN_STATUS, STUCK_REASON, LOOP_LIMITS } from "./loop.constants";
 import type { IRunResult, Reporter } from "./loop.types";
 import { flags } from "../config";
@@ -774,6 +774,31 @@ export function persistDetail(e: IErrorItem): string {
  * optional fix command, validate, and return a terminal result (done/stuck) or
  * null to keep going (having fed the failures back into the conversation).
  */
+/** Repo-relative files changed vs git HEAD (working tree + staged). Empty when
+ *  not a git repo or git is absent — callers then fall back to non-scoped behavior. */
+async function gitChangedFiles(cwd: string): Promise<string[]> {
+  const out = new Set<string>();
+
+  // --relative → paths relative to cwd (matches sourceFiles even in a monorepo
+  // subdir, where the git root differs from the project root).
+  for (const args of [
+    ["diff", "--name-only", "--relative", "HEAD"],
+    ["diff", "--name-only", "--relative", "--staged"],
+  ]) {
+    const res = await runArgvCommand(cwd, ["git", ...args]);
+
+    if (res.exitCode === 0) {
+      for (const f of res.stdout.split("\n").map((s) => s.trim())) {
+        if (f.length > 0) {
+          out.add(f);
+        }
+      }
+    }
+  }
+
+  return [...out];
+}
+
 export async function settleGate(
   ctx: ILoopCtx,
   state: ILoopState,
@@ -827,9 +852,13 @@ export async function settleGate(
   let metaViolations: IMetaRuleViolation[] = [];
 
   try {
+    // Files changed vs git HEAD — lets change-scoped rules (test-sibling-required)
+    // enforce only on what's being worked on, not a repo's pre-existing debt.
+    const changed = await gitChangedFiles(cwd);
     const metaContext = buildMetaRuleContext(
       cwd,
-      ctx.stackProfile?.packs ?? []
+      ctx.stackProfile?.packs ?? [],
+      changed
     );
 
     metaViolations = runMetaRules(META_RULES, metaContext, ctx.ruleOverrides);

--- a/packages/core/src/loop/turn.ts
+++ b/packages/core/src/loop/turn.ts
@@ -780,10 +780,12 @@ async function gitChangedFiles(cwd: string): Promise<string[]> {
   const out = new Set<string>();
 
   // --relative → paths relative to cwd (matches sourceFiles even in a monorepo
-  // subdir, where the git root differs from the project root).
+  // subdir). ls-files --others picks up UNTRACKED new files — the common TDD case
+  // where the agent CREATES a logic file (and should be made to test it).
   for (const args of [
     ["diff", "--name-only", "--relative", "HEAD"],
     ["diff", "--name-only", "--relative", "--staged"],
+    ["ls-files", "--others", "--exclude-standard"],
   ]) {
     const res = await runArgvCommand(cwd, ["git", ...args]);
 

--- a/packages/core/src/meta-rules/context.ts
+++ b/packages/core/src/meta-rules/context.ts
@@ -208,7 +208,8 @@ function parsePackageJson(root: string): Record<string, unknown> | null {
  */
 export function buildMetaRuleContext(
   root: string,
-  activePacks: readonly string[]
+  activePacks: readonly string[],
+  changedFiles: readonly string[] = []
 ): IMetaRuleContext {
   const fileCache = new Map<string, string | null>();
 
@@ -243,6 +244,7 @@ export function buildMetaRuleContext(
     root,
     packageJson: parsePackageJson(root),
     sourceFiles: collectSourceFiles(root),
+    changedFiles,
     configFiles: collectConfigFiles(root),
     workflowFiles: collectWorkflowFiles(root),
     dockerfiles: collectDockerfiles(root),

--- a/packages/core/src/meta-rules/meta-rules.types.ts
+++ b/packages/core/src/meta-rules/meta-rules.types.ts
@@ -29,6 +29,7 @@ export interface IMetaRuleContext {
   readonly root: string;
   readonly packageJson: Record<string, unknown> | null;
   readonly sourceFiles: readonly string[]; // repo-relative .ts/.tsx
+  readonly changedFiles: readonly string[]; // repo-relative files changed vs git HEAD (empty when not a git repo)
   readonly configFiles: readonly string[]; // tsconfig*, eslint*, package.json, *.config.*
   readonly workflowFiles: readonly string[]; // .github/workflows/*.yml|yaml
   readonly dockerfiles: readonly string[]; // Dockerfile, Dockerfile.*, *.Dockerfile (root + 1 level)

--- a/packages/core/src/meta-rules/rules/testing/test-sibling-required.ts
+++ b/packages/core/src/meta-rules/rules/testing/test-sibling-required.ts
@@ -12,7 +12,8 @@ const LOGIC_EXPORTS = [
   /\bexport\s+(default\s+)?(async\s+)?function\b/u,
   /\bexport\s+(abstract\s+)?class\b/u,
   /\bexport\s+default\s+class\b/u,
-  /\bexport\s+const\s+[A-Za-z_$][\w$]*\s*(?::[^=\n]+)?=\s*(async\s+)?(function\b|\([^)]*\)\s*(?::[^=\n]+)?=>|[A-Za-z_$][\w$]*\s*=>)/u,
+  // `[^=]` (not `[^=\n]`) so a multiline type annotation before `=` still matches.
+  /\bexport\s+const\s+[A-Za-z_$][\w$]*\s*(?::[^=]+)?=\s*(async\s+)?(function\b|\([^)]*\)\s*(?::[^=]+)?=>|[A-Za-z_$][\w$]*\s*=>)/u,
 ];
 
 function isTestPath(file: string): boolean {
@@ -45,31 +46,35 @@ function fileExistsAt(root: string, rel: string): boolean {
   }
 }
 
-/** The mirrored test path under `tests/` (src/foo.ts → tests/foo.test.ts), or "". */
-function mirroredTest(file: string, ext: string): string {
-  const stem = file.slice(0, -ext.length);
-
+/** The mirrored test path under `tests/` for a given stem + test extension, or "". */
+function mirroredTest(file: string, stem: string, testExt: string): string {
   if (file.startsWith("src/")) {
-    return `tests/${stem.slice(4)}.test${ext}`;
+    return `tests/${stem.slice(4)}.test${testExt}`;
   }
 
   if (file.startsWith("scripts/")) {
-    return `tests/scripts/${stem.slice(8)}.test${ext}`;
+    return `tests/scripts/${stem.slice(8)}.test${testExt}`;
   }
 
   return "";
 }
 
 /** A test exists if there's a co-located `*.test|spec` sibling OR a mirrored
- *  `tests/` file. Supports both layouts — co-located and a parallel tests tree. */
+ *  `tests/` file. Supports both layouts, and a `.tsx` source whose test is a
+ *  plain `.test.ts` (common for components without JSX in the test). */
 function hasTest(root: string, file: string): boolean {
-  const ext = /\.tsx?$/u.exec(file)?.[0] ?? ".ts";
-  const stem = file.slice(0, -ext.length);
-  const candidates = [
-    `${stem}.test${ext}`,
-    `${stem}.spec${ext}`,
-    mirroredTest(file, ext),
-  ];
+  const srcExt = /\.tsx?$/u.exec(file)?.[0] ?? ".ts";
+  const stem = file.slice(0, -srcExt.length);
+  const testExts = srcExt === ".tsx" ? [".tsx", ".ts"] : [".ts"];
+  const candidates: string[] = [];
+
+  for (const e of testExts) {
+    candidates.push(
+      `${stem}.test${e}`,
+      `${stem}.spec${e}`,
+      mirroredTest(file, stem, e)
+    );
+  }
 
   return candidates.some((c) => c.length > 0 && fileExistsAt(root, c));
 }

--- a/packages/core/src/meta-rules/rules/testing/test-sibling-required.ts
+++ b/packages/core/src/meta-rules/rules/testing/test-sibling-required.ts
@@ -1,111 +1,122 @@
-import { join } from "node:path";
+import { join, dirname, basename } from "node:path";
 import { statSync } from "node:fs";
 import type { IMetaRule, IMetaRuleViolation } from "../../meta-rules.types";
 import { flags } from "../../../config";
 
 /**
- * File suffixes that indicate logic files requiring tests.
+ * Patterns that mean "this file exports real logic" — a function or class (incl.
+ * exported arrow/function consts). Type-only modules, barrels, and data files
+ * don't match, so they're never asked for a test.
  */
-const LOGIC_FILE_SUFFIXES = /\.(service|utils|helpers|handler)\.ts$/u;
+const LOGIC_EXPORTS = [
+  /\bexport\s+(default\s+)?(async\s+)?function\b/u,
+  /\bexport\s+(abstract\s+)?class\b/u,
+  /\bexport\s+default\s+class\b/u,
+  /\bexport\s+const\s+[A-Za-z_$][\w$]*\s*(?::[^=\n]+)?=\s*(async\s+)?(function\b|\([^)]*\)\s*(?::[^=\n]+)?=>|[A-Za-z_$][\w$]*\s*=>)/u,
+];
 
-/**
- * Directories that are logic-heavy by definition.
- */
-const LOGIC_DIRS = new Set(["lib"]);
+function isTestPath(file: string): boolean {
+  return /\.(test|spec)\.[tj]sx?$/u.test(file);
+}
 
-/**
- * Check if a source file looks like a logic module that should have a test.
- * Excludes test files, type-only modules, and barrel exports.
- */
-function isLogicFile(file: string): boolean {
-  // Exclude existing test files
-  if (file.includes(".test.ts") || file.includes(".spec.ts")) {
+/** A source file that EXPORTS logic and should therefore have a test. Excludes
+ *  tests, declaration files, barrels (index), and type-only modules. */
+function isLogicFile(file: string, content: string): boolean {
+  if (!/\.(ts|tsx)$/u.test(file) || file.endsWith(".d.ts")) {
     return false;
   }
 
-  // Exclude barrel exports and type-only modules
-  if (file.endsWith("/index.ts") || file.endsWith(".types.ts")) {
+  if (isTestPath(file) || file.endsWith(".types.ts")) {
     return false;
   }
 
-  // Check for logic file suffix
-  if (LOGIC_FILE_SUFFIXES.test(file)) {
-    return true;
+  if (file === "index.ts" || file.endsWith("/index.ts")) {
+    return false;
   }
 
-  // Check if in a logic directory
-  for (const logicDir of LOGIC_DIRS) {
-    if (
-      file.includes(`/lib/${logicDir}/`) ||
-      file.includes(`\\lib\\${logicDir}\\`)
-    ) {
-      return true;
-    }
+  return LOGIC_EXPORTS.some((re) => re.test(content));
+}
+
+function fileExistsAt(root: string, rel: string): boolean {
+  try {
+    return statSync(join(root, rel)).isFile();
+  } catch {
+    return false;
+  }
+}
+
+/** The mirrored test path under `tests/` (src/foo.ts → tests/foo.test.ts), or "". */
+function mirroredTest(file: string, ext: string): string {
+  const stem = file.slice(0, -ext.length);
+
+  if (file.startsWith("src/")) {
+    return `tests/${stem.slice(4)}.test${ext}`;
   }
 
-  return false;
+  if (file.startsWith("scripts/")) {
+    return `tests/scripts/${stem.slice(8)}.test${ext}`;
+  }
+
+  return "";
+}
+
+/** A test exists if there's a co-located `*.test|spec` sibling OR a mirrored
+ *  `tests/` file. Supports both layouts — co-located and a parallel tests tree. */
+function hasTest(root: string, file: string): boolean {
+  const ext = /\.tsx?$/u.exec(file)?.[0] ?? ".ts";
+  const stem = file.slice(0, -ext.length);
+  const candidates = [
+    `${stem}.test${ext}`,
+    `${stem}.spec${ext}`,
+    mirroredTest(file, ext),
+  ];
+
+  return candidates.some((c) => c.length > 0 && fileExistsAt(root, c));
 }
 
 export const testSiblingRequiredRule: IMetaRule = {
   id: "test-sibling-required",
   category: "testing",
   description:
-    "Logic modules (*.service.ts, *.utils.ts, etc.) should have a co-located *.test.ts sibling.",
+    "A logic file (one that exports a function or class) the agent changes must have a test — co-located (*.test.ts) or mirrored under tests/.",
   severity: "warn",
-  run({ root, sourceFiles }) {
-    const violations: IMetaRuleViolation[] = [];
-    // TDD mode makes a missing test a hard failure ("obsess over tests"); the
-    // default keeps it a nudge so it never blocks a non-TDD build.
+  run({ root, sourceFiles, changedFiles, readFile }) {
+    // TDD mode (default ON) makes a missing test a hard gate failure; off → a
+    // nudge. Either way, SCOPED to files changed vs HEAD — never a repo's
+    // pre-existing untested code. No git signal (empty) → nothing to enforce.
     const severity = flags.tdd() ? "error" : "warn";
+    const changed = new Set(changedFiles.map((f) => f.replace(/\\/gu, "/")));
+
+    if (changed.size === 0) {
+      return [];
+    }
+
+    const violations: IMetaRuleViolation[] = [];
 
     for (const file of sourceFiles) {
-      if (!isLogicFile(file)) {
+      const norm = file.replace(/\\/gu, "/");
+
+      if (!changed.has(norm)) {
         continue;
       }
 
-      // Expected test location: src/foo/bar.ts → tests/foo/bar.test.ts
-      const normalized = file.replace(/\\/g, "/");
+      const content = readFile(file);
 
-      let expectedTest: string;
-
-      if (normalized.startsWith("src/")) {
-        const relativePath = normalized.slice(4); // Remove "src/"
-
-        expectedTest = join(
-          root,
-          "tests",
-          relativePath.replace(/\.ts$/, ".test.ts")
-        );
-      } else if (normalized.startsWith("scripts/")) {
-        const relativePath = normalized.slice(8); // Remove "scripts/"
-
-        expectedTest = join(
-          root,
-          "tests",
-          "scripts",
-          relativePath.replace(/\.ts$/, ".test.ts")
-        );
-      } else {
-        continue; // Unrecognized directory
+      if (
+        content === null ||
+        !isLogicFile(norm, content) ||
+        hasTest(root, norm)
+      ) {
+        continue;
       }
 
-      try {
-        const stat = statSync(expectedTest);
-
-        if (stat.isFile()) {
-          continue; // Test exists
-        }
-      } catch {
-        // Test does not exist
-      }
-
-      const relativeExpectedTest = expectedTest.slice(root.length + 1);
+      const stem = basename(norm).replace(/\.tsx?$/u, "");
 
       violations.push({
         file,
         ruleId: "test-sibling-required",
         severity,
-        message: `Missing unit-test sibling. Expected \`${relativeExpectedTest}\` to exist alongside this logic module.`,
+        message: `Missing test for a logic file you changed. Add \`${join(dirname(norm), `${stem}.test.ts`)}\` (co-located) or the mirrored \`tests/\` equivalent — the harness tests what it writes.`,
       });
     }
 

--- a/packages/core/tests/meta-rules.test.ts
+++ b/packages/core/tests/meta-rules.test.ts
@@ -489,7 +489,8 @@ test("test-sibling-required: detects missing test for .utils.ts", () => {
     "export const add = (a: number, b: number) => a + b;"
   );
 
-  const ctx = buildMetaRuleContext(tempDir, []);
+  // Scoped to changed files: the agent touched helpers.utils.ts.
+  const ctx = buildMetaRuleContext(tempDir, [], ["src/helpers.utils.ts"]);
   const violations = runMetaRules(META_RULES, ctx);
 
   const relevant = violations.filter(
@@ -497,7 +498,7 @@ test("test-sibling-required: detects missing test for .utils.ts", () => {
   );
 
   expect(relevant.length).toBeGreaterThan(0);
-  expect(relevant[0]?.message).toContain("Missing unit-test sibling");
+  expect(relevant[0]?.message).toContain("Missing test");
 });
 
 test("test-sibling-required: passes when test exists", () => {
@@ -513,7 +514,8 @@ test("test-sibling-required: passes when test exists", () => {
     "import { add } from '../src/helpers.utils'; test(() => expect(add(1, 2)).toBe(3));"
   );
 
-  const ctx = buildMetaRuleContext(tempDir, []);
+  // Mirrored tests/ file satisfies it even though the file is in the changed set.
+  const ctx = buildMetaRuleContext(tempDir, [], ["src/helpers.utils.ts"]);
   const violations = runMetaRules(META_RULES, ctx);
 
   const relevant = violations.filter(
@@ -530,7 +532,7 @@ test("test-sibling-required: exempts index.ts", () => {
     "export { add } from './helpers.utils';"
   );
 
-  const ctx = buildMetaRuleContext(tempDir, []);
+  const ctx = buildMetaRuleContext(tempDir, [], ["src/index.ts"]);
   const violations = runMetaRules(META_RULES, ctx);
 
   const relevant = violations.filter(

--- a/packages/core/tests/tdd-mode.test.ts
+++ b/packages/core/tests/tdd-mode.test.ts
@@ -13,15 +13,14 @@ afterEach(() => {
   delete process.env.TSFORGE_TDD;
 });
 
-test("buildSystemPrompt appends TEST-FIRST guidance only when TDD mode is on", () => {
+const SERVICE = "src/account.service.ts";
+
+test("TEST-FIRST guidance is on by default, off only when TSFORGE_TDD=0", () => {
   delete process.env.TSFORGE_TDD;
+  expect(buildSystemPrompt(false, undefined)).toContain("TEST-FIRST");
+
+  process.env.TSFORGE_TDD = "0";
   expect(buildSystemPrompt(false, undefined)).not.toContain("TEST-FIRST");
-
-  process.env.TSFORGE_TDD = "1";
-  const tdd = buildSystemPrompt(false, undefined);
-
-  expect(tdd).toContain("TEST-FIRST");
-  expect(tdd).toContain("SEE IT FAIL");
 });
 
 function logicProjectWithoutTest(): string {
@@ -29,40 +28,70 @@ function logicProjectWithoutTest(): string {
 
   mkdirSync(join(dir, "src"), { recursive: true });
   writeFileSync(
-    join(dir, "src", "account.service.ts"),
+    join(dir, SERVICE),
     "export const balance = (n: number): number => n;\n"
   );
 
   return dir;
 }
 
-test("test-sibling-required is a WARN by default", () => {
+function siblingViolations(dir: string, changed: string[]) {
+  return runMetaRules(
+    META_RULES,
+    buildMetaRuleContext(dir, [], changed)
+  ).filter((x) => x.ruleId === "test-sibling-required");
+}
+
+test("errors by default on a CHANGED logic file with no test", () => {
   delete process.env.TSFORGE_TDD;
   const dir = logicProjectWithoutTest();
 
   try {
-    const v = runMetaRules(META_RULES, buildMetaRuleContext(dir, [])).filter(
-      (x) => x.ruleId === "test-sibling-required"
-    );
+    const v = siblingViolations(dir, [SERVICE]);
 
     expect(v.length).toBeGreaterThan(0);
+    expect(v[0]?.severity).toBe("error");
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("downgrades to a warn when TSFORGE_TDD=0", () => {
+  process.env.TSFORGE_TDD = "0";
+  const dir = logicProjectWithoutTest();
+
+  try {
+    const v = siblingViolations(dir, [SERVICE]);
+
     expect(v[0]?.severity).toBe("warn");
   } finally {
     rmSync(dir, { recursive: true, force: true });
   }
 });
 
-test("test-sibling-required is an ERROR in TDD mode (missing test fails the gate)", () => {
-  process.env.TSFORGE_TDD = "1";
+test("ignores logic files the agent did NOT change (scoped to the diff)", () => {
+  delete process.env.TSFORGE_TDD;
   const dir = logicProjectWithoutTest();
 
   try {
-    const v = runMetaRules(META_RULES, buildMetaRuleContext(dir, [])).filter(
-      (x) => x.ruleId === "test-sibling-required"
-    );
+    // empty changed set → nothing is enforced (e.g. non-git, or untouched)
+    expect(siblingViolations(dir, [])).toHaveLength(0);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
 
-    expect(v.length).toBeGreaterThan(0);
-    expect(v[0]?.severity).toBe("error");
+test("a co-located *.test.ts satisfies the requirement", () => {
+  delete process.env.TSFORGE_TDD;
+  const dir = logicProjectWithoutTest();
+
+  writeFileSync(
+    join(dir, "src", "account.service.test.ts"),
+    'import { test } from "bun:test";\ntest("x", () => {});\n'
+  );
+
+  try {
+    expect(siblingViolations(dir, [SERVICE])).toHaveLength(0);
   } finally {
     rmSync(dir, { recursive: true, force: true });
   }


### PR DESCRIPTION
## Why

The harness's core value is **quality + strictness out of the box**. TDD enforcement existed but was opt-in (`TSFORGE_TDD=1`), narrow (only `*.service/utils/helpers/handler.ts` + `lib/lib`), mirrored-tests-only, and — critically — scanned the **whole repo**, so turning it on naively would fail the gate on a user's pre-existing untested code.

## What changed

`TSFORGE_TDD` now **defaults ON** (`=0` to opt out). `test-sibling-required`:
- **ERROR by default** (was warn) — a logic file with no test fails the gate.
- **Scoped to changed files** — enforces only on files changed vs `git HEAD` (new `gitChangedFiles` in `settleGate`, threaded through `buildMetaRuleContext` as `changedFiles`). So it holds the agent to testing **what it touches**, never the repo's legacy debt. No git → no-op.
- **Broadened** — any file exporting a function/class (via content check), not a fixed suffix list; excludes tests, `.types.ts`, `.d.ts`, and `index` barrels.
- **Both test layouts** — a co-located `*.test.ts` OR a mirrored `tests/` file satisfies it (was mirrored-only — which mismatched its own description and would misfire on co-located repos).

## Safety
- `bun run validate` and non-git eval sweeps are unaffected: meta-rules run only in the **agent gate**, and greenfield sweep run dirs aren't git repos (→ empty `changedFiles` → no enforcement).
- Cross-platform: change-set comparison normalizes `\` → `/`; `git diff --relative` so paths match `sourceFiles` in a monorepo subdir.

## Tested
- Rewrote `tdd-mode.test.ts` to the new contract (default-on, change-scoped, co-located-or-mirrored, opt-out via `=0`) + updated `meta-rules.test.ts` sibling tests. Full `bun run validate`: **1072 pass, 0 fail**; docs build green.