### PR TITLE
fix(docs): refresh GitHub star count live in the browser

### DIFF
--- a/apps/docs/src/components/Header.astro
+++ b/apps/docs/src/components/Header.astro
@@ -85,12 +85,31 @@ const starLabel = formatStars(stars);
 <script>
   // Refresh the GitHub star count in the browser so it's never stale: the
   // server-rendered value is baked at build time and falls back to a constant
-  // whenever GitHub rate-limits the unauthenticated build-time fetch. Each
-  // visitor's browser re-fetches once; on any failure we keep the SSR value.
+  // whenever GitHub rate-limits the unauthenticated build-time fetch. Starlight
+  // is multi-page, so without caching every navigation would re-hit the API and
+  // could exhaust the 60-req/hr unauthenticated budget; a short sessionStorage
+  // TTL keeps it fresh while collapsing per-navigation refetches to one.
   (async () => {
     const el = document.querySelector("[data-gh-stars]");
 
     if (!el) return;
+
+    const CACHE_KEY = "tsforge-stars";
+    const TTL_MS = 15 * 60 * 1000;
+    const format = (n: number): string =>
+      n >= 1000 ? `${(n / 1000).toFixed(1)}k` : String(n);
+
+    try {
+      const cached = JSON.parse(sessionStorage.getItem(CACHE_KEY) ?? "null");
+
+      if (cached && Date.now() < cached.expires) {
+        el.textContent = cached.label;
+
+        return;
+      }
+    } catch {
+      /* malformed cache — fall through and refetch */
+    }
 
     try {
       const res = await fetch("https://api.github.com/repos/agjs/tsforge", {
@@ -104,7 +123,12 @@ const starLabel = formatStars(stars);
 
       if (typeof n !== "number") return;
 
-      el.textContent = n >= 1000 ? `${(n / 1000).toFixed(1)}k` : String(n);
+      const label = format(n);
+      el.textContent = label;
+      sessionStorage.setItem(
+        CACHE_KEY,
+        JSON.stringify({ label, expires: Date.now() + TTL_MS })
+      );
     } catch {
       /* offline / rate-limited — keep the server-rendered value */
     }

--- a/apps/docs/src/components/Header.astro
+++ b/apps/docs/src/components/Header.astro
@@ -17,9 +17,10 @@ const navItems = [
 
 const version = `v${pkg.version}`;
 
-// Real GitHub star count. Fetched at build time (unauthenticated); a baked
-// fallback guarantees a number shows even if the API is rate-limited/offline,
-// and a tiny client script (below) refreshes it live so it never goes stale.
+// Real GitHub star count. Fetched at build time (unauthenticated) for the
+// initial render; a baked fallback guarantees a number shows even when the API
+// is rate-limited/offline. The client script at the end of this file then
+// refreshes it live in the browser so it never goes stale between builds.
 const FALLBACK_STARS = 19;
 let stars: number = FALLBACK_STARS;
 try {
@@ -76,7 +77,36 @@ const starLabel = formatStars(stars);
           d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.01 8.01 0 0 0 16 8c0-4.42-3.58-8-8-8Z"
         ></path>
       </svg>
-      <span class="font-mono">{starLabel}</span>
+      <span class="font-mono" data-gh-stars>{starLabel}</span>
     </a>
   </div>
 </div>
+
+<script>
+  // Refresh the GitHub star count in the browser so it's never stale: the
+  // server-rendered value is baked at build time and falls back to a constant
+  // whenever GitHub rate-limits the unauthenticated build-time fetch. Each
+  // visitor's browser re-fetches once; on any failure we keep the SSR value.
+  (async () => {
+    const el = document.querySelector("[data-gh-stars]");
+
+    if (!el) return;
+
+    try {
+      const res = await fetch("https://api.github.com/repos/agjs/tsforge", {
+        headers: { Accept: "application/vnd.github+json" },
+      });
+
+      if (!res.ok) return;
+
+      const data = await res.json();
+      const n = data?.stargazers_count;
+
+      if (typeof n !== "number") return;
+
+      el.textContent = n >= 1000 ? `${(n / 1000).toFixed(1)}k` : String(n);
+    } catch {
+      /* offline / rate-limited — keep the server-rendered value */
+    }
+  })();
+</script>


### PR DESCRIPTION
The header GitHub star badge was fetched **only at build time** and fell back to a hardcoded `19` whenever GitHub rate-limited the unauthenticated build-time fetch — so it sat stale (the real count is 20). The build-time comment claimed "a tiny client script (below) refreshes it live," but no such script existed.

**Fix:** added the promised client refresh. On every page load the browser re-fetches `stargazers_count` and updates the badge; the SSR/build-time value remains the no-JS initial render, and any fetch failure keeps it. Verified: `astro build` succeeds, the script is inlined into every page, and this build's SSR fetch resolved to the live `20`.

One-file change to `apps/docs/src/components/Header.astro`. Independent of the npm package.

🤖 Generated with [Claude Code](https://claude.com/claude-code)