### PR TITLE
feat: unified action policy + typed run ledger

### DIFF
--- a/.github/workflows/security-deps.yml
+++ b/.github/workflows/security-deps.yml
@@ -86,16 +86,13 @@ jobs:
             exit 1
           fi
 
-          # Count only findings osv-scanner did NOT suppress via osv-scanner.toml.
-          # Accepted-risk IgnoredVulns carry a SARIF `suppressions` entry, so the
-          # gate must honor the allowlist instead of failing on every known
-          # dev-dependency advisory (which counting raw `results[]` did).
-          ACTIONABLE=$(jq -r '[.runs[].results[]? | select((.suppressions // []) | length == 0)] | length' osv-results.sarif)
-          SUPPRESSED=$(jq -r '[.runs[].results[]? | select((.suppressions // []) | length > 0)] | length' osv-results.sarif)
-          echo "osv-scanner findings: ${ACTIONABLE} actionable, ${SUPPRESSED} accepted-risk (osv exit ${OSV_EXIT:-?})"
+          # osv-scanner EXCLUDES osv-scanner.toml-ignored advisories from its
+          # output, so any remaining result is an un-accepted finding.
+          UNFILTERED=$(jq -r '[.runs[].results[]?] | length' osv-results.sarif)
+          echo "Unfiltered osv-scanner findings: ${UNFILTERED}"
 
-          if [ "${ACTIONABLE}" != "0" ]; then
-            echo "osv-scanner reported ${ACTIONABLE} actionable vulnerabilities (not in osv-scanner.toml). Triage and add an entry, or fix the dependency. See SARIF in the Security tab."
+          if [ "${UNFILTERED}" != "0" ]; then
+            echo "osv-scanner reported ${UNFILTERED} unfiltered vulnerabilities. See SARIF in the Security tab."
             exit 1
           fi
 

--- a/.github/workflows/security-deps.yml
+++ b/.github/workflows/security-deps.yml
@@ -86,11 +86,16 @@ jobs:
             exit 1
           fi
 
-          UNFILTERED=$(jq -r '[.runs[].results[]?] | length' osv-results.sarif)
-          echo "Unfiltered osv-scanner findings: ${UNFILTERED}"
+          # Count only findings osv-scanner did NOT suppress via osv-scanner.toml.
+          # Accepted-risk IgnoredVulns carry a SARIF `suppressions` entry, so the
+          # gate must honor the allowlist instead of failing on every known
+          # dev-dependency advisory (which counting raw `results[]` did).
+          ACTIONABLE=$(jq -r '[.runs[].results[]? | select((.suppressions // []) | length == 0)] | length' osv-results.sarif)
+          SUPPRESSED=$(jq -r '[.runs[].results[]? | select((.suppressions // []) | length > 0)] | length' osv-results.sarif)
+          echo "osv-scanner findings: ${ACTIONABLE} actionable, ${SUPPRESSED} accepted-risk (osv exit ${OSV_EXIT:-?})"
 
-          if [ "${UNFILTERED}" != "0" ]; then
-            echo "osv-scanner reported ${UNFILTERED} unfiltered vulnerabilities. See SARIF in the Security tab."
+          if [ "${ACTIONABLE}" != "0" ]; then
+            echo "osv-scanner reported ${ACTIONABLE} actionable vulnerabilities (not in osv-scanner.toml). Triage and add an entry, or fix the dependency. See SARIF in the Security tab."
             exit 1
           fi
 

--- a/.github/workflows/security-deps.yml
+++ b/.github/workflows/security-deps.yml
@@ -104,9 +104,14 @@ jobs:
 
       - name: bun audit
         if: steps.filter.outputs.code == 'true'
-        # GHSA-vmh5-mc38-953g (undici SOCKS5 ProxyAgent TLS bypass) is accepted-risk:
-        # undici 7.24.8 reaches us only via wrangler→miniflare (docs-deploy dev dep),
+        # All ignored GHSAs are undici@7.24.8 advisories — accepted-risk: undici
+        # 7.24.8 reaches us only via wrangler→miniflare (docs-deploy dev dep),
         # never the published @agjs/tsforge package (its undici via jsdom is already
         # 7.28.0/patched). Mirrors the osv-scanner.toml allowlist; re-evaluate by
-        # 2026-09-12 / when wrangler bumps undici. (bun audit keys on the GHSA id.)
-        run: bun audit --audit-level=high --ignore=GHSA-vmh5-mc38-953g
+        # 2026-09-12 / when wrangler bumps undici. (bun audit keys on the GHSA id;
+        # --audit-level=high means only the high-severity undici GHSAs need listing.)
+        run: >-
+          bun audit --audit-level=high
+          --ignore=GHSA-vmh5-mc38-953g
+          --ignore=GHSA-hm92-r4w5-c3mj
+          --ignore=GHSA-vxpw-j846-p89q

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -8,4 +8,5 @@ useDefault = true
 description = "Test fixtures that exercise secret redaction — not real credentials."
 paths = [
   '''packages/core/tests/session-store\.test\.ts''',
+  '''packages/core/tests/ledger\.test\.ts''',
 ]

--- a/osv-scanner.toml
+++ b/osv-scanner.toml
@@ -38,3 +38,32 @@ reason = "undici 7.24.8 reaches us only via wrangler→miniflare (docs-deploy de
 id = "CVE-2026-9697"
 ignoreUntil = 2026-09-12T00:00:00Z
 reason = "undici 7.24.8 (SOCKS5 ProxyAgent TLS-validation bypass) reaches us only via wrangler→miniflare (docs-deploy dev dependency), not the tsforge runtime; the published package's undici (via jsdom) is already 7.28.0 (patched). Re-evaluate when wrangler/miniflare bump undici."
+
+# Five further undici advisories published 2026-06-19, all against the SAME
+# dev-only undici@7.24.8 (verified: bun.lock pins it ONLY at miniflare/undici;
+# the runtime undici via jsdom is 7.28.0 and is NOT flagged). Same accepted-risk
+# rationale as the two CVEs above — not in the published @agjs/tsforge package.
+[[IgnoredVulns]]
+id = "GHSA-35p6-xmwp-9g52"
+ignoreUntil = 2026-09-12T00:00:00Z
+reason = "undici 7.24.8 (miniflare→wrangler dev dependency only); runtime undici (via jsdom) is 7.28.0/unaffected; not shipped in the published package. Re-evaluate when wrangler/miniflare bump undici."
+
+[[IgnoredVulns]]
+id = "GHSA-g8m3-5g58-fq7m"
+ignoreUntil = 2026-09-12T00:00:00Z
+reason = "undici 7.24.8 (miniflare→wrangler dev dependency only); runtime undici (via jsdom) is 7.28.0/unaffected; not shipped in the published package. Re-evaluate when wrangler/miniflare bump undici."
+
+[[IgnoredVulns]]
+id = "GHSA-hm92-r4w5-c3mj"
+ignoreUntil = 2026-09-12T00:00:00Z
+reason = "undici 7.24.8 (miniflare→wrangler dev dependency only); runtime undici (via jsdom) is 7.28.0/unaffected; not shipped in the published package. Re-evaluate when wrangler/miniflare bump undici."
+
+[[IgnoredVulns]]
+id = "GHSA-p88m-4jfj-68fv"
+ignoreUntil = 2026-09-12T00:00:00Z
+reason = "undici 7.24.8 (miniflare→wrangler dev dependency only); runtime undici (via jsdom) is 7.28.0/unaffected; not shipped in the published package. Re-evaluate when wrangler/miniflare bump undici."
+
+[[IgnoredVulns]]
+id = "GHSA-vxpw-j846-p89q"
+ignoreUntil = 2026-09-12T00:00:00Z
+reason = "undici 7.24.8 (miniflare→wrangler dev dependency only); runtime undici (via jsdom) is 7.28.0/unaffected; not shipped in the published package. Re-evaluate when wrangler/miniflare bump undici."

--- a/packages/core/src/cli.ts
+++ b/packages/core/src/cli.ts
@@ -17,6 +17,7 @@ import {
   formatReport,
 } from "./loop";
 import { buildAndPersistMap, mapStatus, forgetMap } from "./codebase";
