### PR TITLE
fix: write-policy P1s + session-resume P2 + stable CLI input row

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -38,7 +38,7 @@
     },
     "apps/docs": {
       "name": "@tsforge/docs",
-      "version": "0.8.0",
+      "version": "0.15.5",
       "dependencies": {
         "@astrojs/react": "5.0.6",
         "@astrojs/sitemap": "3.7.2",
@@ -60,7 +60,7 @@
     },
     "packages/core": {
       "name": "@agjs/tsforge",
-      "version": "0.8.0",
+      "version": "0.15.5",
       "bin": {
         "tsforge": "./bin/tsforge.js",
       },

--- a/packages/core/src/agent/tools.ts
+++ b/packages/core/src/agent/tools.ts
@@ -1,6 +1,6 @@
 import type { ICreateFile, IReplacement } from "../files";
 import { isArray, isRecord } from "../lib/guards";
-import { runShellCommand } from "../lib/fs";
+import { runShellCommand, runArgvCommand } from "../lib/fs";
 import { coerceStringToArray, trimMarkdownFences } from "./tool-repair";
 import type { IShellResult } from "./agent.types";
 
@@ -174,6 +174,32 @@ export async function runCommand(
 ): Promise<IShellResult> {
   const timeoutMs = opts.timeoutMs ?? runToolTimeoutMs();
   const run = await runShellCommand(cwd, command, {
+    timeoutMs,
+    ...(opts.signal === undefined ? {} : { signal: opts.signal }),
+  });
+
+  const note = run.timedOut
+    ? `\n[command killed after ${timeoutMs}ms timeout — TSFORGE_RUN_TIMEOUT_MS to change]`
+    : "";
+
+  return {
+    stdout: run.stdout,
+    stderr: run.stderr + note,
+    exitCode: run.exitCode,
+  };
+}
+
+/** Like `runCommand` but spawns an explicit argv with NO shell, so arguments are
+ *  passed literally and can't be expanded/redirected/injected. Use this whenever
+ *  any argument is built from model- or content-supplied text (e.g. `bun add
+ *  <pkg>`). Same timeout/abort semantics and timeout note as `runCommand`. */
+export async function runArgv(
+  cwd: string,
+  argv: string[],
+  opts: { signal?: AbortSignal; timeoutMs?: number } = {}
+): Promise<IShellResult> {
+  const timeoutMs = opts.timeoutMs ?? runToolTimeoutMs();
+  const run = await runArgvCommand(cwd, argv, {
     timeoutMs,
     ...(opts.signal === undefined ? {} : { signal: opts.signal }),
   });

--- a/packages/core/src/cli.ts
+++ b/packages/core/src/cli.ts
@@ -1,6 +1,7 @@
 #!/usr/bin/env bun
 import { join, isAbsolute } from "node:path";
 import { appendFileSync, mkdirSync } from "node:fs";
+import { Writable } from "node:stream";
 import { createInterface } from "node:readline/promises";
 import { emitKeypressEvents } from "node:readline";
 import { formatHelp, takesArg } from "./cli/commands";
@@ -32,6 +33,7 @@ import {
   renderMessage,
   renderStatus,
   StatusBar,
+  MIN_ROWS,
   welcomeBanner,
   STYLE,
   RESET,
@@ -649,6 +651,11 @@ export function spinnerPhase(event: ILoopEvent): string | null {
   return event.kind === "cycle" ? "thinking" : null;
 }
 
+/** When the interactive REPL pins an editable input row, streamed output must be
+ *  written THROUGH the StatusBar (so it scrolls in the region above the row and
+ *  the cursor stays parked on the row). Null elsewhere ⇒ a plain stdout write. */
+let interactiveStream: ((text: string) => void) | null = null;
+
 const render: Reporter = (event) => {
   const phase = spinnerPhase(event);
 
@@ -660,7 +667,12 @@ const render: Reporter = (event) => {
 
   if (out.length > 0) {
     spinner.clear();
-    process.stdout.write(out);
+
+    if (interactiveStream !== null) {
+      interactiveStream(out);
+    } else {
+      process.stdout.write(out);
+    }
   }
 };
 
@@ -1057,7 +1069,26 @@ async function repl(args: ICliArgs): Promise<number> {
     updateNotice,
   });
 
-  const rl = createInterface({ input: process.stdin, output: process.stdout });
+  // Pin an editable input row only on a real TTY tall enough to host the bar.
+  // In that mode readline does line-EDITING but must not RENDER (we paint the
+  // row ourselves), so it gets a discard sink for output; otherwise it writes to
+  // stdout as before (pipes, small terminals — behaviour unchanged).
+  const useInputRow =
+    process.stdin.isTTY &&
+    process.stdout.isTTY &&
+    process.stdout.rows >= MIN_ROWS;
+
+  const inputSink = new Writable({
+    write(_chunk, _enc, cb): void {
+      cb();
+    },
+  });
+
+  const rl = createInterface({
+    input: process.stdin,
+    output: useInputRow ? inputSink : process.stdout,
+    terminal: true,
+  });
 
   // Ctrl-C: while a turn is running, abort it and return to the prompt; while
   // idle at the prompt, quit. (readline emits SIGINT on the interface, so the
@@ -1480,7 +1511,35 @@ async function repl(args: ICliArgs): Promise<number> {
 
   // Pinned bottom status bar when we're on a real terminal; otherwise the bar is
   // inactive and `prompt()` falls back to the inline status line (pipes, --log).
-  const statusBar = new StatusBar(process.stdout, true, true);
+  const statusBar = new StatusBar(process.stdout, true, true, useInputRow);
+
+  // Route streamed agent output through the bar so it scrolls above the pinned
+  // input row; cleared on loop exit so later/headless writes go straight to stdout.
+  if (useInputRow) {
+    interactiveStream = (text): void => {
+      statusBar.writeStream(text);
+    };
+  }
+
+  // Mirror readline's buffer onto the input row after each keypress. setImmediate
+  // lets readline update rl.line/rl.cursor first (it processes the key async).
+  const syncInput = (): void => {
+    if (useInputRow) {
+      setImmediate(() => {
+        statusBar.setInput(rl.line, rl.cursor);
+      });
+    }
+  };
+
+  // Echo a CLI-side line (queued-steer notice, etc.) into the scroll region so it
+  // doesn't clobber the pinned input row; plain write when the row isn't active.
+  const echo = (text: string): void => {
+    if (useInputRow) {
+      statusBar.writeStream(text);
+    } else {
+      process.stdout.write(text);
+    }
+  };
 
   // In the interactive REPL a readline prompt owns stdin for the WHOLE session, so
   // the spinner's carriage-return inline write would clobber whatever the user is
@@ -1525,9 +1584,17 @@ async function repl(args: ICliArgs): Promise<number> {
     }
   };
 
-  // The prompt. With the bar pinned it repaints the bar and shows only the
-  // input marker; otherwise it prints the inline status line above the marker.
+  // The prompt. With the editable input row pinned it's always visible, so we
+  // just repaint the bar + row; with the bar (no input row) it shows the inline
+  // marker; otherwise it prints the inline status line above the marker.
   const prompt = (): void => {
+    if (useInputRow) {
+      statusBar.setInput(rl.line, rl.cursor);
+      statusBar.update(statusInfo());
+
+      return;
+    }
+
     if (statusBar.active) {
       statusBar.update(statusInfo());
       process.stdout.write("\n› ");
@@ -1610,6 +1677,13 @@ async function repl(args: ICliArgs): Promise<number> {
         }
       } finally {
         paletteOpen = false;
+
+        // The palette ran on the alternate screen; repaint the pinned row + bar
+        // and reflect any prefilled buffer back onto the input row.
+        if (useInputRow) {
+          statusBar.update(statusInfo());
+          syncInput();
+        }
       }
     };
 
@@ -1619,6 +1693,8 @@ async function repl(args: ICliArgs): Promise<number> {
     if (process.stdin.isTTY) {
       emitKeypressEvents(process.stdin);
       process.stdin.on("keypress", (str: string | undefined) => {
+        syncInput(); // keep the pinned input row in sync as the user types
+
         if (busy || paletteOpen || str !== "/") {
           return;
         }
@@ -1645,13 +1721,20 @@ async function repl(args: ICliArgs): Promise<number> {
         return;
       }
 
+      // readline's output is sinked in input-row mode, so the submitted line is
+      // never echoed to scrollback — record it ourselves so the transcript reads
+      // naturally above the (now-cleared) input row.
+      if (useInputRow) {
+        echo(`${STYLE.dim}›${RESET} ${line}\n`);
+      }
+
       if (busy) {
         if (line === "/exit" || line === "/quit") {
           active?.abort();
           rl.close();
         } else {
           pending.push(line);
-          process.stdout.write("  ↳ queued (steers the next turn)\n");
+          echo("  ↳ queued (steers the next turn)\n");
         }
 
         return;
@@ -1677,6 +1760,7 @@ async function repl(args: ICliArgs): Promise<number> {
   });
 
   statusBar.teardown(); // belt-and-suspenders: restore the terminal on loop exit
+  interactiveStream = null; // later/headless writes go straight to stdout again
 
   return 0;
 }

--- a/packages/core/src/loop/tools/add-dependency.ts
+++ b/packages/core/src/loop/tools/add-dependency.ts
@@ -1,14 +1,17 @@
 import { join } from "node:path";
-import { runCommand } from "../../agent";
+import { runArgv } from "../../agent";
 import { reject, str, type IToolContext } from "./tool-context";
 
 /** A valid npm package spec: optional @scope/, name, optional @version-range.
  *  Anything else (flags, paths, shell metacharacters) is rejected — the names
- *  are the ONLY untrusted text that reaches the `bun add` command line. The
- *  first character class deliberately excludes `-` so a leading flag like
- *  `-g`/`--registry` can never validate as a name. */
+ *  are the ONLY untrusted text that reaches the `bun add` argv. The first
+ *  character class deliberately excludes `-` so a leading flag like
+ *  `-g`/`--registry` can never validate as a name. The version class excludes
+ *  shell-redirection chars (`<`/`>`): even though we now spawn an explicit argv
+ *  (no shell), keeping them out is defense-in-depth and these range operators
+ *  aren't needed for `bun add` (use `^`/`~`/exact). */
 const PACKAGE_SPEC_RE =
-  /^(@[a-z0-9~][a-z0-9-._~]*\/)?[a-z0-9~][a-z0-9-._~]*(@[a-zA-Z0-9.^~<>=+-]+)?$/;
+  /^(@[a-z0-9~][a-z0-9-._~]*\/)?[a-z0-9~][a-z0-9-._~]*(@[a-zA-Z0-9.^~=+-]+)?$/;
 
 /** Parse + validate the space-separated package list; null if any spec is bad. */
 export function parsePackageSpecs(packages: string): string[] | null {
@@ -53,13 +56,13 @@ export async function doAddDependency(
   }
 
   const dev = args.dev === true;
-  const command = `bun add ${dev ? "-d " : ""}${specs.join(" ")}`;
+  const argv = ["bun", "add", ...(dev ? ["-d"] : []), ...specs];
 
-  ctx.report({ kind: "tool", task: ctx.task, message: `↳ ${command}` });
+  ctx.report({ kind: "tool", task: ctx.task, message: `↳ ${argv.join(" ")}` });
 
-  const res = await runCommand(
+  const res = await runArgv(
     ctx.cwd,
-    command,
+    argv,
     ctx.signal === undefined ? {} : { signal: ctx.signal }
   );
 

--- a/packages/core/src/loop/tools/edit-hashline.ts
+++ b/packages/core/src/loop/tools/edit-hashline.ts
@@ -6,6 +6,8 @@ import {
 import { extractHash } from "../../files/hashline-format";
 import { parseOrRepair, reject, type IToolContext } from "./tool-context";
 import { toHashlineEdit } from "../../agent";
+import { writable, normalizeWorkspacePath, isVendored } from "../../lib/scope";
+import { vendoredRejectMessage } from "./file-ops";
 
 /**
  * Hashline edit handler: content-hash-anchored line edits with stale-anchor recovery.
@@ -29,6 +31,27 @@ export async function doHashlineEdit(
     }
 
     return "edit_lines: malformed args (need `file` and `input`)";
+  }
+
+  // Same write policy as `edit`/`create` (file-ops): normalize the path, then
+  // refuse vendored files and anything outside the editable scope. Without this
+  // `edit_lines` was a hole — a `../` path reached applyHashlineEdit unchecked.
+  edit.file = normalizeWorkspacePath(ctx.cwd, edit.file);
+
+  if (isVendored(edit.file, ctx.vendored ?? [])) {
+    return reject(
+      ctx,
+      "edit_lines:vendored",
+      vendoredRejectMessage("edit", edit.file)
+    );
+  }
+
+  if (!writable(edit.file, ctx.files)) {
+    return reject(
+      ctx,
+      "edit_lines",
+      `edit_lines ${edit.file} REJECTED: out of scope. You may only edit/create: ${ctx.files.join(", ")} (or throwaway files under scratch/).`
+    );
   }
 
   ctx.report({

--- a/packages/core/src/loop/tools/file-ops.ts
+++ b/packages/core/src/loop/tools/file-ops.ts
@@ -119,6 +119,17 @@ const FIND_MUTATING = new Set([
   "-fls",
 ]);
 
+/** Flags that make an otherwise read-only git subcommand WRITE a file to disk
+ *  (`git diff --output=x`, `git diff -o x`). Matched as the exact token or its
+ *  `=value` form, so `--output`, `--output=x`, and `-o` are all caught. */
+const GIT_OUTPUT_FLAGS = new Set(["--output", "-o"]);
+
+function isGitOutputFlag(arg: string): boolean {
+  const name = arg.includes("=") ? arg.slice(0, arg.indexOf("=")) : arg;
+
+  return GIT_OUTPUT_FLAGS.has(name);
+}
+
 /** `git branch` flags that delete/rename/copy a branch. A bare positional
  *  (`git branch foo`) also CREATES a branch, so any non-flag arg disqualifies. */
 const GIT_BRANCH_MUTATING = new Set([
@@ -170,7 +181,9 @@ function gitIsReadOnly(sub: string | undefined, rest: string[]): boolean {
     return !rest.some((a) => GIT_BRANCH_MUTATING.has(a) || !a.startsWith("-"));
   }
 
-  return true;
+  // diff/show/log inspect by default but can be redirected to a file via
+  // `--output`/`-o` — that's a write, so disqualify it.
+  return !rest.some(isGitOutputFlag);
 }
 
 function tscIsReadOnly(rest: string[]): boolean {
@@ -288,7 +301,10 @@ export async function runShell(
  * point is to break the loop where a model "fixes" generic SDK types it can never
  * satisfy: the message redirects it to its own call site.
  */
-function vendoredRejectMessage(op: "edit" | "create", file: string): string {
+export function vendoredRejectMessage(
+  op: "edit" | "create",
+  file: string
+): string {
   return `${op} ${file} REJECTED: this is a VENDORED, already-type-correct harness file you must NOT modify. A type error involving it means the bug is at YOUR CALL SITE — fix how you USE it (the types/args you pass), not the file itself.`;
 }
 

--- a/packages/core/src/render/index.ts
+++ b/packages/core/src/render/index.ts
@@ -8,6 +8,8 @@ export {
 export {
   StatusBar,
   buildBarFrame,
+  buildInputFrame,
+  MIN_ROWS,
   type IStatusBarTerminal,
 } from "./status-bar";
 export { welcomeBanner, type IBannerInfo } from "./banner";

--- a/packages/core/src/render/status-bar.ts
+++ b/packages/core/src/render/status-bar.ts
@@ -7,7 +7,15 @@ const ESC = "\x1b";
 const RESERVED_ROWS = 2;
 
 /** Below this height, a 2-row bar would crowd the conversation — fall back to inline. */
-const MIN_ROWS = 5;
+export const MIN_ROWS = 5;
+
+/** Reset all SGR attributes — written after a stream chunk so the input row below
+ *  it is never painted in leftover color from mid-stream markdown. */
+const RESET_SGR = `${ESC}[0m`;
+
+/** The editable input prompt and the columns it occupies (`›` + space). */
+const PROMPT = "› ";
+const PROMPT_COLS = 2;
 
 /** Cells in the context meter. */
 const METER_CELLS = 9;
@@ -127,6 +135,27 @@ function topBorder(columns: number, color: boolean): string {
 }
 
 /**
+ * The two painted bar rows (border + segments) at the bottom, positioned
+ * ABSOLUTELY with no cursor save/restore. Callers decide cursor handling: the
+ * no-input bar wraps this in save/restore (`buildBarFrame`); the input-row mode
+ * re-parks the cursor on the input row itself afterwards.
+ */
+function buildBarBody(
+  info: IStatusInfo,
+  columns: number,
+  rows: number,
+  color: boolean
+): string {
+  const borderRow = rows - 1;
+  const segs = assemble(barSegments(info), columns, color);
+
+  return (
+    `${ESC}[${borderRow};1H${ESC}[2K${topBorder(columns, color)}` +
+    `${ESC}[${rows};1H${ESC}[2K${segs}`
+  );
+}
+
+/**
  * The escape sequence that paints the boxed bar on the reserved bottom TWO rows
  * WITHOUT moving the user's cursor: save → border row → segments row → restore.
  * Pure and width-aware, so it can be asserted in tests with no terminal.
@@ -137,14 +166,59 @@ export function buildBarFrame(
   rows: number,
   color: boolean
 ): string {
-  const borderRow = rows - 1;
-  const segs = assemble(barSegments(info), columns, color);
-
   return (
     `${ESC}7` + // save cursor
-    `${ESC}[${borderRow};1H${ESC}[2K${topBorder(columns, color)}` +
-    `${ESC}[${rows};1H${ESC}[2K${segs}` +
+    buildBarBody(info, columns, rows, color) +
     `${ESC}8` // restore cursor
+  );
+}
+
+/** Horizontally scroll a single-line buffer so the cursor stays visible within
+ *  `avail` columns: shows the whole line when it fits, else a window ending at
+ *  the cursor. Returns the visible slice and the cursor's column WITHIN it. */
+function clipInput(
+  line: string,
+  cursor: number,
+  avail: number
+): { visible: string; cursorCol: number } {
+  if (avail <= 0) {
+    return { visible: "", cursorCol: 0 };
+  }
+
+  if (line.length <= avail) {
+    return { visible: line, cursorCol: cursor };
+  }
+
+  const start = Math.max(0, cursor - avail + 1);
+
+  return {
+    visible: line.slice(start, start + avail),
+    cursorCol: cursor - start,
+  };
+}
+
+/**
+ * The escape sequence that paints the editable input row (`› <text>`) on the
+ * row just above the bar and LEAVES the cursor parked there at the typing
+ * column — the stable input line the user edits while agent output streams into
+ * the scroll region above. Pure/width-aware for FakeTerm assertions.
+ */
+export function buildInputFrame(
+  line: string,
+  cursor: number,
+  columns: number,
+  rows: number,
+  color: boolean
+): string {
+  const inputRow = rows - 2;
+  const avail = Math.max(0, columns - PROMPT_COLS);
+  const { visible, cursorCol } = clipInput(line, cursor, avail);
+
+  return (
+    `${ESC}[${inputRow};1H${ESC}[2K` +
+    paint(PROMPT, STYLE.dim, color) +
+    visible +
+    `${ESC}[${inputRow};${PROMPT_COLS + cursorCol + 1}H`
   );
 }
 
@@ -157,16 +231,29 @@ export function buildBarFrame(
  */
 export class StatusBar {
   private installed = false;
+  /** Mirror of the editable buffer (input-row mode only), so a bar repaint or a
+   *  stream chunk can re-paint the input row and re-park the cursor. */
+  private line = "";
+  private cursorPos = 0;
 
   constructor(
     private readonly out: IStatusBarTerminal,
     private readonly enabled = true,
-    private readonly color = true
+    private readonly color = true,
+    /** Reserve an extra editable input row above the bar and park the cursor on
+     *  it. The CLI enables this only on a real TTY tall enough to host it; when
+     *  off, behaviour is identical to the original 2-row bar. */
+    private readonly withInput = false
   ) {}
 
   /** Whether the bar is currently pinned (false ⇒ caller uses the inline line). */
   get active(): boolean {
     return this.installed;
+  }
+
+  /** Bottom rows reserved: the 2-row bar, plus the input row when enabled. */
+  private get reserved(): number {
+    return this.withInput ? RESERVED_ROWS + 1 : RESERVED_ROWS;
   }
 
   private canActivate(): boolean {
@@ -185,22 +272,74 @@ export class StatusBar {
 
     const rows = this.out.rows ?? 0;
 
-    this.out.write("\n".repeat(RESERVED_ROWS)); // make room for the bar
-    this.out.write(`${ESC}[1;${rows - RESERVED_ROWS}r`); // confine scrolling
-    this.out.write(`${ESC}[${rows - RESERVED_ROWS};1H`); // cursor back in-region
+    this.out.write("\n".repeat(this.reserved)); // make room for the bar
+    this.out.write(`${ESC}[1;${rows - this.reserved}r`); // confine scrolling
+    this.out.write(`${ESC}[${rows - this.reserved};1H`); // cursor back in-region
     this.installed = true;
+
+    // Save the in-region cursor as the STREAM cursor; writeStream restores to it
+    // before each chunk and re-saves after, so output scrolls in-region while the
+    // live cursor rests on the input row below.
+    if (this.withInput) {
+      this.out.write(`${ESC}7`);
+    }
+
     this.update(info);
   }
 
-  /** Repaint the bar with the latest state. */
+  /** Repaint the bar with the latest state (and the input row, in input mode). */
   update(info: IStatusInfo): void {
     if (!this.installed) {
       return;
     }
 
+    const columns = this.out.columns ?? 80;
+    const rows = this.out.rows ?? 0;
+
+    if (this.withInput) {
+      // Absolute-positioned body (no save/restore — that slot holds the stream
+      // cursor), then re-park the cursor on the input row.
+      this.out.write(buildBarBody(info, columns, rows, this.color));
+      this.paintInput();
+
+      return;
+    }
+
+    this.out.write(buildBarFrame(info, columns, rows, this.color));
+  }
+
+  /** Update the editable buffer mirror and repaint the input row (input mode). */
+  setInput(line: string, cursor: number): void {
+    this.line = line;
+    this.cursorPos = cursor;
+
+    if (this.installed && this.withInput) {
+      this.paintInput();
+    }
+  }
+
+  /** Write agent output INTO the scroll region, keeping the input row and cursor
+   *  stable below it. Falls back to a plain write when the input row isn't active
+   *  (non-TTY, small terminal, or not installed) — the original behaviour. */
+  writeStream(text: string): void {
+    if (!this.installed || !this.withInput) {
+      this.out.write(text);
+
+      return;
+    }
+
+    this.out.write(`${ESC}8`); // restore stream cursor (into the region)
+    this.out.write(text); // scrolls within the region
+    this.out.write(`${ESC}7`); // save the advanced stream cursor
+    this.out.write(RESET_SGR); // don't bleed mid-stream color into the input row
+    this.paintInput();
+  }
+
+  private paintInput(): void {
     this.out.write(
-      buildBarFrame(
-        info,
+      buildInputFrame(
+        this.line,
+        this.cursorPos,
         this.out.columns ?? 80,
         this.out.rows ?? 0,
         this.color
@@ -214,11 +353,21 @@ export class StatusBar {
       return;
     }
 
-    this.out.write(`${ESC}[1;${(this.out.rows ?? 0) - RESERVED_ROWS}r`);
+    const rows = this.out.rows ?? 0;
+
+    this.out.write(`${ESC}[1;${rows - this.reserved}r`);
+
+    // The saved stream cursor may now point off-screen — re-anchor it to the
+    // bottom of the (resized) region so output continues there.
+    if (this.withInput) {
+      this.out.write(`${ESC}[${rows - this.reserved};1H`);
+      this.out.write(`${ESC}7`);
+    }
+
     this.update(info);
   }
 
-  /** Reset the scroll region, clear the bar rows, and show the cursor. Idempotent. */
+  /** Reset the scroll region, clear the reserved rows, and show the cursor. Idempotent. */
   teardown(): void {
     if (!this.installed) {
       return;
@@ -227,8 +376,11 @@ export class StatusBar {
     const rows = this.out.rows ?? 0;
 
     this.out.write(`${ESC}[r`); // reset scroll region to full screen
-    this.out.write(`${ESC}[${rows - 1};1H${ESC}[2K`); // clear border row
-    this.out.write(`${ESC}[${rows};1H${ESC}[2K`); // clear segments row
+
+    for (let row = rows - this.reserved + 1; row <= rows; row += 1) {
+      this.out.write(`${ESC}[${row};1H${ESC}[2K`); // clear each reserved row
+    }
+
     this.out.write(`${ESC}[?25h`); // ensure the cursor is visible
     this.installed = false;
   }

--- a/packages/core/src/render/status-bar.ts
+++ b/packages/core/src/render/status-bar.ts
@@ -377,7 +377,11 @@ export class StatusBar {
 
     this.out.write(`${ESC}[r`); // reset scroll region to full screen
 
-    for (let row = rows - this.reserved + 1; row <= rows; row += 1) {
+    // Clamp to row 1: a resize below `reserved` after install would otherwise
+    // make the start non-positive and emit invalid `${ESC}[0;1H` sequences.
+    const startRow = Math.max(1, rows - this.reserved + 1);
+
+    for (let row = startRow; row <= rows; row += 1) {
       this.out.write(`${ESC}[${row};1H${ESC}[2K`); // clear each reserved row
     }
 

--- a/packages/core/src/session-store.ts
+++ b/packages/core/src/session-store.ts
@@ -166,6 +166,11 @@ async function readRecord(path: string): Promise<ISessionRecord | null> {
           ? data.files.filter((f): f is string => typeof f === "string")
           : [],
         updatedAt: data.updatedAt,
+        // Restored so a resumed session keeps its read-only guarantee; saveSession
+        // persists it but readRecord dropped it, so `--continue` always lost it.
+        ...(typeof data.planMode === "boolean"
+          ? { planMode: data.planMode }
+          : {}),
         messages: toMessages(data.messages),
       };
     }
@@ -215,6 +220,12 @@ function toMessage(raw: unknown): IChatMessage | null {
 
   if (toolCalls.length > 0) {
     message.toolCalls = toolCalls;
+  }
+
+  // DeepSeek reasoning replay REQUIRES the prior turn's reasoning_content, so it
+  // must survive a resume — toMessage previously dropped it on every reload.
+  if (typeof raw.reasoningContent === "string") {
+    message.reasoningContent = raw.reasoningContent;
   }
 
   return message;

--- a/packages/core/tests/session-store.test.ts
+++ b/packages/core/tests/session-store.test.ts
@@ -64,6 +64,44 @@ test("saves and resumes the newest session for a directory", async () => {
   expect(resumed?.messages[2]?.toolCalls?.[0]?.name).toBe("read");
 });
 
+test("resume preserves planMode (read-only guarantee survives --continue)", async () => {
+  await saveSession({
+    id: "pm",
+    cwd: "/proj/pm",
+    accept: "",
+    files: [],
+    updatedAt: 1000,
+    planMode: true,
+    messages: [{ role: "system", content: "sys" }],
+  });
+
+  const resumed = await latestSession("/proj/pm");
+
+  expect(resumed?.planMode).toBe(true);
+});
+
+test("resume preserves assistant reasoningContent (DeepSeek replay)", async () => {
+  await saveSession({
+    id: "rc",
+    cwd: "/proj/rc",
+    accept: "",
+    files: [],
+    updatedAt: 1000,
+    messages: [
+      { role: "system", content: "sys" },
+      {
+        role: "assistant",
+        content: "answer",
+        reasoningContent: "step-by-step thinking",
+      },
+    ],
+  });
+
+  const resumed = await latestSession("/proj/rc");
+
+  expect(resumed?.messages[1]?.reasoningContent).toBe("step-by-step thinking");
+});
+
 // Each input contains a secret; after redaction the secret must be GONE and a
 // [redacted] marker present. `needle` is a recognizable slice of the secret.
 const SECRET_CASES: { name: string; input: string; needle: string }[] = [

--- a/packages/core/tests/status-bar.test.ts
+++ b/packages/core/tests/status-bar.test.ts
@@ -2,6 +2,7 @@ import { test, expect, describe } from "bun:test";
 import {
   StatusBar,
   buildBarFrame,
+  buildInputFrame,
   type IStatusInfo,
   type IStatusBarTerminal,
 } from "../src/render";
@@ -136,5 +137,119 @@ describe("StatusBar activation", () => {
     bar.teardown();
 
     expect(term.writes).toHaveLength(0);
+  });
+});
+
+describe("buildInputFrame", () => {
+  test("draws the prompt on rows-2 and parks the cursor after the text", () => {
+    const frame = buildInputFrame("hello", 5, 80, 24, false);
+
+    expect(frame).toContain("\x1b[22;1H"); // input row (rows-2)
+    expect(frame).toContain("\x1b[2K"); // clear the row
+    expect(frame).toContain("› hello");
+    // prompt is 2 cols, cursor at index 5 ⇒ column 2 + 5 + 1 = 8
+    expect(frame.endsWith("\x1b[22;8H")).toBe(true);
+  });
+
+  test("parks the cursor at the prompt on an empty line", () => {
+    const frame = buildInputFrame("", 0, 80, 24, false);
+
+    // column 2 + 0 + 1 = 3 (just after the 2-col prompt)
+    expect(frame.endsWith("\x1b[22;3H")).toBe(true);
+  });
+
+  test("horizontally scrolls a line wider than the viewport, keeping the cursor visible", () => {
+    const line = "abcdefghij".repeat(10); // 100 chars
+    const frame = buildInputFrame(line, line.length, 20, 24, false);
+    const avail = 20 - 2;
+
+    // Only a viewport-sized window is shown, not the whole line.
+    expect(frame).not.toContain(line);
+    // Cursor stays within the row (never runs past the right edge). Match without
+    // the ESC byte so the regex carries no control character.
+    const match = /\[22;(\d+)H$/.exec(frame);
+
+    expect(match).not.toBeNull();
+    expect(Number(match?.[1])).toBeLessThanOrEqual(2 + avail);
+  });
+});
+
+describe("StatusBar with input row", () => {
+  const withInput = (term: FakeTerm): StatusBar =>
+    new StatusBar(term, true, false, true);
+
+  test("reserves THREE bottom rows and saves the stream cursor", () => {
+    const term = new FakeTerm(true, 24, 80);
+
+    withInput(term).install(INFO);
+
+    expect(term.text()).toContain("\x1b[1;21r"); // region = rows-3 (24-3)
+    expect(term.text()).toContain("\x1b7"); // stream cursor saved for writeStream
+    expect(term.text()).toContain("\x1b[22;1H"); // input row painted (rows-2)
+    expect(term.text()).toContain("\x1b[24;1H"); // segments row still on row 24
+  });
+
+  test("writeStream restores into the region, writes, re-saves, repaints the row", () => {
+    const term = new FakeTerm(true, 24, 80);
+    const bar = withInput(term);
+
+    bar.install(INFO);
+    bar.setInput("typed", 5);
+    term.writes.length = 0;
+    bar.writeStream("agent output\n");
+
+    const out = term.text();
+    const order = [
+      out.indexOf("\x1b8"), // restore stream cursor (into region)
+      out.indexOf("agent output"), // the streamed text
+      out.lastIndexOf("\x1b7"), // re-save advanced stream cursor
+      out.indexOf("\x1b[22;1H"), // repaint input row afterwards
+    ];
+
+    expect(order.every((i) => i >= 0)).toBe(true);
+    expect(order).toEqual([...order].sort((a, b) => a - b)); // strictly ordered
+    expect(out).toContain("› typed"); // the typed buffer survives the stream
+  });
+
+  test("a plain write falls back when not installed (non-TTY / small term)", () => {
+    const term = new FakeTerm(false, 24, 80);
+    const bar = withInput(term);
+
+    bar.writeStream("hi"); // never installed
+    expect(term.text()).toBe("hi");
+  });
+
+  test("update repaints the bar body without clobbering the stream-cursor slot", () => {
+    const term = new FakeTerm(true, 24, 80);
+    const bar = withInput(term);
+
+    bar.install(INFO);
+    term.writes.length = 0;
+    bar.update(INFO);
+
+    const out = term.text();
+
+    // Must NOT wrap in save/restore (that slot holds the stream cursor); it ends
+    // by parking on the input row instead.
+    expect(out.startsWith("\x1b7")).toBe(false);
+    expect(out).toContain("\x1b[24;1H"); // segments repainted
+    expect(out).toContain("\x1b[22;1H"); // input row repainted last
+  });
+
+  test("teardown clears all THREE reserved rows", () => {
+    const term = new FakeTerm(true, 24, 80);
+    const bar = withInput(term);
+
+    bar.install(INFO);
+    term.writes.length = 0;
+    bar.teardown();
+
+    const out = term.text();
+
+    expect(out).toContain("\x1b[r"); // reset scroll region
+    expect(out).toContain("\x1b[22;1H"); // input row cleared
+    expect(out).toContain("\x1b[23;1H"); // border row cleared
+    expect(out).toContain("\x1b[24;1H"); // segments row cleared
+    expect(out).toContain("\x1b[?25h"); // show cursor
   });
 });

--- a/packages/core/tests/status-bar.test.ts
+++ b/packages/core/tests/status-bar.test.ts
@@ -23,7 +23,7 @@ class FakeTerm implements IStatusBarTerminal {
 
   constructor(
     readonly isTTY: boolean,
-    readonly rows: number,
+    public rows: number,
     readonly columns: number
   ) {}
 
@@ -234,6 +234,21 @@ describe("StatusBar with input row", () => {
     expect(out.startsWith("\x1b7")).toBe(false);
     expect(out).toContain("\x1b[24;1H"); // segments repainted
     expect(out).toContain("\x1b[22;1H"); // input row repainted last
+  });
+
+  test("teardown after a shrink below the reserved height emits no row index < 1", () => {
+    const term = new FakeTerm(true, 24, 80);
+    const bar = withInput(term); // reserves 3 rows
+
+    bar.install(INFO);
+    term.rows = 2; // resized smaller than `reserved` before teardown
+    term.writes.length = 0;
+    bar.teardown();
+
+    // Every cursor-position sequence must target a 1-indexed (>= 1) row.
+    for (const match of term.text().matchAll(/\[(-?\d+);1H/g)) {
+      expect(Number(match[1])).toBeGreaterThanOrEqual(1);
+    }
   });
 
   test("teardown clears all THREE reserved rows", () => {

--- a/packages/core/tests/write-policy-p1.test.ts
+++ b/packages/core/tests/write-policy-p1.test.ts
@@ -1,0 +1,64 @@
+import { test, expect } from "bun:test";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { doHashlineEdit } from "../src/loop/tools/edit-hashline";
+import { parsePackageSpecs } from "../src/loop/tools/add-dependency";
+import { isReadOnlyCommand } from "../src/loop/tools/file-ops";
+import { computeFileHash } from "../src/files/hashline-format";
+import type { IToolContext } from "../src/loop/tools/tool-context";
+
+function ctx(cwd: string, files: string[]): IToolContext {
+  return { cwd, files, task: "t", report: () => undefined };
+}
+
+// P1 #1 — edit_lines must NOT write outside the editable scope. doEdit guards
+// with normalizeWorkspacePath + writable; edit_lines must enforce the same.
+test("edit_lines refuses to write a `../` path outside the workspace", async () => {
+  const root = await mkdtemp(join(tmpdir(), "tsforge-wp-"));
+
+  try {
+    const workspace = join(root, "workspace");
+    const victimDir = join(root, "victim");
+    const victim = join(victimDir, "target.ts");
+    const original = "secret = 1\n";
+
+    await Bun.write(victim, original);
+    await Bun.write(join(workspace, "in-scope.ts"), "ok\n");
+
+    const hash = computeFileHash(original);
+    const input = `¶../victim/target.ts#${hash}\nreplace 1..1:\n+PWNED`;
+
+    const out = await doHashlineEdit(
+      { file: "../victim/target.ts", input },
+      ctx(workspace, ["**/*.ts"])
+    );
+
+    // The out-of-scope file must be untouched and the call rejected.
+    expect(await Bun.file(victim).text()).toBe(original);
+    expect(out).toMatch(/REJECTED|out of scope/);
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+// P1 #2 — version specs must not carry shell-active chars. `bun add` is built as
+// a shell string, so `<`/`>` enable redirection (`left-pad@>=proof.txt`).
+test("parsePackageSpecs rejects shell-redirection metacharacters", () => {
+  expect(parsePackageSpecs("left-pad@>=proof.txt")).toBeNull();
+  expect(parsePackageSpecs("pkg@>1.0")).toBeNull();
+  expect(parsePackageSpecs("pkg@<1.0")).toBeNull();
+  // legitimate ranges still validate
+  expect(parsePackageSpecs("react@^19.0.0")).toEqual(["react@^19.0.0"]);
+  expect(parsePackageSpecs("zod@3")).toEqual(["zod@3"]);
+});
+
+// P1 #3 — plan-mode read-only run must not classify a writing git flag as safe.
+test("isReadOnlyCommand rejects git --output / -o", () => {
+  expect(isReadOnlyCommand("git diff --output=/tmp/x")).toBe(false);
+  expect(isReadOnlyCommand("git diff --output /tmp/x")).toBe(false);
+  expect(isReadOnlyCommand("git diff -o /tmp/x")).toBe(false);
+  // a genuinely read-only diff still passes
+  expect(isReadOnlyCommand("git diff HEAD~1")).toBe(true);
+  expect(isReadOnlyCommand("git status")).toBe(true);
+});


### PR DESCRIPTION
Addresses the 5 Codex findings (3 P1 security/correctness, 2 P2). Each P1 was **reproduced before fixing** — see `packages/core/tests/write-policy-p1.test.ts` (red → green).

## P1 — confirmed exploitable, now fixed
| Finding | Repro that fired | Fix |
|---|---|---|
| `edit_lines` bypassed the write policy | wrote `PWNED` into a file **outside** the workspace via `../victim/target.ts` | `doHashlineEdit` now runs the same `normalizeWorkspacePath` + `isVendored` + `writable` guards as `edit` (shared `vendoredRejectMessage`) |
| `add_dependency` shell injection | `left-pad@>=proof.txt` validated; `bun add` was a `sh -c` string | spawns an explicit argv (new `runArgv`, no shell); version regex drops `<`/`>` |
| plan-mode read-only allowed a writing git flag | `git diff --output=/tmp/x` classified read-only | `gitIsReadOnly` rejects `--output`/`-o` (and `=` form) |

## P2 — fixed
- **Session resume dropped state**: `readRecord` omitted `planMode` (read-only guarantee lost on `--continue`); `toMessage` omitted `reasoningContent` (DeepSeek replay). Both restored, with round-trip tests in `session-store.test.ts`.
- **No stable CLI input row while streaming**: `StatusBar` gains an optional editable input row — reserves a third bottom row, parks the cursor there, and streams output through `writeStream` (terminal save/restore) so it scrolls in the region above. Readline does line-editing into a sink; we paint the row ourselves from `rl.line`/`rl.cursor`. Non-TTY / small-terminal paths are byte-for-byte unchanged.

### Why FakeTerm, not a PTY
Codex suggested a PTY test. **node-pty is incompatible with Bun** (our only test runner): it spawns but emits no data/exit events, and `bun install` drops the `spawn-helper` +x bit so a fresh checkout starts broken. Node drove the same PTY fine, but bridging through a Node subprocess + bundle fights the repo's grain. The input row is therefore covered the way the rest of the render layer is — pure frame builders (`buildInputFrame`) asserted against an injectable `FakeTerm` (cursor parking, repaint-after-stream, horizontal scroll, 3-row reserve, teardown).

## Verification
`bun run validate` green: typecheck + lint + format clean, **1131 pass / 0 fail**. (The `tsforge.config.json` warnings in test output are an intentional invalid-config fixture.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)