### PR TITLE
fix(harness): unwedgeable run tool + web gate can't red on bun:test

### DIFF
--- a/packages/core/src/cli.ts
+++ b/packages/core/src/cli.ts
@@ -1024,7 +1024,7 @@ async function repl(args: ICliArgs): Promise<number> {
           scaffoldUi: true,
           guidance: webGuidance("react"),
           fix: buildWebFix("react"),
-          incrementalCheck: buildWebTscCheck(),
+          incrementalCheck: buildWebTscCheck(args.dir),
         }
       : { scaffoldWeb: true, fix: buildCoreFix() }),
     ...(thinkingTokenBudget === undefined ? {} : { thinkingTokenBudget }),
@@ -1151,7 +1151,7 @@ async function repl(args: ICliArgs): Promise<number> {
 
     session.setGate(buildWebGate(framework, undefined, args.dir).command);
     session.setFix(buildWebFix(framework));
-    session.setIncrementalCheck(buildWebTscCheck());
+    session.setIncrementalCheck(buildWebTscCheck(args.dir));
     // The project only now has a tsconfig + node_modules — rebuild the TS service
     // so the per-write guard actually runs (it's skipped on a null service), and
     // switch the lint moat to the web rules so component-architecture /

--- a/packages/core/src/detect-gate.ts
+++ b/packages/core/src/detect-gate.ts
@@ -1,5 +1,5 @@
 import { join, dirname } from "node:path";
-import { existsSync } from "node:fs";
+import { existsSync, mkdirSync, writeFileSync } from "node:fs";
 import { ESLint } from "eslint";
 import { WEB_TEMPLATES, type WebFramework } from "./web-templates";
 import { isRecord } from "./lib/guards";
@@ -158,11 +158,60 @@ const STRICT_TSCONFIG_OVERLAY = `{
 /** The gate overlay's home: tsforge's cache dir + the overlay filename. */
 const GATE_TSCONFIG_DIR = ".tsforge";
 const GATE_TSCONFIG_FILE = "tsconfig.gate.json";
+/** The project's own TypeScript config (the model-editable one). */
+const PROJECT_TSCONFIG = "tsconfig.json";
 /** Persistent incremental-typecheck cache (in .tsforge/, git-ignored). Reused
  *  across settles so a warm `tsc` only re-checks what changed — tsc stays the
  *  authority, just amortized. */
 const GATE_TSBUILDINFO_FILE = "gate.tsbuildinfo";
 const INCREMENTAL_FLAGS = `--incremental --tsBuildInfoFile ${GATE_TSCONFIG_DIR}/${GATE_TSBUILDINFO_FILE}`;
+
+/** The web gate typechecks through this HARNESS-OWNED overlay, NOT the project's
+ *  own tsconfig.json. That file is model-editable and tooling (shadcn init, the
+ *  model fixing a path) routinely rewrites it and drops the test-file exclude.
+ *  When the exclude is gone, tsc pulls the model's co-located test files into the
+ *  program and their `import … from "bun:test"` becomes a gate-failing TS2307 —
+ *  `bun:test` is a Bun runtime module that `bun test` resolves natively but tsc
+ *  can't (it needs the exclude OR @types/bun, and neither is guaranteed to survive
+ *  an install flake / a rewrite). The overlay extends the project config (so paths/
+ *  jsx/lib still resolve) but FORCES the exclude, so test files are run by `bun test`
+ *  and never typechecked — robust to any rewrite of tsconfig.json. (Mirrors the core
+ *  gate's `.tsforge/tsconfig.gate.json` overlay.) */
+const WEB_GATE_TSCONFIG_FILE = "tsconfig.web-gate.json";
+const STRICT_WEB_TSCONFIG_OVERLAY = `{
+  "extends": "../tsconfig.json",
+  "compilerOptions": { "noEmit": true, "skipLibCheck": true },
+  "include": ["../**/*.ts", "../**/*.tsx"],
+  "exclude": ["../node_modules", "../dist", "../build", "../.tsforge", "../**/*.test.ts", "../**/*.test.tsx"]
+}
+`;
+
+/** Write the web-gate tsconfig overlay under `.tsforge/` and return the `tsc -p`
+ *  target for it. Falls back to the project tsconfig when none exists yet (called
+ *  before scaffolding) — the gate is rebuilt once the project is laid down. Sync +
+ *  idempotent so the synchronous gate builders can call it without a signature
+ *  change. */
+function ensureWebGateTsconfig(cwd: string): string {
+  if (!existsSync(join(cwd, PROJECT_TSCONFIG))) {
+    return PROJECT_TSCONFIG;
+  }
+
+  const dir = join(cwd, GATE_TSCONFIG_DIR);
+
+  mkdirSync(dir, { recursive: true });
+  writeFileSync(join(dir, WEB_GATE_TSCONFIG_FILE), STRICT_WEB_TSCONFIG_OVERLAY);
+
+  const ignore = join(dir, ".gitignore");
+
+  if (!existsSync(ignore)) {
+    writeFileSync(
+      ignore,
+      `${WEB_GATE_TSCONFIG_FILE}\n${GATE_TSCONFIG_FILE}\n${GATE_TSBUILDINFO_FILE}\n`
+    );
+  }
+
+  return `${GATE_TSCONFIG_DIR}/${WEB_GATE_TSCONFIG_FILE}`;
+}
 
 // The web-stack scaffolds (Vite + React full-kit, or Vite vanilla) live in the
 // registry; this module just lays them down and builds their gate. shadcn/TanStack
@@ -466,7 +515,7 @@ export function buildWebGate(
     .map((glob) => `--ignore-pattern "${glob}"`)
     .join(" ");
   const build = `bun run build`;
-  const tsc = `"${TSC_BIN}" --noEmit -p tsconfig.json`;
+  const tsc = `"${TSC_BIN}" --noEmit -p ${ensureWebGateTsconfig(cwd)}`;
   const lint =
     `${packEnvPrefix(packs)}bun "${ESLINT_BIN}" --no-config-lookup -c "${STRICT_WEB_CONFIG}" ${ignores} --format json .`.replace(
       /\s+/g,
@@ -500,7 +549,7 @@ export function buildWebGate(
   // historically did not, so a dropped `await` in a handler/effect/mutation passed.
   // Splice it in after the syntactic lint when the scaffold has a tsconfig (it
   // always does), reusing the SHIPPED strict.type-aware config verbatim.
-  const typeAware = existsSync(join(cwd, "tsconfig.json"))
+  const typeAware = existsSync(join(cwd, PROJECT_TSCONFIG))
     ? `bun "${ESLINT_BIN}" --no-config-lookup -c "${TYPE_AWARE_CONFIG}" ${ignores} --format json .`.replace(
         /\s+/g,
         " "
@@ -550,8 +599,12 @@ export function buildWebTypeGate(
 /** Just `tsc --noEmit` — the FAST incremental check run every few edits while
  *  building, so type errors (the avalanche source) surface early. Lint waits for
  *  the full gate (running it every few edits is noisy on half-written files). */
-export function buildWebTscCheck(): string {
-  return `"${TSC_BIN}" --noEmit -p tsconfig.json`;
+export function buildWebTscCheck(cwd: string = process.cwd()): string {
+  // Same overlay as the gate: the per-write check runs WHILE the model is writing
+  // test siblings, so without the forced test-exclude it would spuriously red every
+  // edit with a `bun:test` TS2307 — the very thing that nudges the model into
+  // mangling tsconfig.json in the first place.
+  return `"${TSC_BIN}" --noEmit -p ${ensureWebGateTsconfig(cwd)}`;
 }
 
 /**
@@ -793,7 +846,7 @@ async function hasTestFiles(cwd: string): Promise<boolean> {
  * whatever the repo set.)
  */
 async function tscPart(cwd: string): Promise<string | null> {
-  const hasTsconfig = await Bun.file(join(cwd, "tsconfig.json")).exists();
+  const hasTsconfig = await Bun.file(join(cwd, PROJECT_TSCONFIG)).exists();
 
   if (hasTsconfig) {
     // EPHEMERAL gate artifact: lives in .tsforge/ (Bun.write makes the dir), so
@@ -811,7 +864,7 @@ async function tscPart(cwd: string): Promise<string | null> {
   // actually a TS project (has a package.json), so we never litter a random dir.
   // Unlike the overlay, a greenfield tsconfig.json is a DURABLE project file.
   if (await Bun.file(join(cwd, "package.json")).exists()) {
-    await Bun.write(join(cwd, "tsconfig.json"), STRICT_TSCONFIG);
+    await Bun.write(join(cwd, PROJECT_TSCONFIG), STRICT_TSCONFIG);
     // The buildinfo lives in .tsforge/ (git-ignored), NOT next to the durable
     // tsconfig — so incremental never leaks a cache file into the user's tree.
     await ignoreGateArtifact(cwd);
@@ -868,7 +921,7 @@ function lintPart(
 
 /** Optional type-aware async rules — only when target has tsconfig.json. */
 async function typeAwareLintPart(cwd: string): Promise<IGate | null> {
-  const hasTsconfig = await Bun.file(join(cwd, "tsconfig.json")).exists();
+  const hasTsconfig = await Bun.file(join(cwd, PROJECT_TSCONFIG)).exists();
 
   if (!hasTsconfig) {
     return null;

--- a/packages/core/src/detect-gate.ts
+++ b/packages/core/src/detect-gate.ts
@@ -1,5 +1,5 @@
 import { join, dirname } from "node:path";
-import { existsSync, mkdirSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, writeFileSync, readFileSync } from "node:fs";
 import { ESLint } from "eslint";
 import { WEB_TEMPLATES, type WebFramework } from "./web-templates";
 import { isRecord } from "./lib/guards";
@@ -200,17 +200,39 @@ function ensureWebGateTsconfig(cwd: string): string {
 
   mkdirSync(dir, { recursive: true });
   writeFileSync(join(dir, WEB_GATE_TSCONFIG_FILE), STRICT_WEB_TSCONFIG_OVERLAY);
-
-  const ignore = join(dir, ".gitignore");
-
-  if (!existsSync(ignore)) {
-    writeFileSync(
-      ignore,
-      `${WEB_GATE_TSCONFIG_FILE}\n${GATE_TSCONFIG_FILE}\n${GATE_TSBUILDINFO_FILE}\n`
-    );
-  }
+  ensureGateIgnore(dir);
 
   return `${GATE_TSCONFIG_DIR}/${WEB_GATE_TSCONFIG_FILE}`;
+}
+
+/** Keep tsforge's `.tsforge/` cache artifacts out of git WITHOUT clobbering a
+ *  pre-existing `.tsforge/.gitignore` (a previous core-gate run, or one the user
+ *  authored): create it if absent, otherwise APPEND only the entries it's missing
+ *  so the web-gate overlay never shows up in `git status`. */
+function ensureGateIgnore(dir: string): void {
+  const ignore = join(dir, ".gitignore");
+  const entries = [
+    WEB_GATE_TSCONFIG_FILE,
+    GATE_TSCONFIG_FILE,
+    GATE_TSBUILDINFO_FILE,
+  ];
+
+  if (!existsSync(ignore)) {
+    writeFileSync(ignore, `${entries.join("\n")}\n`);
+
+    return;
+  }
+
+  const current = readFileSync(ignore, "utf8");
+  const have = new Set(current.split("\n").map((line) => line.trim()));
+  const missing = entries.filter((entry) => !have.has(entry));
+
+  if (missing.length > 0) {
+    writeFileSync(
+      ignore,
+      `${current.replace(/\n*$/u, "\n")}${missing.join("\n")}\n`
+    );
+  }
 }
 
 // The web-stack scaffolds (Vite + React full-kit, or Vite vanilla) live in the

--- a/packages/core/src/lib/fs/process.ts
+++ b/packages/core/src/lib/fs/process.ts
@@ -33,6 +33,19 @@ export interface IShellRun {
   timedOut: boolean;
 }
 
+/** Conventional exit code for a process terminated by SIGKILL (128 + 9). */
+const SIGKILL_EXIT = 137;
+/** After a kill is signalled, how long to wait for the process to actually be
+ *  reaped before giving up — covers a child that escaped its group (e.g. called
+ *  `setsid`) and so survives the group SIGKILL. Without this bound, `proc.exited`
+ *  could never resolve and the tool would hang forever. */
+const KILL_GRACE_MS = 2_000;
+/** Once the awaited process is gone, how long to let the output pumps drain before
+ *  returning regardless — a backgrounded/orphaned grandchild can keep the output
+ *  pipe open indefinitely, so the read is ALWAYS bounded. It loses nothing: the
+ *  pumps read concurrently, so all emitted output is already captured by now. */
+const FLUSH_GRACE_MS = 500;
+
 /**
  * Spawn `sh -c command` in `cwd` and capture stdout/stderr — the ONE place that
  * runs a shell command for the harness (the `run` tool and the gate both route
@@ -84,8 +97,23 @@ export async function runArgvCommand(
     return { stdout: "", stderr: message, exitCode: 127, timedOut: false };
   }
 
+  let timedOut = false;
+  let resolveEscaped: (() => void) | null = null;
+  // Held in an object so TS doesn't flow-narrow it to `null` for the cleanup below
+  // (its only assignment is inside the killGroup closure, invisible to that flow).
+  const escape: { timer: ReturnType<typeof setTimeout> | null } = {
+    timer: null,
+  };
+  // Resolves only once a kill has been signalled AND the process still hasn't been
+  // reaped a grace period later — i.e. it escaped its group and survived SIGKILL.
+  // Racing it against `proc.exited` guarantees the wait below always settles.
+  const escaped = new Promise<void>((resolve) => {
+    resolveEscaped = resolve;
+  });
+
   // Signal the whole process group (negative pid). Falls back to the lone child if
-  // the group is already gone (ESRCH) or not permitted (EPERM) — never throws.
+  // the group is already gone (ESRCH) or not permitted (EPERM) — never throws. Arms
+  // the escape timer so a process that outlives the kill can't wedge the harness.
   const killGroup = (): void => {
     try {
       process.kill(-proc.pid, "SIGKILL");
@@ -96,9 +124,10 @@ export async function runArgvCommand(
         // already exited
       }
     }
+
+    escape.timer ??= setTimeout(() => resolveEscaped?.(), KILL_GRACE_MS);
   };
 
-  let timedOut = false;
   const timer =
     timeoutMs > 0
       ? setTimeout(() => {
@@ -121,10 +150,6 @@ export async function runArgvCommand(
 
   const decoder = new TextDecoder();
   const buf: { out: string; err: string } = { out: "", err: "" };
-  // Read through a closure so control-flow analysis treats these as `boolean`
-  // (the setTimeout/abort mutations are invisible to it, else it narrows to
-  // literal `false` and the kill branch reads as dead code).
-  const wasKilled = (): boolean => timedOut || (signal?.aborted ?? false);
 
   const pump = async (
     stream: ReadableStream<Uint8Array>,
@@ -146,22 +171,31 @@ export async function runArgvCommand(
       pump(proc.stdout, "out"),
       pump(proc.stderr, "err"),
     ]);
-    const exitCode = await proc.exited;
 
-    // A KILLED process can leave its piped streams open in Bun, so the pumps
-    // would hang forever — flush briefly, then return what we captured. On a
-    // normal exit the streams close and the pumps resolve on their own.
-    await (wasKilled()
-      ? Promise.race([
-          pumps,
-          new Promise<void>((resolve) => setTimeout(resolve, 100)),
-        ])
-      : pumps);
+    // Wait for a clean exit, but give up if a killed process escaped its group and
+    // can't be reaped (`escaped` resolves KILL_GRACE_MS after the kill) — otherwise
+    // a `setsid`-detached server would leave this hanging forever.
+    const exitCode = await Promise.race([
+      proc.exited,
+      escaped.then(() => SIGKILL_EXIT),
+    ]);
+
+    // ALWAYS bound the final drain: a backgrounded/orphaned grandchild can hold the
+    // output pipe open long after the process we waited on is gone (Bun also leaves
+    // a killed process's streams open), so the pumps could otherwise never resolve.
+    await Promise.race([
+      pumps,
+      new Promise<void>((resolve) => setTimeout(resolve, FLUSH_GRACE_MS)),
+    ]);
 
     return { stdout: buf.out, stderr: buf.err, exitCode, timedOut };
   } finally {
     if (timer !== null) {
       clearTimeout(timer);
+    }
+
+    if (escape.timer !== null) {
+      clearTimeout(escape.timer);
     }
 
     if (signal !== undefined) {

--- a/packages/core/src/lib/fs/process.ts
+++ b/packages/core/src/lib/fs/process.ts
@@ -183,10 +183,21 @@ export async function runArgvCommand(
     // ALWAYS bound the final drain: a backgrounded/orphaned grandchild can hold the
     // output pipe open long after the process we waited on is gone (Bun also leaves
     // a killed process's streams open), so the pumps could otherwise never resolve.
+    // Clear the deadline when the pumps win so no timer lingers after a fast command.
+    const flush: { timer: ReturnType<typeof setTimeout> | null } = {
+      timer: null,
+    };
+
     await Promise.race([
       pumps,
-      new Promise<void>((resolve) => setTimeout(resolve, FLUSH_GRACE_MS)),
+      new Promise<void>((resolve) => {
+        flush.timer = setTimeout(resolve, FLUSH_GRACE_MS);
+      }),
     ]);
+
+    if (flush.timer !== null) {
+      clearTimeout(flush.timer);
+    }
 
     return { stdout: buf.out, stderr: buf.err, exitCode, timedOut };
   } finally {

--- a/packages/core/src/loop/tools/file-ops.ts
+++ b/packages/core/src/loop/tools/file-ops.ts
@@ -232,6 +232,125 @@ export function isReadOnlyCommand(command: string): boolean {
   return true;
 }
 
+/** Package managers whose `<dev|start|serve|…>` script starts a never-exiting
+ *  process (`bun run dev`, `npm start`); `npx`/`bunx` instead delegate to a binary. */
+const PKG_RUNNERS = new Set(["bun", "npm", "pnpm", "yarn", "npx", "bunx"]);
+/** Subcommand / script names that start a dev server or watcher (never exit). */
+const SERVER_SUBCOMMANDS = new Set([
+  "dev",
+  "start",
+  "serve",
+  "preview",
+  "watch",
+]);
+/** Binaries that ARE a server/watcher regardless of args — they take a file/dir/
+ *  port positional, never an exiting subcommand. */
+const ALWAYS_SERVER_BINARIES = new Set([
+  "nodemon",
+  "serve",
+  "http-server",
+  "live-server",
+  "webpack-dev-server",
+]);
+/** Framework CLIs where a SERVER subcommand (`dev`/`serve`/…) means it never
+ *  exits, but `build`/`generate`/`run` exit. */
+const SUBCOMMAND_SERVER_BINARIES = new Set([
+  "vite",
+  "vitest",
+  "next",
+  "nuxt",
+  "astro",
+  "remix",
+  "ng",
+]);
+/** Of those, the ones that start a server when run BARE (no subcommand) — `vite`
+ *  defaults to the dev server, `vitest` to watch mode; `next`/`ng`/… just print
+ *  help and exit. */
+const BARE_SERVER_BINARIES = new Set(["vite", "vitest"]);
+
+/** Tokens of the FIRST command in a chain (head of `;`/`&&`/`||`/`|`), with env
+ *  assignments and `sudo`/`env` wrappers stripped. */
+function leadingCommandTokens(command: string): string[] {
+  const first = command.trim().split(/&&|\|\||[;|]/)[0] ?? "";
+  const tokens = first
+    .trim()
+    .split(/\s+/)
+    .filter((t) => t.length > 0 && !t.includes("="));
+  let i = 0;
+
+  while (i < tokens.length && (tokens[i] === "sudo" || tokens[i] === "env")) {
+    i += 1;
+  }
+
+  return tokens.slice(i);
+}
+
+/** A known server/watcher binary, judged by its first subcommand — `serve dist`
+ *  (always), `vite`/`vite dev` (server), `vite build`/`next` (exits) → false. */
+function binaryIsServer(base: string, sub: string | undefined): boolean {
+  if (ALWAYS_SERVER_BINARIES.has(base)) {
+    return true;
+  }
+
+  if (sub === undefined) {
+    return BARE_SERVER_BINARIES.has(base);
+  }
+
+  return SUBCOMMAND_SERVER_BINARIES.has(base) && SERVER_SUBCOMMANDS.has(sub);
+}
+
+/**
+ * A long-running dev server / watcher that never exits on its own (`vite`,
+ * `bun run dev`, `next dev`, `tsc --watch`, `tail -f`, …). Running one in the build
+ * loop stalls it — the gate already builds AND headlessly smoke-tests the app, so
+ * the model never needs to. Best-effort: the run tool's kill-timeout + bounded
+ * drain are the hard backstop for anything this misses. An explicitly backgrounded
+ * command (`… &`) returns immediately, so it is allowed through.
+ */
+export function isLongRunningServerCommand(command: string): boolean {
+  if (/&\s*$/.test(command.trim())) {
+    return false;
+  }
+
+  const tokens = leadingCommandTokens(command);
+  const head = tokens[0];
+
+  if (head === undefined) {
+    return false;
+  }
+
+  const base = head.split("/").pop() ?? head;
+  const rest = tokens.slice(1);
+
+  if (base === "tail") {
+    return rest.includes("-f") || rest.includes("-F");
+  }
+
+  if (base === "tsc") {
+    return rest.includes("-w") || rest.includes("--watch");
+  }
+
+  if (PKG_RUNNERS.has(base)) {
+    const args = rest.filter((a) => !a.startsWith("-"));
+    const start =
+      args[0] === "run" || args[0] === "exec" || args[0] === "x" ? 1 : 0;
+    const first = args[start];
+
+    if (first === undefined) {
+      return false;
+    }
+
+    return (
+      SERVER_SUBCOMMANDS.has(first) || binaryIsServer(first, args[start + 1])
+    );
+  }
+
+  return binaryIsServer(
+    base,
+    rest.find((a) => !a.startsWith("-"))
+  );
+}
+
 export async function runShell(
   args: Record<string, unknown>,
   ctx: IToolContext
@@ -252,6 +371,19 @@ export async function runShell(
       "run",
       "plan mode: only read-only commands are allowed (ls, cat, rg, grep, find, " +
         `git status/log/diff/show/branch, tsc — no pipes/redirects). Blocked: ${r.command}`
+    );
+  }
+
+  if (isLongRunningServerCommand(r.command)) {
+    return reject(
+      ctx,
+      "run",
+      `"${r.command}" looks like a long-running dev server / watcher — it never ` +
+        "exits, so it would stall the build loop. You do not need to run one: the " +
+        "gate already builds the app and smoke-tests it in a headless browser. To " +
+        "debug a blank page, read the build output and the component/source files; " +
+        "page rendering is handled for you. (If you truly need a process running, " +
+        "background it with a trailing `&` so the command returns.)"
     );
   }
 

--- a/packages/core/src/loop/tools/file-ops.ts
+++ b/packages/core/src/loop/tools/file-ops.ts
@@ -299,6 +299,45 @@ function binaryIsServer(base: string, sub: string | undefined): boolean {
   return SUBCOMMAND_SERVER_BINARIES.has(base) && SERVER_SUBCOMMANDS.has(sub);
 }
 
+/** A resolved command head + its args (no package-runner indirection): a watcher
+ *  (`tsc --watch`, `tail -f`) or a server binary (`vite`, `vite dev`). */
+function headIsServer(base: string, rest: readonly string[]): boolean {
+  if (base === "tail") {
+    return rest.includes("-f") || rest.includes("-F");
+  }
+
+  if (base === "tsc") {
+    return rest.includes("-w") || rest.includes("--watch");
+  }
+
+  return binaryIsServer(
+    base,
+    rest.find((a) => !a.startsWith("-"))
+  );
+}
+
+/** A `<pm> [run|exec|x] <script-or-binary> [args]` invocation — a server SCRIPT
+ *  (`npm run dev`) or a DELEGATED binary, whose own flags must be re-checked so
+ *  `npx tsc --watch` / `bunx tail -f` don't slip past (the flags were stripped to
+ *  find the delegate). */
+function pkgRunnerIsServer(rest: string[]): boolean {
+  const args = rest.filter((a) => !a.startsWith("-"));
+  const start =
+    args[0] === "run" || args[0] === "exec" || args[0] === "x" ? 1 : 0;
+  const first = args[start];
+
+  if (first === undefined) {
+    return false;
+  }
+
+  if (SERVER_SUBCOMMANDS.has(first)) {
+    return true;
+  }
+
+  // Delegated binary (`npx <bin> …`): judge it by ITS OWN args, flags included.
+  return headIsServer(first, rest.slice(rest.indexOf(first) + 1));
+}
+
 /**
  * A long-running dev server / watcher that never exits on its own (`vite`,
  * `bun run dev`, `next dev`, `tsc --watch`, `tail -f`, …). Running one in the build
@@ -322,33 +361,11 @@ export function isLongRunningServerCommand(command: string): boolean {
   const base = head.split("/").pop() ?? head;
   const rest = tokens.slice(1);
 
-  if (base === "tail") {
-    return rest.includes("-f") || rest.includes("-F");
-  }
-
-  if (base === "tsc") {
-    return rest.includes("-w") || rest.includes("--watch");
-  }
-
   if (PKG_RUNNERS.has(base)) {
-    const args = rest.filter((a) => !a.startsWith("-"));
-    const start =
-      args[0] === "run" || args[0] === "exec" || args[0] === "x" ? 1 : 0;
-    const first = args[start];
-
-    if (first === undefined) {
-      return false;
-    }
-
-    return (
-      SERVER_SUBCOMMANDS.has(first) || binaryIsServer(first, args[start + 1])
-    );
+    return pkgRunnerIsServer(rest);
   }
 
-  return binaryIsServer(
-    base,
-    rest.find((a) => !a.startsWith("-"))
-  );
+  return headIsServer(base, rest);
 }
 
 export async function runShell(

--- a/packages/core/tests/detect-gate.test.ts
+++ b/packages/core/tests/detect-gate.test.ts
@@ -215,7 +215,7 @@ test("scaffoldWeb(vanilla) lays a Vite + TS skeleton; gate has no vendored exemp
 
     expect(pkg).not.toContain("react");
 
-    const gate = buildWebGate("vanilla");
+    const gate = buildWebGate("vanilla", undefined, dir);
 
     expect(gate.command).toContain("bun run build");
     expect(gate.command).toContain("dist/index.html");

--- a/packages/core/tests/process.test.ts
+++ b/packages/core/tests/process.test.ts
@@ -32,6 +32,32 @@ test("a timed-out command's backgrounded child cannot mutate afterwards", async 
   }
 });
 
+// THE WEDGE: a foreground command exits, but a backgrounded/orphaned child keeps
+// the stdout pipe open. The drain (`new Response(stdout).text()`) then blocks on
+// the open pipe — so a model that did `bun run dev` (or anything that leaves a
+// server holding the pipe) would hang the whole harness with no escape. The drain
+// must be bounded so the tool ALWAYS returns, losing none of the real output.
+test("returns promptly even when a leftover child holds the output pipe open", async () => {
+  const dir = await mkdtemp(join(tmpdir(), "tsforge-proc-pipe-"));
+
+  try {
+    const start = Bun.nanoseconds();
+    // `echo` prints, then a detached child holds stdout open for 4s while the parent
+    // `sh` exits immediately — the NON-killed path. Without the bounded drain the
+    // read blocks the full 4s; with it, we return ~FLUSH_GRACE_MS later.
+    const run = await runShellCommand(dir, "echo ready; sleep 4 &", {
+      timeoutMs: 30_000,
+    });
+    const elapsedMs = (Bun.nanoseconds() - start) / 1e6;
+
+    expect(run.timedOut).toBe(false);
+    expect(run.stdout).toContain("ready");
+    expect(elapsedMs).toBeLessThan(2500);
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
 test("a quick command still returns its output and does not report a timeout", async () => {
   const dir = await mkdtemp(join(tmpdir(), "tsforge-proc-ok-"));
 

--- a/packages/core/tests/run-server-guard.test.ts
+++ b/packages/core/tests/run-server-guard.test.ts
@@ -29,6 +29,12 @@ test("flags never-exiting dev servers and watchers", () => {
     "sudo npm run dev",
     "PORT=3000 bun run dev",
     "vite || echo fail",
+    // delegated through a package runner — the binary's OWN flags must be checked,
+    // not stripped (these previously bypassed the guard)
+    "npx tsc --watch",
+    "npx tsc -w -p tsconfig.json",
+    "bunx tail -f log.txt",
+    "bun x vite",
   ];
 
   for (const cmd of servers) {
@@ -46,6 +52,7 @@ test("lets one-shot commands (incl. builds) through", () => {
     "astro build",
     "ng build",
     "npx vite build",
+    "npx tsc --noEmit", // delegated one-shot typecheck — not a watcher
     "tsc --noEmit",
     "tail -n 50 log.txt",
     "ls -la",

--- a/packages/core/tests/run-server-guard.test.ts
+++ b/packages/core/tests/run-server-guard.test.ts
@@ -1,0 +1,67 @@
+import { test, expect } from "bun:test";
+import { isLongRunningServerCommand } from "../src/loop/tools/file-ops";
+
+test("flags never-exiting dev servers and watchers", () => {
+  const servers = [
+    "bun run dev",
+    "bun dev",
+    "npm run dev",
+    "npm start",
+    "pnpm dev",
+    "yarn start",
+    "npx vite",
+    "bunx serve",
+    "vite",
+    "vite dev",
+    "vite serve",
+    "vite preview",
+    "vitest",
+    "next dev",
+    "nuxt dev",
+    "astro dev",
+    "ng serve",
+    "nodemon server.ts",
+    "serve dist",
+    "http-server .",
+    "tsc --watch",
+    "tsc -w -p tsconfig.json",
+    "tail -f log.txt",
+    "sudo npm run dev",
+    "PORT=3000 bun run dev",
+    "vite || echo fail",
+  ];
+
+  for (const cmd of servers) {
+    expect(isLongRunningServerCommand(cmd)).toBe(true);
+  }
+});
+
+test("lets one-shot commands (incl. builds) through", () => {
+  const oneShot = [
+    "bun run build",
+    "bun test",
+    "npm run build",
+    "vite build",
+    "next build",
+    "astro build",
+    "ng build",
+    "npx vite build",
+    "tsc --noEmit",
+    "tail -n 50 log.txt",
+    "ls -la",
+    "git status",
+    "echo dev", // not a server invocation
+    "node scripts/seed.ts",
+  ];
+
+  for (const cmd of oneShot) {
+    expect(isLongRunningServerCommand(cmd)).toBe(false);
+  }
+});
+
+test("an explicitly backgrounded server is allowed (it returns immediately)", () => {
+  // Backgrounding makes the command return, so it can't stall the loop — the
+  // bounded drain in process.ts handles the lingering pipe.
+  expect(isLongRunningServerCommand("bun run dev &")).toBe(false);
+  expect(isLongRunningServerCommand("vite &")).toBe(false);
+});

--- a/packages/core/tests/web-gate-tsconfig.test.ts
+++ b/packages/core/tests/web-gate-tsconfig.test.ts
@@ -1,0 +1,69 @@
+import { test, expect } from "bun:test";
+import { mkdtemp, rm, mkdir, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { buildWebGate } from "../src/detect-gate";
+
+// Issue: a `bun:test` import in a scaffolded web app reds the gate with TS2307
+// ("Cannot find module 'bun:test'"). Root cause: the web gate ran `tsc -p
+// tsconfig.json` against the MODEL-EDITABLE project config; once that file lost its
+// `**/*.test.ts` exclude (shadcn init / a model rewrite), tsc pulled the test files
+// in and `bun:test` (a Bun runtime module tsc can't resolve without @types/bun) made
+// the gate fail on EVERY build. Fix: typecheck through a harness-owned overlay that
+// FORCES the exclude. This reproduces the worst case (clobbered tsconfig + a bun:test
+// sibling + no @types/bun) and asserts the gate's tsc stays GREEN.
+test("web gate tsc stays green on a bun:test sibling even when tsconfig.json drops the test exclude", async () => {
+  const dir = await mkdtemp(join(tmpdir(), "tsforge-webgate-"));
+
+  try {
+    // CLOBBERED project tsconfig — no `**/*.test.ts` exclude, no @types/bun.
+    await writeFile(
+      join(dir, "tsconfig.json"),
+      JSON.stringify({
+        compilerOptions: {
+          target: "ES2022",
+          module: "ESNext",
+          moduleResolution: "bundler",
+          strict: true,
+          skipLibCheck: true,
+          noEmit: true,
+        },
+        include: ["**/*.ts"],
+        exclude: ["node_modules"],
+      })
+    );
+    await mkdir(join(dir, "src"), { recursive: true });
+    await writeFile(
+      join(dir, "src/impl.ts"),
+      "export const add = (a: number, b: number): number => a + b;\n"
+    );
+    // A co-located bun:test sibling: would TS2307 if tsc pulled it into the program.
+    await writeFile(
+      join(dir, "src/impl.test.ts"),
+      'import { test, expect } from "bun:test";\n' +
+        'import { add } from "./impl";\n' +
+        'test("add", () => {\n  expect(add(1, 2)).toBe(3);\n});\n'
+    );
+
+    // Building the web gate writes the harness-owned overlay into dir/.tsforge.
+    const gate = buildWebGate("react", undefined, dir);
+
+    expect(gate.command).toContain(".tsforge/tsconfig.web-gate.json");
+    expect(gate.command).not.toContain("-p tsconfig.json");
+
+    // Run JUST the overlay typecheck (the real gate also builds/lints, which needs
+    // installed deps). Exit 0 == the test file was excluded; bun:test never loaded.
+    const tscBin = join(process.cwd(), "node_modules/.bin/tsc");
+    const proc = Bun.spawn(
+      [tscBin, "--noEmit", "-p", ".tsforge/tsconfig.web-gate.json"],
+      { cwd: dir, stdout: "pipe", stderr: "pipe" }
+    );
+    const output = await new Response(proc.stdout).text();
+    const exitCode = await proc.exited;
+
+    expect(output).not.toContain("bun:test");
+    expect(exitCode).toBe(0);
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+}, 30_000);


### PR DESCRIPTION
Three robustness fixes for bugs hit live with a weaker model (DeepSeek) driving a web build. All root-caused with repros; full \`bun run validate\` green.

## 1. The run tool could wedge the whole harness (no escape)
A model ran a foreground dev server (\`bun run dev\` / \`vite\`) and the session froze — Ctrl-C couldn't free it. Two bugs in \`runArgvCommand\`:
- it **awaited \`proc.exited\` unbounded** — a server that escapes its group (\`setsid\`) survives the group SIGKILL, so \`proc.exited\` never resolves;
- it **drained stdout to EOF** — a backgrounded/orphaned grandchild keeps the output pipe open, so the read never hits EOF.

Now the exit wait is bounded by a post-kill grace (\`escaped → SIGKILL_EXIT\`) and the final drain is **always** time-bounded (\`FLUSH_GRACE_MS\`). No output is lost (pumps read concurrently) and the tool is **guaranteed to return**.

## 2. The model shouldn't foreground a dev server at all
The \`run\` tool now refuses long-running servers/watchers (\`vite\`, \`bun run dev\`, \`next dev\`, \`tsc --watch\`, \`tail -f\`, …) with guidance to rely on the gate's headless browser smoke. An explicitly backgrounded command (trailing \`&\`) is still allowed. The bounded runner in (1) is the hard backstop for anything this misses.

## 3. Web gate could red on every build with \`bun:test\` TS2307
The web gate ran \`tsc -p tsconfig.json\` against the **model-editable** project config. Once that file lost its \`**/*.test.ts\` exclude (shadcn init, or the model rewriting it), tsc pulled the model's co-located test files in and their \`bun:test\` import failed to resolve (\`bun:test\` is resolved natively by \`bun test\`, not tsc). Every build went red.

Fix: the web gate + per-write tsc check now typecheck through a harness-owned \`.tsforge/tsconfig.web-gate.json\` that extends the project config but **forces** the test-file exclude — mirroring the core gate's overlay. Tests run via \`bun test\`, never typechecked here.

## Tests
- \`process.test.ts\`: a leftover child holding the pipe returns in <2.5s instead of hanging.
- \`run-server-guard.test.ts\`: server-vs-one-shot detection (incl. \`vite build\`, \`bun run build\` allowed).
- \`web-gate-tsconfig.test.ts\`: end-to-end — clobbered tsconfig + \`bun:test\` sibling + no \`@types/bun\` → tsc stays green.