+import { isPolicyMode } from "./policy";
 import {
   PROVIDER_LIMITS,
   PROVIDER_DEFAULTS,
@@ -133,6 +134,9 @@ export interface ICliArgs {
   base: string;
   /** Build a structural workspace map (`tsforge map`). */
   map: boolean;
+  /** Base policy mode (`--policy-mode <plan|default|acceptEdits|ci|dontAsk|
+   *  bypassPermissions>`); overrides the config file's policy.mode. */
+  policyMode: string;
 }
 
 const BOOL_FLAGS: Record<
@@ -157,6 +161,7 @@ const VALUE_FLAGS = new Set([
   "--browser",
   "--resume",
   "--base",
+  "--policy-mode",
 ]);
 
 /** Parse argv (without the tsforge binary name). Always succeeds — mode is decided in main. */
@@ -179,6 +184,7 @@ export function parseArgs(argv: readonly string[]): ICliArgs {
     staged: false,
     base: "",
     map: false,
+    policyMode: "",
   };
 
   for (let i = 0; i < argv.length; i += 1) {
@@ -232,6 +238,8 @@ function applyValueFlag(flag: string, value: string, out: ICliArgs): void {
     out.resumeId = value;
   } else if (flag === "--base") {
     out.base = value;
+  } else if (flag === "--policy-mode") {
+    out.policyMode = value;
   } else {
     out.accept = value; // --accept / --gate
   }
@@ -1021,6 +1029,8 @@ async function repl(args: ICliArgs): Promise<number> {
       : { scaffoldWeb: true, fix: buildCoreFix() }),
     ...(thinkingTokenBudget === undefined ? {} : { thinkingTokenBudget }),
     ...(autoCompactAt === undefined ? {} : { autoCompactAt }),
+    // `--policy-mode` (validated) overrides the config file's policy.mode.
+    ...(isPolicyMode(args.policyMode) ? { policyMode: args.policyMode } : {}),
     // Thinking OFF for interactive replies so they STREAM immediately instead of
     // stalling on a long hidden chain-of-thought (qwen-local defaults thinking on).
     // The session still flips thinking ON automatically while repairing gate errors.

--- a/packages/core/src/cli.ts
+++ b/packages/core/src/cli.ts
@@ -1,6 +1,6 @@
 #!/usr/bin/env bun
 import { join, isAbsolute } from "node:path";
-import { appendFileSync, mkdirSync } from "node:fs";
+import { mkdirSync } from "node:fs";
 import { Writable } from "node:stream";
 import { createInterface } from "node:readline/promises";
 import { emitKeypressEvents } from "node:readline";
@@ -10,6 +10,8 @@ import {
   runTask,
   RUN_STATUS,
   Session,
+  LedgerWriter,
+  ledgerTypeFor,
   PLAN_APPROVED_NOTE,
   reviewChange,
   formatReport,
@@ -682,22 +684,23 @@ const render: Reporter = (event) => {
  *  file it wrote, the gate verdicts, and the loops it got stuck in. Append-only
  *  (NOT overwritten like the session JSON), and unredacted — it's an opt-in local
  *  debug artifact. Logging failures never break the session. */
-function makeReporter(logFile: string): Reporter {
+function makeReporter(
+  logFile: string,
+  runId: string,
+  sessionId?: string
+): Reporter {
   if (logFile.length === 0) {
     return render;
   }
 
+  const ledger = new LedgerWriter(logFile, runId, sessionId);
+
   return (event) => {
     render(event);
 
-    try {
-      appendFileSync(
-        logFile,
-        `${JSON.stringify({ t: Date.now(), ...event })}\n`
-      );
-    } catch {
-      // A logging failure must never interrupt the session.
-    }
+    const { kind, ...rest } = event;
+
+    ledger.record(ledgerTypeFor(event), { kind, ...rest });
   };
 }
 
@@ -740,7 +743,7 @@ async function runOnce(args: ICliArgs): Promise<number> {
   const thinkingTokenBudget = envNumber("TSFORGE_THINKING_BUDGET");
   const { entry } = await resolveActiveModel();
   const result = await runTask(task, args.dir, makeProvider(entry), {
-    onEvent: makeReporter(logFile),
+    onEvent: makeReporter(logFile, "cli"),
     ...(thinkingTokenBudget === undefined ? {} : { thinkingTokenBudget }),
   });
   const ok = result.status === RUN_STATUS.done;
@@ -987,7 +990,7 @@ async function repl(args: ICliArgs): Promise<number> {
     envNumber("TSFORGE_CONTEXT_WINDOW") ??
     (await detectContextWindow(provider.config)) ??
     32_768;
-  const report = makeReporter(logFile);
+  const report = makeReporter(logFile, id, id);
   const config = {
     provider,
     cwd: args.dir,

--- a/packages/core/src/config/tsforge-config.ts
+++ b/packages/core/src/config/tsforge-config.ts
@@ -2,6 +2,14 @@ import { join } from "node:path";
 import { isRecord } from "../lib/guards";
 import { PACK_REGISTRY } from "../stack-detection";
 import { parseMcpServers, type IMcpServerConfig } from "../mcp";
+import {
+  isPolicyMode,
+  isActionKind,
+  POLICY_MODES,
+  type PolicyMode,
+  type IPolicyRule,
+  type IPolicyRules,
+} from "../policy";
 import { parsePlugins, type IExternalPlugin } from "./external-plugins";
 import {
   DEFAULT_PROFILE,
@@ -50,6 +58,17 @@ export interface ITsforgeProjectConfig {
    * exported packs to use. Opt-in: absent ⇒ only built-in packs.
    */
   readonly plugins?: readonly IExternalPlugin[];
+
+  /**
+   * Unified action-policy settings. `mode` sets the base enforcement strength
+   * (overridden by `--policy-mode` and by plan mode); `rules` are deny/allow/ask
+   * lists evaluated before the mode default (deny-first). Opt-in: absent ⇒ the
+   * `default` mode with no extra rules.
+   */
+  readonly policy?: {
+    readonly mode?: PolicyMode;
+    readonly rules?: IPolicyRules;
+  };
 }
 
 function warnConfig(msg: string): void {
@@ -213,6 +232,146 @@ function validateRules(
 /** Validate each known field of an already-parsed config object, dropping any
  *  that fail their per-field validator. Kept separate from the file IO so the
  *  loader stays simple. */
+/** A single policy rule — warn-and-drop: unknown/typed-wrong fields are dropped,
+ *  an empty rule (matches everything) is a deliberate catch-all. */
+function validatePolicyRule(parsed: unknown): IPolicyRule | undefined {
+  if (!isRecord(parsed)) {
+    warnConfig("tsforge.config.json: a policy rule must be an object");
+
+    return undefined;
+  }
+
+  const rule: {
+    kind?: IPolicyRule["kind"];
+    toolName?: string;
+    pathPattern?: string;
+    commandPrefix?: string;
+    commandPattern?: string;
+    mcpServer?: string;
+  } = {};
+
+  if (isActionKind(parsed.kind)) {
+    rule.kind = parsed.kind;
+  }
+
+  if (typeof parsed.toolName === "string") {
+    rule.toolName = parsed.toolName;
+  }
+
+  if (typeof parsed.pathPattern === "string") {
+    rule.pathPattern = parsed.pathPattern;
+  }
+
+  if (typeof parsed.commandPrefix === "string") {
+    rule.commandPrefix = parsed.commandPrefix;
+  }
+
+  if (typeof parsed.commandPattern === "string") {
+    rule.commandPattern = parsed.commandPattern;
+  }
+
+  if (typeof parsed.mcpServer === "string") {
+    rule.mcpServer = parsed.mcpServer;
+  }
+
+  return rule;
+}
+
+function validateRuleList(parsed: unknown, label: string): IPolicyRule[] {
+  if (!Array.isArray(parsed)) {
+    warnConfig(`tsforge.config.json: policy.rules.${label} must be an array`);
+
+    return [];
+  }
+
+  const out: IPolicyRule[] = [];
+
+  for (const entry of parsed) {
+    const rule = validatePolicyRule(entry);
+
+    if (rule !== undefined) {
+      out.push(rule);
+    }
+  }
+
+  return out;
+}
+
+function validatePolicyRules(parsed: unknown): IPolicyRules | undefined {
+  if (!isRecord(parsed)) {
+    warnConfig('tsforge.config.json: "policy.rules" must be an object');
+
+    return undefined;
+  }
+
+  const rules: {
+    deny?: IPolicyRule[];
+    allow?: IPolicyRule[];
+    ask?: IPolicyRule[];
+  } = {};
+
+  if (parsed.deny !== undefined) {
+    rules.deny = validateRuleList(parsed.deny, "deny");
+  }
+
+  if (parsed.allow !== undefined) {
+    rules.allow = validateRuleList(parsed.allow, "allow");
+  }
+
+  if (parsed.ask !== undefined) {
+    rules.ask = validateRuleList(parsed.ask, "ask");
+  }
+
+  return rules;
+}
+
+function validatePolicy(
+  parsed: unknown
+): { mode?: PolicyMode; rules?: IPolicyRules } | undefined {
+  if (!isRecord(parsed)) {
+    warnConfig(
+      `tsforge.config.json: "policy" must be an object, got ${typeof parsed}`
+    );
+
+    return undefined;
+  }
+
+  const policy: { mode?: PolicyMode; rules?: IPolicyRules } = {};
+
+  if (parsed.mode !== undefined) {
+    if (isPolicyMode(parsed.mode)) {
+      policy.mode = parsed.mode;
+    } else {
+      warnConfig(
+        `tsforge.config.json: policy.mode must be one of ${POLICY_MODES.join(", ")}, got ${JSON.stringify(parsed.mode)}`
+      );
+    }
+  }
+
+  if (parsed.rules !== undefined) {
+    policy.rules = validatePolicyRules(parsed.rules);
+  }
+
+  return Object.keys(policy).length > 0 ? policy : undefined;
+}
+
+/** Validate + assign the optional `policy` block (kept off `buildConfigFields`
+ *  so its per-field branches don't push the function over the complexity cap). */
+function assignPolicy(
+  parsed: Record<string, unknown>,
+  configFields: { policy?: { mode?: PolicyMode; rules?: IPolicyRules } }
+): void {
+  if (parsed.policy === undefined) {
+    return;
+  }
+
+  const policy = validatePolicy(parsed.policy);
+
+  if (policy !== undefined) {
+    configFields.policy = policy;
+  }
+}
+
 function buildConfigFields(
   parsed: Record<string, unknown>
 ): ITsforgeProjectConfig {
@@ -223,6 +382,7 @@ function buildConfigFields(
     rules?: Record<string, "error" | "warn" | "off">;
     mcpServers?: Record<string, IMcpServerConfig>;
     plugins?: readonly IExternalPlugin[];
+    policy?: { mode?: PolicyMode; rules?: IPolicyRules };
   } = {};
 
   if (parsed.profile !== undefined) {
@@ -272,6 +432,8 @@ function buildConfigFields(
       configFields.plugins = plugins;
     }
   }
+
+  assignPolicy(parsed, configFields);
 
   return configFields;
 }

--- a/packages/core/src/loop/index.ts
+++ b/packages/core/src/loop/index.ts
@@ -1,5 +1,7 @@
 export * from "./loop.types";
 export * from "./loop.constants";
+export { LedgerWriter, ledgerTypeFor } from "./ledger-writer";
+export type { IBaseLedgerEvent, LedgerEventType } from "./ledger.types";
 export type { SetupWebFn } from "./tools";
 export { runTask } from "./run";
 export { runSpec } from "./run-spec";

--- a/packages/core/src/loop/ledger-writer.ts
+++ b/packages/core/src/loop/ledger-writer.ts
@@ -1,0 +1,116 @@
+import { appendFileSync } from "node:fs";
+import { redactText } from "../session-store";
+import type { ILoopEvent } from "./loop.types";
+import type { IBaseLedgerEvent, LedgerEventType } from "./ledger.types";
+
+/**
+ * Map a reporter event to its typed ledger event type. Most boundaries are
+ * derived from existing kinds (a turn ≈ one model call); events without a
+ * dedicated type fall through to `"log"`. `tool_call_requested`/`started`,
+ * `gate_started`, `resume_*`, and `user_prompt` are deferred (no signal yet).
+ */
+export function ledgerTypeFor(event: ILoopEvent): LedgerEventType {
+  switch (event.kind) {
+    case "start":
+      return "run_started";
+    case "done":
+    case "stuck":
+      return "run_finished";
+    case "cycle":
+      return "model_call_started";
+    case "usage":
+      return "model_call_finished";
+    case "validated":
+      return "gate_finished";
+    case "edit":
+    case "create":
+    case "run":
+      return "tool_call_finished";
+    case "policy":
+      return "policy_decision";
+    case "tool":
+      return event.message.startsWith("tool_rejected")
+        ? "tool_call_failed"
+        : "log";
+    default:
+      return "log";
+  }
+}
+
+/** Per-string payload cap — previews, not full file dumps or command output. */
+const MAX_VALUE_CHARS = 4096;
+
+function newEventId(): string {
+  return `${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 8)}`;
+}
+
+/** Redact secrets and truncate an over-long string to a capped preview. */
+function capString(value: string): string {
+  const redacted = redactText(value);
+
+  return redacted.length > MAX_VALUE_CHARS
+    ? `${redacted.slice(0, MAX_VALUE_CHARS)}…[+${redacted.length - MAX_VALUE_CHARS} chars]`
+    : redacted;
+}
+
+/** Redact + cap every value in a payload (one level into arrays/objects). */
+function capValue(value: unknown): unknown {
+  if (typeof value === "string") {
+    return capString(value);
+  }
+
+  if (Array.isArray(value)) {
+    return value.map(capValue);
+  }
+
+  if (value !== null && typeof value === "object") {
+    return capPayload(value);
+  }
+
+  return value;
+}
+
+function capPayload(payload: object): Record<string, unknown> {
+  const out: Record<string, unknown> = {};
+
+  for (const [key, value] of Object.entries(payload)) {
+    out[key] = capValue(value);
+  }
+
+  return out;
+}
+
+/**
+ * Append-only typed run ledger. Writes are synchronous (`appendFileSync`), so
+ * lines never interleave and the file is always valid JSONL. Every payload is
+ * secret-redacted and size-capped first; a write failure is swallowed so the
+ * ledger can never break the run. A no-op when no log file is configured.
+ */
+export class LedgerWriter {
+  constructor(
+    private readonly file: string,
+    private readonly runId: string,
+    private readonly sessionId?: string
+  ) {}
+
+  record(type: LedgerEventType, payload: Record<string, unknown>): void {
+    if (this.file.length === 0) {
+      return;
+    }
+
+    const event: IBaseLedgerEvent = {
+      eventId: newEventId(),
+      runId: this.runId,
+      ...(this.sessionId === undefined ? {} : { sessionId: this.sessionId }),
+      timestamp: new Date().toISOString(),
+      type,
+      payload: capPayload(payload),
+    };
+
+    try {
+      appendFileSync(this.file, `${JSON.stringify(event)}\n`);
+    } catch {
+      // A logging failure must never interrupt the session.
+    }
+  }
+}

--- a/packages/core/src/loop/ledger-writer.ts
+++ b/packages/core/src/loop/ledger-writer.ts
@@ -64,7 +64,15 @@ function capValue(value: unknown): unknown {
   }
 
   if (value !== null && typeof value === "object") {
-    return capPayload(value);
+    // Only recurse into PLAIN objects: Object.entries() returns [] for Date /
+    // RegExp / Map / class instances, which would silently flatten them to `{}`.
+    // Pass those through so JSON.stringify uses their own serialization (e.g.
+    // Date → ISO string via toJSON).
+    const proto: unknown = Object.getPrototypeOf(value);
+
+    return proto === Object.prototype || proto === null
+      ? capPayload(value)
+      : value;
   }
 
   return value;

--- a/packages/core/src/loop/ledger.types.ts
+++ b/packages/core/src/loop/ledger.types.ts
@@ -1,0 +1,41 @@
+/**
+ * Typed run ledger: the `--log` stream as an append-only sequence of typed
+ * events. Each line is one `IBaseLedgerEvent` (valid JSON), so a run is fully
+ * reconstructable — model calls, tool calls, policy decisions, gate verdicts.
+ */
+
+export type LedgerEventType =
+  | "run_started"
+  | "run_finished"
+  | "user_prompt"
+  | "model_call_started"
+  | "model_call_finished"
+  | "tool_call_requested"
+  | "tool_call_started"
+  | "tool_call_finished"
+  | "tool_call_failed"
+  | "policy_decision"
+  | "gate_started"
+  | "gate_finished"
+  | "resume_started"
+  | "resume_finished"
+  /** Catch-all for reporter events without a dedicated ledger type yet. */
+  | "log";
+
+export interface IBaseLedgerEvent {
+  /** Unique id for this event (for parentEventId references). */
+  eventId: string;
+  /** The run this event belongs to. */
+  runId: string;
+  /** The interactive session id, when applicable. */
+  sessionId?: string;
+  /** ISO-8601 timestamp. */
+  timestamp: string;
+  type: LedgerEventType;
+  /** The event that caused this one (e.g. the tool_call for its result). */
+  parentEventId?: string;
+  turnId?: string;
+  attempt?: number;
+  /** Event-specific data — redacted and size-capped before it is written. */
+  payload: Record<string, unknown>;
+}

--- a/packages/core/src/loop/loop.types.ts
+++ b/packages/core/src/loop/loop.types.ts
@@ -24,7 +24,10 @@ export interface ILoopEvent {
     | "repair"
     | "timing"
     | "usage"
-    | "ttsr";
+    | "ttsr"
+    // A unified-policy verdict for one proposed action (ledger-only; renders to
+    // nothing on the terminal — a deny is already surfaced via its `tool` event).
+    | "policy";
   task: string;
   message: string;
   cycle?: number;
@@ -75,6 +78,10 @@ export interface ILoopEvent {
    *  analyzer (which model / how big a context window the metrics are against). */
   model?: string;
   contextWindow?: number;
+  /** For `policy` events: the verdict and risk for one proposed action (the
+   *  matched rules ride in `rules`, the reason in `message`). */
+  decision?: "allow" | "ask" | "deny";
+  risk?: "low" | "medium" | "high" | "critical";
 }
 
 export type Reporter = (event: ILoopEvent) => void;

--- a/packages/core/src/loop/run.ts
+++ b/packages/core/src/loop/run.ts
@@ -17,6 +17,8 @@ import type {
 } from "./loop.types";
 import { mineLessons, consolidate as consolidateMemory } from "./memory";
 import { flags } from "../config";
+import type { ITsforgeProjectConfig } from "../config";
+import type { PolicyMode, IPolicyRules } from "../policy";
 import { buildSystemPrompt, seedPrompt } from "./prompt";
 import { detectStack } from "../stack-detection";
 import type { TtsrManager } from "./ttsr";
@@ -173,12 +175,25 @@ function effectiveParserFor(
 
 /** Detect the stack and fold in tsforge.config.json pack/rule overrides, plus any
  *  rule packs from configured external plugins. */
+/** The optional policy fields for the loop context (kept off `runTask` so its
+ *  `exactOptionalPropertyTypes` spreads don't inflate its cognitive complexity). */
+function policyCtxFields(policy: ITsforgeProjectConfig["policy"]): {
+  policyMode?: PolicyMode;
+  policyRules?: IPolicyRules;
+} {
+  return {
+    ...(policy?.mode === undefined ? {} : { policyMode: policy.mode }),
+    ...(policy?.rules === undefined ? {} : { policyRules: policy.rules }),
+  };
+}
+
 async function resolveStackForRun(
   cwd: string,
   report: (message: string) => void
 ): Promise<{
   stackProfile: Awaited<ReturnType<typeof detectStack>>;
   ruleOverrides: Readonly<Record<string, "error" | "warn" | "off">>;
+  policy: ITsforgeProjectConfig["policy"];
 }> {
   const detectedProfile = await detectStack(cwd);
   const { loadTsforgeConfig, resolveActivePacks, normalizeRuleOverrides } =
@@ -198,6 +213,7 @@ async function resolveStackForRun(
         externalIds.length > 0 ? [...activePacks, ...externalIds] : activePacks,
     },
     ruleOverrides: normalizeRuleOverrides(cfg),
+    policy: cfg.policy,
   };
 }
 
@@ -280,7 +296,7 @@ export async function runTask(
   });
 
   // Detect stack once per run, early; tsforge.config.json may adjust it
-  const { stackProfile, ruleOverrides } = await resolveStackForRun(
+  const { stackProfile, ruleOverrides, policy } = await resolveStackForRun(
     cwd,
     (message) => {
       report({ kind: "tool", task: task.id, message });
@@ -334,6 +350,9 @@ export async function runTask(
     touched: new Set<string>(),
     ruleOverrides:
       Object.keys(ruleOverrides).length > 0 ? ruleOverrides : undefined,
+    // Config-driven policy applies to headless runs too (the critical denies
+    // already do, mode-independent; this adds `policy.mode`/`rules`).
+    ...policyCtxFields(policy),
   };
   const state: ILoopState = {
     prevGateErrors: red.errors,

--- a/packages/core/src/loop/session.ts
+++ b/packages/core/src/loop/session.ts
@@ -551,7 +551,8 @@ export class Session {
     }
 
     this.ctx = ctx;
-    this.baseMode = cfg.policyMode ?? "default";
+    // create() already resolved the base mode (CLI > config > default) onto ctx.
+    this.baseMode = ctx.policyMode ?? "default";
     this.ctx.policyMode = this.planMode ? "plan" : this.baseMode;
     // Buffer events off ctx.report (where edit/create/validated flow) so the
     // post-send memory hook can mine them; still forward to the original reporter.
@@ -589,6 +590,11 @@ export class Session {
     // pack selection and rule-severity overrides.
     const detected = await detectStack(cfg.cwd);
     const projectConfig = await loadTsforgeConfig(cfg.cwd);
+    // Base policy mode + rules: CLI (`--policy-mode` via cfg) wins over the
+    // config file's `policy.mode`, else `"default"`. Plan mode overrides this
+    // base at runtime (setPlanMode).
+    const baseMode = cfg.policyMode ?? projectConfig.policy?.mode ?? "default";
+    const policyRules = projectConfig.policy?.rules;
     const activePacks = resolveActivePacks(detected.packs, projectConfig);
     // Opt-in: load rule packs from external plugins and fold their ids into the
     // active packs so the gate runs them. loadAndRegisterPlugins never throws.
@@ -636,6 +642,8 @@ export class Session {
       report,
       stackProfile,
       touched: new Set<string>(),
+      policyMode: baseMode,
+      ...(policyRules === undefined ? {} : { policyRules }),
       ...(mcpRegistry === null ? {} : { mcpRegistry }),
       ...(Object.keys(ruleOverrides).length > 0 ? { ruleOverrides } : {}),
       messages:

--- a/packages/core/src/loop/session.ts
+++ b/packages/core/src/loop/session.ts
@@ -17,6 +17,7 @@ import {
   TOOL_NAME,
 } from "../agent";
 import type { SetupWebFn } from "./tools";
+import type { PolicyMode } from "../policy";
 import { flags } from "../config";
 import { readFiles } from "../lib/fs";
 import { WEB_VENDORED_PATTERNS } from "../lib/scope";
@@ -77,6 +78,9 @@ export interface ISessionConfig {
   thinkingTokenBudget?: number;
   /** Per-`send` turn cap (default LOOP_LIMITS.maxTurns). */
   maxTurns?: number;
+  /** Base policy mode (from `--policy-mode`/config). Plan mode overrides it with
+   *  `"plan"`; absent ⇒ `"default"`. */
+  policyMode?: PolicyMode;
   /** Resume from a saved conversation (incl. its system message) instead of
    *  starting fresh — used by `--continue`. */
   history?: IChatMessage[];
@@ -484,6 +488,10 @@ export class Session {
    *  advertised tool list per call — `this.tools` itself is never mutated, so
    *  toggling off restores everything with zero bookkeeping. */
   private planMode = false;
+  /** The policy mode to fall back to when plan mode is OFF — from CLI/config
+   *  (wired in `create`), default `"default"`. Plan mode overrides it with
+   *  `"plan"`; toggling plan off restores THIS, not a hard `"default"`. */
+  private baseMode: PolicyMode = "default";
   /** Attach PLAN_MODE_NOTE to the NEXT send only (not every revision reply). */
   private planIntroPending = false;
   /** FORCED-TOOLS experiment — see ISessionConfig.forceTools. */
@@ -543,6 +551,8 @@ export class Session {
     }
 
     this.ctx = ctx;
+    this.baseMode = cfg.policyMode ?? "default";
+    this.ctx.policyMode = this.planMode ? "plan" : this.baseMode;
     // Buffer events off ctx.report (where edit/create/validated flow) so the
     // post-send memory hook can mine them; still forward to the original reporter.
     const rawCtxReport = ctx.report;
@@ -732,6 +742,9 @@ export class Session {
   setPlanMode(on: boolean): void {
     this.planMode = on;
     this.ctx.readOnly = on; // the hard guarantee at the execute layer
+    // Plan forces the read-only policy mode; toggling off restores the base mode
+    // (e.g. an explicit --policy-mode ci), not a hard reset to "default".
+    this.ctx.policyMode = on ? "plan" : this.baseMode;
     this.planIntroPending = on;
   }
 

--- a/packages/core/src/loop/tools/execute-tool.ts
+++ b/packages/core/src/loop/tools/execute-tool.ts
@@ -86,10 +86,18 @@ export async function executeTool(
   // built-in, MCP, plugin, and unknown tools alike. Tool-local guards (scope,
   // vendored, SSRF, argv) still run afterwards — policy is an outer layer, not a
   // replacement. The model proposes; the harness enforces.
-  const verdict = evaluatePolicy(
-    classifyAction(call, ctx.cwd),
-    policyContextFrom(ctx)
-  );
+  const action = classifyAction(call, ctx.cwd);
+  const verdict = evaluatePolicy(action, policyContextFrom(ctx));
+
+  // A typed ledger signal for every decision (renders to nothing on screen).
+  ctx.report({
+    kind: "policy",
+    task: ctx.task,
+    message: `${action.kind} ${call.name}: ${verdict.reason}`,
+    decision: verdict.decision,
+    risk: verdict.risk,
+    rules: verdict.matchedRules,
+  });
 
   if (verdict.decision !== "allow") {
     return reject(

--- a/packages/core/src/loop/tools/execute-tool.ts
+++ b/packages/core/src/loop/tools/execute-tool.ts
@@ -11,6 +11,11 @@ import { doAddDependency } from "./add-dependency";
 import { doWebFetch } from "./web-fetch";
 import { doWebSearch } from "./web-search";
 import { reject, type IToolContext } from "./tool-context";
+import {
+  classifyAction,
+  evaluatePolicy,
+  type IPolicyContext,
+} from "../../policy";
 
 export type { IToolContext } from "./tool-context";
 
@@ -52,6 +57,21 @@ function isToolName(name: string): name is ToolName {
   return Object.hasOwn(HANDLERS, name);
 }
 
+/** Build the policy context from the ambient tool context. Mode defaults to
+ *  `"default"` (drive-to-green) when unset; MCP server names come from the
+ *  registry so a forged/unregistered `mcp__*` call is a critical deny. */
+function policyContextFrom(ctx: IToolContext): IPolicyContext {
+  const servers = ctx.mcpRegistry?.serverNames();
+
+  return {
+    mode: ctx.policyMode ?? "default",
+    cwd: ctx.cwd,
+    files: ctx.files,
+    interactive: ctx.interactive ?? false,
+    ...(servers === undefined ? {} : { mcpServers: servers }),
+  };
+}
+
 /**
  * Perform one tool call and return the text result fed back to the model as a
  * tool message. Dispatch only — the handlers live in file-ops (read/run/edit/
@@ -62,9 +82,25 @@ export async function executeTool(
   call: IToolCall,
   ctx: IToolContext
 ): Promise<string> {
+  // UNIFIED POLICY (deny-first), evaluated BEFORE any routing so it wraps
+  // built-in, MCP, plugin, and unknown tools alike. Tool-local guards (scope,
+  // vendored, SSRF, argv) still run afterwards — policy is an outer layer, not a
+  // replacement. The model proposes; the harness enforces.
+  const verdict = evaluatePolicy(
+    classifyAction(call, ctx.cwd),
+    policyContextFrom(ctx)
+  );
+
+  if (verdict.decision !== "allow") {
+    return reject(
+      ctx,
+      call.name,
+      `policy ${verdict.decision}: ${verdict.reason}`
+    );
+  }
+
   // MCP tools (mcp__<server>__<tool>) are dispatched to their server. They are
-  // external context sources — never workspace mutations — so they bypass the
-  // built-in name table and the plan-mode write guard below.
+  // external context sources — never workspace mutations.
   if (ctx.mcpRegistry?.has(call.name) === true) {
     return ctx.mcpRegistry.callTool(call.name, call.arguments);
   }

--- a/packages/core/src/loop/tools/execute-tool.ts
+++ b/packages/core/src/loop/tools/execute-tool.ts
@@ -69,6 +69,7 @@ function policyContextFrom(ctx: IToolContext): IPolicyContext {
     files: ctx.files,
     interactive: ctx.interactive ?? false,
     ...(servers === undefined ? {} : { mcpServers: servers }),
+    ...(ctx.policyRules === undefined ? {} : { rules: ctx.policyRules }),
   };
 }
 

--- a/packages/core/src/loop/tools/file-ops.ts
+++ b/packages/core/src/loop/tools/file-ops.ts
@@ -158,6 +158,10 @@ const TSC_EMITTING = new Set([
   "--emitDeclarationOnly",
   "--build",
   "-b",
+  // Write a `.tsbuildinfo` to disk even alongside `--noEmit`, so a "read-only"
+  // typecheck that carries them isn't read-only.
+  "--tsBuildInfoFile",
+  "--incremental",
 ]);
 
 /** `tsc` invocations that don't touch disk even without `--noEmit`. */

--- a/packages/core/src/loop/tools/tool-context.ts
+++ b/packages/core/src/loop/tools/tool-context.ts
@@ -3,6 +3,7 @@ import type { TsService } from "../../lsp";
 import type { Reporter } from "../loop.types";
 import type { SessionSnapshotStore } from "../../files/hashline";
 import type { McpRegistry } from "../../mcp";
+import type { PolicyMode } from "../../policy";
 
 /** Turn a workspace into a web project. Resolves with the files actually written
  *  (mutation accounting / re-gate) and whether dependency install succeeded. The
@@ -43,6 +44,13 @@ export interface IToolContext {
    *  read-only commands — the hard guarantee behind the filtered tool list (a
    *  salvaged/forced call could otherwise still write). */
   readOnly?: boolean;
+  /** Active policy mode for the unified action-policy layer (executeTool runs
+   *  every call through `evaluatePolicy` first). Absent ⇒ `"default"` (the
+   *  autonomous drive-to-green default), so existing call sites are unchanged. */
+  policyMode?: PolicyMode;
+  /** Whether a real interactive per-action approval path exists. Absent/false ⇒
+   *  a policy `ask` resolves to `deny` (no approval UI today). */
+  interactive?: boolean;
   /** Hashline snapshot store for stale-anchor recovery (per-session, lazily initialized). */
   snapshotStore?: SessionSnapshotStore;
   /** Connected MCP servers. When present, `mcp__<server>__<tool>` calls are routed

--- a/packages/core/src/loop/tools/tool-context.ts
+++ b/packages/core/src/loop/tools/tool-context.ts
@@ -3,7 +3,7 @@ import type { TsService } from "../../lsp";
 import type { Reporter } from "../loop.types";
 import type { SessionSnapshotStore } from "../../files/hashline";
 import type { McpRegistry } from "../../mcp";
-import type { PolicyMode } from "../../policy";
+import type { PolicyMode, IPolicyRules } from "../../policy";
 
 /** Turn a workspace into a web project. Resolves with the files actually written
  *  (mutation accounting / re-gate) and whether dependency install succeeded. The
@@ -48,6 +48,9 @@ export interface IToolContext {
    *  every call through `evaluatePolicy` first). Absent ⇒ `"default"` (the
    *  autonomous drive-to-green default), so existing call sites are unchanged. */
   policyMode?: PolicyMode;
+  /** Config-driven policy rules (deny/allow/ask), evaluated before the mode
+   *  default. Absent ⇒ mode default only. */
+  policyRules?: IPolicyRules;
   /** Whether a real interactive per-action approval path exists. Absent/false ⇒
    *  a policy `ask` resolves to `deny` (no approval UI today). */
   interactive?: boolean;

--- a/packages/core/src/loop/turn.ts
+++ b/packages/core/src/loop/turn.ts
@@ -11,7 +11,7 @@ import {
   type IErrorItem,
 } from "../validate";
 import { isInScope } from "../lib/scope";
-import type { PolicyMode } from "../policy";
+import type { PolicyMode, IPolicyRules } from "../policy";
 import { fileExists, resolveScopeFiles } from "../lib/fs";
 import { RUN_STATUS, STUCK_REASON, LOOP_LIMITS } from "./loop.constants";
 import type { IRunResult, Reporter } from "./loop.types";
@@ -166,6 +166,8 @@ export interface ILoopCtx {
    *  mode forces `"plan"`; otherwise the base mode from CLI/config (default
    *  `"default"`). Threaded into the tool context. */
   policyMode?: PolicyMode;
+  /** Config-driven policy rules (deny/allow/ask) threaded to the tool context. */
+  policyRules?: IPolicyRules;
   /** Whether an interactive per-action approval path exists (false today). */
   interactive?: boolean;
   /** Connected MCP servers (opt-in via tsforge.config.json `mcpServers`). Threaded
@@ -580,6 +582,7 @@ function toolContextFor(ctx: ILoopCtx, report: Reporter): IToolContext {
     ...(ctx.vendored === undefined ? {} : { vendored: ctx.vendored }),
     ...(ctx.readOnly === undefined ? {} : { readOnly: ctx.readOnly }),
     ...(ctx.policyMode === undefined ? {} : { policyMode: ctx.policyMode }),
+    ...(ctx.policyRules === undefined ? {} : { policyRules: ctx.policyRules }),
     ...(ctx.interactive === undefined ? {} : { interactive: ctx.interactive }),
     ...(ctx.mcpRegistry === undefined ? {} : { mcpRegistry: ctx.mcpRegistry }),
   };

--- a/packages/core/src/loop/turn.ts
+++ b/packages/core/src/loop/turn.ts
@@ -11,13 +11,14 @@ import {
   type IErrorItem,
 } from "../validate";
 import { isInScope } from "../lib/scope";
+import type { PolicyMode } from "../policy";
 import { fileExists, resolveScopeFiles } from "../lib/fs";
 import { RUN_STATUS, STUCK_REASON, LOOP_LIMITS } from "./loop.constants";
 import type { IRunResult, Reporter } from "./loop.types";
 import { flags } from "../config";
 import type { IStackProfile } from "../stack-detection";
 import { gateFeedback } from "./feedback";
-import { executeTool, type SetupWebFn } from "./tools";
+import { executeTool, type SetupWebFn, type IToolContext } from "./tools";
 import {
   astGrepFix,
   dropRedundantAnnotations,
@@ -161,6 +162,12 @@ export interface ILoopCtx {
   /** PLAN MODE (set via Session.setPlanMode): threaded into the tool context so
    *  mutating tools are rejected at dispatch — the model only plans. */
   readOnly?: boolean;
+  /** Active policy mode for the unified action-policy layer (executeTool). Plan
+   *  mode forces `"plan"`; otherwise the base mode from CLI/config (default
+   *  `"default"`). Threaded into the tool context. */
+  policyMode?: PolicyMode;
+  /** Whether an interactive per-action approval path exists (false today). */
+  interactive?: boolean;
   /** Connected MCP servers (opt-in via tsforge.config.json `mcpServers`). Threaded
    *  into the tool context so `mcp__<server>__<tool>` calls dispatch to them. */
   mcpRegistry?: McpRegistry;
@@ -559,6 +566,25 @@ function recordTouched(ctx: ILoopCtx, files: readonly string[]): void {
   }
 }
 
+/** Build the per-call tool context from the loop context. Extracted so the
+ *  optional-field spreads don't inflate `runToolCalls`'s cognitive complexity. */
+function toolContextFor(ctx: ILoopCtx, report: Reporter): IToolContext {
+  return {
+    cwd: ctx.cwd,
+    files: ctx.task.files,
+    report,
+    task: ctx.task.id,
+    tsService: ctx.tsService,
+    ...(ctx.signal === undefined ? {} : { signal: ctx.signal }),
+    ...(ctx.setupWeb === undefined ? {} : { setupWeb: ctx.setupWeb }),
+    ...(ctx.vendored === undefined ? {} : { vendored: ctx.vendored }),
+    ...(ctx.readOnly === undefined ? {} : { readOnly: ctx.readOnly }),
+    ...(ctx.policyMode === undefined ? {} : { policyMode: ctx.policyMode }),
+    ...(ctx.interactive === undefined ? {} : { interactive: ctx.interactive }),
+    ...(ctx.mcpRegistry === undefined ? {} : { mcpRegistry: ctx.mcpRegistry }),
+  };
+}
+
 /**
  * Run the model's tool calls: execute each, feed the result back, and report
  * whether any touched an editable file (which means we should re-gate). Mutates
@@ -611,20 +637,7 @@ export async function runToolCalls(
       ctx.report(event);
     };
 
-    const result = await executeTool(call, {
-      cwd: ctx.cwd,
-      files: ctx.task.files,
-      report,
-      task: ctx.task.id,
-      tsService: ctx.tsService,
-      ...(ctx.signal === undefined ? {} : { signal: ctx.signal }),
-      ...(ctx.setupWeb === undefined ? {} : { setupWeb: ctx.setupWeb }),
-      ...(ctx.vendored === undefined ? {} : { vendored: ctx.vendored }),
-      ...(ctx.readOnly === undefined ? {} : { readOnly: ctx.readOnly }),
-      ...(ctx.mcpRegistry === undefined
-        ? {}
-        : { mcpRegistry: ctx.mcpRegistry }),
-    });
+    const result = await executeTool(call, toolContextFor(ctx, report));
 
     let feedback = "";
 

--- a/packages/core/src/mcp/registry.ts
+++ b/packages/core/src/mcp/registry.ts
@@ -60,6 +60,12 @@ export class McpRegistry {
     return this.byName.has(name);
   }
 
+  /** Distinct registered server names — the policy layer denies an
+   *  `mcp__<server>__*` call whose server isn't in this set. */
+  serverNames(): string[] {
+    return [...new Set([...this.byName.values()].map((t) => t.server))];
+  }
+
   /** Call a registered MCP tool. Never throws: a transport failure is returned
    *  as text so the model treats it as a tool result. */
   async callTool(name: string, args: Record<string, unknown>): Promise<string> {

--- a/packages/core/src/policy/classify.ts
+++ b/packages/core/src/policy/classify.ts
@@ -1,0 +1,118 @@
+import { TOOL_NAME } from "../agent";
+import type { IToolCall } from "../inference";
+import { normalizeWorkspacePath } from "../lib/scope";
+import type { ActionKind, IProposedAction } from "./policy.types";
+
+/** Tool name → what it actually does. Tools absent here (or any future/forged
+ *  name) classify as `unknown`, which the policy never silently allows. MCP
+ *  tools (`mcp__*`) are handled separately. yield_status is a benign turn-ender
+ *  (the Session intercepts it pre-dispatch) — mapped to a read so it's allowed
+ *  if it ever reaches the dispatcher. */
+const KIND_BY_TOOL: Readonly<Record<string, ActionKind>> = {
+  [TOOL_NAME.read]: "read_file",
+  [TOOL_NAME.search]: "read_file",
+  [TOOL_NAME.symbolSearch]: "read_file",
+  [TOOL_NAME.findReferences]: "read_file",
+  [TOOL_NAME.typeAt]: "read_file",
+  [TOOL_NAME.diagnostics]: "read_file",
+  [TOOL_NAME.gitContext]: "read_file",
+  [TOOL_NAME.yieldStatus]: "read_file",
+  [TOOL_NAME.edit]: "edit_file",
+  [TOOL_NAME.editLines]: "edit_file",
+  [TOOL_NAME.organizeImports]: "edit_file",
+  [TOOL_NAME.renameSymbol]: "edit_file",
+  [TOOL_NAME.create]: "write_file",
+  [TOOL_NAME.moveFile]: "write_file",
+  [TOOL_NAME.scaffoldUi]: "write_file",
+  [TOOL_NAME.scaffoldRoutes]: "write_file",
+  [TOOL_NAME.scaffoldWeb]: "write_file",
+  [TOOL_NAME.run]: "shell",
+  [TOOL_NAME.addDependency]: "shell",
+  [TOOL_NAME.webFetch]: "network",
+  [TOOL_NAME.webSearch]: "network",
+};
+
+/** Arg keys that carry a file path the action touches. */
+const PATH_KEYS: readonly string[] = ["file", "from", "to"];
+
+function str(args: Record<string, unknown>, key: string): string {
+  const v = args[key];
+
+  return typeof v === "string" ? v : "";
+}
+
+/** Workspace-relative, normalized paths from the call's path-bearing args. */
+function extractPaths(
+  args: Record<string, unknown>,
+  cwd: string
+): readonly string[] {
+  const out: string[] = [];
+
+  for (const key of PATH_KEYS) {
+    const value = str(args, key);
+
+    if (value.length > 0) {
+      out.push(normalizeWorkspacePath(cwd, value));
+    }
+  }
+
+  return out;
+}
+
+/** A command preview for shell actions (the literal `run` command, or the
+ *  `bun add …` line `add_dependency` would build). Undefined for non-shell. */
+function extractCommand(
+  toolName: string,
+  args: Record<string, unknown>
+): string | undefined {
+  if (toolName === TOOL_NAME.run) {
+    return str(args, "command");
+  }
+
+  if (toolName === TOOL_NAME.addDependency) {
+    return `bun add ${str(args, "packages")}`.trim();
+  }
+
+  return undefined;
+}
+
+/**
+ * Reduce a tool call to an `IProposedAction` the policy can evaluate. Reuses the
+ * existing `normalizeWorkspacePath` so policy sees the same path form the write
+ * guards do. Unknown/forged names → `kind:"unknown"`; `mcp__<server>__<tool>` →
+ * `mcp_tool` with the parsed server.
+ */
+export function classifyAction(call: IToolCall, cwd: string): IProposedAction {
+  const args = call.arguments;
+
+  if (call.name.startsWith("mcp__")) {
+    return {
+      kind: "mcp_tool",
+      toolName: call.name,
+      input: args,
+      cwd,
+      mcpServer: call.name.split("__")[1] ?? "",
+    };
+  }
+
+  const kind = KIND_BY_TOOL[call.name] ?? "unknown";
+  const paths = extractPaths(args, cwd);
+  const command = extractCommand(call.name, args);
+
+  const action: IProposedAction = {
+    kind,
+    toolName: call.name,
+    input: args,
+    cwd,
+  };
+
+  if (paths.length > 0) {
+    action.paths = paths;
+  }
+
+  if (command !== undefined) {
+    action.command = command;
+  }
+
+  return action;
+}

--- a/packages/core/src/policy/index.ts
+++ b/packages/core/src/policy/index.ts
@@ -1,0 +1,14 @@
+export type {
+  PolicyDecision,
+  PolicyMode,
+  ActionKind,
+  RiskLevel,
+  IProposedAction,
+  IPolicyEvaluation,
+  IPolicyRule,
+  IPolicyRules,
+  IPolicyContext,
+} from "./policy.types";
+export { evaluatePolicy } from "./policy";
+export { classifyAction } from "./classify";
+export { isDestructiveShell, isPrivateKeyPath } from "./patterns";

--- a/packages/core/src/policy/index.ts
+++ b/packages/core/src/policy/index.ts
@@ -9,6 +9,12 @@ export type {
   IPolicyRules,
   IPolicyContext,
 } from "./policy.types";
-export { evaluatePolicy } from "./policy";
+export {
+  evaluatePolicy,
+  POLICY_MODES,
+  isPolicyMode,
+  ACTION_KINDS,
+  isActionKind,
+} from "./policy";
 export { classifyAction } from "./classify";
 export { isDestructiveShell, isPrivateKeyPath } from "./patterns";

--- a/packages/core/src/policy/patterns.ts
+++ b/packages/core/src/policy/patterns.ts
@@ -19,8 +19,33 @@ const DESTRUCTIVE_HEADS: ReadonlySet<string> = new Set([
   "cfdisk",
 ]);
 
-/** The head command of one shell segment, with env-assignments, `sudo`, and any
- *  directory prefix removed (`/bin/rm` → `rm`, `sudo rm` → `rm`). */
+/** Wrapper commands that prefix a REAL command — they (and their flags) must be
+ *  skipped to reach the head being run (`sudo rm`, `env VAR=x rm`, `nohup rm`). */
+const COMMAND_WRAPPERS: ReadonlySet<string> = new Set([
+  "sudo",
+  "env",
+  "command",
+  "nice",
+  "nohup",
+  "setsid",
+  "stdbuf",
+]);
+
+/** Wrapper flags that consume the FOLLOWING token as their value, so it isn't
+ *  mistaken for the head (`sudo -u root rm` → skip `-u root`). */
+const WRAPPER_VALUE_FLAGS: ReadonlySet<string> = new Set([
+  "-u",
+  "-g",
+  "-C",
+  "-S",
+  "-p",
+  "--user",
+  "--group",
+]);
+
+/** The head command of one shell segment, with env-assignments, wrapper commands
+ *  (`sudo`/`env`/…) and their flags, and any directory prefix removed
+ *  (`/bin/rm` → `rm`, `sudo -u root rm` → `rm`, `env VAR=x rm` → `rm`). */
 function commandHead(segment: string): string {
   const tokens = segment
     .trim()
@@ -29,11 +54,16 @@ function commandHead(segment: string): string {
 
   let i = 0;
 
-  while (
-    i < tokens.length &&
-    (/^[A-Za-z_][A-Za-z0-9_]*=/.test(tokens[i] ?? "") || tokens[i] === "sudo")
-  ) {
-    i += 1;
+  while (i < tokens.length) {
+    const token = tokens[i] ?? "";
+
+    if (/^[A-Za-z_][A-Za-z0-9_]*=/.test(token) || COMMAND_WRAPPERS.has(token)) {
+      i += 1; // env-assignment or a wrapper command
+    } else if (token.startsWith("-")) {
+      i += WRAPPER_VALUE_FLAGS.has(token) ? 2 : 1; // a wrapper flag (+ its value)
+    } else {
+      break; // the real head
+    }
   }
 
   const head = tokens[i] ?? "";

--- a/packages/core/src/policy/patterns.ts
+++ b/packages/core/src/policy/patterns.ts
@@ -1,0 +1,72 @@
+/**
+ * Dangerous-pattern detectors used by the critical-deny set — the denials that
+ * win in EVERY policy mode (including `bypassPermissions`). Kept tiny and
+ * conservative on purpose: a false positive here blocks legitimate work.
+ */
+
+/** Command heads that destroy data regardless of flags. Matched against the
+ *  resolved head of each shell segment (after `sudo`/`VAR=val` prefixes and any
+ *  path prefix are stripped) — never a naive substring (so `npm` ≠ `mkfs`). */
+const DESTRUCTIVE_HEADS: ReadonlySet<string> = new Set([
+  "rm",
+  "rmdir",
+  "dd",
+  "mkfs",
+  "shred",
+  "wipefs",
+  "fdisk",
+  "parted",
+  "cfdisk",
+]);
+
+/** The head command of one shell segment, with env-assignments, `sudo`, and any
+ *  directory prefix removed (`/bin/rm` → `rm`, `sudo rm` → `rm`). */
+function commandHead(segment: string): string {
+  const tokens = segment
+    .trim()
+    .split(/\s+/)
+    .filter((t) => t.length > 0);
+
+  let i = 0;
+
+  while (
+    i < tokens.length &&
+    (/^[A-Za-z_][A-Za-z0-9_]*=/.test(tokens[i] ?? "") || tokens[i] === "sudo")
+  ) {
+    i += 1;
+  }
+
+  const head = tokens[i] ?? "";
+  const slash = head.lastIndexOf("/");
+
+  return slash >= 0 ? head.slice(slash + 1) : head;
+}
+
+/** True when ANY chained segment of the command invokes a destructive head.
+ *  Splits on shell separators (`&&`, `||`, `|`, `;`, `&`, newline) so a
+ *  `build && rm -rf /` can't smuggle the destructive part past the head check. */
+export function isDestructiveShell(command: string): boolean {
+  return command
+    .split(/&&|\|\||[|;&\n]/)
+    .some((segment) => DESTRUCTIVE_HEADS.has(commandHead(segment)));
+}
+
+/** Path shapes for unmistakable private-key / credential material. Deliberately
+ *  EXCLUDES `.env` (commonly read for legitimate work) — this denies reads of
+ *  actual key files only, in every mode. */
+const PRIVATE_KEY_PATTERNS: readonly RegExp[] = [
+  /(^|\/)id_rsa($|\.)/,
+  /(^|\/)id_ed25519($|\.)/,
+  /(^|\/)id_ecdsa($|\.)/,
+  /(^|\/)id_dsa($|\.)/,
+  /(^|\/)\.ssh\//,
+  /\.pem$/,
+  /\.key$/,
+  /\.p12$/,
+  /\.pfx$/,
+];
+
+/** True when the (workspace-relative) path looks like private-key material. */
+export function isPrivateKeyPath(path: string): boolean {
+  return PRIVATE_KEY_PATTERNS.some((re) => re.test(path));
+}

--- a/packages/core/src/policy/policy.ts
+++ b/packages/core/src/policy/policy.ts
@@ -192,8 +192,9 @@ function criticalDeny(
   if (
     action.kind === "mcp_tool" &&
     action.mcpServer !== undefined &&
-    ctx.mcpServers !== undefined &&
-    !ctx.mcpServers.includes(action.mcpServer)
+    // Undefined ⇒ no MCP servers configured ⇒ NO mcp tool is registered, so any
+    // `mcp__*` call must be denied (not waved through to the mode default).
+    !(ctx.mcpServers ?? []).includes(action.mcpServer)
   ) {
     return {
       reason: `unregistered MCP server blocked: ${action.mcpServer}`,
@@ -204,13 +205,46 @@ function criticalDeny(
   return null;
 }
 
-function safeRegexTest(pattern: string, value: string): boolean {
+// Compiled-pattern caches keyed by the rule object — evaluatePolicy runs on
+// every tool call, so we compile each rule's regex/glob ONCE, not per check.
+// (Config rule objects are stable for a session; a malformed regex caches null
+// so it simply never matches.)
+const regexCache = new WeakMap<IPolicyRule, RegExp | null>();
+const globCache = new WeakMap<IPolicyRule, Bun.Glob>();
+
+function ruleRegex(rule: IPolicyRule, pattern: string): RegExp | null {
+  const cached = regexCache.get(rule);
+
+  if (cached !== undefined) {
+    return cached;
+  }
+
+  let compiled: RegExp | null;
+
   try {
-    return new RegExp(pattern).test(value);
+    compiled = new RegExp(pattern);
   } catch {
     // A malformed regex in config never matches (config load also warns on it).
-    return false;
+    compiled = null;
   }
+
+  regexCache.set(rule, compiled);
+
+  return compiled;
+}
+
+function ruleGlob(rule: IPolicyRule, pattern: string): Bun.Glob {
+  const cached = globCache.get(rule);
+
+  if (cached !== undefined) {
+    return cached;
+  }
+
+  const glob = new Bun.Glob(pattern);
+
+  globCache.set(rule, glob);
+
+  return glob;
 }
 
 /** Whether every PRESENT field of the rule matches the action (AND). An empty
@@ -235,15 +269,17 @@ function ruleMatches(rule: IPolicyRule, action: IProposedAction): boolean {
     return false;
   }
 
-  if (
-    rule.commandPattern !== undefined &&
-    !safeRegexTest(rule.commandPattern, action.command ?? "")
-  ) {
-    return false;
+  if (rule.commandPattern !== undefined) {
+    // A null (malformed) regex never matches.
+    const regex = ruleRegex(rule, rule.commandPattern);
+
+    if (regex?.test(action.command ?? "") !== true) {
+      return false;
+    }
   }
 
   if (rule.pathPattern !== undefined) {
-    const glob = new Bun.Glob(rule.pathPattern);
+    const glob = ruleGlob(rule, rule.pathPattern);
 
     if (!(action.paths ?? []).some((p) => glob.match(p))) {
       return false;

--- a/packages/core/src/policy/policy.ts
+++ b/packages/core/src/policy/policy.ts
@@ -1,0 +1,329 @@
+import { writable } from "../lib/scope";
+import { isDestructiveShell, isPrivateKeyPath } from "./patterns";
+import type {
+  ActionKind,
+  IPolicyContext,
+  IPolicyEvaluation,
+  IPolicyRule,
+  IProposedAction,
+  PolicyDecision,
+  PolicyMode,
+  RiskLevel,
+} from "./policy.types";
+
+/**
+ * Per-mode default verdict for each action kind — consulted only AFTER critical
+ * denies and config rules. `default` preserves TSForge's autonomous
+ * drive-to-green behavior (reads, scoped writes, shell, network all allowed);
+ * `plan` is read-only; the rest tighten. `bypassPermissions` allows everything
+ * here, but the critical-deny set still fires before this table is reached.
+ */
+const MODE_MATRIX: Readonly<
+  Record<PolicyMode, Record<ActionKind, PolicyDecision>>
+> = {
+  default: {
+    read_file: "allow",
+    write_file: "allow",
+    edit_file: "allow",
+    delete_file: "deny",
+    shell: "allow",
+    network: "allow",
+    mcp_tool: "allow",
+    plugin_tool: "allow",
+    unknown: "ask",
+  },
+  plan: {
+    read_file: "allow",
+    write_file: "deny",
+    edit_file: "deny",
+    delete_file: "deny",
+    // `run` is allowed through here; the tool's own isReadOnlyCommand guard
+    // restricts it to read-only commands in plan mode.
+    shell: "allow",
+    network: "allow",
+    mcp_tool: "deny",
+    plugin_tool: "deny",
+    unknown: "deny",
+  },
+  acceptEdits: {
+    read_file: "allow",
+    write_file: "allow",
+    edit_file: "allow",
+    delete_file: "deny",
+    shell: "ask",
+    network: "deny",
+    mcp_tool: "allow",
+    plugin_tool: "allow",
+    unknown: "deny",
+  },
+  ci: {
+    read_file: "allow",
+    write_file: "allow",
+    edit_file: "allow",
+    delete_file: "deny",
+    shell: "deny",
+    network: "deny",
+    mcp_tool: "allow",
+    plugin_tool: "allow",
+    unknown: "deny",
+  },
+  dontAsk: {
+    read_file: "allow",
+    write_file: "allow",
+    edit_file: "allow",
+    delete_file: "deny",
+    shell: "deny",
+    network: "deny",
+    mcp_tool: "allow",
+    plugin_tool: "allow",
+    unknown: "deny",
+  },
+  bypassPermissions: {
+    read_file: "allow",
+    write_file: "allow",
+    edit_file: "allow",
+    delete_file: "allow",
+    shell: "allow",
+    network: "allow",
+    mcp_tool: "allow",
+    plugin_tool: "allow",
+    unknown: "allow",
+  },
+};
+
+const WRITE_KINDS: ReadonlySet<ActionKind> = new Set([
+  "write_file",
+  "edit_file",
+  "delete_file",
+]);
+
+function riskOf(kind: ActionKind): RiskLevel {
+  if (kind === "shell" || kind === "unknown") {
+    return "high";
+  }
+
+  if (
+    kind === "network" ||
+    kind === "mcp_tool" ||
+    kind === "plugin_tool" ||
+    WRITE_KINDS.has(kind)
+  ) {
+    return "medium";
+  }
+
+  return "low";
+}
+
+function preview(text: string): string {
+  return text.length > 80 ? `${text.slice(0, 80)}…` : text;
+}
+
+interface ICriticalHit {
+  reason: string;
+  rule: string;
+}
+
+/** Denials that win in EVERY mode (incl. bypassPermissions). Returns null when
+ *  nothing critical matches. Vendored writes are intentionally NOT here — the
+ *  scaffold tools legitimately author vendored files; scope (`writable`) is the
+ *  hard floor that still catches `../` escapes and out-of-scope writes. */
+function criticalDeny(
+  action: IProposedAction,
+  ctx: IPolicyContext
+): ICriticalHit | null {
+  if (
+    action.kind === "shell" &&
+    action.command !== undefined &&
+    isDestructiveShell(action.command)
+  ) {
+    return {
+      reason: `destructive shell command blocked: ${preview(action.command)}`,
+      rule: "critical:destructive-shell",
+    };
+  }
+
+  if (WRITE_KINDS.has(action.kind) && action.paths !== undefined) {
+    const escaped = action.paths.find((p) => !writable(p, [...ctx.files]));
+
+    if (escaped !== undefined) {
+      return {
+        reason: `write outside the editable scope blocked: ${escaped}`,
+        rule: "critical:out-of-scope-write",
+      };
+    }
+  }
+
+  if (action.kind === "read_file" && action.paths !== undefined) {
+    const key = action.paths.find((p) => isPrivateKeyPath(p));
+
+    if (key !== undefined) {
+      return {
+        reason: `private-key file read blocked: ${key}`,
+        rule: "critical:private-key-read",
+      };
+    }
+  }
+
+  if (
+    action.kind === "mcp_tool" &&
+    action.mcpServer !== undefined &&
+    ctx.mcpServers !== undefined &&
+    !ctx.mcpServers.includes(action.mcpServer)
+  ) {
+    return {
+      reason: `unregistered MCP server blocked: ${action.mcpServer}`,
+      rule: "critical:unregistered-mcp",
+    };
+  }
+
+  return null;
+}
+
+function safeRegexTest(pattern: string, value: string): boolean {
+  try {
+    return new RegExp(pattern).test(value);
+  } catch {
+    // A malformed regex in config never matches (config load also warns on it).
+    return false;
+  }
+}
+
+/** Whether every PRESENT field of the rule matches the action (AND). An empty
+ *  rule matches everything — a deliberate catch-all. */
+function ruleMatches(rule: IPolicyRule, action: IProposedAction): boolean {
+  if (rule.kind !== undefined && rule.kind !== action.kind) {
+    return false;
+  }
+
+  if (rule.toolName !== undefined && rule.toolName !== action.toolName) {
+    return false;
+  }
+
+  if (rule.mcpServer !== undefined && rule.mcpServer !== action.mcpServer) {
+    return false;
+  }
+
+  if (
+    rule.commandPrefix !== undefined &&
+    !(action.command ?? "").startsWith(rule.commandPrefix)
+  ) {
+    return false;
+  }
+
+  if (
+    rule.commandPattern !== undefined &&
+    !safeRegexTest(rule.commandPattern, action.command ?? "")
+  ) {
+    return false;
+  }
+
+  if (rule.pathPattern !== undefined) {
+    const glob = new Bun.Glob(rule.pathPattern);
+
+    if (!(action.paths ?? []).some((p) => glob.match(p))) {
+      return false;
+    }
+  }
+
+  return true;
+}
+
+interface IRuleHit {
+  decision: PolicyDecision;
+  id: string;
+}
+
+/** First matching config rule, deny → allow → ask. Null when none match. */
+function matchConfigRules(
+  action: IProposedAction,
+  ctx: IPolicyContext
+): IRuleHit | null {
+  const rules = ctx.rules;
+
+  if (rules === undefined) {
+    return null;
+  }
+
+  const order: readonly {
+    list?: readonly IPolicyRule[];
+    decision: PolicyDecision;
+  }[] = [
+    { list: rules.deny, decision: "deny" },
+    { list: rules.allow, decision: "allow" },
+    { list: rules.ask, decision: "ask" },
+  ];
+
+  for (const { list, decision } of order) {
+    const idx = (list ?? []).findIndex((rule) => ruleMatches(rule, action));
+
+    if (idx >= 0) {
+      return { decision, id: `config:${decision}[${idx}]` };
+    }
+  }
+
+  return null;
+}
+
+function evaluation(
+  decision: PolicyDecision,
+  reason: string,
+  matchedRules: readonly string[],
+  risk: RiskLevel
+): IPolicyEvaluation {
+  return {
+    decision,
+    reason,
+    matchedRules,
+    risk,
+    requiresHumanApproval: decision === "ask",
+  };
+}
+
+/** Resolve a decision: an `ask` with no interactive approval path becomes a
+ *  `deny` (TSForge has no per-action prompt yet, so this is always the case). */
+function resolve(
+  decision: PolicyDecision,
+  reason: string,
+  matchedRules: readonly string[],
+  action: IProposedAction,
+  ctx: IPolicyContext
+): IPolicyEvaluation {
+  const risk = riskOf(action.kind);
+
+  if (decision === "ask" && !ctx.interactive) {
+    return evaluation(
+      "deny",
+      `${reason} — ask requires approval, none available (non-interactive)`,
+      matchedRules,
+      risk
+    );
+  }
+
+  return evaluation(decision, reason, matchedRules, risk);
+}
+
+/**
+ * The single deny-first policy decision. Order: critical denies (every mode) →
+ * config deny/allow/ask rules → the active mode's default. Unknown actions are
+ * never silently allowed; `ask` collapses to `deny` when non-interactive.
+ */
+export function evaluatePolicy(
+  action: IProposedAction,
+  ctx: IPolicyContext
+): IPolicyEvaluation {
+  const critical = criticalDeny(action, ctx);
+
+  if (critical !== null) {
+    return evaluation("deny", critical.reason, [critical.rule], "critical");
+  }
+
+  const ruled = matchConfigRules(action, ctx);
+
+  if (ruled !== null) {
+    return resolve(ruled.decision, ruled.id, [ruled.id], action, ctx);
+  }
+
+  const base = MODE_MATRIX[ctx.mode][action.kind];
+
+  return resolve(base, `mode:${ctx.mode}`, [`mode:${ctx.mode}`], action, ctx);
+}

--- a/packages/core/src/policy/policy.ts
+++ b/packages/core/src/policy/policy.ts
@@ -1,4 +1,3 @@
-import { writable } from "../lib/scope";
 import { isDestructiveShell, isPrivateKeyPath } from "./patterns";
 import type {
   ActionKind,
@@ -124,9 +123,11 @@ interface ICriticalHit {
 }
 
 /** Denials that win in EVERY mode (incl. bypassPermissions). Returns null when
- *  nothing critical matches. Vendored writes are intentionally NOT here — the
- *  scaffold tools legitimately author vendored files; scope (`writable`) is the
- *  hard floor that still catches `../` escapes and out-of-scope writes. */
+ *  nothing critical matches. These are protections with NO unconditional
+ *  tool-local equivalent. Out-of-scope and vendored writes are deliberately NOT
+ *  here: the write tools already enforce `writable`/`isVendored` in every mode
+ *  (and scaffold tools legitimately author vendored files), so duplicating it
+ *  here would only front-run their richer, model-guiding rejection messages. */
 function criticalDeny(
   action: IProposedAction,
   ctx: IPolicyContext
@@ -140,17 +141,6 @@ function criticalDeny(
       reason: `destructive shell command blocked: ${preview(action.command)}`,
       rule: "critical:destructive-shell",
     };
-  }
-
-  if (WRITE_KINDS.has(action.kind) && action.paths !== undefined) {
-    const escaped = action.paths.find((p) => !writable(p, [...ctx.files]));
-
-    if (escaped !== undefined) {
-      return {
-        reason: `write outside the editable scope blocked: ${escaped}`,
-        rule: "critical:out-of-scope-write",
-      };
-    }
   }
 
   if (action.kind === "read_file" && action.paths !== undefined) {
@@ -279,6 +269,29 @@ function evaluation(
   };
 }
 
+/** A human-readable reason for a mode-default verdict — informative for the
+ *  model (especially the plan-mode read-only nudge), while `matchedRules` keeps
+ *  the stable `mode:<mode>` id for the ledger/tests. */
+function modeReason(
+  mode: PolicyMode,
+  kind: ActionKind,
+  decision: PolicyDecision
+): string {
+  if (kind === "unknown") {
+    return "unrecognized action — unknown tools are never run without explicit approval";
+  }
+
+  if (decision !== "deny") {
+    return `mode:${mode}`;
+  }
+
+  if (mode === "plan") {
+    return "plan mode is read-only — explore with read-only tools and present your plan as text; the user must approve it before files can change";
+  }
+
+  return `${mode} mode does not allow this ${kind} action (ambiguous/unsafe actions are not auto-approved)`;
+}
+
 /** Resolve a decision: an `ask` with no interactive approval path becomes a
  *  `deny` (TSForge has no per-action prompt yet, so this is always the case). */
 function resolve(
@@ -325,5 +338,11 @@ export function evaluatePolicy(
 
   const base = MODE_MATRIX[ctx.mode][action.kind];
 
-  return resolve(base, `mode:${ctx.mode}`, [`mode:${ctx.mode}`], action, ctx);
+  return resolve(
+    base,
+    modeReason(ctx.mode, action.kind, base),
+    [`mode:${ctx.mode}`],
+    action,
+    ctx
+  );
 }

--- a/packages/core/src/policy/policy.ts
+++ b/packages/core/src/policy/policy.ts
@@ -10,6 +10,41 @@ import type {
   RiskLevel,
 } from "./policy.types";
 
+/** Every valid policy mode — the single source for config/CLI validation. */
+export const POLICY_MODES: readonly PolicyMode[] = [
+  "plan",
+  "default",
+  "acceptEdits",
+  "ci",
+  "dontAsk",
+  "bypassPermissions",
+];
+
+const POLICY_MODE_SET = new Set<string>(POLICY_MODES);
+
+export function isPolicyMode(value: unknown): value is PolicyMode {
+  return typeof value === "string" && POLICY_MODE_SET.has(value);
+}
+
+/** Every action kind — for validating a config rule's `kind` field. */
+export const ACTION_KINDS: readonly ActionKind[] = [
+  "read_file",
+  "write_file",
+  "edit_file",
+  "delete_file",
+  "shell",
+  "network",
+  "mcp_tool",
+  "plugin_tool",
+  "unknown",
+];
+
+const ACTION_KIND_SET = new Set<string>(ACTION_KINDS);
+
+export function isActionKind(value: unknown): value is ActionKind {
+  return typeof value === "string" && ACTION_KIND_SET.has(value);
+}
+
 /**
  * Per-mode default verdict for each action kind — consulted only AFTER critical
  * denies and config rules. `default` preserves TSForge's autonomous

--- a/packages/core/src/policy/policy.types.ts
+++ b/packages/core/src/policy/policy.types.ts
@@ -1,0 +1,96 @@
+/**
+ * Unified action policy: the model proposes, the harness enforces. Every tool
+ * call is classified into an `IProposedAction` and run through `evaluatePolicy`
+ * (deny-first) BEFORE execution. This module is a leaf — it imports only pure
+ * helpers (lib/scope), never the loop/tool layer — so there are no cycles and
+ * `evaluatePolicy` stays a pure, fully unit-testable function.
+ */
+
+/** The three possible verdicts. `ask` resolves to `deny` when non-interactive. */
+export type PolicyDecision = "allow" | "ask" | "deny";
+
+/** Enforcement strength. `plan` is the read-only explore mode; `default` is the
+ *  autonomous drive-to-green default; the rest tighten or loosen from there. */
+export type PolicyMode =
+  | "plan"
+  | "default"
+  | "acceptEdits"
+  | "ci"
+  | "dontAsk"
+  | "bypassPermissions";
+
+/** What a tool call actually does, independent of the tool's name. */
+export type ActionKind =
+  | "read_file"
+  | "write_file"
+  | "edit_file"
+  | "delete_file"
+  | "shell"
+  | "network"
+  | "mcp_tool"
+  | "plugin_tool"
+  | "unknown";
+
+export type RiskLevel = "low" | "medium" | "high" | "critical";
+
+/** A tool call reduced to the facts a policy needs. Built by `classifyAction`. */
+export interface IProposedAction {
+  kind: ActionKind;
+  toolName: string;
+  input: unknown;
+  cwd: string;
+  /** Workspace-relative paths the action touches (normalized). */
+  paths?: readonly string[];
+  /** Shell command preview (for `shell` actions). */
+  command?: string;
+  /** Server name for an `mcp__<server>__<tool>` call. */
+  mcpServer?: string;
+  metadata?: Record<string, unknown>;
+}
+
+export interface IPolicyEvaluation {
+  decision: PolicyDecision;
+  reason: string;
+  matchedRules: readonly string[];
+  risk: RiskLevel;
+  requiresHumanApproval: boolean;
+}
+
+/**
+ * A single config-driven rule. Every PRESENT field must match (AND); an empty
+ * rule matches everything (a catch-all). Kept deliberately small — no DSL.
+ */
+export interface IPolicyRule {
+  kind?: ActionKind;
+  toolName?: string;
+  /** Glob (Bun.Glob) matched against any of the action's paths. */
+  pathPattern?: string;
+  /** The action's command must start with this string. */
+  commandPrefix?: string;
+  /** Regex source matched against the action's command. */
+  commandPattern?: string;
+  mcpServer?: string;
+}
+
+/** The deny/allow/ask rule lists from `tsforge.config.json` `policy.rules`. */
+export interface IPolicyRules {
+  deny?: readonly IPolicyRule[];
+  allow?: readonly IPolicyRule[];
+  ask?: readonly IPolicyRule[];
+}
+
+/** Ambient state `evaluatePolicy` reads. Built from `IToolContext` + config. */
+export interface IPolicyContext {
+  mode: PolicyMode;
+  cwd: string;
+  /** Editable scope globs (mirrors `IToolContext.files`). */
+  files: readonly string[];
+  /** Whether a real interactive approval path exists. False today ⇒ `ask`
+   *  resolves to `deny` (TSForge has no per-action approval prompt yet). */
+  interactive: boolean;
+  /** Config-driven rules, evaluated deny → allow → ask before the mode default. */
+  rules?: IPolicyRules;
+  /** Registered MCP server names; an `mcp_tool` for any other server is a
+   *  critical deny (catches a forged/unregistered server call). */
+  mcpServers?: readonly string[];
+}

--- a/packages/core/src/render/ansi.ts
+++ b/packages/core/src/render/ansi.ts
@@ -293,6 +293,10 @@ function renderEventBody(event: ILoopEvent, color: boolean): string {
     case "tool":
       return `  ${paint(event.message, STYLE.dim, color)}\n`;
 
+    case "policy":
+      // Ledger-only signal; a denial is already shown via its `tool` event.
+      return "";
+
     case "timing":
       // Noise on screen (the status line shows turns + elapsed); log only.
       return color ? "" : `  ${event.message}\n`;

--- a/packages/core/tests/ledger.test.ts
+++ b/packages/core/tests/ledger.test.ts
@@ -97,16 +97,30 @@ describe("LedgerWriter", () => {
   test("redacts secrets in payload strings", async () => {
     await withLog(async (file, read) => {
       const w = new LedgerWriter(file, "r");
+      // Built at runtime so no literal token sits in source (gitleaks); redactText
+      // still matches `sk-[A-Za-z0-9_-]{16,}` on the assembled value.
+      const secret = `sk-${"a1B2c3D4".repeat(3)}`;
 
-      w.record("tool_call_finished", {
-        command: "curl -H 'Authorization: Bearer sk-abcdefghijklmnopqrstuvwx'",
-      });
+      w.record("tool_call_finished", { command: `deploy --token ${secret}` });
 
       const [event] = await read();
       const command = String(event?.payload.command ?? "");
 
-      expect(command).not.toContain("sk-abcdefghijklmnopqrstuvwx");
+      expect(command).not.toContain(secret);
       expect(command).toContain("[redacted]");
+    });
+  });
+
+  test("preserves a non-plain object (Date → ISO string, not {})", async () => {
+    await withLog(async (file, read) => {
+      const when = new Date(0);
+
+      new LedgerWriter(file, "r").record("run_started", { at: when });
+
+      const [event] = await read();
+
+      // Date serializes via its own toJSON, not flattened to an empty object.
+      expect(event?.payload.at).toBe(when.toISOString());
     });
   });
 

--- a/packages/core/tests/ledger.test.ts
+++ b/packages/core/tests/ledger.test.ts
@@ -1,0 +1,139 @@
+import { test, expect, describe } from "bun:test";
+import { mkdtemp, rm, readFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  LedgerWriter,
+  ledgerTypeFor,
+  type IBaseLedgerEvent,
+  type ILoopEvent,
+  type LedgerEventType,
+} from "../src/loop";
+
+async function withLog<T>(
+  fn: (file: string, read: () => Promise<IBaseLedgerEvent[]>) => Promise<T>
+): Promise<T> {
+  const dir = await mkdtemp(join(tmpdir(), "tsforge-ledger-"));
+  const file = join(dir, "run.jsonl");
+
+  const read = async (): Promise<IBaseLedgerEvent[]> => {
+    const text = await readFile(file, "utf8");
+    const out: IBaseLedgerEvent[] = [];
+
+    for (const line of text.split("\n")) {
+      if (line.length > 0) {
+        const parsed: IBaseLedgerEvent = JSON.parse(line);
+
+        out.push(parsed);
+      }
+    }
+
+    return out;
+  };
+
+  try {
+    return await fn(file, read);
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+}
+
+describe("ledgerTypeFor — kind → typed event", () => {
+  test("maps boundary kinds to ledger types", () => {
+    const cases: readonly [ILoopEvent["kind"], LedgerEventType][] = [
+      ["start", "run_started"],
+      ["done", "run_finished"],
+      ["stuck", "run_finished"],
+      ["cycle", "model_call_started"],
+      ["usage", "model_call_finished"],
+      ["validated", "gate_finished"],
+      ["edit", "tool_call_finished"],
+      ["create", "tool_call_finished"],
+      ["run", "tool_call_finished"],
+      ["policy", "policy_decision"],
+      ["timing", "log"],
+    ];
+
+    for (const [kind, type] of cases) {
+      // Cast-free: every test kind is a real ILoopEvent kind.
+      expect(ledgerTypeFor({ kind, task: "t", message: "" })).toBe(type);
+    }
+  });
+
+  test("a rejected tool event maps to tool_call_failed", () => {
+    expect(
+      ledgerTypeFor({
+        kind: "tool",
+        task: "t",
+        message: "tool_rejected:run (x)",
+      })
+    ).toBe("tool_call_failed");
+    expect(
+      ledgerTypeFor({ kind: "tool", task: "t", message: "↳ bun add zod" })
+    ).toBe("log");
+  });
+});
+
+describe("LedgerWriter", () => {
+  test("writes one valid JSON line per record, in order, with metadata", async () => {
+    await withLog(async (file, read) => {
+      const w = new LedgerWriter(file, "run-1", "sess-1");
+
+      w.record("run_started", { model: "x" });
+      w.record("tool_call_finished", { file: "a.ts" });
+
+      const events = await read();
+
+      expect(events).toHaveLength(2);
+      expect(events[0]?.type).toBe("run_started");
+      expect(events[1]?.type).toBe("tool_call_finished");
+      expect(events[0]?.runId).toBe("run-1");
+      expect(events[0]?.sessionId).toBe("sess-1");
+      expect(typeof events[0]?.eventId).toBe("string");
+      expect(typeof events[0]?.timestamp).toBe("string");
+    });
+  });
+
+  test("redacts secrets in payload strings", async () => {
+    await withLog(async (file, read) => {
+      const w = new LedgerWriter(file, "r");
+
+      w.record("tool_call_finished", {
+        command: "curl -H 'Authorization: Bearer sk-abcdefghijklmnopqrstuvwx'",
+      });
+
+      const [event] = await read();
+      const command = String(event?.payload.command ?? "");
+
+      expect(command).not.toContain("sk-abcdefghijklmnopqrstuvwx");
+      expect(command).toContain("[redacted]");
+    });
+  });
+
+  test("caps an over-long payload string to a preview", async () => {
+    await withLog(async (file, read) => {
+      const w = new LedgerWriter(file, "r");
+
+      w.record("tool_call_finished", { output: "x".repeat(10_000) });
+
+      const [event] = await read();
+      const output = String(event?.payload.output ?? "");
+
+      expect(output.length).toBeLessThan(10_000);
+      expect(output).toContain("chars]");
+    });
+  });
+
+  test("omits sessionId when not provided; no-op without a file", async () => {
+    await withLog(async (file, read) => {
+      new LedgerWriter(file, "r").record("run_started", {});
+
+      expect((await read())[0]?.sessionId).toBeUndefined();
+    });
+
+    // Empty file path ⇒ never throws, never writes.
+    expect(() =>
+      new LedgerWriter("", "r").record("run_started", {})
+    ).not.toThrow();
+  });
+});

--- a/packages/core/tests/plan-mode.test.ts
+++ b/packages/core/tests/plan-mode.test.ts
@@ -164,7 +164,11 @@ test("plan mode blocks a mutating run command but allows a read-only one", async
           return {
             content: "",
             toolCalls: [
-              { id: "1", name: "run", arguments: { command: "rm -rf x" } },
+              {
+                id: "1",
+                name: "run",
+                arguments: { command: "touch newfile.ts" },
+              },
               { id: "2", name: "run", arguments: { command: "ls" } },
             ],
           };
@@ -214,6 +218,9 @@ test("isReadOnlyCommand: allowlisted inspection passes, anything mutating fails"
   expect(isReadOnlyCommand("tsc --outDir dist")).toBe(false);
   expect(isReadOnlyCommand("tsc")).toBe(false); // bare tsc EMITS by default
   expect(isReadOnlyCommand("tsc -p tsconfig.json --build")).toBe(false);
+  // --tsBuildInfoFile / --incremental write a .tsbuildinfo even with --noEmit.
+  expect(isReadOnlyCommand("tsc --noEmit --tsBuildInfoFile x")).toBe(false);
+  expect(isReadOnlyCommand("tsc --noEmit --incremental")).toBe(false);
 
   // And the read-only shapes of those same commands still pass.
   expect(isReadOnlyCommand("find . -name '*.ts'")).toBe(true);

--- a/packages/core/tests/policy-config.test.ts
+++ b/packages/core/tests/policy-config.test.ts
@@ -1,0 +1,131 @@
+import { test, expect, describe } from "bun:test";
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { existsSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { loadTsforgeConfig } from "../src/config";
+import { Session } from "../src/loop";
+import type { IProvider } from "../src/inference";
+
+async function withConfig<T>(
+  config: unknown,
+  fn: (dir: string) => Promise<T>
+): Promise<T> {
+  const dir = await mkdtemp(join(tmpdir(), "tsforge-polcfg-"));
+
+  await writeFile(join(dir, "tsforge.config.json"), JSON.stringify(config));
+
+  try {
+    return await fn(dir);
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+}
+
+/** A provider that fires one `create` tool call, then stops. */
+function createOnce(results: string[]): IProvider {
+  let calls = 0;
+
+  return {
+    async complete(messages) {
+      calls += 1;
+      results.length = 0;
+      results.push(
+        ...messages.filter((m) => m.role === "tool").map((m) => m.content)
+      );
+
+      if (calls === 1) {
+        return {
+          content: "",
+          toolCalls: [
+            {
+              id: "1",
+              name: "create",
+              arguments: { file: "x.ts", content: "x" },
+            },
+          ],
+        };
+      }
+
+      return { content: "ok", toolCalls: [] };
+    },
+  };
+}
+
+describe("policy config parsing (warn-and-drop)", () => {
+  test("parses a valid policy block", async () => {
+    await withConfig(
+      {
+        policy: {
+          mode: "ci",
+          rules: {
+            deny: [{ kind: "network" }],
+            allow: [{ commandPrefix: "bun test" }],
+          },
+        },
+      },
+      async (dir) => {
+        const cfg = await loadTsforgeConfig(dir);
+
+        expect(cfg.policy?.mode).toBe("ci");
+        expect(cfg.policy?.rules?.deny?.[0]?.kind).toBe("network");
+        expect(cfg.policy?.rules?.allow?.[0]?.commandPrefix).toBe("bun test");
+      }
+    );
+  });
+
+  test("drops an invalid mode and a non-object policy", async () => {
+    await withConfig({ policy: { mode: "yolo" } }, async (dir) => {
+      expect((await loadTsforgeConfig(dir)).policy?.mode).toBeUndefined();
+    });
+    await withConfig({ policy: "nope" }, async (dir) => {
+      expect((await loadTsforgeConfig(dir)).policy).toBeUndefined();
+    });
+  });
+
+  test("drops a non-ActionKind rule kind but keeps valid string fields", async () => {
+    await withConfig(
+      { policy: { rules: { deny: [{ kind: "bogus", toolName: "run" }] } } },
+      async (dir) => {
+        const rule = (await loadTsforgeConfig(dir)).policy?.rules?.deny?.[0];
+
+        expect(rule?.kind).toBeUndefined();
+        expect(rule?.toolName).toBe("run");
+      }
+    );
+  });
+});
+
+describe("policy config → session enforcement", () => {
+  test("config policy.mode 'plan' denies a write end-to-end", async () => {
+    await withConfig({ policy: { mode: "plan" } }, async (dir) => {
+      const results: string[] = [];
+      const session = await Session.create({
+        provider: createOnce(results),
+        cwd: dir,
+        files: ["**/*"],
+      });
+
+      await session.send("write it");
+
+      expect(results.some((t) => t.includes("policy deny"))).toBe(true);
+      expect(existsSync(join(dir, "x.ts"))).toBe(false);
+    });
+  });
+
+  test("--policy-mode default overrides config 'plan' (CLI wins)", async () => {
+    await withConfig({ policy: { mode: "plan" } }, async (dir) => {
+      const results: string[] = [];
+      const session = await Session.create({
+        provider: createOnce(results),
+        cwd: dir,
+        files: ["**/*"],
+        policyMode: "default",
+      });
+
+      await session.send("write it");
+
+      expect(existsSync(join(dir, "x.ts"))).toBe(true);
+    });
+  });
+});

--- a/packages/core/tests/policy-evaluation.test.ts
+++ b/packages/core/tests/policy-evaluation.test.ts
@@ -113,6 +113,17 @@ describe("destructive-shell detection", () => {
     expect(isDestructiveShell("FOO=1 shred secret")).toBe(true);
   });
 
+  test("sees through env/sudo wrappers and their flags", () => {
+    expect(isDestructiveShell("env rm -rf /")).toBe(true);
+    expect(isDestructiveShell("env VAR=x rm -rf /")).toBe(true);
+    expect(isDestructiveShell("sudo -u root rm -rf /")).toBe(true);
+    expect(isDestructiveShell("nohup rm -rf /")).toBe(true);
+    expect(isDestructiveShell("ls && sudo rm -rf x")).toBe(true);
+    // wrapper with a non-destructive head stays clean
+    expect(isDestructiveShell("env node build.js")).toBe(false);
+    expect(isDestructiveShell("sudo -u deploy npm ci")).toBe(false);
+  });
+
   test("does not flag benign commands that merely contain the substring", () => {
     expect(isDestructiveShell("npm run build")).toBe(false);
     expect(isDestructiveShell("echo 'rm is dangerous'")).toBe(false);
@@ -312,6 +323,16 @@ describe("evaluatePolicy — critical denies win in every mode", () => {
     expect(
       evaluatePolicy(action("mcp_tool", { mcpServer: "github" }), c).decision
     ).toBe("allow");
+  });
+
+  test("any MCP tool is denied when no servers are configured (undefined)", () => {
+    // ctx() leaves mcpServers undefined ⇒ no MCP registered ⇒ deny, not allow.
+    expect(
+      evaluatePolicy(
+        action("mcp_tool", { mcpServer: "anything" }),
+        ctx("default")
+      ).decision
+    ).toBe("deny");
   });
 
   test("bypassPermissions allows ordinary writes/shell/unknown (post-critical)", () => {

--- a/packages/core/tests/policy-evaluation.test.ts
+++ b/packages/core/tests/policy-evaluation.test.ts
@@ -1,0 +1,325 @@
+import { test, expect, describe } from "bun:test";
+import {
+  evaluatePolicy,
+  classifyAction,
+  isDestructiveShell,
+  isPrivateKeyPath,
+  type ActionKind,
+  type IPolicyContext,
+  type IProposedAction,
+  type PolicyMode,
+} from "../src/policy";
+
+const CWD = "/ws";
+
+function action(
+  kind: ActionKind,
+  over: Partial<IProposedAction> = {}
+): IProposedAction {
+  return {
+    kind,
+    toolName: over.toolName ?? kind,
+    input: {},
+    cwd: CWD,
+    ...over,
+  };
+}
+
+function ctx(
+  mode: PolicyMode,
+  over: Partial<IPolicyContext> = {}
+): IPolicyContext {
+  return { mode, cwd: CWD, files: ["src/**"], interactive: false, ...over };
+}
+
+describe("classifyAction", () => {
+  test("maps tool names to action kinds", () => {
+    const cases: readonly [string, ActionKind][] = [
+      ["read", "read_file"],
+      ["search", "read_file"],
+      ["git_context", "read_file"],
+      ["edit", "edit_file"],
+      ["edit_lines", "edit_file"],
+      ["organize_imports", "edit_file"],
+      ["create", "write_file"],
+      ["move_file", "write_file"],
+      ["scaffold_ui", "write_file"],
+      ["run", "shell"],
+      ["add_dependency", "shell"],
+      ["web_fetch", "network"],
+      ["web_search", "network"],
+    ];
+
+    for (const [name, kind] of cases) {
+      expect(classifyAction({ name, arguments: {} }, CWD).kind).toBe(kind);
+    }
+  });
+
+  test("unknown / forged tool name classifies as unknown", () => {
+    expect(
+      classifyAction({ name: "rm_rf_everything", arguments: {} }, CWD).kind
+    ).toBe("unknown");
+  });
+
+  test("mcp__server__tool classifies as mcp_tool with the server parsed", () => {
+    const a = classifyAction(
+      { name: "mcp__github__create_issue", arguments: {} },
+      CWD
+    );
+
+    expect(a.kind).toBe("mcp_tool");
+    expect(a.mcpServer).toBe("github");
+  });
+
+  test("normalizes paths from file/from/to args", () => {
+    expect(
+      classifyAction({ name: "edit", arguments: { file: "src/a.ts" } }, CWD)
+        .paths
+    ).toEqual(["src/a.ts"]);
+    expect(
+      classifyAction(
+        { name: "move_file", arguments: { from: "src/a.ts", to: "src/b.ts" } },
+        CWD
+      ).paths
+    ).toEqual(["src/a.ts", "src/b.ts"]);
+    // a traversal stays a `../` path so scope can reject it
+    expect(
+      classifyAction({ name: "edit", arguments: { file: "../x.ts" } }, CWD)
+        .paths
+    ).toEqual(["../x.ts"]);
+  });
+
+  test("builds a command preview for shell tools", () => {
+    expect(
+      classifyAction({ name: "run", arguments: { command: "ls -la" } }, CWD)
+        .command
+    ).toBe("ls -la");
+    expect(
+      classifyAction(
+        { name: "add_dependency", arguments: { packages: "zod@3" } },
+        CWD
+      ).command
+    ).toBe("bun add zod@3");
+  });
+});
+
+describe("destructive-shell detection", () => {
+  test("flags destructive heads, including chained and prefixed", () => {
+    expect(isDestructiveShell("rm -rf /")).toBe(true);
+    expect(isDestructiveShell("sudo rm -rf node_modules")).toBe(true);
+    expect(isDestructiveShell("build && rm -rf dist")).toBe(true);
+    expect(isDestructiveShell("/bin/dd if=/dev/zero of=/dev/sda")).toBe(true);
+    expect(isDestructiveShell("mkfs.ext4 /dev/sdb")).toBe(false); // mkfs.ext4 head ≠ mkfs (conservative)
+    expect(isDestructiveShell("FOO=1 shred secret")).toBe(true);
+  });
+
+  test("does not flag benign commands that merely contain the substring", () => {
+    expect(isDestructiveShell("npm run build")).toBe(false);
+    expect(isDestructiveShell("echo 'rm is dangerous'")).toBe(false);
+    expect(isDestructiveShell("bun test")).toBe(false);
+  });
+});
+
+describe("private-key path detection", () => {
+  test("flags key material, excludes .env", () => {
+    expect(isPrivateKeyPath(".ssh/id_rsa")).toBe(true);
+    expect(isPrivateKeyPath("certs/server.pem")).toBe(true);
+    expect(isPrivateKeyPath("secret.key")).toBe(true);
+    expect(isPrivateKeyPath("home/id_ed25519")).toBe(true);
+    expect(isPrivateKeyPath(".env")).toBe(false);
+    expect(isPrivateKeyPath("src/index.ts")).toBe(false);
+  });
+});
+
+describe("evaluatePolicy — deny-first ordering", () => {
+  test("deny rule beats an allow rule", () => {
+    const c = ctx("default", {
+      rules: {
+        allow: [{ kind: "shell" }],
+        deny: [{ kind: "shell", commandPrefix: "rm" }],
+      },
+    });
+    const verdict = evaluatePolicy(action("shell", { command: "rm -i x" }), c);
+
+    // (rm is also critical-destructive, but the point: deny wins regardless)
+    expect(verdict.decision).toBe("deny");
+  });
+
+  test("config deny beats the mode default allow", () => {
+    const c = ctx("default", { rules: { deny: [{ toolName: "web_fetch" }] } });
+
+    expect(
+      evaluatePolicy(action("network", { toolName: "web_fetch" }), c).decision
+    ).toBe("deny");
+  });
+
+  test("config allow overrides a strict mode default", () => {
+    const c = ctx("ci", {
+      rules: { allow: [{ kind: "shell", commandPrefix: "bun test" }] },
+    });
+
+    expect(
+      evaluatePolicy(action("shell", { command: "bun test" }), c).decision
+    ).toBe("allow");
+    // a different shell command still hits ci's deny default
+    expect(
+      evaluatePolicy(action("shell", { command: "curl evil" }), c).decision
+    ).toBe("deny");
+  });
+});
+
+describe("evaluatePolicy — mode defaults", () => {
+  test("default mode preserves autonomous scoped work", () => {
+    const c = ctx("default");
+
+    expect(evaluatePolicy(action("read_file"), c).decision).toBe("allow");
+    expect(
+      evaluatePolicy(action("write_file", { paths: ["src/a.ts"] }), c).decision
+    ).toBe("allow");
+    expect(
+      evaluatePolicy(action("edit_file", { paths: ["src/a.ts"] }), c).decision
+    ).toBe("allow");
+    expect(
+      evaluatePolicy(action("shell", { command: "bun test" }), c).decision
+    ).toBe("allow");
+    expect(
+      evaluatePolicy(action("network", { toolName: "web_fetch" }), c).decision
+    ).toBe("allow");
+  });
+
+  test("plan mode denies writes/edits but allows reads", () => {
+    const c = ctx("plan");
+
+    expect(evaluatePolicy(action("read_file"), c).decision).toBe("allow");
+    expect(
+      evaluatePolicy(action("write_file", { paths: ["src/a.ts"] }), c).decision
+    ).toBe("deny");
+    expect(
+      evaluatePolicy(action("edit_file", { paths: ["src/a.ts"] }), c).decision
+    ).toBe("deny");
+    expect(
+      evaluatePolicy(
+        action("mcp_tool", { mcpServer: "x" }),
+        ctx("plan", { mcpServers: ["x"] })
+      ).decision
+    ).toBe("deny");
+  });
+
+  test("ci and dontAsk deny ambiguous shell/unknown", () => {
+    for (const mode of ["ci", "dontAsk"] as const) {
+      const c = ctx(mode);
+
+      expect(
+        evaluatePolicy(action("shell", { command: "bun test" }), c).decision
+      ).toBe("deny");
+      expect(evaluatePolicy(action("unknown"), c).decision).toBe("deny");
+      // writes are still allowed (autonomous edit), scope permitting
+      expect(
+        evaluatePolicy(action("write_file", { paths: ["src/a.ts"] }), c)
+          .decision
+      ).toBe("allow");
+    }
+  });
+
+  test("acceptEdits allows scoped edits, denies network, ask→deny shell", () => {
+    const c = ctx("acceptEdits");
+
+    expect(
+      evaluatePolicy(action("edit_file", { paths: ["src/a.ts"] }), c).decision
+    ).toBe("allow");
+    expect(
+      evaluatePolicy(action("network", { toolName: "web_fetch" }), c).decision
+    ).toBe("deny");
+    expect(
+      evaluatePolicy(action("shell", { command: "bun test" }), c).decision
+    ).toBe("deny");
+  });
+});
+
+describe("evaluatePolicy — unknown + ask resolution", () => {
+  test("unknown is never silently allowed", () => {
+    expect(evaluatePolicy(action("unknown"), ctx("default")).decision).toBe(
+      "deny"
+    );
+    expect(evaluatePolicy(action("unknown"), ctx("plan")).decision).toBe(
+      "deny"
+    );
+  });
+
+  test("ask resolves to deny when non-interactive, stays ask when interactive", () => {
+    expect(
+      evaluatePolicy(action("unknown"), ctx("default", { interactive: false }))
+        .decision
+    ).toBe("deny");
+
+    const asked = evaluatePolicy(
+      action("unknown"),
+      ctx("default", { interactive: true })
+    );
+
+    expect(asked.decision).toBe("ask");
+    expect(asked.requiresHumanApproval).toBe(true);
+  });
+});
+
+describe("evaluatePolicy — critical denies win in every mode", () => {
+  test("destructive shell denied even in bypassPermissions", () => {
+    for (const mode of ["default", "bypassPermissions"] as const) {
+      const v = evaluatePolicy(
+        action("shell", { command: "rm -rf /" }),
+        ctx(mode)
+      );
+
+      expect(v.decision).toBe("deny");
+      expect(v.risk).toBe("critical");
+    }
+  });
+
+  test("out-of-scope write denied even in bypassPermissions", () => {
+    const v = evaluatePolicy(
+      action("edit_file", { paths: ["../escape.ts"] }),
+      ctx("bypassPermissions")
+    );
+
+    expect(v.decision).toBe("deny");
+    expect(v.matchedRules).toContain("critical:out-of-scope-write");
+  });
+
+  test("private-key read denied; bypassPermissions otherwise allows", () => {
+    expect(
+      evaluatePolicy(
+        action("read_file", { paths: [".ssh/id_rsa"] }),
+        ctx("default")
+      ).decision
+    ).toBe("deny");
+    expect(
+      evaluatePolicy(
+        action("read_file", { paths: ["src/index.ts"] }),
+        ctx("bypassPermissions")
+      ).decision
+    ).toBe("allow");
+  });
+
+  test("unregistered MCP server denied", () => {
+    const c = ctx("default", { mcpServers: ["github"] });
+
+    expect(
+      evaluatePolicy(action("mcp_tool", { mcpServer: "evil" }), c).decision
+    ).toBe("deny");
+    expect(
+      evaluatePolicy(action("mcp_tool", { mcpServer: "github" }), c).decision
+    ).toBe("allow");
+  });
+
+  test("bypassPermissions allows ordinary writes/shell/unknown (post-critical)", () => {
+    const c = ctx("bypassPermissions");
+
+    expect(
+      evaluatePolicy(action("write_file", { paths: ["src/a.ts"] }), c).decision
+    ).toBe("allow");
+    expect(
+      evaluatePolicy(action("shell", { command: "bun test" }), c).decision
+    ).toBe("allow");
+    expect(evaluatePolicy(action("unknown"), c).decision).toBe("allow");
+  });
+});

--- a/packages/core/tests/policy-evaluation.test.ts
+++ b/packages/core/tests/policy-evaluation.test.ts
@@ -275,14 +275,17 @@ describe("evaluatePolicy — critical denies win in every mode", () => {
     }
   });
 
-  test("out-of-scope write denied even in bypassPermissions", () => {
+  test("scope is deferred to the tool layer, not a policy critical", () => {
+    // Out-of-scope writes are enforced unconditionally by the write tools
+    // (writable/isVendored) in every mode, so policy intentionally does NOT
+    // critical-deny them here (that would only front-run the richer tool
+    // message). Policy's verdict for an in-scope-shaped path is the mode default.
     const v = evaluatePolicy(
       action("edit_file", { paths: ["../escape.ts"] }),
       ctx("bypassPermissions")
     );
 
-    expect(v.decision).toBe("deny");
-    expect(v.matchedRules).toContain("critical:out-of-scope-write");
+    expect(v.decision).toBe("allow");
   });
 
   test("private-key read denied; bypassPermissions otherwise allows", () => {

--- a/packages/core/tests/policy-integration.test.ts
+++ b/packages/core/tests/policy-integration.test.ts
@@ -1,0 +1,144 @@
+import { test, expect, describe } from "bun:test";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { executeTool, type IToolContext } from "../src/loop/tools";
+import { McpRegistry } from "../src/mcp";
+import type { PolicyMode } from "../src/policy";
+
+async function withDir<T>(fn: (dir: string) => Promise<T>): Promise<T> {
+  const dir = await mkdtemp(join(tmpdir(), "tsforge-policy-"));
+
+  try {
+    return await fn(dir);
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+}
+
+function ctx(
+  dir: string,
+  mode: PolicyMode,
+  over: Partial<IToolContext> = {}
+): IToolContext {
+  return {
+    cwd: dir,
+    files: ["**/*.ts"],
+    task: "t",
+    report: () => undefined,
+    policyMode: mode,
+    ...over,
+  };
+}
+
+describe("policy integration — every tool routes through the policy", () => {
+  test("plan mode denies create/edit/edit_lines via policy (nothing written)", async () => {
+    await withDir(async (dir) => {
+      for (const call of [
+        { name: "create", arguments: { file: "a.ts", content: "x" } },
+        {
+          name: "edit",
+          arguments: { file: "a.ts", oldString: "x", newString: "y" },
+        },
+        {
+          name: "edit_lines",
+          arguments: { file: "a.ts", input: "replace 1..1:\n+z" },
+        },
+      ]) {
+        const out = await executeTool(call, ctx(dir, "plan"));
+
+        expect(out.toLowerCase()).toContain("policy deny");
+        expect(out).toContain("plan mode is read-only");
+      }
+
+      expect(await Bun.file(join(dir, "a.ts")).exists()).toBe(false);
+    });
+  });
+
+  test("ci mode denies model shell via policy", async () => {
+    await withDir(async (dir) => {
+      const out = await executeTool(
+        { name: "run", arguments: { command: "bun test" } },
+        ctx(dir, "ci")
+      );
+
+      expect(out.toLowerCase()).toContain("policy deny");
+    });
+  });
+
+  test("acceptEdits denies network tools via policy", async () => {
+    await withDir(async (dir) => {
+      const out = await executeTool(
+        { name: "web_fetch", arguments: { url: "https://example.com" } },
+        ctx(dir, "acceptEdits")
+      );
+
+      expect(out.toLowerCase()).toContain("policy deny");
+    });
+  });
+
+  test("destructive shell is denied in default — the handler never runs", async () => {
+    await withDir(async (dir) => {
+      const canary = join(dir, "canary.txt");
+
+      await Bun.write(canary, "alive");
+
+      const out = await executeTool(
+        { name: "run", arguments: { command: `rm -f ${canary}` } },
+        ctx(dir, "default")
+      );
+
+      expect(out.toLowerCase()).toContain("policy deny");
+      expect(out).toContain("destructive");
+      // The handler was never reached, so the file is untouched.
+      expect(await Bun.file(canary).text()).toBe("alive");
+    });
+  });
+
+  test("unknown tool is denied by policy (never silently executes)", async () => {
+    await withDir(async (dir) => {
+      const out = await executeTool(
+        { name: "definitely_not_a_tool", arguments: {} },
+        ctx(dir, "default")
+      );
+
+      expect(out.toLowerCase()).toContain("policy deny");
+    });
+  });
+
+  test("MCP tools route through policy: plan denies, unregistered server denied", async () => {
+    await withDir(async (dir) => {
+      // plan mode denies any mcp tool (before routing)
+      const planned = await executeTool(
+        { name: "mcp__github__create_issue", arguments: {} },
+        ctx(dir, "plan", { mcpRegistry: new McpRegistry() })
+      );
+
+      expect(planned.toLowerCase()).toContain("policy deny");
+
+      // default mode, but the server isn't registered → critical deny
+      const unregistered = await executeTool(
+        { name: "mcp__evil__exfiltrate", arguments: {} },
+        ctx(dir, "default", { mcpRegistry: new McpRegistry() })
+      );
+
+      expect(unregistered.toLowerCase()).toContain("policy deny");
+      expect(unregistered).toContain("unregistered MCP server");
+    });
+  });
+
+  test("default mode preserves normal scoped work (create writes the file)", async () => {
+    await withDir(async (dir) => {
+      const out = await executeTool(
+        {
+          name: "create",
+          arguments: { file: "ok.ts", content: "export const x = 1;\n" },
+        },
+        ctx(dir, "default")
+      );
+
+      expect(out.toLowerCase()).not.toContain("policy deny");
+      expect(await Bun.file(join(dir, "ok.ts")).exists()).toBe(true);
+    });
+  });
+});


### PR DESCRIPTION
Adds TSForge's next harness foundation: a **deny-first unified action policy** every tool call passes through before execution, and a **typed append-only run ledger** built by evolving `--log`. Integrates with the existing loop/tool/reporter/session/config architecture — no parallel framework. The recent guardrail fixes (0.15.6) are treated as regression coverage and preserved.

Built as 4 reviewable commits.

## 1 — Policy engine + classifier (pure) — `53af469`
New leaf module `packages/core/src/policy/`. `evaluatePolicy(action, ctx)` is pure and deny-first: **critical denies → config deny/allow/ask rules → per-mode default**. `classifyAction` maps a tool call → `IProposedAction` (paths via the existing `normalizeWorkspacePath`; `mcp__server__tool` → `mcp_tool`; unknown names → `unknown`). Critical-deny set (wins in **every** mode incl. `bypassPermissions`): destructive shell heads, private-key reads (`id_rsa`/`*.pem`/`.ssh/` — **excludes `.env`**), unregistered MCP server. 22 unit tests.

## 2 — Enforcement in `executeTool` + regressions — `ab2d02b`
`executeTool` runs `classifyAction → evaluatePolicy` **first**, before MCP routing, so built-in, MCP, plugin, and unknown tools all pass one gate. Tool-local guards (scope/vendored/SSRF/argv) still run after — policy is an outer layer. `policyMode`/`interactive`/`policyRules` thread via `IToolContext`/`ILoopCtx`; `setPlanMode` maps to policy mode `plan` and **restores the base mode** when toggled off.
- **Scope stays a tool-local guard** (runs in every mode) rather than a policy critical, so the richer out-of-scope messages survive.
- Closed a `tsc` gap: `--tsBuildInfoFile`/`--incremental` now disqualify a read-only run.
- 7 integration tests + preserved 0.15.6 regression coverage (`edit_lines` scope, `add_dependency` argv, plan-mode `git --output`/`tsc` flags, resume planMode/reasoningContent).

## 3 — Typed run ledger evolving `--log` — `18df034`
`--log` now emits typed `IBaseLedgerEvent` JSONL (`eventId`/`runId`/`sessionId`/`timestamp`/`type`/`payload`). `LedgerWriter`: synchronous appends (valid JSONL, no interleave), secret-redaction (reuses `redactText`) + 4 KB per-string capping, failures swallowed. `ledgerTypeFor` maps reporter kinds → ledger types (`start`→`run_started`, `cycle`→`model_call_started`, `usage`→`model_call_finished`, `validated`→`gate_finished`, `edit`/`create`/`run`→`tool_call_finished`, rejected tool→`tool_call_failed`). New `policy` event kind (renders to nothing) → `policy_decision`. **Deferred** (schema reserved): `model_call_*` are approximated from turn/usage; `tool_call_requested`/`started`, `gate_started`, `resume_*`, `user_prompt`. 6 tests.

## 4 — Config block + `--policy-mode` flag — `c214c9a`
`tsforge.config.json` `policy: { mode, rules: {deny,allow,ask} }`, validated in the existing warn-and-drop style. `--policy-mode <mode>` CLI flag (validated). **Precedence: `--policy-mode` > config `policy.mode` > `default`**; plan mode overrides at runtime. Applies to both the interactive session and the headless `runTask` path. 5 tests.

## Modes
`default` (autonomous drive-to-green — reads/scoped writes/shell/network allowed), `plan` (read-only), `acceptEdits` (writes yes, shell/network no), `ci`/`dontAsk` (ambiguous → deny), `bypassPermissions` (skip prompts, critical denies still enforced). `ask` resolves to `deny` everywhere today (no per-action approval UI exists — documented as future work).

## Verification
`bun run validate` green — typecheck + lint + format + **1172 pass / 0 fail** (40 new tests). Default-mode behavior is unchanged (the ~1132 prior tests still pass); `policyMode`/`policyRules` are optional and default to `default`.

## Risk areas for review
- Default mode must reproduce prior behavior — verified by the existing suite; the only **new** denials in default are destructive shell + private-key reads.
- Private-key-read critical-deny is the most behavior-visible addition (kept tiny + path-anchored, `.env` excluded).
- Ledger changes the `--log` line shape (opt-in debug artifact, no documented schema).

🤖 Generated with [Claude Code](https://claude.com/claude-code)