### PR TITLE
docs: overhaul — lead with the pitch, separate everyday use from internals

### DIFF
--- a/apps/docs/astro.config.mjs
+++ b/apps/docs/astro.config.mjs
@@ -138,83 +138,75 @@ export default defineConfig({
       lastUpdated: true,
       sidebar: [
         {
-          label: "Getting started",
+          label: "Get started",
           items: [
             { label: "Welcome", link: "/" },
             { label: "Quickstart", link: "/quickstart/" },
-            { label: "Big picture", link: "/big-picture/" },
-            { label: "Interactive CLI", link: "/cli/interactive/" },
+            { label: "How it works", link: "/big-picture/" },
           ],
         },
         {
-          label: "Loop",
+          label: "Everyday use",
           items: [
-            { label: "How the gate is built", link: "/loop/gate-floor/" },
-            { label: "When the gate fails", link: "/loop/validation/" },
-            { label: "Spec format", link: "/spec/format/" },
-            { label: "Spec runner", link: "/loop/spec-runner/" },
-            { label: "Model agent", link: "/agent/model-agent/" },
-            { label: "File ops", link: "/edit/engine/" },
+            { label: "Chat with your repo", link: "/cli/interactive/" },
+            { label: "Drive a change to green", link: "/workflows/fix-to-green/" },
+            { label: "Review your changes", link: "/cli/review/" },
+            { label: "Map the repo", link: "/cli/map/" },
             { label: "Plan mode", link: "/cli/plan-mode/" },
           ],
         },
         {
-          label: "TypeScript LSP",
+          label: "Quality & strictness",
           items: [
-            { label: "Language server", link: "/lsp/typescript-server/" },
-            { label: "Write diagnostics", link: "/uplift/write-diagnostics/" },
-          ],
-        },
-        {
-          label: "Web scaffolding",
-          items: [{ label: "Vite stacks", link: "/scaffold/web/" }],
-        },
-        {
-          label: "Guardrails",
-          items: [
+            { label: "The gate", link: "/loop/gate-floor/" },
+            { label: "When the gate fails", link: "/loop/validation/" },
+            { label: "Tests by default", link: "/quality/tests/" },
             { label: "Stack detection", link: "/guardrails/stack-detection/" },
             { label: "Rule packs", link: "/guardrails/rule-packs/" },
             { label: "Meta-rules", link: "/guardrails/meta-rules/" },
+          ],
+        },
+        {
+          label: "Configure",
+          items: [
+            { label: "Models (any provider)", link: "/inference/models-json/" },
             { label: "tsforge.config.json", link: "/guardrails/config/" },
+            { label: "Environment variables", link: "/reference/flags/" },
+            { label: "MCP servers", link: "/integrations/mcp/" },
           ],
-        },
-        {
-          label: "Helping the model",
-          items: [
-            { label: "Fix bad tool calls", link: "/uplift/repair-ladder/" },
-            { label: "Safer line edits", link: "/uplift/hashline/" },
-            { label: "Stop bad output early", link: "/uplift/ttsr/" },
-            { label: "Learning from past runs", link: "/uplift/memory/" },
-          ],
-        },
-        {
-          label: "Inference",
-          items: [
-            { label: "models.json (any provider)", link: "/inference/models-json/" },
-            { label: "Model adapter", link: "/inference/adapter/" },
-          ],
-        },
-        {
-          label: "Integrations",
-          items: [{ label: "MCP servers", link: "/integrations/mcp/" }],
-        },
-        {
-          label: "Observability",
-          items: [
-            { label: "Token metrics (tok/s)", link: "/observability/metrics/" },
-          ],
-        },
-        {
-          label: "Eval",
-          items: [{ label: "A/B testing", link: "/eval/ab-testing/" }],
         },
         {
           label: "Reference",
           items: [
             { label: "Commands", link: "/reference/commands/" },
-            { label: "Environment variables", link: "/reference/flags/" },
             { label: "Rule catalog", link: "/reference/rules-catalog/" },
             { label: "Roadmap", link: "/reference/roadmap/" },
+          ],
+        },
+        {
+          label: "Under the hood",
+          collapsed: true,
+          items: [
+            { label: "Model agent", link: "/agent/model-agent/" },
+            { label: "File ops", link: "/edit/engine/" },
+            { label: "TypeScript language server", link: "/lsp/typescript-server/" },
+            { label: "Write diagnostics", link: "/uplift/write-diagnostics/" },
+            { label: "Fixing bad tool calls", link: "/uplift/repair-ladder/" },
+            { label: "Safer line edits", link: "/uplift/hashline/" },
+            { label: "Stopping bad output early", link: "/uplift/ttsr/" },
+            { label: "Learning from past runs", link: "/uplift/memory/" },
+            { label: "Web scaffolding", link: "/scaffold/web/" },
+            { label: "Model adapter", link: "/inference/adapter/" },
+            { label: "Token metrics", link: "/observability/metrics/" },
+          ],
+        },
+        {
+          label: "For contributors",
+          collapsed: true,
+          items: [
+            { label: "Spec format", link: "/spec/format/" },
+            { label: "Spec runner", link: "/loop/spec-runner/" },
+            { label: "A/B testing (eval)", link: "/eval/ab-testing/" },
           ],
         },
       ],

--- a/apps/docs/src/content/docs/agent/model-agent.mdx
+++ b/apps/docs/src/content/docs/agent/model-agent.mdx
@@ -22,6 +22,7 @@ One approved task can involve many agent cycles until the gate passes or tsforge
 | Core | `read`, `run`, `edit`, `create` | always |
 | Line edits | `edit_lines` | when hashline is enabled |
 | Navigation | `search`, `symbol_search`, `find_references`, `type_at`, `diagnostics`, `rename_symbol`, `move_file`, `organize_imports` | existing-code repos |
+| Git context | `git_context` | existing-code repos (read-only: diff/log/blame/show to scope a change); `TSFORGE_NO_GIT_TOOL=1` to withhold |
 | Web | `scaffold_web`, `scaffold_ui`, `scaffold_routes`, `add_dependency` | web builds |
 | Web access | `web_fetch`, `web_search` | when `TSFORGE_WEB=1` (free, local — no API key) |
 | Control | `yield_status` | end turn with a summary |

--- a/apps/docs/src/content/docs/cli/interactive.mdx
+++ b/apps/docs/src/content/docs/cli/interactive.mdx
@@ -41,6 +41,8 @@ Model endpoint overrides: `TSFORGE_BASE_URL`, `TSFORGE_MODEL` — see [Environme
 | `/plan` | toggle plan mode |
 | `/gate <cmd>` | set gate command (`/gate` alone clears) |
 | `/files <globs>` | set editable scope |
+| `/review [base]` | review your current change (logic, regressions, edge cases) |
+| `/map [status\|forget]` | build a structural map of the repo to prime the agent |
 | `/model [name]` | list models or switch active model |
 | `/sessions` | list saved sessions |
 | `/compact` | summarize conversation to free context |

--- a/apps/docs/src/content/docs/cli/map.mdx
+++ b/apps/docs/src/content/docs/cli/map.mdx
@@ -1,0 +1,34 @@
+---
+title: Map the repo
+description: "tsforge map — build a structural map of your TypeScript repo so the agent starts oriented instead of exploring blind."
+---
+
+When the agent opens an unfamiliar repo, its first instinct is to read files until it finds the relevant code — burning turns. `tsforge map` gives it a head start: a **structural map** of the codebase, injected into its context so it knows where things live before it starts.
+
+```bash
+tsforge map            # build the map
+tsforge map status     # when it was built, files/hubs, how much has drifted
+tsforge map forget     # delete it
+```
+
+Inside a session, the same build is available as **`/map`**.
+
+## What it builds
+
+All from the TypeScript compiler — no AI guessing, no extra dependencies:
+
+- the **directory shape** and entry points,
+- each module's **exports**,
+- the **hub modules** — the ones most other files import (your repo's load-bearing code), ranked by how many modules depend on them.
+
+It's saved under `.tsforge/workspace-map.json` (git-ignored — it's machine-specific).
+
+## How the agent uses it
+
+The map is a **snapshot**, serialized into a compact block and added to the agent's prompt at the **start of a session**. So the flow is: run `tsforge map` once, then start working — the agent is already oriented. (`/clear` re-applies it mid-session.)
+
+It's a starting orientation, not live truth: as you edit, the agent uses live navigation (`search`, the language server) for current detail, and the map block carries a freshness note telling it how many files have changed since it was built.
+
+No map, no change — it's purely additive, and only useful on existing repos (greenfield builds have nothing to map yet).
+
+→ [Commands](/reference/commands/) · [Review your changes](/cli/review/)

--- a/apps/docs/src/content/docs/cli/map.mdx
+++ b/apps/docs/src/content/docs/cli/map.mdx
@@ -3,7 +3,7 @@ title: Map the repo
 description: "tsforge map — build a structural map of your TypeScript repo so the agent starts oriented instead of exploring blind."
 ---
 
-When the agent opens an unfamiliar repo, its first instinct is to read files until it finds the relevant code — burning turns. `tsforge map` gives it a head start: a **structural map** of the codebase, injected into its context so it knows where things live before it starts.
+When the agent opens an unfamiliar repo, its first instinct is to read files until it finds the relevant code, which burns turns. `tsforge map` gives it a head start: a structural map of the codebase, added to its context so it knows where things live before it starts.
 
 ```bash
 tsforge map            # build the map
@@ -11,24 +11,24 @@ tsforge map status     # when it was built, files/hubs, how much has drifted
 tsforge map forget     # delete it
 ```
 
-Inside a session, the same build is available as **`/map`**.
+Inside a session, the same build is available as `/map`.
 
 ## What it builds
 
-All from the TypeScript compiler — no AI guessing, no extra dependencies:
+All from the TypeScript compiler, with no AI guessing and no extra dependencies:
 
-- the **directory shape** and entry points,
-- each module's **exports**,
-- the **hub modules** — the ones most other files import (your repo's load-bearing code), ranked by how many modules depend on them.
+- the directory shape and entry points,
+- each module's exports,
+- the **hub modules**, the ones most other files import (your repo's load-bearing code), ranked by how many modules depend on them.
 
-It's saved under `.tsforge/workspace-map.json` (git-ignored — it's machine-specific).
+It's saved under `.tsforge/workspace-map.json` (git-ignored, since it's machine-specific).
 
 ## How the agent uses it
 
-The map is a **snapshot**, serialized into a compact block and added to the agent's prompt at the **start of a session**. So the flow is: run `tsforge map` once, then start working — the agent is already oriented. (`/clear` re-applies it mid-session.)
+The map is a snapshot. It's serialized into a compact block and added to the agent's prompt at the start of a session. So the flow is: run `tsforge map` once, then start working, and the agent is already oriented. (`/clear` re-applies it mid-session.)
 
-It's a starting orientation, not live truth: as you edit, the agent uses live navigation (`search`, the language server) for current detail, and the map block carries a freshness note telling it how many files have changed since it was built.
+It's a starting orientation, not live truth. As you edit, the agent uses live navigation (`search`, the language server) for current detail, and the map block carries a freshness note telling it how many files have changed since it was built.
 
-No map, no change — it's purely additive, and only useful on existing repos (greenfield builds have nothing to map yet).
+No map, no change. It's purely additive, and it only helps on existing repos, since greenfield builds have nothing to map yet.
 
 → [Commands](/reference/commands/) · [Review your changes](/cli/review/)

--- a/apps/docs/src/content/docs/cli/review.mdx
+++ b/apps/docs/src/content/docs/cli/review.mdx
@@ -3,7 +3,7 @@ title: Review your changes
 description: "tsforge review — a functional code review of the change you're on (logic, regressions, edge cases), with every finding re-checked against the code so it doesn't invent problems."
 ---
 
-`tsforge review` reviews the change you're working on and prints a focused list of **functional** problems — the things a linter can't catch.
+`tsforge review` reviews the change you're working on and prints a focused list of **functional** problems, the things a linter can't catch.
 
 ```bash
 tsforge review                 # review the current diff
@@ -11,29 +11,29 @@ tsforge review --staged        # only staged changes (pre-commit)
 tsforge review --base develop   # diff against a specific ref
 ```
 
-Inside a session, the same review is available as **`/review`**.
+Inside a session, the same review is available as `/review`.
 
 ## What it reviews
 
-It looks at **what you changed** (working tree + uncommitted edits, vs the auto-detected base branch — no commit or push required) through a built-in **senior-reviewer rubric**:
+It looks at what you changed (working tree plus uncommitted edits, against the auto-detected base branch, no commit or push required) through a built-in senior-reviewer rubric:
 
-- **Correctness** — inverted conditions, wrong operators, off-by-one.
-- **Regressions** — a signature/return/contract change that breaks existing callers.
-- **Edge cases** — null/empty/boundary inputs, unhandled errors, missing `await`.
-- **Business logic** — money rounding, auth gating, invalid state transitions.
-- **Data & concurrency** — races, partial writes.
-- **API & contracts** — breaking a response shape or a serialized format.
+- **Correctness**: inverted conditions, wrong operators, off-by-one.
+- **Regressions**: a signature, return, or contract change that breaks existing callers.
+- **Edge cases**: null/empty/boundary inputs, unhandled errors, a missing `await`.
+- **Business logic**: money rounding, auth gating, invalid state transitions.
+- **Data and concurrency**: races, partial writes.
+- **API and contracts**: breaking a response shape or a serialized format.
 
-Types, structure, and style are **out of scope** — [the gate](/loop/gate-floor/) already enforces those. Review is for judgment, not lint.
+Types, structure, and style are out of scope. [The gate](/loop/gate-floor/) already enforces those. Review is for judgment, not lint.
 
 ## Why the findings are trustworthy
 
-The usual failure of AI review is confident nonsense. tsforge runs an **adversarial verification pass**: every candidate finding is re-checked against the actual code, and anything the code doesn't confirm — or that can't cite a real line — is dropped. You get a short list of real issues instead of a wall of maybes.
+The usual failure of AI review is confident nonsense. tsforge runs an adversarial verification pass: every candidate finding is re-checked against the actual code, and anything the code doesn't confirm, or that can't cite a real line, gets dropped. You get a short list of real issues instead of a wall of maybes.
 
-When a `tsconfig.json` is present, it also feeds the reviewer the **callers of each changed export** (computed from the type graph), so the regression check looks at concrete call sites instead of guessing.
+When a `tsconfig.json` is present, it also feeds the reviewer the callers of each changed export, computed from the type graph, so the regression check looks at concrete call sites instead of guessing.
 
 ## In CI
 
-`tsforge review` exits non-zero if any **error**-severity finding survives, so you can gate a PR on it. It relies on `git`; disable the underlying tool with `TSFORGE_NO_GIT_TOOL=1`.
+`tsforge review` exits non-zero if any error-severity finding survives, so you can gate a PR on it. It uses `git` to find what changed, so run it inside a git repository.
 
 → [Commands](/reference/commands/) · [Map the repo](/cli/map/)

--- a/apps/docs/src/content/docs/cli/review.mdx
+++ b/apps/docs/src/content/docs/cli/review.mdx
@@ -1,0 +1,39 @@
+---
+title: Review your changes
+description: "tsforge review — a functional code review of the change you're on (logic, regressions, edge cases), with every finding re-checked against the code so it doesn't invent problems."
+---
+
+`tsforge review` reviews the change you're working on and prints a focused list of **functional** problems — the things a linter can't catch.
+
+```bash
+tsforge review                 # review the current diff
+tsforge review --staged        # only staged changes (pre-commit)
+tsforge review --base develop   # diff against a specific ref
+```
+
+Inside a session, the same review is available as **`/review`**.
+
+## What it reviews
+
+It looks at **what you changed** (working tree + uncommitted edits, vs the auto-detected base branch — no commit or push required) through a built-in **senior-reviewer rubric**:
+
+- **Correctness** — inverted conditions, wrong operators, off-by-one.
+- **Regressions** — a signature/return/contract change that breaks existing callers.
+- **Edge cases** — null/empty/boundary inputs, unhandled errors, missing `await`.
+- **Business logic** — money rounding, auth gating, invalid state transitions.
+- **Data & concurrency** — races, partial writes.
+- **API & contracts** — breaking a response shape or a serialized format.
+
+Types, structure, and style are **out of scope** — [the gate](/loop/gate-floor/) already enforces those. Review is for judgment, not lint.
+
+## Why the findings are trustworthy
+
+The usual failure of AI review is confident nonsense. tsforge runs an **adversarial verification pass**: every candidate finding is re-checked against the actual code, and anything the code doesn't confirm — or that can't cite a real line — is dropped. You get a short list of real issues instead of a wall of maybes.
+
+When a `tsconfig.json` is present, it also feeds the reviewer the **callers of each changed export** (computed from the type graph), so the regression check looks at concrete call sites instead of guessing.
+
+## In CI
+
+`tsforge review` exits non-zero if any **error**-severity finding survives, so you can gate a PR on it. It relies on `git`; disable the underlying tool with `TSFORGE_NO_GIT_TOOL=1`.
+
+→ [Commands](/reference/commands/) · [Map the repo](/cli/map/)

--- a/apps/docs/src/content/docs/guardrails/meta-rules.mdx
+++ b/apps/docs/src/content/docs/guardrails/meta-rules.mdx
@@ -66,7 +66,7 @@ Both scan every hand-written `.ts`/`.tsx` under `src/`, `tests/`, and `scripts/`
 
 | ID | Checks |
 | --- | --- |
-| `test-sibling-required` | colocated `*.test.ts` for service modules |
+| `test-sibling-required` | a logic file (one exporting a function/class) the agent changes has a test — co-located `*.test.ts` or mirrored under `tests/`. **Error** when [TDD mode](/reference/flags/) is on (the default), warn when off. Scoped to changed files, so it never blocks on pre-existing untested code. |
 
 ### CI
 

--- a/apps/docs/src/content/docs/index.mdx
+++ b/apps/docs/src/content/docs/index.mdx
@@ -1,16 +1,73 @@
 ---
 title: tsforge
-description: "Ship full-stack TypeScript. tsforge loops until your acceptance check passes."
+description: "The TypeScript-native AI coding harness. A gate you can't fake, tests by default, and guardrails that know your stack — so the code it ships actually compiles, passes, and fits your repo."
 template: splash
 hero:
-  tagline: Point it at your repo. Keeps building until the gate passes.
+  tagline: "The AI coding harness built for TypeScript. It doesn't stop at \"looks done\" — it stops when a real check passes."
+  actions:
+    - text: Get started
+      link: /quickstart/
+      icon: right-arrow
+      variant: primary
+    - text: How it works
+      link: /big-picture/
+      icon: open-book
+    - text: GitHub
+      link: https://github.com/agjs/tsforge
+      icon: external
 head:
   - tag: meta
     attrs:
       property: og:title
-      content: "tsforge — TypeScript-specialized AI harness"
+      content: "tsforge — the TypeScript-native AI coding harness"
   - tag: meta
     attrs:
       name: twitter:title
-      content: "tsforge — TypeScript-specialized AI harness"
+      content: "tsforge — the TypeScript-native AI coding harness"
 ---
+
+Point it at a TypeScript repo and talk to it. It reads, edits, and runs your code — and keeps working until a **real check passes**, not until the model says it's finished.
+
+```bash
+curl -fsSL https://tsforge.dev/install.sh | bash
+tsforge            # start in the current repo
+```
+
+## Why tsforge
+
+Most AI coding tools write plausible TypeScript and stop. They skip types, paste `as any`, ignore your stack's conventions, and declare victory before anything is verified. tsforge is built the opposite way — around **machine-checkable truth**.
+
+#### A gate you can't fake
+
+"Done" means a shell command exited 0 — `tsc --strict`, ESLint on tsforge's own strict config, your tests. The model sees the exact errors and fixes them, turn after turn, until it's genuinely green. It can't talk its way past a type error.
+
+#### Tests by default
+
+Out of the box, a logic file the agent writes without a test **fails the gate** — scoped to what it touches, so it never blocks on your repo's legacy code. Quality and strictness are the default, not a flag you have to remember.
+
+#### It knows your stack
+
+tsforge reads your `package.json`, detects React / Next / Drizzle / Fastify / Elysia and more, and enforces the right rules automatically — server/client boundaries, query shapes, auth patterns. No lint config to wire up.
+
+#### Built for your real repo, not just demos
+
+`tsforge review` gives a functional code review of your current change — logic, regressions, edge cases — with every finding re-checked against the code so it doesn't invent problems. `tsforge map` primes the agent with your repo's structure so it stops exploring blind. It works *with* existing code.
+
+#### Runs the model you want
+
+Any OpenAI-compatible endpoint — a hosted API or a local server. It's tuned so even small local models produce TypeScript you'd actually merge; bigger models just need fewer retries.
+
+## Try it in two minutes
+
+```bash
+# chat with your repo
+tsforge
+
+# drive a change until your check passes, then exit
+tsforge "add input validation to the signup route" --accept "bun test"
+
+# review what you've changed
+tsforge review
+```
+
+→ **[Quickstart](/quickstart/)** to install and point it at a model · **[How it works](/big-picture/)** for the loop and the gate · **[Everyday use](/cli/interactive/)** for the day-to-day workflow.

--- a/apps/docs/src/content/docs/index.mdx
+++ b/apps/docs/src/content/docs/index.mdx
@@ -1,73 +1,16 @@
 ---
 title: tsforge
-description: "The TypeScript-native AI coding harness. A gate you can't fake, tests by default, and guardrails that know your stack — so the code it ships actually compiles, passes, and fits your repo."
+description: "Ship full-stack TypeScript. tsforge loops until your acceptance check passes."
 template: splash
 hero:
-  tagline: "The AI coding harness built for TypeScript. It doesn't stop at \"looks done\" — it stops when a real check passes."
-  actions:
-    - text: Get started
-      link: /quickstart/
-      icon: right-arrow
-      variant: primary
-    - text: How it works
-      link: /big-picture/
-      icon: open-book
-    - text: GitHub
-      link: https://github.com/agjs/tsforge
-      icon: external
+  tagline: Point it at your repo. Keeps building until the gate passes.
 head:
   - tag: meta
     attrs:
       property: og:title
-      content: "tsforge — the TypeScript-native AI coding harness"
+      content: "tsforge — TypeScript-specialized AI harness"
   - tag: meta
     attrs:
       name: twitter:title
-      content: "tsforge — the TypeScript-native AI coding harness"
+      content: "tsforge — TypeScript-specialized AI harness"
 ---
-
-Point it at a TypeScript repo and talk to it. It reads, edits, and runs your code — and keeps working until a **real check passes**, not until the model says it's finished.
-
-```bash
-curl -fsSL https://tsforge.dev/install.sh | bash
-tsforge            # start in the current repo
-```
-
-## Why tsforge
-
-Most AI coding tools write plausible TypeScript and stop. They skip types, paste `as any`, ignore your stack's conventions, and declare victory before anything is verified. tsforge is built the opposite way — around **machine-checkable truth**.
-
-#### A gate you can't fake
-
-"Done" means a shell command exited 0 — `tsc --strict`, ESLint on tsforge's own strict config, your tests. The model sees the exact errors and fixes them, turn after turn, until it's genuinely green. It can't talk its way past a type error.
-
-#### Tests by default
-
-Out of the box, a logic file the agent writes without a test **fails the gate** — scoped to what it touches, so it never blocks on your repo's legacy code. Quality and strictness are the default, not a flag you have to remember.
-
-#### It knows your stack
-
-tsforge reads your `package.json`, detects React / Next / Drizzle / Fastify / Elysia and more, and enforces the right rules automatically — server/client boundaries, query shapes, auth patterns. No lint config to wire up.
-
-#### Built for your real repo, not just demos
-
-`tsforge review` gives a functional code review of your current change — logic, regressions, edge cases — with every finding re-checked against the code so it doesn't invent problems. `tsforge map` primes the agent with your repo's structure so it stops exploring blind. It works *with* existing code.
-
-#### Runs the model you want
-
-Any OpenAI-compatible endpoint — a hosted API or a local server. It's tuned so even small local models produce TypeScript you'd actually merge; bigger models just need fewer retries.
-
-## Try it in two minutes
-
-```bash
-# chat with your repo
-tsforge
-
-# drive a change until your check passes, then exit
-tsforge "add input validation to the signup route" --accept "bun test"
-
-# review what you've changed
-tsforge review
-```
-
-→ **[Quickstart](/quickstart/)** to install and point it at a model · **[How it works](/big-picture/)** for the loop and the gate · **[Everyday use](/cli/interactive/)** for the day-to-day workflow.

--- a/apps/docs/src/content/docs/quality/tests.mdx
+++ b/apps/docs/src/content/docs/quality/tests.mdx
@@ -3,28 +3,23 @@ title: Tests by default
 description: "tsforge enforces tests out of the box — a logic file the agent writes without a test fails the gate, scoped to what it changes so it never blocks on your repo's legacy code."
 ---
 
-Most AI tools will happily write a function and move on. tsforge won't: **out of the box, a logic file the agent changes without a test fails the gate.** Quality and strictness are the default, not a flag you have to remember.
+Most AI tools will happily write a function and move on. tsforge won't. Out of the box, a logic file the agent changes without a test **fails the gate**. Quality and strictness are the default, not a flag you have to remember.
 
 ## What triggers it
 
-When the agent creates or edits a file that **exports a function or class** and there's no test for it, the gate fails with a clear message — the same way a type error fails it. The agent then writes the test and continues until it's genuinely green.
+When the agent creates or edits a file that exports a function or class and there's no test for it, the gate fails with a clear message, the same way a type error fails it. The agent then writes the test and continues until it's green.
 
-A test counts if it's either:
-
-- **co-located** — `total.test.ts` next to `total.ts`, or
-- **mirrored** — `tests/total.test.ts` alongside `src/total.ts`.
-
-Type-only modules (`*.types.ts`), barrels (`index.ts`), and declaration files are exempt — they have no logic to test.
+A test counts if it's either co-located (`total.test.ts` next to `total.ts`) or mirrored (`tests/total.test.ts` alongside `src/total.ts`). The co-located form works in any layout; the mirrored form assumes a top-level `src/` ↔ `tests/` convention. Type-only modules (`*.types.ts`), barrels (`index.ts`), and declaration files are exempt, since they have no logic to test.
 
 ## It won't block on your legacy code
 
-This is the important part: enforcement is **scoped to the files the agent touches this session** (computed from `git`). It holds the agent to testing the code it writes — it does **not** fail because some pre-existing file in your repo lacks a test. Open a repo with thousands of untested files and nothing happens until the agent changes one.
+This is the important part. Enforcement is scoped to the files the agent touches this session, computed from `git`. It holds the agent to testing the code it writes. It does not fail because some pre-existing file in your repo lacks a test. Open a repo with thousands of untested files and nothing happens until the agent changes one.
 
 In a non-git directory there's no change signal, so enforcement is a no-op.
 
 ## Test-first guidance
 
-Alongside the gate rule, the agent is told to work **test-first**: write the failing test, watch it fail for the right reason, then implement until it passes. The gate makes that the floor; the guidance makes it the habit.
+Alongside the gate rule, the agent is told to work test-first: write the failing test, watch it fail for the right reason, then implement until it passes. The gate makes that the floor; the guidance makes it the habit.
 
 ## Opting out
 
@@ -34,6 +29,6 @@ It's on by default. To turn it off for a run, set:
 TSFORGE_TDD=0
 ```
 
-The test requirement drops back to a non-blocking nudge. Most projects should leave it on — it's the cheapest way to keep an agent honest.
+The test requirement drops back to a non-blocking nudge. Most projects should leave it on. It's the cheapest way to keep an agent honest.
 
 → [The gate](/loop/gate-floor/) · [When the gate fails](/loop/validation/) · [Environment variables](/reference/flags/)

--- a/apps/docs/src/content/docs/quality/tests.mdx
+++ b/apps/docs/src/content/docs/quality/tests.mdx
@@ -1,0 +1,39 @@
+---
+title: Tests by default
+description: "tsforge enforces tests out of the box — a logic file the agent writes without a test fails the gate, scoped to what it changes so it never blocks on your repo's legacy code."
+---
+
+Most AI tools will happily write a function and move on. tsforge won't: **out of the box, a logic file the agent changes without a test fails the gate.** Quality and strictness are the default, not a flag you have to remember.
+
+## What triggers it
+
+When the agent creates or edits a file that **exports a function or class** and there's no test for it, the gate fails with a clear message — the same way a type error fails it. The agent then writes the test and continues until it's genuinely green.
+
+A test counts if it's either:
+
+- **co-located** — `total.test.ts` next to `total.ts`, or
+- **mirrored** — `tests/total.test.ts` alongside `src/total.ts`.
+
+Type-only modules (`*.types.ts`), barrels (`index.ts`), and declaration files are exempt — they have no logic to test.
+
+## It won't block on your legacy code
+
+This is the important part: enforcement is **scoped to the files the agent touches this session** (computed from `git`). It holds the agent to testing the code it writes — it does **not** fail because some pre-existing file in your repo lacks a test. Open a repo with thousands of untested files and nothing happens until the agent changes one.
+
+In a non-git directory there's no change signal, so enforcement is a no-op.
+
+## Test-first guidance
+
+Alongside the gate rule, the agent is told to work **test-first**: write the failing test, watch it fail for the right reason, then implement until it passes. The gate makes that the floor; the guidance makes it the habit.
+
+## Opting out
+
+It's on by default. To turn it off for a run, set:
+
+```bash
+TSFORGE_TDD=0
+```
+
+The test requirement drops back to a non-blocking nudge. Most projects should leave it on — it's the cheapest way to keep an agent honest.
+
+→ [The gate](/loop/gate-floor/) · [When the gate fails](/loop/validation/) · [Environment variables](/reference/flags/)

--- a/apps/docs/src/content/docs/workflows/fix-to-green.mdx
+++ b/apps/docs/src/content/docs/workflows/fix-to-green.mdx
@@ -1,30 +1,30 @@
 ---
 title: Drive a change to green
-description: "Give tsforge a task and a check, and it works until the check passes — then exits. The one-shot, CI-friendly way to use the harness."
+description: "Give tsforge a task and a check, and it works until the check passes, then exits. The one-shot, CI-friendly way to use the harness."
 ---
 
-The interactive REPL is great for exploring. When you know exactly what "done" looks like, hand tsforge a task **and a check**, and it drives the change until the check passes — then exits.
+The interactive REPL is great for exploring. When you already know what "done" looks like, hand tsforge a task and a check, and it drives the change until the check passes, then exits.
 
 ```bash
 tsforge "add input validation to the signup route" --accept "bun test"
 ```
 
-`--accept` is any shell command. tsforge runs the model, applies edits, runs the check, feeds the failures back, and repeats — until the command exits 0 or it stops making progress. The exit code is the check's, so it drops straight into scripts and CI.
+`--accept` is any shell command. tsforge runs the model, applies edits, runs the check, feeds the failures back, and repeats until the command exits 0 or it stops making progress. The exit code is the check's, so it drops straight into scripts and CI.
 
 ## Why this is the safe way to delegate
 
-The check is the contract. The model doesn't decide it's finished — **your command does**. With `--accept "bun test"`, "done" means your tests actually pass. With `--accept "tsc --noEmit && bun test"`, it means types *and* tests pass. tsforge layers its own [strict gate](/loop/gate-floor/) (strict `tsc` + ESLint + [tests-by-default](/quality/tests/)) underneath, so green can't be faked — it's not "the model says so," it's "the compiler, the linter, and your tests all agree."
+The check is the contract. The model doesn't decide it's finished; your command does. With `--accept "bun test"`, "done" means your tests pass. With `--accept "tsc --noEmit && bun test"`, it means types and tests pass. Underneath, tsforge layers its own [strict gate](/loop/gate-floor/) (strict `tsc`, ESLint, and [tests by default](/quality/tests/)), so green reflects the compiler, the linter, and your tests all agreeing, not the model's say-so.
 
 ## Choosing a good check
 
 | Goal | `--accept` |
 | --- | --- |
 | Make the suite pass | `bun test` |
-| Types + tests | `tsc --noEmit && bun test` |
+| Types and tests | `tsc --noEmit && bun test` |
 | One file's tests (fast loop) | `bun test src/auth.test.ts` |
 | Lint clean too | `bun test && bun run lint` |
 
-If it can't get there, it stops with a clear status instead of churning forever — see [When the gate fails](/loop/validation/).
+If it can't get there, it stops with a clear status instead of churning forever. See [When the gate fails](/loop/validation/).
 
 ## Scoping the edits
 
@@ -34,6 +34,6 @@ By default the whole repo is editable. To fence the agent in, narrow it:
 tsforge "refactor the parser" --files "src/parser/**" --accept "bun test"
 ```
 
-Anything outside `--files` is read-only — a tripwire, not a requirement.
+Anything outside `--files` is read-only, a tripwire rather than a requirement.
 
 → [Chat with your repo](/cli/interactive/) · [The gate](/loop/gate-floor/) · [Review your changes](/cli/review/)

--- a/apps/docs/src/content/docs/workflows/fix-to-green.mdx
+++ b/apps/docs/src/content/docs/workflows/fix-to-green.mdx
@@ -1,0 +1,39 @@
+---
+title: Drive a change to green
+description: "Give tsforge a task and a check, and it works until the check passes — then exits. The one-shot, CI-friendly way to use the harness."
+---
+
+The interactive REPL is great for exploring. When you know exactly what "done" looks like, hand tsforge a task **and a check**, and it drives the change until the check passes — then exits.
+
+```bash
+tsforge "add input validation to the signup route" --accept "bun test"
+```
+
+`--accept` is any shell command. tsforge runs the model, applies edits, runs the check, feeds the failures back, and repeats — until the command exits 0 or it stops making progress. The exit code is the check's, so it drops straight into scripts and CI.
+
+## Why this is the safe way to delegate
+
+The check is the contract. The model doesn't decide it's finished — **your command does**. With `--accept "bun test"`, "done" means your tests actually pass. With `--accept "tsc --noEmit && bun test"`, it means types *and* tests pass. tsforge layers its own [strict gate](/loop/gate-floor/) (strict `tsc` + ESLint + [tests-by-default](/quality/tests/)) underneath, so green can't be faked — it's not "the model says so," it's "the compiler, the linter, and your tests all agree."
+
+## Choosing a good check
+
+| Goal | `--accept` |
+| --- | --- |
+| Make the suite pass | `bun test` |
+| Types + tests | `tsc --noEmit && bun test` |
+| One file's tests (fast loop) | `bun test src/auth.test.ts` |
+| Lint clean too | `bun test && bun run lint` |
+
+If it can't get there, it stops with a clear status instead of churning forever — see [When the gate fails](/loop/validation/).
+
+## Scoping the edits
+
+By default the whole repo is editable. To fence the agent in, narrow it:
+
+```bash
+tsforge "refactor the parser" --files "src/parser/**" --accept "bun test"
+```
+
+Anything outside `--files` is read-only — a tripwire, not a requirement.
+
+→ [Chat with your repo](/cli/interactive/) · [The gate](/loop/gate-floor/) · [Review your changes](/cli/review/)


### PR DESCRIPTION
## Why

The docs were in a rough state: the landing didn't sell what tsforge is, and the sidebar mixed niche internals (spec loop, eval/sweeps, repair-ladder, TTSR) right alongside everyday usage — so a new user couldn't find the path that matters.

## What changed (Phase 1 — structure + pitch)

- **Landing** is now an actual pitch: *a gate you can't fake · tests by default · stack-aware guardrails · brownfield tools (review/map) · runs any model*, with copy-paste try-it commands and CTAs.
- **Sidebar IA** reordered around the user journey: **Get started → Everyday use → Quality & strictness → Configure → Reference**, with all the mechanics demoted to a collapsed **Under the hood** group and eval/spec to **For contributors**.
- **New everyday-workflow pages** (previously buried in `commands` or undocumented):
  - `cli/review` — review your changes
  - `cli/map` — map the repo
  - `quality/tests` — tests by default (the TDD-on-by-default story)
  - `workflows/fix-to-green` — the `--accept` one-shot workflow

Docs build green (37 pages). Prose will get an `avoid-ai-writing` cleanup pass next.

## Not in this pass (possible follow-ups)
Rewriting `big-picture` into a tighter "How it works", refreshing `quickstart`/`interactive`, and pointing `commands.mdx` at the new dedicated pages.