### PR TITLE
chore: release 0.15.2

### DIFF
--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -2,7 +2,7 @@
   "name": "@tsforge/docs",
   "type": "module",
   "private": true,
-  "version": "0.15.1",
+  "version": "0.15.2",
   "description": "tsforge docs — Astro Starlight product site.",
   "scripts": {
     "sync:rules": "bun scripts/sync-rules-catalog.ts",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "tsforge",
   "type": "module",
-  "version": "0.15.1",
+  "version": "0.15.2",
   "license": "MIT",
   "description": "TypeScript coding harness with a deterministic gate, stack-aware guardrails, and stream-level correction.",
   "scripts": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@agjs/tsforge",
   "type": "module",
-  "version": "0.15.1",
+  "version": "0.15.2",
   "license": "MIT",
   "description": "TypeScript coding harness with a deterministic gate, stack-aware guardrails, and stream-level correction.",
   "repository": {


### PR DESCRIPTION
Patch release cutting the homepage + docs redesign (PR #16) live. Docs-only — no CLI/package code changes; version bump keeps the published package and docs in lockstep.