### PR TITLE
fix(harness-review): deepen server guard + CRLF-safe .gitignore append

### DIFF
--- a/packages/core/src/detect-gate.ts
+++ b/packages/core/src/detect-gate.ts
@@ -223,16 +223,33 @@ function ensureGateIgnore(dir: string): void {
     return;
   }
 
-  const current = readFileSync(ignore, "utf8");
-  const have = new Set(current.split("\n").map((line) => line.trim()));
+  const next = gitignoreWithEntries(readFileSync(ignore, "utf8"), entries);
+
+  if (next !== null) {
+    writeFileSync(ignore, next);
+  }
+}
+
+/** Compute new `.gitignore` content with any missing `entries` appended, PRESERVING
+ *  the file's EOL style (a CRLF file stays all-CRLF — appending `\n` after CRLF
+ *  lines produced mixed endings; mirrors the issue #24 fuzzy-edit fix). Returns null
+ *  when nothing is missing, so the caller skips a no-op write. */
+function gitignoreWithEntries(
+  current: string,
+  entries: readonly string[]
+): string | null {
+  const have = new Set(current.split(/\r?\n/).map((line) => line.trim()));
   const missing = entries.filter((entry) => !have.has(entry));
 
-  if (missing.length > 0) {
-    writeFileSync(
-      ignore,
-      `${current.replace(/\n*$/u, "\n")}${missing.join("\n")}\n`
-    );
+  if (missing.length === 0) {
+    return null;
   }
+
+  const eol = current.includes("\r\n") ? "\r\n" : "\n";
+  const base = current.replace(/(?:\r?\n)+$/u, "");
+  const prefix = base.length > 0 ? `${base}${eol}` : "";
+
+  return `${prefix}${missing.join(eol)}${eol}`;
 }
 
 // The web-stack scaffolds (Vite + React full-kit, or Vite vanilla) live in the
@@ -914,14 +931,10 @@ async function ignoreGateArtifact(cwd: string): Promise<void> {
 
   // Exists (maybe a user's, or an older tsforge one without the buildinfo line):
   // append only the missing entries so we never clobber what's there.
-  const current = await file.text();
-  const missing = entries.filter((e) => !current.split("\n").includes(e));
+  const next = gitignoreWithEntries(await file.text(), entries);
 
-  if (missing.length > 0) {
-    await Bun.write(
-      ignore,
-      `${current.replace(/\n*$/u, "\n")}${missing.join("\n")}\n`
-    );
+  if (next !== null) {
+    await Bun.write(ignore, next);
   }
 }
 

--- a/packages/core/src/loop/tools/file-ops.ts
+++ b/packages/core/src/loop/tools/file-ops.ts
@@ -331,9 +331,14 @@ function isRuntimeServer(base: string, rest: readonly string[]): boolean {
   }
 
   if (base === "deno") {
+    if (rest.includes("--watch")) {
+      return true;
+    }
+
+    // `deno task <name>` — the name can sit behind flags (`deno task --cwd app dev`),
+    // so match a server name ANYWHERE after `task`, not just at a fixed position.
     return (
-      rest.includes("--watch") ||
-      (rest[0] === "task" && SERVER_SUBCOMMANDS.has(rest[1] ?? ""))
+      rest[0] === "task" && rest.slice(1).some((a) => SERVER_SUBCOMMANDS.has(a))
     );
   }
 
@@ -359,6 +364,16 @@ function headIsServer(base: string, rest: readonly string[]): boolean {
     base,
     rest.find((a) => !a.startsWith("-"))
   );
+}
+
+/** Blank (→ single space) quoted spans that protect an argument — those containing
+ *  whitespace or a shell separator (`;`/`|`/`&`). A quoted bare word (`'vite'`) is
+ *  left as-is so a genuinely-quoted command name is still detected. */
+function blankProtectedQuotes(command: string): string {
+  const blank = (match: string, inner: string): string =>
+    /[\s;|&]/u.test(inner) ? " " : match;
+
+  return command.replace(/"([^"]*)"/gu, blank).replace(/'([^']*)'/gu, blank);
 }
 
 /** Is THIS single segment a foreground server/watcher? */
