### PR TITLE
fix(harness): address codebase review findings (P1 gate integrity + P2 correctness)

### DIFF
--- a/apps/docs/src/content/docs/loop/gate-floor.mdx
+++ b/apps/docs/src/content/docs/loop/gate-floor.mdx
@@ -70,10 +70,12 @@ Why separate? tsforge ships rules tuned for AI-written code and your stack (Reac
 
 The core ESLint config is **syntactic-only** (no type-aware rules) so it runs on any `.ts` file without the target's full type graph. It also caps **cognitive complexity at 20** and **nesting depth at 4** — a sprawling, deeply-nested function fails the gate until it is split into named helpers.
 
-Whenever the project has a `tsconfig.json`, tsforge adds a **type-aware pass** that catches what `tsc --strict` and the syntactic rules can't:
+On the **strict** [profile](/guardrails/config/#profiles) — any project with a `tsconfig.json` — tsforge adds a **type-aware pass** that catches what `tsc --strict` and the syntactic rules can't:
 
 - **Async correctness** — `no-floating-promises`, `no-misused-promises`: a dropped `await` is a gate error.
-- **Implicit-`any` containment** — the `no-unsafe-*` family. `no-explicit-any` bans the literal `any` token, but it cannot see `any` that leaks in from an untyped boundary (`JSON.parse`, `await res.json()`, an untyped dependency), which `tsc` propagates silently. These rules force you to validate the boundary, then the data is typed. Web-app gates run this pass too.
+- **Implicit-`any` containment** — the `no-unsafe-*` family. `no-explicit-any` bans the literal `any` token, but it cannot see `any` that leaks in from an untyped boundary (`JSON.parse`, `await res.json()`, an untyped dependency), which `tsc` propagates silently. These rules force you to validate the boundary, then the data is typed.
+
+The default `recommended` profile keeps the gate syntactic-only — faster, and these type-aware rules can be noisy on existing code. Set `"profile": "strict"` in [tsforge.config.json](/guardrails/config/) to turn the pass on. Web-app gates run it regardless of profile.
 
 Baseline stylistic rules (all stacks) include blank lines before `return` and around block-like statements via `@stylistic/padding-line-between-statements`. That rule is **auto-fixed by `eslint --fix`**, not Prettier — Prettier does not enforce semantic blank lines. Non-web sessions run the same eslint + prettier janitor (`buildCoreFix`) before the gate, so the blank line is inserted without model turns.
 

--- a/packages/core/src/cli.ts
+++ b/packages/core/src/cli.ts
@@ -1311,6 +1311,9 @@ async function repl(args: ICliArgs): Promise<number> {
 
         activeName = result.activeName;
         contextWindow = result.contextWindow;
+        // Keep auto-compaction in sync with the new model's window — not just the
+        // status bar. Otherwise a swap to a smaller model compacts too late.
+        session.setContextWindow(contextWindow);
         break;
       }
 

--- a/packages/core/src/detect-gate.ts
+++ b/packages/core/src/detect-gate.ts
@@ -438,13 +438,21 @@ export const WEB_PACKS: readonly string[] = [
   "tanstack-query",
 ];
 
+/** POSIX-safe single-quote a value for interpolation into a `sh -c` command:
+ *  wrap in single quotes and rewrite each embedded `'` as `'\''` (close quote,
+ *  escaped quote, reopen). Single quoting is required because the value is a JSON
+ *  blob — left unquoted, the shell strips its double quotes (`{"a":"off"}` →
+ *  `{a:off}`), which fails `JSON.parse` in the config and is silently ignored, so
+ *  rule overrides never reached eslint. Escaping the embedded quote is required
+ *  because a pack id or rule key can carry a `'` (e.g. from a malicious
+ *  tsforge.config.json in an untrusted repo) — naive single-quoting would let it
+ *  break out and inject shell commands. */
+function shSingleQuote(value: string): string {
+  return `'${value.replaceAll("'", "'\\''")}'`;
+}
+
 /** Build the `KEY='val' ` shell prefix that hands packs (+ rule overrides) to a
- *  bundled eslint config, which reads them from the environment at load time.
- *  The whole command runs through `sh -c`, so the JSON value MUST be single-
- *  quoted: an unquoted `{"a":"off"}` has its double quotes stripped by the shell
- *  to `{a:off}`, which fails `JSON.parse` in the config and is then silently
- *  ignored — so rule overrides never reached eslint. JSON.stringify never emits
- *  a single quote, so single-quoting the value is lossless. */
+ *  bundled eslint config, which reads them from the environment at load time. */
 function packEnvPrefix(
   packs?: readonly string[],
   ruleOverrides?: Readonly<Record<string, "error" | "warn" | "off">>
@@ -452,11 +460,13 @@ function packEnvPrefix(
   const envParts: string[] = [];
 
   if (packs !== undefined && packs.length > 0) {
-    envParts.push(`TSFORGE_PACKS='${packs.join(",")}'`);
+    envParts.push(`TSFORGE_PACKS=${shSingleQuote(packs.join(","))}`);
   }
 
   if (ruleOverrides !== undefined && Object.keys(ruleOverrides).length > 0) {
-    envParts.push(`TSFORGE_RULE_OVERRIDES='${JSON.stringify(ruleOverrides)}'`);
+    envParts.push(
+      `TSFORGE_RULE_OVERRIDES=${shSingleQuote(JSON.stringify(ruleOverrides))}`
+    );
   }
 
   return envParts.length > 0 ? `${envParts.join(" ")} ` : "";

--- a/packages/core/src/detect-gate.ts
+++ b/packages/core/src/detect-gate.ts
@@ -438,9 +438,13 @@ export const WEB_PACKS: readonly string[] = [
   "tanstack-query",
 ];
 
-/** Build the `KEY=val ` shell prefix that hands packs (+ rule overrides) to a
+/** Build the `KEY='val' ` shell prefix that hands packs (+ rule overrides) to a
  *  bundled eslint config, which reads them from the environment at load time.
- *  JSON.stringify emits no spaces, so this survives a later whitespace-collapse. */
+ *  The whole command runs through `sh -c`, so the JSON value MUST be single-
+ *  quoted: an unquoted `{"a":"off"}` has its double quotes stripped by the shell
+ *  to `{a:off}`, which fails `JSON.parse` in the config and is then silently
+ *  ignored — so rule overrides never reached eslint. JSON.stringify never emits
+ *  a single quote, so single-quoting the value is lossless. */
 function packEnvPrefix(
   packs?: readonly string[],
   ruleOverrides?: Readonly<Record<string, "error" | "warn" | "off">>
@@ -448,11 +452,11 @@ function packEnvPrefix(
   const envParts: string[] = [];
 
   if (packs !== undefined && packs.length > 0) {
-    envParts.push(`TSFORGE_PACKS=${packs.join(",")}`);
+    envParts.push(`TSFORGE_PACKS='${packs.join(",")}'`);
   }
 
   if (ruleOverrides !== undefined && Object.keys(ruleOverrides).length > 0) {
-    envParts.push(`TSFORGE_RULE_OVERRIDES=${JSON.stringify(ruleOverrides)}`);
+    envParts.push(`TSFORGE_RULE_OVERRIDES='${JSON.stringify(ruleOverrides)}'`);
   }
 
   return envParts.length > 0 ? `${envParts.join(" ")} ` : "";

--- a/packages/core/src/loop/session.ts
+++ b/packages/core/src/loop/session.ts
@@ -668,6 +668,14 @@ export class Session {
     this.ctx.task.files = globs;
   }
 
+  /** Update the context window mid-session (e.g. after a `/model` hot-swap to a
+   *  model with a different window). Without this, `autoCompactPct()` keeps using
+   *  the original window, so switching to a SMALLER model would compact too late
+   *  and overflow it — even though the status bar already shows the new size. */
+  setContextWindow(window: number): void {
+    this.cfg.contextWindow = window;
+  }
+
   /** Wire the web-setup callback the `scaffold_web` tool invokes when the AGENT
    *  decides the task is a from-scratch web app — scaffolds the stack and flips
    *  this session to the web gate/guidance. Late-bound (after create) because the

--- a/packages/core/src/loop/turn.ts
+++ b/packages/core/src/loop/turn.ts
@@ -528,11 +528,14 @@ export async function runToolCalls(
       feedback = await runWriteGuard(ctx, wrote.path);
     }
 
-    // A semantic write (rename/organize_imports) is scope-enforced internally and
-    // mutates on success — re-gate to confirm. (These don't feed state.edits.)
+    // A semantic write (rename/organize_imports/move_file) is scope-enforced
+    // internally and mutates on success — re-gate to confirm. move_file relocates
+    // a file AND rewrites every importer, so omitting it let a move end as
+    // "responded" without the gate ever running. (These don't feed state.edits.)
     if (
       call.name === TOOL_NAME.renameSymbol ||
-      call.name === TOOL_NAME.organizeImports
+      call.name === TOOL_NAME.organizeImports ||
+      call.name === TOOL_NAME.moveFile
     ) {
       touchedEditable = true;
     }

--- a/packages/core/tests/gate-packs.test.ts
+++ b/packages/core/tests/gate-packs.test.ts
@@ -212,6 +212,31 @@ describe("rule overrides take effect through the shell (P1b)", () => {
 
     expect(ruleIds).toContain("tsforge/timestamp-must-specify-mode");
   }, 30_000);
+
+  // P1b (security): single-quoting the JSON is not enough on its own — a `'` in an
+  // override key (e.g. from a malicious tsforge.config.json) must be escaped, or it
+  // breaks out of the quoting and injects shell commands run by `sh -c`.
+  test("a single quote in an override key cannot inject shell commands", async () => {
+    const marker = join(fixtureDir, "pwned.txt");
+
+    rmSync(marker, { force: true });
+
+    // Key crafted to break out of a naive single-quote wrap and run `touch`.
+    const gate = await buildGate(fixtureDir, ["drizzle"], {
+      "x'; touch pwned.txt; '": "off",
+    });
+    const proc = Bun.spawn(["sh", "-c", lintSubCommand(gate.command)], {
+      cwd: fixtureDir,
+      env: process.env,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+
+    await proc.exited;
+
+    // With proper escaping the key is inert data, not a command — no file written.
+    expect(await Bun.file(marker).exists()).toBe(false);
+  }, 30_000);
 });
 
 describe("gate eslint CLI path (end-to-end)", () => {

--- a/packages/core/tests/gate-packs.test.ts
+++ b/packages/core/tests/gate-packs.test.ts
@@ -93,7 +93,7 @@ describe("gate command construction", () => {
   test("includes TSFORGE_PACKS env prefix when packs are provided", async () => {
     const gate = await buildGate(fixtureDir, ["drizzle", "elysia"]);
 
-    expect(gate.command).toContain("TSFORGE_PACKS=drizzle,elysia");
+    expect(gate.command).toContain("TSFORGE_PACKS='drizzle,elysia'");
     expect(gate.command).toContain("bun");
   });
 
@@ -109,8 +109,8 @@ describe("gate command construction", () => {
       "timestamp-must-specify-mode": "off",
     });
 
-    expect(gate.command).toContain("TSFORGE_PACKS=drizzle");
-    expect(gate.command).toContain("TSFORGE_RULE_OVERRIDES=");
+    expect(gate.command).toContain("TSFORGE_PACKS='drizzle'");
+    expect(gate.command).toContain("TSFORGE_RULE_OVERRIDES='");
     expect(gate.command).toContain("timestamp-must-specify-mode");
   });
 
@@ -149,6 +149,69 @@ describe("makeFileLinter with packs (API path)", () => {
 
     expect(packProblems).toEqual([]);
   });
+});
+
+/** Run a gate sub-command string through `sh -c` — exactly how the real gate
+ *  runs it. This is what exercises the env-prefix shell quoting; running eslint
+ *  via argv `env:{}` (as runGateEslint does) bypasses the shell and hides the
+ *  bug. Returns the tsforge/* rule IDs eslint reported on stdout. */
+async function runGateLintViaShell(command: string): Promise<string[]> {
+  const proc = Bun.spawn(["sh", "-c", command], {
+    cwd: fixtureDir,
+    env: process.env,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const stdout = await new Response(proc.stdout).text();
+
+  await proc.exited;
+
+  const parsed: unknown = JSON.parse(stdout);
+
+  if (!isLintedFileArray(parsed)) {
+    throw new Error(`unexpected eslint output: ${stdout.slice(0, 200)}`);
+  }
+
+  return parsed
+    .flatMap((f) => f.messages)
+    .map((m) => m.ruleId ?? "")
+    .filter((id) => id.startsWith("tsforge/"));
+}
+
+/** Pull the eslint sub-command (env prefix + invocation) out of the full gate
+ *  command so it can be run alone and its JSON output parsed. */
+function lintSubCommand(gateCommand: string): string {
+  const part = gateCommand
+    .split(" && ")
+    .find((p) => p.includes("eslint") && p.includes("TSFORGE_PACKS"));
+
+  if (part === undefined) {
+    throw new Error(`no lint sub-command in: ${gateCommand}`);
+  }
+
+  return part;
+}
+
+// P1: rule overrides are handed to the bundled eslint config via a shell env
+// prefix. The JSON value MUST be shell-quoted — an unquoted `{"x":"off"}` has its
+// quotes stripped by `sh -c` to `{x:off}`, fails JSON.parse, and is silently
+// ignored, so the override never applies. These run the REAL command via a shell.
+describe("rule overrides take effect through the shell (P1b)", () => {
+  test("override 'off' suppresses the rule through sh -c", async () => {
+    const gate = await buildGate(fixtureDir, ["drizzle"], {
+      "timestamp-must-specify-mode": "off",
+    });
+    const ruleIds = await runGateLintViaShell(lintSubCommand(gate.command));
+
+    expect(ruleIds).not.toContain("tsforge/timestamp-must-specify-mode");
+  }, 30_000);
+
+  test("without the override the same shell path still flags it", async () => {
+    const gate = await buildGate(fixtureDir, ["drizzle"]);
+    const ruleIds = await runGateLintViaShell(lintSubCommand(gate.command));
+
+    expect(ruleIds).toContain("tsforge/timestamp-must-specify-mode");
+  }, 30_000);
 });
 
 describe("gate eslint CLI path (end-to-end)", () => {

--- a/packages/core/tests/git-ops.test.ts
+++ b/packages/core/tests/git-ops.test.ts
@@ -26,6 +26,9 @@ beforeAll(() => {
   git(repo, "init", "-q");
   git(repo, "config", "user.email", "t@t.t");
   git(repo, "config", "user.name", "t");
+  // Don't inherit a global commit.gpgsign=true — signing via an unavailable agent
+  // (e.g. a locked 1Password) would make the temp-repo commits fail spuriously.
+  git(repo, "config", "commit.gpgsign", "false");
   writeFileSync(
     join(repo, "a.ts"),
     "export const a = 1;\nexport const b = 2;\n"

--- a/packages/core/tests/review-change.test.ts
+++ b/packages/core/tests/review-change.test.ts
@@ -42,6 +42,9 @@ beforeEach(() => {
   git("init", "-q");
   git("config", "user.email", "t@t.t");
   git("config", "user.name", "t");
+  // Don't inherit a global commit.gpgsign=true — signing via an unavailable agent
+  // would make these temp-repo commits fail spuriously.
+  git("config", "commit.gpgsign", "false");
   writeFileSync(
     join(repo, "discount.ts"),
     "export function discount(price: number, off: number): number {\n  return price - off;\n}\n"
@@ -139,6 +142,7 @@ test("injects the caller blast-radius signal into the find prompt", async () => 
   pgit("init", "-q");
   pgit("config", "user.email", "t@t.t");
   pgit("config", "user.name", "t");
+  pgit("config", "commit.gpgsign", "false");
   pgit("add", "-A");
   pgit("commit", "-q", "-m", "init");
   writeFileSync(

--- a/packages/core/tests/run-branches.test.ts
+++ b/packages/core/tests/run-branches.test.ts
@@ -75,6 +75,9 @@ test("a git_context tool call runs inside a full loop turn, then drives to done"
   execFileSync("git", ["init", "-q"], { cwd: dir });
   execFileSync("git", ["config", "user.email", "t@t.t"], { cwd: dir });
   execFileSync("git", ["config", "user.name", "t"], { cwd: dir });
+  // Don't inherit a global commit.gpgsign=true — signing via an unavailable agent
+  // would make this temp-repo commit fail spuriously.
+  execFileSync("git", ["config", "commit.gpgsign", "false"], { cwd: dir });
   execFileSync("git", ["commit", "-q", "--allow-empty", "-m", "init"], {
     cwd: dir,
   });

--- a/packages/core/tests/session.test.ts
+++ b/packages/core/tests/session.test.ts
@@ -548,6 +548,53 @@ test("auto-compacts before a send once context exceeds the window threshold", as
   }
 });
 
+// P2: a `/model` hot-swap to a smaller-window model must update auto-compaction,
+// not just the status bar. setContextWindow feeds autoCompactPct; without it the
+// session keeps the original (larger) window and compacts too late, overflowing
+// the new model.
+test("setContextWindow makes auto-compaction use the new (smaller) window", async () => {
+  const dir = await mkdtemp(join(tmpdir(), "tsforge-session-"));
+
+  try {
+    let compactions = 0;
+    const provider: IProvider = {
+      async complete(messages) {
+        if (
+          (messages[0]?.content ?? "").includes("compacting a coding session")
+        ) {
+          compactions += 1;
+
+          return { content: "summary", toolCalls: [] };
+        }
+
+        // 90 tokens: 9% of the original 1000-window (safe), but 90% of a
+        // hot-swapped 100-window (over the 80% threshold).
+        return {
+          content: "ok",
+          toolCalls: [],
+          usage: { promptTokens: 90, completionTokens: 5, totalTokens: 95 },
+        };
+      },
+    };
+    const session = await Session.create({
+      provider,
+      cwd: dir,
+      contextWindow: 1000,
+      autoCompactAt: 0.8,
+    });
+
+    await session.send("first"); // 90/1000 = 9% → no compaction
+    expect(compactions).toBe(0);
+
+    session.setContextWindow(100); // swap to a smaller model
+
+    await session.send("second"); // now 90/100 = 90% ≥ 80% → compacts
+    expect(compactions).toBe(1);
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
 test("does NOT auto-compact when no context window is configured", async () => {
   const dir = await mkdtemp(join(tmpdir(), "tsforge-session-"));
 

--- a/packages/core/tests/tool-accounting.test.ts
+++ b/packages/core/tests/tool-accounting.test.ts
@@ -3,6 +3,7 @@ import { mkdtemp, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { runToolCalls, type ILoopCtx, type ILoopState } from "../src/loop";
+import { TsService } from "../src/lsp";
 
 function freshState(): ILoopState {
   return {
@@ -74,6 +75,67 @@ test("an out-of-scope edit is NOT counted and does not re-gate", async () => {
 
     expect(touched).toBe(false);
     expect(state.edits).toBe(0);
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+// P1: move_file relocates a file AND rewrites every importer, but reports a
+// `tool` event (not edit/create) so `wrote.value` stays false. It must still be
+// counted as a semantic write so the gate re-runs — otherwise a move could end
+// the turn as "responded" with the relocation/import-rewrites never gated.
+test("a move_file re-gates even though it is not an edit/create", async () => {
+  const dir = await mkdtemp(join(tmpdir(), "tsforge-acct-move-"));
+
+  try {
+    await Bun.write(
+      join(dir, "tsconfig.json"),
+      JSON.stringify({
+        compilerOptions: {
+          target: "ES2022",
+          module: "ES2022",
+          moduleResolution: "bundler",
+          strict: true,
+          skipLibCheck: true,
+        },
+        include: ["**/*.ts"],
+      })
+    );
+    await Bun.write(
+      join(dir, "types.ts"),
+      "export interface IThing {\n  value: number;\n}\n"
+    );
+    await Bun.write(
+      join(dir, "use.ts"),
+      'import type { IThing } from "./types";\nexport const f = (t: IThing): number => t.value;\n'
+    );
+
+    const ctx: ILoopCtx = {
+      task: { id: "t", accept: "true", files: ["**/*"] },
+      cwd: dir,
+      tsService: new TsService(dir),
+      parse: undefined,
+      report: () => undefined,
+      messages: [],
+    };
+    const state = freshState();
+    const touched = await runToolCalls(
+      [
+        {
+          name: "move_file",
+          arguments: { from: "types.ts", to: "lib/types.ts" },
+        },
+      ],
+      ctx,
+      state
+    );
+
+    // The move actually happened...
+    expect(await Bun.file(join(dir, "lib/types.ts")).exists()).toBe(true);
+    expect(await Bun.file(join(dir, "use.ts")).text()).toContain("lib/types");
+    // ...and it re-gates (this was `false` before the fix). Semantic writes
+    // don't feed state.edits, so only the re-gate signal changes.
+    expect(touched).toBe(true);
   } finally {
     await rm(dir, { recursive: true, force: true });
   }


### PR DESCRIPTION
Acts on a full-codebase review (Codex). I verified each finding against the code before fixing; all five were real.

## P1a — `move_file` could skip the gate
`doMoveFile` reports a `tool` event (not `edit`/`create`), so `wrote.value` stayed false, and `move_file` was missing from the semantic-write list in `runToolCalls`. A move — which relocates a file **and** rewrites every importer — could end the turn as "responded" with the change never gated. Added `TOOL_NAME.moveFile` alongside rename/organize.

## P1b — `tsforge.config.json` rule overrides silently dropped
The gate runs through `sh -c`, which strips the double quotes from an unquoted `TSFORGE_RULE_OVERRIDES={"x":"off"}` → `{x:off}`. The eslint config's `JSON.parse` then fails and **silently ignores** it (its `catch {}` literally says so), so overrides never reached eslint. Confirmed empirically. Fix: single-quote the env values in `packEnvPrefix` (`JSON.stringify` never emits a single quote, so it's lossless). The existing end-to-end test passed env via argv `env:{}`, bypassing the shell — which is why it never caught this.

## P2a — docs honesty (per maintainer decision)
`gate-floor.mdx` claimed the type-aware pass runs for any project with a `tsconfig.json`, but it's **intentionally** gated to the `strict` profile (default is `recommended`). Corrected the docs rather than changing behavior; noted web gates run it regardless of profile.

## P2b — `/model` hot-swap left auto-compaction on the old window
The CLI updated a local `contextWindow` (status bar) but not `session.cfg.contextWindow`, which `autoCompactPct()` reads — so switching to a smaller model compacted too late and could overflow it. Added `Session.setContextWindow` and call it from the `/model` handler.

## P2c — temp git repos inherited global commit signing
Tests set name/email but not `commit.gpgsign`, so a machine with global `commit.gpgsign=true` + an unavailable signing agent (e.g. a locked 1Password) failed `git-ops`/`review-change`/`run-branches`. Set `commit.gpgsign=false` in each temp repo. (This is the exact flake that made our own `validate` runs unreliable.)

## Tests
- `move_file` re-gates — `tool-accounting.test.ts` (real `TsService`, asserts the move happened and `runToolCalls` returns true).
- Rule override `off` takes effect through a real `sh -c` — `gate-packs.test.ts`, paired with a no-override control that still flags the rule (so it fails on the old code).
- `setContextWindow` drives auto-compaction to the new window — `session.test.ts`.

Verified: typecheck + lint + format clean; 93 tests across the 8 affected files pass (the three git tests now pass while spawning real commits).