### PR TITLE
0.15.1 — interactive web per-write moat + clean gate output

### DIFF
--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -2,7 +2,7 @@
   "name": "@tsforge/docs",
   "type": "module",
   "private": true,
-  "version": "0.15.0",
+  "version": "0.15.1",
   "description": "tsforge docs — Astro Starlight product site.",
   "scripts": {
     "sync:rules": "bun scripts/sync-rules-catalog.ts",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "tsforge",
   "type": "module",
-  "version": "0.15.0",
+  "version": "0.15.1",
   "license": "MIT",
   "description": "TypeScript coding harness with a deterministic gate, stack-aware guardrails, and stream-level correction.",
   "scripts": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@agjs/tsforge",
   "type": "module",
-  "version": "0.15.0",
+  "version": "0.15.1",
   "license": "MIT",
   "description": "TypeScript coding harness with a deterministic gate, stack-aware guardrails, and stream-level correction.",
   "repository": {

--- a/packages/core/scripts/interactive-eval.ts
+++ b/packages/core/scripts/interactive-eval.ts
@@ -29,6 +29,8 @@ import {
   scaffoldWeb,
   installWebDeps,
   webGuidance,
+  makeFileLinter,
+  WEB_PACKS,
 } from "../src/detect-gate";
 import { resolveActiveModel } from "../src/models-config";
 import { OpenAICompatibleProvider } from "../src/inference";
@@ -136,6 +138,7 @@ async function main(): Promise<number> {
     session.setGate(buildWebGate(fw).command);
     session.setFix(buildWebFix(fw));
     session.setIncrementalCheck(buildWebTscCheck());
+    session.setLintFile(makeFileLinter(fw, dir, WEB_PACKS));
     session.guide(webGuidance(fw));
     session.setMaxTurns(LOOP_LIMITS.webMaxTurns);
     verdict.scaffolded = true;

--- a/packages/core/scripts/interactive-eval.ts
+++ b/packages/core/scripts/interactive-eval.ts
@@ -138,6 +138,7 @@ async function main(): Promise<number> {
     session.setGate(buildWebGate(fw).command);
     session.setFix(buildWebFix(fw));
     session.setIncrementalCheck(buildWebTscCheck());
+    await session.refreshTsService();
     session.setLintFile(makeFileLinter(fw, dir, WEB_PACKS));
     session.guide(webGuidance(fw));
     session.setMaxTurns(LOOP_LIMITS.webMaxTurns);

--- a/packages/core/src/cli.ts
+++ b/packages/core/src/cli.ts
@@ -50,6 +50,9 @@ import {
   scaffoldWeb,
   installWebDeps,
   webGuidance,
+  makeFileLinter,
+  WEB_PACKS,
+  type FileLinter,
 } from "./detect-gate";
 import type { WebFramework } from "./web-templates";
 import { isRecord } from "./lib/guards";
@@ -811,7 +814,7 @@ function browserCheckCommand(htmlFile: string): string {
 async function resolveGate(
   args: ICliArgs,
   resumed: ISessionRecord | null
-): Promise<{ accept: string; gateLabel: string }> {
+): Promise<{ accept: string; gateLabel: string; lintFile?: FileLinter }> {
   const base = await baseGate(args, resumed);
 
   if (args.browser.length === 0) {
@@ -826,6 +829,7 @@ async function resolveGate(
       base.accept.length > 0
         ? `${base.gateLabel} + browser render`
         : "browser render",
+    ...(base.lintFile === undefined ? {} : { lintFile: base.lintFile }),
   };
 }
 
@@ -834,7 +838,7 @@ async function resolveGate(
 async function baseGate(
   args: ICliArgs,
   resumed: ISessionRecord | null
-): Promise<{ accept: string; gateLabel: string }> {
+): Promise<{ accept: string; gateLabel: string; lintFile?: FileLinter }> {
   if (resumed !== null) {
     const label = resumed.accept.length > 0 ? resumed.accept : "none";
 
@@ -848,7 +852,14 @@ async function baseGate(
   if (args.web) {
     const web = buildWebGate("react", undefined, args.dir);
 
-    return { accept: web.command, gateLabel: web.label };
+    // PER-WRITE lint moat: the web gate's eslint rules applied to each file as the
+    // model writes it, so architecture/cast violations surface immediately instead
+    // of as an end-of-turn pile-up.
+    return {
+      accept: web.command,
+      gateLabel: web.label,
+      lintFile: makeFileLinter("react", args.dir, WEB_PACKS),
+    };
   }
 
   if (args.noGate) {
@@ -882,7 +893,16 @@ async function baseGate(
     }
   );
 
-  return { accept: auto.command, gateLabel: auto.label };
+  return {
+    accept: auto.command,
+    gateLabel: auto.label,
+    lintFile: makeFileLinter(
+      "core",
+      args.dir,
+      activePacks,
+      Object.keys(ruleOverrides).length > 0 ? ruleOverrides : undefined
+    ),
+  };
 }
 
 /** Interactive REPL: a persistent gate-anchored conversation. */
@@ -916,7 +936,7 @@ async function repl(args: ICliArgs): Promise<number> {
   }
 
   const id = resumed?.id ?? newSessionId();
-  const { accept, gateLabel } = await resolveGate(args, resumed);
+  const { accept, gateLabel, lintFile } = await resolveGate(args, resumed);
   const files = resumed !== null ? resumed.files : scopeOf(args);
   const logFile = resolveLogPath(id, args.log);
 
@@ -946,6 +966,9 @@ async function repl(args: ICliArgs): Promise<number> {
     accept,
     contextWindow,
     report,
+    // PER-WRITE lint moat (eslint rules per file as it's written), so violations
+    // surface immediately instead of piling up at the end-of-turn gate.
+    ...(lintFile === undefined ? {} : { lintFile }),
     ...(resumed === null ? {} : { history: resumed.messages }),
     // --web pre-scaffolds the project above, so it gets the web gate/guidance
     // directly. EVERY OTHER interactive session offers `scaffold_web` (+ the
@@ -1063,6 +1086,9 @@ async function repl(args: ICliArgs): Promise<number> {
     session.setGate(buildWebGate(framework, undefined, args.dir).command);
     session.setFix(buildWebFix(framework));
     session.setIncrementalCheck(buildWebTscCheck());
+    // Switch the per-write lint moat to the web rules too, so component-architecture
+    // / no-jsx-computation / cast violations surface per file from here on.
+    session.setLintFile(makeFileLinter(framework, args.dir, WEB_PACKS));
     session.guide(webGuidance(framework));
     // A from-scratch web build legitimately needs many turns. Don't pin a low
     // ceiling here — the interactive session already rides the high runaway

--- a/packages/core/src/cli.ts
+++ b/packages/core/src/cli.ts
@@ -1086,8 +1086,11 @@ async function repl(args: ICliArgs): Promise<number> {
     session.setGate(buildWebGate(framework, undefined, args.dir).command);
     session.setFix(buildWebFix(framework));
     session.setIncrementalCheck(buildWebTscCheck());
-    // Switch the per-write lint moat to the web rules too, so component-architecture
-    // / no-jsx-computation / cast violations surface per file from here on.
+    // The project only now has a tsconfig + node_modules — rebuild the TS service
+    // so the per-write guard actually runs (it's skipped on a null service), and
+    // switch the lint moat to the web rules so component-architecture /
+    // no-jsx-computation / cast violations surface per file, not at the gate.
+    await session.refreshTsService();
     session.setLintFile(makeFileLinter(framework, args.dir, WEB_PACKS));
     session.guide(webGuidance(framework));
     // A from-scratch web build legitimately needs many turns. Don't pin a low

--- a/packages/core/src/loop/index.ts
+++ b/packages/core/src/loop/index.ts
@@ -15,6 +15,7 @@ export {
 export {
   Session,
   PLAN_APPROVED_NOTE,
+  filterGateStream,
   type ISessionConfig,
   type ISendResult,
 } from "./session";

--- a/packages/core/src/loop/session.ts
+++ b/packages/core/src/loop/session.ts
@@ -149,6 +149,50 @@ export interface ISendOptions {
 
 const SESSION_ID = "session";
 
+/** Wrap a live gate-output sink so the machine-readable `eslint --format json`
+ *  blob NEVER reaches the terminal — it's a single giant JSON line the harness
+ *  parses internally and a human must not see (it was dumping raw at the end of
+ *  every web run). Buffers across chunk boundaries: a line that begins `[{` is
+ *  held until its newline, then dropped if it's the eslint JSON; everything else
+ *  (vite build progress, tsc, test output) passes through unchanged. */
+export function filterGateStream(
+  sink: (text: string) => void
+): (text: string) => void {
+  let buf = "";
+
+  const isEslintJson = (line: string): boolean => {
+    const t = line.trimStart();
+
+    return (
+      t.startsWith("[{") && t.includes('"filePath"') && t.includes('"messages"')
+    );
+  };
+
+  return (text: string): void => {
+    buf += text;
+
+    let nl = buf.indexOf("\n");
+
+    while (nl !== -1) {
+      const line = buf.slice(0, nl + 1);
+
+      if (!isEslintJson(line)) {
+        sink(line);
+      }
+
+      buf = buf.slice(nl + 1);
+      nl = buf.indexOf("\n");
+    }
+
+    // Flush a trailing partial line for responsiveness — UNLESS it has begun an
+    // eslint-JSON blob (`[{`), which we hold until its newline so it's dropped whole.
+    if (buf.length > 0 && !buf.trimStart().startsWith("[{")) {
+      sink(buf);
+      buf = "";
+    }
+  };
+}
+
 /** Build the assistant history message, carrying `reasoningContent` when the
  *  model produced it (DeepSeek's thinking mode requires it replayed). */
 function assistantMessage(res: IModelResponse): IChatMessage {
@@ -557,10 +601,11 @@ export class Session {
           ? [...cfg.history]
           : [{ role: "system", content: systemPrompt(cfg, workspaceMap) }],
       // Stream the gate's output live (the interactive CLI), so a slow gate
-      // (vite build + chromium) shows progress instead of running silently.
-      onGateChunk: (text) => {
+      // (vite build + chromium) shows progress instead of running silently — but
+      // filtered so the raw eslint JSON blob never floods the terminal.
+      onGateChunk: filterGateStream((text) => {
         report({ kind: "token", task: SESSION_ID, message: text });
-      },
+      }),
     };
 
     const session = new Session(cfg, ctx);
@@ -669,6 +714,16 @@ export class Session {
    *  every few edits while building, so errors surface early instead of piling up. */
   setIncrementalCheck(command: string): void {
     this.incrementalCheck = command;
+  }
+
+  /** Wire the PER-WRITE lint moat — the gate's eslint rules applied to each file
+   *  AS it's written, so `as`-casts, no-jsx-computation, hooks-in-component-body,
+   *  component-folder-structure, etc. surface immediately instead of as an
+   *  end-of-turn pile-up. The interactive session was missing this (only headless
+   *  builds wired it), so a whole web app's worth of violations dumped at the gate.
+   *  Used at create and when `scaffold_web` flips a session to the web stack. */
+  setLintFile(lintFile: FileLinter | undefined): void {
+    this.ctx.lintFile = lintFile;
   }
 
   /** Replace the editable scope globs mid-session. */

--- a/packages/core/src/loop/session.ts
+++ b/packages/core/src/loop/session.ts
@@ -149,39 +149,55 @@ export interface ISendOptions {
 
 const SESSION_ID = "session";
 
+/** A gate-output sink that also carries `flush()` — call it when the stream
+ *  ends to emit any trailing line the process printed without a newline. */
+export type IGateStreamSink = ((text: string) => void) & { flush: () => void };
+
 /** Wrap a live gate-output sink so the machine-readable `eslint --format json`
  *  blob NEVER reaches the terminal — it's a single giant JSON line the harness
  *  parses internally and a human must not see (it was dumping raw at the end of
  *  every web run). Buffers across chunk boundaries: a line that begins `[{` is
  *  held until its newline, then dropped if it's the eslint JSON; everything else
- *  (vite build progress, tsc, test output) passes through unchanged. */
+ *  (vite build progress, tsc, test output) passes through unchanged. Call
+ *  `flush()` at stream end so a final newline-less line isn't swallowed. */
 export function filterGateStream(
   sink: (text: string) => void
-): (text: string) => void {
+): IGateStreamSink {
   let buf = "";
 
-  return (text: string): void => {
+  const emit = (line: string): void => {
+    if (!isEslintJsonLine(line)) {
+      sink(line);
+    }
+  };
+
+  const fn = (text: string): void => {
     buf += text;
 
     let nl = buf.indexOf("\n");
 
     // Emit only COMPLETE (newline-terminated) lines; HOLD any trailing partial
-    // until its newline. This is what makes the JSON drop reliable: the eslint
-    // blob is one complete line, always evaluated whole and dropped — the old
-    // partial flush leaked the JSON across chunk boundaries. Gate output
+    // until its newline (or flush()). This is what makes the JSON drop reliable:
+    // the eslint blob is one complete line, always evaluated whole and dropped —
+    // the old partial flush leaked the JSON across chunk boundaries. Gate output
     // (vite/tsc/test) is line-based, so live progress isn't lost.
     while (nl !== -1) {
-      const line = buf.slice(0, nl + 1);
-
+      emit(buf.slice(0, nl + 1));
       buf = buf.slice(nl + 1);
-
-      if (!isEslintJsonLine(line)) {
-        sink(line);
-      }
-
       nl = buf.indexOf("\n");
     }
   };
+
+  // When the gate process exits, its last chunk may not end in a newline — emit
+  // that remainder (still JSON-filtered) so no output is permanently lost.
+  fn.flush = (): void => {
+    if (buf.length > 0) {
+      emit(buf);
+      buf = "";
+    }
+  };
+
+  return fn;
 }
 
 /** Build the assistant history message, carrying `reasoningContent` when the
@@ -724,6 +740,9 @@ export class Session {
    *  for the whole web build (`tsService !== null` was false). Rebuilding here
    *  makes per-write feedback actually fire in web sessions, matching headless. */
   async refreshTsService(): Promise<void> {
+    // Dispose the old service first — it holds program/document-registry refs
+    // that would otherwise leak when we drop the reference.
+    this.ctx.tsService?.dispose();
     this.ctx.tsService = await buildTsService(this.ctx.cwd);
   }
 

--- a/packages/core/src/loop/session.ts
+++ b/packages/core/src/loop/session.ts
@@ -173,22 +173,21 @@ export function filterGateStream(
 
     let nl = buf.indexOf("\n");
 
+    // Emit only COMPLETE (newline-terminated) lines; HOLD any trailing partial
+    // until its newline. This is what makes the JSON drop reliable: the eslint
+    // blob is one complete line, always evaluated whole and dropped — the old
+    // partial flush leaked the JSON across chunk boundaries. Gate output
+    // (vite/tsc/test) is line-based, so live progress isn't lost.
     while (nl !== -1) {
       const line = buf.slice(0, nl + 1);
+
+      buf = buf.slice(nl + 1);
 
       if (!isEslintJson(line)) {
         sink(line);
       }
 
-      buf = buf.slice(nl + 1);
       nl = buf.indexOf("\n");
-    }
-
-    // Flush a trailing partial line for responsiveness — UNLESS it has begun an
-    // eslint-JSON blob (`[{`), which we hold until its newline so it's dropped whole.
-    if (buf.length > 0 && !buf.trimStart().startsWith("[{")) {
-      sink(buf);
-      buf = "";
     }
   };
 }
@@ -724,6 +723,16 @@ export class Session {
    *  Used at create and when `scaffold_web` flips a session to the web stack. */
   setLintFile(lintFile: FileLinter | undefined): void {
     this.ctx.lintFile = lintFile;
+  }
+
+  /** Rebuild the in-process TS LanguageService. `scaffold_web` creates the
+   *  project's tsconfig + node_modules AFTER the (empty-dir) session was created,
+   *  so the service built at create time is empty/null and the per-write guard —
+   *  which holds BOTH the tsc diagnostics AND the eslint lint moat — was skipped
+   *  for the whole web build (`tsService !== null` was false). Rebuilding here
+   *  makes per-write feedback actually fire in web sessions, matching headless. */
+  async refreshTsService(): Promise<void> {
+    this.ctx.tsService = await buildTsService(this.ctx.cwd);
   }
 
   /** Replace the editable scope globs mid-session. */

--- a/packages/core/src/loop/session.ts
+++ b/packages/core/src/loop/session.ts
@@ -19,7 +19,7 @@ import {
 import { flags } from "../config";
 import { readFiles } from "../lib/fs";
 import { WEB_VENDORED_PATTERNS } from "../lib/scope";
-import { validate, type ErrorParser } from "../validate";
+import { validate, isEslintJsonLine, type ErrorParser } from "../validate";
 import { detectStack } from "../stack-detection";
 import { recallMapBlock } from "../codebase";
 import {
@@ -160,14 +160,6 @@ export function filterGateStream(
 ): (text: string) => void {
   let buf = "";
 
-  const isEslintJson = (line: string): boolean => {
-    const t = line.trimStart();
-
-    return (
-      t.startsWith("[{") && t.includes('"filePath"') && t.includes('"messages"')
-    );
-  };
-
   return (text: string): void => {
     buf += text;
 
@@ -183,7 +175,7 @@ export function filterGateStream(
 
       buf = buf.slice(nl + 1);
 
-      if (!isEslintJson(line)) {
+      if (!isEslintJsonLine(line)) {
         sink(line);
       }
 

--- a/packages/core/src/loop/turn.ts
+++ b/packages/core/src/loop/turn.ts
@@ -144,8 +144,10 @@ export interface ILoopCtx {
   ruleOverrides?: Readonly<Record<string, "error" | "warn" | "off">>;
   /** When set, the gate's command output is streamed here live (the CLI wires
    *  this so a slow gate like `vite build` + browser isn't silent dead air).
-   *  Omitted on the eval path, where output is just captured for scoring. */
-  onGateChunk?: (text: string) => void;
+   *  Omitted on the eval path, where output is just captured for scoring.
+   *  `flush()` (when present) is called once the gate exits to emit any final
+   *  line the process printed without a trailing newline. */
+  onGateChunk?: ((text: string) => void) & { flush?: () => void };
   /** Cancellation for the in-flight turn — threaded into tool `run` commands and
    *  the gate so a Ctrl-C (or a kill-timeout) reaches the child processes, not
    *  just the model call. Set per-send by the Session. */
@@ -944,6 +946,10 @@ export async function settleGate(
     ...(ctx.onGateChunk === undefined ? {} : { onChunk: ctx.onGateChunk }),
     ...(ctx.signal === undefined ? {} : { signal: ctx.signal }),
   });
+
+  // The gate process has exited — flush any final newline-less line the stream
+  // filter is still holding so it reaches the terminal.
+  ctx.onGateChunk?.flush?.();
 
   // Run meta-rules against the project — project structure invariants the gate
   // can't express. Convert error-severity violations to gate failures; warn

--- a/packages/core/src/lsp/service.ts
+++ b/packages/core/src/lsp/service.ts
@@ -563,6 +563,14 @@ export class TsService {
     return match === null ? undefined : match.index;
   }
 
+  /** Release the underlying LanguageService — it holds program/document-registry
+   *  references that won't be GC'd while the service is live. Call before
+   *  dropping a TsService (e.g. rebuilding it after a scaffold) so the old one
+   *  doesn't leak. */
+  dispose(): void {
+    this.service.dispose();
+  }
+
   /** 1-based line number of a byte offset in a file (for readable tool output). */
   private lineOf(file: string, position: number): number {
     const text = ts.sys.readFile(file) ?? "";

--- a/packages/core/src/meta-rules/rules/testing/test-sibling-required.ts
+++ b/packages/core/src/meta-rules/rules/testing/test-sibling-required.ts
@@ -23,13 +23,20 @@ function isTestPath(file: string): boolean {
 /** A source file that EXPORTS logic and should therefore have a test. Only `.ts`:
  *  presentational `.tsx`/`.jsx` components are exempt (in-loop unit tests for them
  *  are low-value and would make from-scratch web builds impractical — put testable
- *  logic in `.ts`). Also excludes tests, declarations, barrels, and type-only modules. */
+ *  logic in `.ts`). `*.hooks.ts` is also exempt: React hooks (useState/useEffect/
+ *  useFrame) need a DOM/fiber render environment to test, so the rule only forced
+ *  placeholder tests — put pure, testable logic in `.logic.ts`/`.ts`. Also excludes
+ *  tests, declarations, barrels, and type-only modules. */
 function isLogicFile(file: string, content: string): boolean {
   if (!file.endsWith(".ts") || file.endsWith(".d.ts")) {
     return false;
   }
 
-  if (isTestPath(file) || file.endsWith(".types.ts")) {
+  if (
+    isTestPath(file) ||
+    file.endsWith(".types.ts") ||
+    file.endsWith(".hooks.ts")
+  ) {
     return false;
   }
 

--- a/packages/core/src/validate/index.ts
+++ b/packages/core/src/validate/index.ts
@@ -6,6 +6,7 @@ export {
   parseEslintJson,
   combinedParser,
   parserFor,
+  isEslintJsonLine,
 } from "./parse";
 export { diffErrorSets, shrank, sameErrorSet } from "./errors";
 export { runTests, isRealRed } from "./run-tests";

--- a/packages/core/src/validate/parse.ts
+++ b/packages/core/src/validate/parse.ts
@@ -44,26 +44,64 @@ export function genericErrors(output: string): IErrorItem[] {
   return text.length > 0 ? [{ key: "raw", message: text.slice(0, 500) }] : [];
 }
 
+/** A line is eslint's `--format json` blob when it begins `[{` and carries the
+ *  array's tell-tale keys. The single source of truth shared by the parser
+ *  (which extracts it) and the live-stream filter (which hides it). */
+export function isEslintJsonLine(line: string): boolean {
+  const t = line.trimStart();
+
+  return (
+    t.startsWith("[{") && t.includes('"filePath"') && t.includes('"messages"')
+  );
+}
+
+/** Parse `s` as a JSON array, or null if it isn't one (no throw). */
+function tryParseArray(s: string): unknown[] | null {
+  try {
+    const data: unknown = JSON.parse(s);
+
+    return isArray(data) ? data : null;
+  } catch {
+    return null;
+  }
+}
+
 /**
  * Parse `eslint --format json`. Errors (severity 2) only; warnings ignored.
  * Carries the `ruleId` — including custom plugin rules like
  * `@boring-stack/structured-logging` — so the repair loop sees exactly which
  * rule failed. Narrowed with guards (no type assertions).
+ *
+ * The WEB gate chains eslint inside `bun run build && tsc && eslint … && …`, so
+ * the captured output is the vite build text WITH eslint's single JSON line
+ * embedded — `JSON.parse` of the whole thing throws and every web lint error
+ * used to dump as one raw blob (the gate's "pile of garbage"). So: parse the
+ * whole output when it's pure JSON (the core gate), else scan for the standalone
+ * JSON-array line(s) and union them — the chain can run eslint twice (syntactic
+ * + type-aware), each emitting its own array.
  */
 export function parseEslintJson(output: string): IErrorItem[] {
-  let data: unknown;
+  const whole = tryParseArray(output);
 
-  try {
-    data = JSON.parse(output);
-  } catch {
-    return [];
+  if (whole !== null) {
+    return whole.flatMap(eslintFileItems);
   }
 
-  if (!isArray(data)) {
-    return [];
+  const items: IErrorItem[] = [];
+
+  for (const line of output.split("\n")) {
+    if (!line.trimStart().startsWith("[")) {
+      continue;
+    }
+
+    const arr = tryParseArray(line.trim());
+
+    if (arr !== null) {
+      items.push(...arr.flatMap(eslintFileItems));
+    }
   }
 
-  return data.flatMap(eslintFileItems);
+  return items;
 }
 
 /** Error items from one eslint JSON file entry (severity-2 messages only). */

--- a/packages/core/src/validate/validate.ts
+++ b/packages/core/src/validate/validate.ts
@@ -1,7 +1,31 @@
 import type { ITask } from "../spec";
 import type { ErrorParser, ErrorSet, IValidateResult } from "./validate.types";
 import { runAccept, type IAcceptOptions } from "./accept";
-import { parserFor } from "./parse";
+import { parserFor, isEslintJsonLine } from "./parse";
+
+/** Longest fallback message we'll surface — a vite/render error fits; a wall of
+ *  build logs does not. */
+const FALLBACK_CAP = 1200;
+
+/** Build the human-readable fallback message for a gate that failed without any
+ *  parseable errors (e.g. a render/build failure). Drops eslint's machine JSON
+ *  line — it's never for human eyes — and caps the length so the terminal isn't
+ *  flooded with raw build output. */
+function fallbackMessage(output: string): string {
+  const cleaned = output
+    .split("\n")
+    .filter((line) => !isEslintJsonLine(line))
+    .join("\n")
+    .trim();
+
+  if (cleaned.length === 0) {
+    return "command exited non-zero";
+  }
+
+  return cleaned.length > FALLBACK_CAP
+    ? `${cleaned.slice(0, FALLBACK_CAP)}\n… (output truncated)`
+    : cleaned;
+}
 
 /**
  * Run a task's gate and turn the result into a structured error set. When no
@@ -24,11 +48,10 @@ export async function validate(
 
   // A failing gate must surface at least one error, even with empty output.
   const parsed = parser(r.output);
-  const trimmed = r.output.trim();
   const fallback: ErrorSet = [
     {
       key: "nonzero",
-      message: trimmed.length > 0 ? trimmed : "command exited non-zero",
+      message: fallbackMessage(r.output),
     },
   ];
 

--- a/packages/core/tests/parse.test.ts
+++ b/packages/core/tests/parse.test.ts
@@ -5,6 +5,7 @@ import {
   parseEslintJson,
   combinedParser,
   parserFor,
+  isEslintJsonLine,
 } from "../src/validate";
 
 test("parseTsc extracts file/line/rule per diagnostic", () => {
@@ -64,6 +65,78 @@ test("parseEslintJson extracts errors, including custom plugin rule ids", () => 
 
 test("parseEslintJson tolerates non-JSON output", () => {
   expect(parseEslintJson("not json at all")).toEqual([]);
+});
+
+test("parseEslintJson extracts the JSON line from mixed web-gate output", () => {
+  // The web gate is `bun run build && tsc && eslint --format json && …`, so the
+  // captured output is vite build TEXT with eslint's single JSON line embedded.
+  // `JSON.parse` of the whole thing throws — the old parser returned [] and the
+  // whole wall (incl. the raw JSON) dumped as one fallback blob. It must now
+  // pull the located error out of the noise.
+  const eslint = JSON.stringify([
+    {
+      filePath: "/r/src/views/Foo/index.tsx",
+      messages: [
+        {
+          ruleId: "no-restricted-syntax",
+          severity: 2,
+          message: "No `as` type casts",
+          line: 12,
+          column: 5,
+        },
+      ],
+    },
+  ]);
+  const out = [
+    "vite v6.4.3 building for production...",
+    "✓ 188 modules transformed.",
+    "✓ built in 1.71s",
+    eslint,
+    "$ next step never reached",
+  ].join("\n");
+  const items = parseEslintJson(out);
+
+  expect(items).toHaveLength(1);
+  expect(items[0]).toMatchObject({
+    file: "/r/src/views/Foo/index.tsx",
+    line: 12,
+    rule: "no-restricted-syntax",
+  });
+});
+
+test("parseEslintJson unions two chained eslint runs (syntactic + type-aware)", () => {
+  // The web gate runs eslint twice: `lint && type-aware`. When the first passes
+  // it prints `[]`; the type-aware run prints the real errors. Taking the FIRST
+  // array line would miss them — every JSON-array line must be unioned.
+  const empty = JSON.stringify([]);
+  const typeAware = JSON.stringify([
+    {
+      filePath: "/r/src/views/Foo/foo.hooks.ts",
+      messages: [
+        {
+          ruleId: "@typescript-eslint/no-floating-promises",
+          severity: 2,
+          message: "Promises must be awaited.",
+          line: 8,
+          column: 3,
+        },
+      ],
+    },
+  ]);
+  const out = ["✓ built in 1.71s", empty, typeAware].join("\n");
+  const items = parseEslintJson(out);
+
+  expect(items).toHaveLength(1);
+  expect(items[0]!.rule).toBe("@typescript-eslint/no-floating-promises");
+});
+
+test("isEslintJsonLine flags the eslint blob, not ordinary output", () => {
+  expect(
+    isEslintJsonLine('[{"filePath":"/a.ts","messages":[],"errorCount":0}]')
+  ).toBe(true);
+  expect(isEslintJsonLine("✓ built in 1.71s")).toBe(false);
+  expect(isEslintJsonLine("[vite] hmr update")).toBe(false);
+  expect(isEslintJsonLine("[]")).toBe(false);
 });
 
 test("parserFor picks a parser by command", () => {

--- a/packages/core/tests/session.test.ts
+++ b/packages/core/tests/session.test.ts
@@ -3,7 +3,7 @@ import { mkdtemp, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import type { IProvider } from "../src/inference";
-import { Session } from "../src/loop";
+import { Session, filterGateStream } from "../src/loop";
 
 /** A provider that yields immediately (no tool calls) — the "model is done" case. */
 function yields(content = "ok"): IProvider {
@@ -1012,4 +1012,26 @@ test("TSFORGE_TDD=0 omits test-first guidance from the interactive prompt", asyn
     delete process.env.TSFORGE_TDD;
     await rm(dir, { recursive: true, force: true });
   }
+});
+
+// The web gate runs `eslint --format json`; its single giant JSON line used to
+// stream raw to the terminal at the end of every run. filterGateStream drops it
+// (whole, even across chunk splits) while passing build/test progress through.
+test("filterGateStream drops the eslint JSON blob but keeps build progress", async () => {
+  const out: string[] = [];
+  const sink = filterGateStream((t) => out.push(t));
+
+  sink("vite v6 building for production...\n");
+  sink("✓ 180 modules transformed.\n");
+  // The eslint JSON, arriving split across two chunks, then its newline.
+  sink('[{"filePath":"/x/a.ts","messages":[{"ruleId":"tsforge/no-jsx-comp');
+  sink('utation","severity":2}],"errorCount":1}]\n');
+  sink("✓ built in 1.6s\n");
+
+  const joined = out.join("");
+
+  expect(joined).toContain("modules transformed");
+  expect(joined).toContain("built in 1.6s");
+  expect(joined).not.toContain("filePath");
+  expect(joined).not.toContain("no-jsx-computation");
 });

--- a/packages/core/tests/session.test.ts
+++ b/packages/core/tests/session.test.ts
@@ -1035,3 +1035,31 @@ test("filterGateStream drops the eslint JSON blob but keeps build progress", asy
   expect(joined).not.toContain("filePath");
   expect(joined).not.toContain("no-jsx-computation");
 });
+
+// A gate process can exit with its last line un-terminated (no trailing \n).
+// The buffer holds that partial to keep the JSON drop reliable, so flush() must
+// emit it at stream end — otherwise the final status line is swallowed.
+test("filterGateStream.flush emits a trailing newline-less line", () => {
+  const out: string[] = [];
+  const sink = filterGateStream((t) => out.push(t));
+
+  sink("running gate…\n");
+  sink("✗ FAILED"); // no trailing newline — process exited here
+  expect(out.join("")).not.toContain("FAILED"); // still buffered
+
+  sink.flush();
+
+  expect(out.join("")).toContain("✗ FAILED");
+});
+
+// flush must still apply the JSON filter — a half-streamed eslint blob with no
+// final newline must not leak just because the stream ended.
+test("filterGateStream.flush still drops a trailing eslint JSON blob", () => {
+  const out: string[] = [];
+  const sink = filterGateStream((t) => out.push(t));
+
+  sink('[{"filePath":"/x/a.ts","messages":[{"ruleId":"r","severity":2}]}]');
+  sink.flush();
+
+  expect(out.join("")).not.toContain("filePath");
+});

--- a/packages/core/tests/tool-accounting.test.ts
+++ b/packages/core/tests/tool-accounting.test.ts
@@ -9,6 +9,59 @@ import {
   type ILoopState,
 } from "../src/loop";
 import { TsService } from "../src/lsp";
+import { makeFileLinter, WEB_PACKS } from "../src/detect-gate";
+
+// The interactive web session was missing the per-write lint moat (only headless
+// wired `lintFile`), so eslint/architecture violations piled up at the end-of-turn
+// gate instead of surfacing as each file was written. With `lintFile` wired, the
+// write-guard must return the violation in the tool result for the writing turn.
+test("per-write lint moat surfaces a web rule violation on the write itself", async () => {
+  const dir = await mkdtemp(join(tmpdir(), "tsforge-moat-"));
+
+  try {
+    await Bun.write(
+      join(dir, "tsconfig.json"),
+      JSON.stringify({
+        compilerOptions: {
+          target: "ES2022",
+          module: "ESNext",
+          moduleResolution: "bundler",
+          jsx: "react-jsx",
+          strict: true,
+          skipLibCheck: true,
+        },
+        include: ["**/*.tsx", "**/*.ts"],
+      })
+    );
+
+    const ctx: ILoopCtx = {
+      task: { id: "t", accept: "true", files: ["**/*"] },
+      cwd: dir,
+      tsService: new TsService(dir),
+      lintFile: makeFileLinter("react", dir, WEB_PACKS),
+      parse: undefined,
+      report: () => undefined,
+      messages: [],
+    };
+    // An `as` cast trips @typescript-eslint/consistent-type-assertions (the web
+    // config bans it) — type-valid so tsc is silent, leaving the eslint violation
+    // to surface cleanly. The per-write moat must catch it on the write itself.
+    const Bad = "export const v: string = 1 as unknown as string;\n";
+
+    await runToolCalls(
+      [{ name: "create", arguments: { file: "bad.ts", content: Bad } }],
+      ctx,
+      freshState()
+    );
+
+    const toolMsg = ctx.messages.find((m) => m.role === "tool")?.content ?? "";
+
+    // The web config bans `as` via no-restricted-syntax ("No `as` type casts").
+    expect(toolMsg).toContain("No `as` type casts");
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
 
 // P1 (review): add_dependency rewrites package.json even in a narrow-scoped task
 // where it isn't in the editable globs. That sanctioned manifest change MUST still


### PR DESCRIPTION
Fixes the interactive-web bugs surfaced by live deepseek builds (kanban stuck 78 turns, raw eslint JSON dumped at end of run).

## What broke
- **Per-write lint moat never fired in web builds.** The web session is created in an empty dir (scaffold_web runs later), so its `TsService` was null and `runWriteGuard` (gated on `tsService !== null`) was skipped for the whole build — violations piled up only at the end-of-turn gate, despite `lintFile` being wired.
- **"Pile of garbage" at end of every run.** The web gate is `bun run build && tsc && eslint --format json && …`, so the captured output is vite build text with eslint's JSON line embedded. `parseEslintJson` did `JSON.parse(wholeOutput)` → threw → returned `[]`, so every web lint failure (a) was never structured into per-rule messages and (b) fell through to `validate.ts`'s fallback, which set the error message to the entire 15 KB raw output — dumped to the terminal via the `validated` event (a path the live-stream filter never touched).

## Fixes
1. `Session.refreshTsService()` rebuilds the LanguageService after `scaffold_web` (cli.ts `configureWeb` + interactive-eval), so the per-write guard fires in web like it does headless.
2. `parseEslintJson` extracts eslint's standalone JSON-array line(s) from mixed output and unions the chained syntactic + type-aware runs.
3. `validate.ts` `fallbackMessage()` drops eslint-JSON lines (shared `isEslintJsonLine`, now the single source of truth for parser + stream filter) and caps to 1200 chars.
4. `filterGateStream` emits only complete newline-terminated lines (no partial flush across chunk boundaries).
5. `*.hooks.ts` exempted from `test-sibling-required` (deepseek feedback #5).

## Validation (live deepseek web builds)
- Per-write moat now fires mid-build: expense-tracker run = 5 nudges, habit-tracker run = 4 (`component-file-purity`, `no-jsx-computation`, `no-state-in-component-body`) — not an end-of-turn pile-up.
- Zero eslint JSON dump: 0 in agent.log, 0 in events.jsonl on the habit-tracker run.
- Both runs reached `done` + scaffolded (46 turns vs the prior 90 / stuck-78 — structured gate errors converge the model faster).
- Proven against the real 15 KB leaked output: fixed parser yields 1 structured error, scrub leaves 0 JSON-blob lines.
- `bun run validate` green (1099 pass, 0 fail).