@@ -414,15 +429,19 @@ function pkgRunnerIsServer(rest: string[]): boolean {
  * is allowed through.
  */
 export function isLongRunningServerCommand(command: string): boolean {
-  const trimmed = command.trim();
+  // Blank out quoted spans that PROTECT an argument (they contain whitespace or a
+  // shell separator) FIRST, so a `;`/`||`/binary-name inside a commit message or an
+  // echo string can't cause a false split/match. A quoted bare word (`'vite'`,
+  // `"npm"`) is left intact — `unwrapToken` resolves it to the real command.
+  const unquoted = blankProtectedQuotes(command.trim()).trim();
 
   // A trailing single `&` (not `&&`) backgrounds the command — it returns at once.
-  if (/(?:^|[^&])&$/u.test(trimmed)) {
+  if (/(?:^|[^&])&$/u.test(unquoted)) {
     return false;
   }
 
   // A server anywhere in a `&&`/`||`/`;`/`|` chain stalls the loop just the same.
-  return trimmed
+  return unquoted
     .split(/&&|\|\||[;|]/u)
     .some((segment) => segmentIsServer(segment));
 }

--- a/packages/core/src/loop/tools/file-ops.ts
+++ b/packages/core/src/loop/tools/file-ops.ts
@@ -268,17 +268,37 @@ const SUBCOMMAND_SERVER_BINARIES = new Set([
  *  help and exit. */
 const BARE_SERVER_BINARIES = new Set(["vite", "vitest"]);
 
-/** Tokens of the FIRST command in a chain (head of `;`/`&&`/`||`/`|`), with env
- *  assignments and `sudo`/`env` wrappers stripped. */
-function leadingCommandTokens(command: string): string[] {
-  const first = command.trim().split(/&&|\|\||[;|]/)[0] ?? "";
-  const tokens = first
+/** Command wrappers that delegate to the REAL command after them (and their own
+ *  args), so the head must be taken from beyond them. */
+const COMMAND_WRAPPERS = new Set([
+  "sudo",
+  "env",
+  "exec",
+  "nohup",
+  "setsid",
+  "stdbuf",
+  "nice",
+  "time",
+  "command",
+]);
+
+/** Strip wrapping quotes / a leading `(` subshell / trailing `)` from a token so
+ *  `"npm"`, `'vite'`, `(npm` resolve to the bare command name. */
+function unwrapToken(token: string): string {
+  return token.replace(/^[("']+/u, "").replace(/[)"']+$/u, "");
+}
+
+/** Tokens of ONE shell segment, with quotes/parens stripped, env assignments
+ *  dropped, and leading wrapper commands (`sudo`/`env`/`exec`/…) skipped. */
+function segmentTokens(segment: string): string[] {
+  const tokens = segment
     .trim()
     .split(/\s+/)
+    .map(unwrapToken)
     .filter((t) => t.length > 0 && !t.includes("="));
   let i = 0;
 
-  while (i < tokens.length && (tokens[i] === "sudo" || tokens[i] === "env")) {
+  while (i < tokens.length && COMMAND_WRAPPERS.has(tokens[i] ?? "")) {
     i += 1;
   }
 
@@ -299,8 +319,29 @@ function binaryIsServer(base: string, sub: string | undefined): boolean {
   return SUBCOMMAND_SERVER_BINARIES.has(base) && SERVER_SUBCOMMANDS.has(sub);
 }
 
+/** Language-runtime built-in servers: `php -S`, `python -m http.server`,
+ *  `deno task <server>` / `deno run --watch`. */
+function isRuntimeServer(base: string, rest: readonly string[]): boolean {
+  if (base === "php") {
+    return rest.includes("-S");
+  }
+
+  if (base === "python" || base === "python3") {
+    return rest.includes("http.server");
+  }
+
+  if (base === "deno") {
+    return (
+      rest.includes("--watch") ||
+      (rest[0] === "task" && SERVER_SUBCOMMANDS.has(rest[1] ?? ""))
+    );
+  }
+
+  return false;
+}
+
 /** A resolved command head + its args (no package-runner indirection): a watcher
- *  (`tsc --watch`, `tail -f`) or a server binary (`vite`, `vite dev`). */
+ *  (`tsc --watch`, `tail -f`), a runtime server, or a server binary (`vite dev`). */
 function headIsServer(base: string, rest: readonly string[]): boolean {
   if (base === "tail") {
     return rest.includes("-f") || rest.includes("-F");
@@ -310,10 +351,33 @@ function headIsServer(base: string, rest: readonly string[]): boolean {
     return rest.includes("-w") || rest.includes("--watch");
   }
 
+  if (isRuntimeServer(base, rest)) {
+    return true;
+  }
+
   return binaryIsServer(
     base,
     rest.find((a) => !a.startsWith("-"))
   );
+}
+
+/** Is THIS single segment a foreground server/watcher? */
+function segmentIsServer(segment: string): boolean {
+  const tokens = segmentTokens(segment);
+  const head = tokens[0];
+
+  if (head === undefined) {
+    return false;
+  }
+
+  const base = head.split("/").pop() ?? head;
+  const rest = tokens.slice(1);
+
+  if (PKG_RUNNERS.has(base)) {
+    return pkgRunnerIsServer(rest);
+  }
+
+  return headIsServer(base, rest);
 }
 
 /** A `<pm> [run|exec|x] <script-or-binary> [args]` invocation — a server SCRIPT
@@ -340,32 +404,27 @@ function pkgRunnerIsServer(rest: string[]): boolean {
 
 /**
  * A long-running dev server / watcher that never exits on its own (`vite`,
- * `bun run dev`, `next dev`, `tsc --watch`, `tail -f`, …). Running one in the build
- * loop stalls it — the gate already builds AND headlessly smoke-tests the app, so
- * the model never needs to. Best-effort: the run tool's kill-timeout + bounded
- * drain are the hard backstop for anything this misses. An explicitly backgrounded
- * command (`… &`) returns immediately, so it is allowed through.
+ * `bun run dev`, `next dev`, `tsc --watch`, `tail -f`, `php -S`, …). Running one in
+ * the build loop stalls it — the gate already builds AND headlessly smoke-tests the
+ * app, so the model never needs to. Checks EVERY segment of a chain (`cd app &&
+ * npm run dev`), looks through wrappers (`exec`/`sudo`/quotes/subshell), and judges
+ * package-runner delegates by their own flags. Best-effort: the run tool's
+ * kill-timeout + bounded drain are the hard backstop for anything this misses. An
+ * explicitly backgrounded whole command (`… &`, not `&&`) returns immediately, so it
+ * is allowed through.
  */
 export function isLongRunningServerCommand(command: string): boolean {
-  if (/&\s*$/.test(command.trim())) {
+  const trimmed = command.trim();
+
+  // A trailing single `&` (not `&&`) backgrounds the command — it returns at once.
+  if (/(?:^|[^&])&$/u.test(trimmed)) {
     return false;
   }
 
-  const tokens = leadingCommandTokens(command);
-  const head = tokens[0];
-
-  if (head === undefined) {
-    return false;
-  }
-
-  const base = head.split("/").pop() ?? head;
-  const rest = tokens.slice(1);
-
-  if (PKG_RUNNERS.has(base)) {
-    return pkgRunnerIsServer(rest);
-  }
-
-  return headIsServer(base, rest);
+  // A server anywhere in a `&&`/`||`/`;`/`|` chain stalls the loop just the same.
+  return trimmed
+    .split(/&&|\|\||[;|]/u)
+    .some((segment) => segmentIsServer(segment));
 }
 
 export async function runShell(

--- a/packages/core/tests/run-server-guard.test.ts
+++ b/packages/core/tests/run-server-guard.test.ts
@@ -49,6 +49,7 @@ test("flags never-exiting dev servers and watchers", () => {
     "nohup vite",
     // language-runtime built-in servers
     "deno task dev",
+    "deno task --cwd app dev", // task name behind a value-flag
     "php -S localhost:8000",
     "python -m http.server 8000",
     "python3 -m http.server",
@@ -83,6 +84,22 @@ test("lets one-shot commands (incl. builds) through", () => {
   ];
 
   for (const cmd of oneShot) {
+    expect(isLongRunningServerCommand(cmd)).toBe(false);
+  }
+});
+
+test("does not false-positive on a server name inside a quoted string", () => {
+  // The separator/binary lives in a quoted arg — splitting on it or matching the
+  // head would wrongly block a perfectly fine one-shot command.
+  const quoted = [
+    'git commit -m "feat: add vite; fix tests"',
+    'echo "starting || vite"',
+    'echo "run npm run dev later"',
+    `git commit -m 'serve the dist; then vite'`,
+    "node -e \"console.log('next dev')\"",
+  ];
+
+  for (const cmd of quoted) {
     expect(isLongRunningServerCommand(cmd)).toBe(false);
   }
 });

--- a/packages/core/tests/run-server-guard.test.ts
+++ b/packages/core/tests/run-server-guard.test.ts
@@ -35,6 +35,23 @@ test("flags never-exiting dev servers and watchers", () => {
     "npx tsc -w -p tsconfig.json",
     "bunx tail -f log.txt",
     "bun x vite",
+    // a server ANYWHERE in a chain stalls the loop just the same
+    "cd src && npm run dev",
+    "echo starting; npm run dev",
+    "cat log | npm run dev",
+    "false || npm run dev",
+    "npm run build && npm run preview",
+    // wrappers / subshell / quotes must be seen through
+    "exec npm run dev",
+    "(npm run dev)",
+    '"npm" run dev',
+    "'vite'",
+    "nohup vite",
+    // language-runtime built-in servers
+    "deno task dev",
+    "php -S localhost:8000",
+    "python -m http.server 8000",
+    "python3 -m http.server",
   ];
 
   for (const cmd of servers) {
@@ -59,6 +76,10 @@ test("lets one-shot commands (incl. builds) through", () => {
     "git status",
     "echo dev", // not a server invocation
     "node scripts/seed.ts",
+    "cd app && bun run build", // chain of one-shots
+    "vite build && echo done",
+    "cat a.txt | grep error",
+    "python script.py", // not http.server
   ];
 
   for (const cmd of oneShot) {

--- a/packages/core/tests/web-gate-tsconfig.test.ts
+++ b/packages/core/tests/web-gate-tsconfig.test.ts
@@ -67,3 +67,29 @@ test("web gate tsc stays green on a bun:test sibling even when tsconfig.json dro
     await rm(dir, { recursive: true, force: true });
   }
 }, 30_000);
+
+test("appending to a CRLF .tsforge/.gitignore preserves CRLF (no mixed endings)", async () => {
+  const dir = await mkdtemp(join(tmpdir(), "tsforge-webgate-ignore-"));
+
+  try {
+    await writeFile(join(dir, "tsconfig.json"), "{}");
+    // A pre-existing CRLF .gitignore (e.g. authored on Windows) missing our entries.
+    await mkdir(join(dir, ".tsforge"), { recursive: true });
+    await writeFile(
+      join(dir, ".tsforge/.gitignore"),
+      "node_modules\r\n*.log\r\n"
+    );
+
+    // buildWebGate → ensureWebGateTsconfig → ensureGateIgnore appends the overlay.
+    buildWebGate("react", undefined, dir);
+
+    const out = await Bun.file(join(dir, ".tsforge/.gitignore")).text();
+
+    expect(out).toContain("tsconfig.web-gate.json");
+    expect(out).toContain("node_modules"); // pre-existing entry preserved
+    // After stripping every proper CRLF pair, no lone \n may remain (issue #24 lens).
+    expect(out.replace(/\r\n/g, "").includes("\n")).toBe(false);
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
Follow-up from the adversarial subsystem review (5 reviewers, repro-driven, over lib/fs · tools · gate · web-scaffold · oracles).

## What the review found
- **3 subsystems clean** (oracles, web-scaffold, gate-overlay core) — verified with real repros; they also independently re-confirmed the #26 fixes hold (group-kill, bounded drain, overlay correctness, install-truth).
- **Dismissed after re-triage** (agents over-rated): lib/fs "abort `timedOut=false`" is correct by design (abort ≠ timeout); `scratch/` symlink-escape is outside the stated threat model ("mistakes, not a hostile operator") and the proposed `realpath` fix breaks new-file creation; tools plan-mode "stuck" is the *designed* graceful give-up (repetition-loop detection), not a hang.
- **2 genuinely worth fixing — this PR.**

## 1. (P2) Server guard was too shallow
Confirmed bypasses (all reproduced): only the **first** chain segment was checked, so `cd app && npm run dev`, `echo x; vite`, `cat log | npm run dev`, `false || npm run dev` all passed; `exec`/subshell/quotes hid the head (`exec npm run dev`, `(npm run dev)`, `"npm" run dev`); and `deno task dev` / `php -S` / `python -m http.server` were unknown.

Now: checks **every** `&&`/`||`/`;`/`|` segment, sees through wrapper commands (`sudo`/`env`/`exec`/`nohup`/…) and strips quotes/parens, and recognizes the runtime servers. Still **best-effort** — the run tool's kill-timeout + bounded drain (#26) are the hard backstop — and a trailing single `&` is still the allowed escape hatch.

## 2. (P3) CRLF mixed endings in the `.gitignore` append
`ensureGateIgnore` (and its async twin `ignoreGateArtifact`) appended `\n` after CRLF lines → mixed endings. Extracted a shared `gitignoreWithEntries()` that detects and preserves the file's EOL — same lens as the #25/#24 CRLF fix.

## Tests
- ~20 new server-guard cases: chains / wrappers / quotes / `deno`+`php`+`python` flagged; `vite build`, `cd app && bun run build`, `cat a | grep x`, `python script.py` stay allowed.
- CRLF `.gitignore` regression exercised through the real `buildWebGate` path (no lone `\n` remains, pre-existing entries preserved).

`bun run validate` green (1183 pass, 0 fail).