### PR TITLE
feat(eval): trace hygiene + policy-aware metrics + tsforge trace

### DIFF
--- a/apps/docs/astro.config.mjs
+++ b/apps/docs/astro.config.mjs
@@ -218,6 +218,7 @@ export default defineConfig({
             { label: "Web scaffolding", link: "/scaffold/web/" },
             { label: "Model adapter", link: "/inference/adapter/" },
             { label: "Token metrics", link: "/observability/metrics/" },
+            { label: "Trace a run", link: "/observability/trace/" },
           ],
         },
         {

--- a/apps/docs/src/content/docs/observability/metrics.mdx
+++ b/apps/docs/src/content/docs/observability/metrics.mdx
@@ -41,14 +41,22 @@ A low number usually points at the *serving* setup (quantization, batch size, GP
 
 ## 3. `--log` — analyse a whole run
 
-Start the CLI (or an eval) with `--log` and every model call is written to `~/.tsforge/logs/<timestamp>.jsonl` as a `usage` event:
+Start the CLI (or an eval) with `--log` and the whole run is written to `~/.tsforge/logs/<timestamp>.jsonl` as a typed ledger — one event per line, each wrapped in a `payload` (model calls, tool calls, policy decisions, gate verdicts):
 
 ```json
-{ "kind": "usage", "task": "session", "promptTokens": 2031,
-  "completionTokens": 240, "tokensPerSecond": 46, "ms": 5200 }
+{ "type": "model_call_finished", "runId": "…", "timestamp": "…",
+  "payload": { "kind": "usage", "promptTokens": 2031,
+               "completionTokens": 240, "tokensPerSecond": 46, "ms": 5200 } }
 ```
 
-Turn a log into a summary with the built-in analyzer:
+Turn a log into a one-screen summary — including **policy denials by risk** — with [`tsforge trace`](/observability/trace/):
+
+```bash
+tsforge trace            # newest log
+tsforge trace run.jsonl  # a specific one
+```
+
+There's also the lower-level analyzer script (same numbers, more fields like hallucinated imports):
 
 ```bash
 bun run packages/core/scripts/cli-metrics.ts            # newest log

--- a/apps/docs/src/content/docs/observability/trace.mdx
+++ b/apps/docs/src/content/docs/observability/trace.mdx
@@ -1,0 +1,70 @@
+---
+title: Trace a run
+description: Turn a --log run into a human-readable summary — model/tool calls, policy decisions, gate verdicts, and turns-to-green — with tsforge trace.
+---
+
+When you run with `--log`, tsforge writes the whole run to `~/.tsforge/logs/<timestamp>.jsonl` as a typed [ledger](#the-log-ledger). `tsforge trace` reads that ledger back and prints a one-screen summary of what actually happened — **deterministically, with no model call**.
+
+## `tsforge trace`
+
+```bash
+tsforge trace                 # summarize the newest log
+tsforge trace run.jsonl       # a specific log file
+```
+
+Inside an interactive session, **`/trace`** does the same and prefers the current session's own log:
+
+```
+› /trace
+trace of ~/.tsforge/logs/2026-06-19-…​.jsonl
+
+model              qwen3.6-27b
+final status       done
+failure class      none
+turns              1
+turns to green     1
+model calls        1
+tokens out         380
+peak context       4200 (13% of 32000)
+edits/creates      1 (0 created)
+gate runs          1
+policy denials     1 (1 high)
+policy asks        0
+wall clock         0s
+```
+
+| Field | Meaning |
+| --- | --- |
+| `final status` / `failure class` | how the run ended, and — if it didn't reach green — one structured reason why (e.g. `type-error (TS18048)`) |
+| `turns` / `turns to green` | repair iterations, and how many it took to first pass the gate (lower is better) |
+| `model calls` / `tokens out` / `peak context` | call count, completion tokens, and the context high-water mark |
+| `edits/creates` / `gate runs` | file mutations and how many times the gate ran |
+| `policy denials` / `policy asks` | [action-policy](/guardrails/config/) verdicts that blocked or paused an action, denials bucketed by risk |
+
+## The `--log` ledger
+
+Each line is one typed event (valid JSON), so a run is fully reconstructable. Events are wrapped in a `payload`:
+
+```json
+{ "type": "policy_decision", "runId": "…", "timestamp": "…",
+  "payload": { "kind": "policy", "decision": "deny", "risk": "high",
+               "message": "blocked rm -rf /", "rules": ["no-destructive-shell"] } }
+```
+
+Policy decisions — allow / ask / deny, with their risk and the rules that matched — are recorded alongside model calls, tool calls, and gate verdicts. `tsforge trace` surfaces the denials and asks so you can see where the harness stepped in.
+
+## Programmatic access
+
+The same distillation is available from the eval module of `@agjs/tsforge`:
+
+```ts
+import { parseEventLog, analyzeEvents, formatTrace } from "@agjs/tsforge";
+
+const events = parseEventLog(await Bun.file("run.jsonl").text());
+const metrics = analyzeEvents(events); // { turns, tokensOut, policyDenies, denialsByRisk, … }
+console.log(formatTrace(events));
+```
+
+`parseEventLog` tolerates both the ledger shape and the older flat shape, and `analyzeEvents` feeds the [A/B sweep report](/eval/ab-testing/#why-runs-failed).
+
+→ [Token metrics](/observability/metrics/) · [tsforge.config.json](/guardrails/config/) · [A/B testing](/eval/ab-testing/)

--- a/apps/docs/src/content/docs/reference/commands.mdx
+++ b/apps/docs/src/content/docs/reference/commands.mdx
@@ -45,6 +45,15 @@ tsforge map forget     # delete it
 
 `tsforge map` (or `/map` in a session) builds a deterministic structural map of a TypeScript repo — the directory shape, what each module exports, and the **hub modules** everything imports — and persists it under `.tsforge/`. On the next session it's injected into the agent's context so it starts oriented instead of exploring from scratch. All compiler facts (no AI guessing, no extra dependencies); it primes future sessions (run `/clear` to apply mid-session). Best for existing repos; greenfield builds don't need it.
 
+## Trace a run
+
+```bash
+tsforge trace            # summarize the newest --log run
+tsforge trace run.jsonl  # a specific log file
+```
+
+`tsforge trace` (or `/trace` in a session) reads a `--log` ledger and prints a one-screen summary — model/tool calls, **policy decisions** (allow/ask/deny by risk), gate verdicts, and turns-to-green — deterministically, with no model call. See [Trace a run](/observability/trace/).
+
 ## Merge gate (repo root)
 
 Commands for people working on the tsforge repository itself:

--- a/packages/core/scripts/cli-metrics.ts
+++ b/packages/core/scripts/cli-metrics.ts
@@ -146,8 +146,11 @@ function analyze(lines: string[]): IMetrics {
 
     // The `--log` ledger wraps each event in `payload` ({type, payload:{kind,…}});
     // a legacy flat line IS the event. Read through whichever shape this line is,
-    // or every field comes back empty and the metrics silently read zero.
-    const src = isRecord(event.payload) ? event.payload : event;
+    // or every field comes back empty and the metrics silently read zero. Gate on
+    // top-level `kind` being ABSENT (only the wrapped shape lacks it) so a flat
+    // event carrying its own `payload` field isn't misread as wrapped.
+    const src =
+      !("kind" in event) && isRecord(event.payload) ? event.payload : event;
 
     // Concatenate ALL message/output text, then scan once — a "Cannot find
     // module" can be split across streamed token chunks.

--- a/packages/core/scripts/cli-metrics.ts
+++ b/packages/core/scripts/cli-metrics.ts
@@ -144,10 +144,15 @@ function analyze(lines: string[]): IMetrics {
       continue;
     }
 
+    // The `--log` ledger wraps each event in `payload` ({type, payload:{kind,…}});
+    // a legacy flat line IS the event. Read through whichever shape this line is,
+    // or every field comes back empty and the metrics silently read zero.
+    const src = isRecord(event.payload) ? event.payload : event;
+
     // Concatenate ALL message/output text, then scan once — a "Cannot find
     // module" can be split across streamed token chunks.
-    allText += `${str(event.message)}\n${str(event.output)}\n`;
-    HANDLERS[str(event.kind)]?.(m, event, created);
+    allText += `${str(src.message)}\n${str(src.output)}\n`;
+    HANDLERS[str(src.kind)]?.(m, src, created);
   }
 
   const hallucinated = new Set<string>();

--- a/packages/core/src/cli.ts
+++ b/packages/core/src/cli.ts
@@ -1,6 +1,7 @@
 #!/usr/bin/env bun
 import { join, isAbsolute } from "node:path";
 import { mkdirSync } from "node:fs";
+import { readdir } from "node:fs/promises";
 import { Writable } from "node:stream";
 import { createInterface } from "node:readline/promises";
 import { emitKeypressEvents } from "node:readline";
@@ -17,6 +18,7 @@ import {
   formatReport,
 } from "./loop";
 import { buildAndPersistMap, mapStatus, forgetMap } from "./codebase";
+import { parseEventLog, formatTrace } from "./eval";
 import { isPolicyMode } from "./policy";
 import {
   PROVIDER_LIMITS,
@@ -134,6 +136,8 @@ export interface ICliArgs {
   base: string;
   /** Build a structural workspace map (`tsforge map`). */
   map: boolean;
+  /** Summarize a `--log` run (`tsforge trace [logfile]`); `task` carries the path. */
+  trace: boolean;
   /** Base policy mode (`--policy-mode <plan|default|acceptEdits|ci|dontAsk|
    *  bypassPermissions>`); overrides the config file's policy.mode. */
   policyMode: string;
@@ -184,6 +188,7 @@ export function parseArgs(argv: readonly string[]): ICliArgs {
     staged: false,
     base: "",
     map: false,
+    trace: false,
     policyMode: "",
   };
 
@@ -215,6 +220,9 @@ export function parseArgs(argv: readonly string[]): ICliArgs {
     out.task = positional.slice(1).join(" ").trim();
   } else if (positional[0] === "map") {
     out.map = true;
+    out.task = positional.slice(1).join(" ").trim();
+  } else if (positional[0] === "trace") {
+    out.trace = true;
     out.task = positional.slice(1).join(" ").trim();
   }
 
@@ -1403,6 +1411,10 @@ async function repl(args: ICliArgs): Promise<number> {
         await runMapCommand(args.dir, arg);
         break;
 
+      case "trace":
+        await runTraceCommand(arg, logFile);
+        break;
+
       case "files": {
         const globs = arg
           .split(",")
@@ -1865,6 +1877,73 @@ async function mapMode(args: ICliArgs): Promise<number> {
   return 0;
 }
 
+/** Resolve the newest `--log` JSONL under ~/.tsforge/logs, or "" if none. */
+async function newestLogFile(): Promise<string> {
+  try {
+    // Filenames are ISO-timestamp-prefixed, so lexicographic sort = chronological.
+    const names = (await readdir(logsDir()))
+      .filter((n) => n.endsWith(".jsonl"))
+      .sort();
+    const latest = names.at(-1);
+
+    return latest === undefined ? "" : join(logsDir(), latest);
+  } catch {
+    return "";
+  }
+}
+
+/** A user-supplied log path resolved against cwd, or "" when none was given. */
+function resolveLogArg(arg: string): string {
+  if (arg.length === 0) {
+    return "";
+  }
+
+  return isAbsolute(arg) ? arg : join(process.cwd(), arg);
+}
+
+/** `tsforge trace [logfile]` / `/trace` — summarize a `--log` run: model/tool
+ *  calls, policy decisions (allow/ask/deny by risk), gate verdicts, and
+ *  turns-to-green. Deterministic, no model call. With no path it prefers `prefer`
+ *  (the live session log) and falls back to the newest log on disk. */
+async function runTraceCommand(arg: string, prefer = ""): Promise<number> {
+  let file = resolveLogArg(arg);
+
+  if (file.length === 0) {
+    file = prefer;
+  }
+
+  if (file.length === 0) {
+    file = await newestLogFile();
+  }
+
+  if (file.length === 0) {
+    process.stdout.write(
+      "no log to analyze — run with --log first, or pass a path\n"
+    );
+
+    return 1;
+  }
+
+  const text = await Bun.file(file)
+    .text()
+    .catch(() => "");
+  const events = parseEventLog(text);
+
+  if (events.length === 0) {
+    process.stdout.write(`no events parsed from ${file}\n`);
+
+    return 1;
+  }
+
+  process.stdout.write(`trace of ${file}\n\n${formatTrace(events)}\n`);
+
+  return 0;
+}
+
+async function traceMode(args: ICliArgs): Promise<number> {
+  return runTraceCommand(args.task);
+}
+
 export async function main(): Promise<number> {
   const args = parseArgs(process.argv.slice(2));
 
@@ -1874,6 +1953,10 @@ export async function main(): Promise<number> {
 
   if (args.map) {
     return mapMode(args);
+  }
+
+  if (args.trace) {
+    return traceMode(args);
   }
 
   // A positional task with a scope + gate ⇒ one-shot; otherwise interactive.

--- a/packages/core/src/cli/commands.ts
+++ b/packages/core/src/cli/commands.ts
@@ -49,6 +49,11 @@ export const COMMANDS: readonly ICommandSpec[] = [
     summary: "build a structural map of the repo to prime the agent",
   },
   {
+    name: "/trace",
+    arg: "[logfile]",
+    summary: "summarize a --log run (calls, policy, gate, turns-to-green)",
+  },
+  {
     name: "/model",
     arg: "[name]",
     summary: "list configured models (★ active), or switch to <name>",

--- a/packages/core/src/eval/index.ts
+++ b/packages/core/src/eval/index.ts
@@ -11,6 +11,7 @@ export {
   type IFailureSignals,
 } from "./failure-class";
 export { parseEventLog } from "./parse-log";
+export { formatTrace } from "./trace";
 export {
   buildSweepReport,
   renderSweepReportMarkdown,

--- a/packages/core/src/eval/metrics.ts
+++ b/packages/core/src/eval/metrics.ts
@@ -32,6 +32,13 @@ export interface IRunMetrics {
   wallClockSeconds: number;
   /** Mean output rate across calls that reported one (tokens/second). */
   avgTokensPerSecond: number;
+  /** Policy verdicts that DENIED a proposed action (the safety tripwire count). */
+  policyDenies: number;
+  /** Policy verdicts that asked for confirmation (resolve-to-deny in headless). */
+  policyAsks: number;
+  /** Denials bucketed by risk (e.g. {"high":1,"critical":1}); empty when none —
+   *  so a run shows not just how often the policy fired but how dangerous it was. */
+  denialsByRisk: Record<string, number>;
 }
 
 function emptyMetrics(): IRunMetrics {
@@ -48,7 +55,24 @@ function emptyMetrics(): IRunMetrics {
     turnsToGreen: null,
     wallClockSeconds: 0,
     avgTokensPerSecond: 0,
+    policyDenies: 0,
+    policyAsks: 0,
+    denialsByRisk: {},
   };
+}
+
+/** Tally one policy verdict into the metrics (deny → bucketed by risk; ask → its
+ *  own counter). Allows are not counted — only the tripwires matter for a run. */
+function countPolicy(m: IRunMetrics, event: ILoopEvent): void {
+  if (event.decision === "deny") {
+    m.policyDenies += 1;
+
+    const risk = event.risk ?? "low";
+
+    m.denialsByRisk[risk] = (m.denialsByRisk[risk] ?? 0) + 1;
+  } else if (event.decision === "ask") {
+    m.policyAsks += 1;
+  }
 }
 
 /** Reduce a run's event stream to its behavioral metrics. Pure — feed it the
@@ -88,6 +112,8 @@ export function analyzeEvents(events: readonly ILoopEvent[]): IRunMetrics {
       m.turnsToGreen ??= m.turns;
     } else if (event.kind === "stuck") {
       m.finalStatus = "stuck";
+    } else if (event.kind === "policy") {
+      countPolicy(m, event);
     }
   }
 

--- a/packages/core/src/eval/parse-log.ts
+++ b/packages/core/src/eval/parse-log.ts
@@ -21,6 +21,7 @@ const KNOWN_KINDS = new Set<string>([
   "timing",
   "usage",
   "ttsr",
+  "policy",
 ]);
 
 function isKind(value: string): value is ILoopEvent["kind"] {
@@ -31,6 +32,12 @@ function optionalString(value: unknown): string | undefined {
   return typeof value === "string" ? value : undefined;
 }
 
+function optionalNumber(value: unknown): number | undefined {
+  return typeof value === "number" && Number.isFinite(value)
+    ? value
+    : undefined;
+}
+
 function stringArray(value: unknown): string[] | undefined {
   if (!Array.isArray(value)) {
     return undefined;
@@ -39,15 +46,121 @@ function stringArray(value: unknown): string[] | undefined {
   return value.filter((v): v is string => typeof v === "string");
 }
 
-/** Coerce one parsed JSONL record into an ILoopEvent, or null when it isn't one.
- *  Reads only the fields the failure classifier + metrics consume — enough to
- *  reconstruct a typed event stream from a `--log` file. */
-function coerceEvent(record: unknown): ILoopEvent | null {
+function toDecision(value: unknown): ILoopEvent["decision"] {
+  return value === "allow" || value === "ask" || value === "deny"
+    ? value
+    : undefined;
+}
+
+function toRisk(value: unknown): ILoopEvent["risk"] {
+  return value === "low" ||
+    value === "medium" ||
+    value === "high" ||
+    value === "critical"
+    ? value
+    : undefined;
+}
+
+/** The event's field source. The `--log` ledger wraps every event in `payload`
+ *  ({type, payload:{kind,…}}); a legacy/raw stream IS the event ({kind,…}). Read
+ *  through whichever shape this line is, so both parse identically. */
+function eventSource(record: unknown): Record<string, unknown> | null {
   if (!isRecord(record)) {
     return null;
   }
 
-  const kind = record.kind;
+  return isRecord(record.payload) ? record.payload : record;
+}
+
+function assignText(event: ILoopEvent, src: Record<string, unknown>): void {
+  const output = optionalString(src.output);
+  const file = optionalString(src.file);
+  const model = optionalString(src.model);
+  const detail = optionalString(src.detail);
+
+  if (output !== undefined) {
+    event.output = output;
+  }
+
+  if (file !== undefined) {
+    event.file = file;
+  }
+
+  if (model !== undefined) {
+    event.model = model;
+  }
+
+  if (detail !== undefined) {
+    event.detail = detail;
+  }
+}
+
+function assignNumbers(event: ILoopEvent, src: Record<string, unknown>): void {
+  const ms = optionalNumber(src.ms);
+  const promptTokens = optionalNumber(src.promptTokens);
+  const completionTokens = optionalNumber(src.completionTokens);
+  const totalTokens = optionalNumber(src.totalTokens);
+  const tokensPerSecond = optionalNumber(src.tokensPerSecond);
+  const contextWindow = optionalNumber(src.contextWindow);
+
+  if (ms !== undefined) {
+    event.ms = ms;
+  }
+
+  if (promptTokens !== undefined) {
+    event.promptTokens = promptTokens;
+  }
+
+  if (completionTokens !== undefined) {
+    event.completionTokens = completionTokens;
+  }
+
+  if (totalTokens !== undefined) {
+    event.totalTokens = totalTokens;
+  }
+
+  if (tokensPerSecond !== undefined) {
+    event.tokensPerSecond = tokensPerSecond;
+  }
+
+  if (contextWindow !== undefined) {
+    event.contextWindow = contextWindow;
+  }
+}
+
+function assignVerdict(event: ILoopEvent, src: Record<string, unknown>): void {
+  const decision = toDecision(src.decision);
+  const risk = toRisk(src.risk);
+  const rules = stringArray(src.rules);
+
+  if (decision !== undefined) {
+    event.decision = decision;
+  }
+
+  if (risk !== undefined) {
+    event.risk = risk;
+  }
+
+  if (typeof src.passed === "boolean") {
+    event.passed = src.passed;
+  }
+
+  if (rules !== undefined) {
+    event.rules = rules;
+  }
+}
+
+/** Coerce one parsed JSONL record into an ILoopEvent, or null when it isn't one.
+ *  Carries the fields the failure classifier, the metrics, and the trace summary
+ *  consume — enough to reconstruct a typed event stream from a `--log` file. */
+function coerceEvent(record: unknown): ILoopEvent | null {
+  const src = eventSource(record);
+
+  if (src === null) {
+    return null;
+  }
+
+  const kind = src.kind;
 
   if (typeof kind !== "string" || !isKind(kind)) {
     return null;
@@ -55,29 +168,20 @@ function coerceEvent(record: unknown): ILoopEvent | null {
 
   const event: ILoopEvent = {
     kind,
-    task: optionalString(record.task) ?? "",
-    message: optionalString(record.message) ?? "",
+    task: optionalString(src.task) ?? "",
+    message: optionalString(src.message) ?? "",
   };
-  const output = optionalString(record.output);
-  const rules = stringArray(record.rules);
 
-  if (output !== undefined) {
-    event.output = output;
-  }
-
-  if (typeof record.passed === "boolean") {
-    event.passed = record.passed;
-  }
-
-  if (rules !== undefined) {
-    event.rules = rules;
-  }
+  assignText(event, src);
+  assignNumbers(event, src);
+  assignVerdict(event, src);
 
   return event;
 }
 
 /** Parse a `--log` JSONL transcript (one serialized event per line) into a typed
- *  event stream. Malformed lines and non-event records are skipped. */
+ *  event stream. Malformed lines and non-event records are skipped. Tolerates
+ *  both the ledger shape ({type, payload:{kind,…}}) and the flat shape ({kind,…}). */
 export function parseEventLog(jsonl: string): ILoopEvent[] {
   const events: ILoopEvent[] = [];
 

--- a/packages/core/src/eval/parse-log.ts
+++ b/packages/core/src/eval/parse-log.ts
@@ -63,13 +63,18 @@ function toRisk(value: unknown): ILoopEvent["risk"] {
 
 /** The event's field source. The `--log` ledger wraps every event in `payload`
  *  ({type, payload:{kind,…}}); a legacy/raw stream IS the event ({kind,…}). Read
- *  through whichever shape this line is, so both parse identically. */
+ *  through whichever shape this line is, so both parse identically. A wrapped
+ *  ledger line never has a top-level `kind` (it lives in `payload`), so gating on
+ *  its ABSENCE keeps a legacy flat event that happens to carry its own `payload`
+ *  field (e.g. tool args) from being misread as wrapped. */
 function eventSource(record: unknown): Record<string, unknown> | null {
   if (!isRecord(record)) {
     return null;
   }
 
-  return isRecord(record.payload) ? record.payload : record;
+  return !("kind" in record) && isRecord(record.payload)
+    ? record.payload
+    : record;
 }
 
 function assignText(event: ILoopEvent, src: Record<string, unknown>): void {

--- a/packages/core/src/eval/trace.ts
+++ b/packages/core/src/eval/trace.ts
@@ -1,0 +1,65 @@
+import type { ILoopEvent } from "../loop/loop.types";
+import { analyzeEvents } from "./metrics";
+
+/** Run identity from the `start` event (a `--log` is self-describing). */
+function runMeta(events: readonly ILoopEvent[]): {
+  model: string;
+  contextWindow: number;
+} {
+  const start = events.find((e) => e.kind === "start");
+
+  return {
+    model: start?.model ?? "?",
+    contextWindow: start?.contextWindow ?? 0,
+  };
+}
+
+/** A compact "n high, 1 critical" summary of denials by risk (empty → ""). */
+function denialBreakdown(denialsByRisk: Record<string, number>): string {
+  return Object.entries(denialsByRisk)
+    .map(([risk, n]) => `${n} ${risk}`)
+    .join(", ");
+}
+
+/**
+ * Render a `--log` event stream as a human-readable run summary — the
+ * deterministic counterpart to Codebuff's LLM trace-analyzer. Reuses
+ * `analyzeEvents` (no model call), and surfaces policy decisions, which the eval
+ * parser used to drop. Feed it `parseEventLog(<log text>)`.
+ */
+export function formatTrace(events: readonly ILoopEvent[]): string {
+  const m = analyzeEvents(events);
+  const { model, contextWindow } = runMeta(events);
+  const pct =
+    contextWindow > 0 ? Math.round((m.peakContext / contextWindow) * 100) : 0;
+  const denials = denialBreakdown(m.denialsByRisk);
+  const rows: [string, string][] = [
+    ["model", model],
+    ["final status", m.finalStatus],
+    ["failure class", m.failureClass],
+    ["turns", String(m.turns)],
+    ["turns to green", m.turnsToGreen === null ? "—" : String(m.turnsToGreen)],
+    ["model calls", String(m.modelCalls)],
+    ["tokens out", String(m.tokensOut)],
+    [
+      "peak context",
+      contextWindow > 0
+        ? `${m.peakContext} (${pct}% of ${contextWindow})`
+        : String(m.peakContext),
+    ],
+    ["edits/creates", `${m.edits} (${m.filesCreated} created)`],
+    ["gate runs", String(m.gateRuns)],
+    [
+      "policy denials",
+      denials.length > 0
+        ? `${m.policyDenies} (${denials})`
+        : String(m.policyDenies),
+    ],
+    ["policy asks", String(m.policyAsks)],
+    ["wall clock", `${m.wallClockSeconds}s`],
+  ];
+
+  return rows
+    .map(([label, value]) => `${label.padEnd(18)} ${value}`)
+    .join("\n");
+}

--- a/packages/core/tests/trace.test.ts
+++ b/packages/core/tests/trace.test.ts
@@ -103,6 +103,23 @@ describe("trace parser: writer↔reader contract", () => {
 
     expect(parsed.map((e) => e.kind)).toEqual(["cycle", "done"]);
   });
+
+  // A flat event can legitimately carry its OWN `payload` field (e.g. tool args).
+  // The source-shape check must key on top-level `kind` being absent — not just on
+  // a `payload` existing — or the flat event's real fields get discarded.
+  test("a flat event with its own `payload` field still reads top-level fields", () => {
+    const line = JSON.stringify({
+      kind: "run",
+      task: "t",
+      message: "ran",
+      payload: { foo: "bar" },
+    });
+    const parsed = parseEventLog(line);
+
+    expect(parsed).toHaveLength(1);
+    expect(parsed[0]?.kind).toBe("run");
+    expect(parsed[0]?.message).toBe("ran");
+  });
 });
 
 describe("trace metrics: policy counts", () => {

--- a/packages/core/tests/trace.test.ts
+++ b/packages/core/tests/trace.test.ts
@@ -1,0 +1,182 @@
+import { test, expect, describe } from "bun:test";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { ILoopEvent } from "../src/loop/loop.types";
+import { LedgerWriter, ledgerTypeFor } from "../src/loop";
+import { parseEventLog, analyzeEvents, formatTrace } from "../src/eval";
+
+/** Mirror cli.ts makeReporter: the only thing that writes a `--log` file is the
+ *  LedgerWriter, with payload = the full event. */
+function writeLedger(file: string, events: readonly ILoopEvent[]): void {
+  const ledger = new LedgerWriter(file, "run-1");
+
+  for (const event of events) {
+    ledger.record(ledgerTypeFor(event), { ...event });
+  }
+}
+
+describe("trace parser: writer↔reader contract", () => {
+  // THE BUG: `--log` writes nested ledger lines ({type, payload:{kind,…}}) but the
+  // parser read top-level `record.kind`, so parseEventLog on a real log yielded an
+  // EMPTY stream — the analyzer silently saw nothing. This locks the round-trip.
+  test("parseEventLog reads a real LedgerWriter-produced --log file", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "tsforge-trace-"));
+
+    try {
+      const file = join(dir, "run.jsonl");
+      const events: ILoopEvent[] = [
+        {
+          kind: "start",
+          task: "t",
+          message: "",
+          model: "qwen",
+          contextWindow: 8000,
+        },
+        { kind: "cycle", task: "t", message: "", cycle: 1 },
+        {
+          kind: "usage",
+          task: "t",
+          message: "",
+          promptTokens: 500,
+          completionTokens: 120,
+          tokensPerSecond: 40,
+        },
+        { kind: "done", task: "t", message: "" },
+      ];
+
+      writeLedger(file, events);
+
+      const parsed = parseEventLog(await Bun.file(file).text());
+
+      expect(parsed.length).toBe(events.length);
+      expect(parsed.map((e) => e.kind)).toEqual([
+        "start",
+        "cycle",
+        "usage",
+        "done",
+      ]);
+      // Numeric fields must survive so analyzeEvents on a log is accurate.
+      const usage = parsed.find((e) => e.kind === "usage");
+
+      expect(usage?.completionTokens).toBe(120);
+      expect(usage?.promptTokens).toBe(500);
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  test("policy events round-trip with decision + risk (were dropped entirely)", () => {
+    const events: ILoopEvent[] = [
+      {
+        kind: "policy",
+        task: "t",
+        message: "blocked rm -rf /",
+        decision: "deny",
+        risk: "high",
+        rules: ["no-destructive-shell"],
+      },
+    ];
+    // Serialize through the ledger shape, then parse it back.
+    const line = JSON.stringify({
+      eventId: "e1",
+      runId: "run-1",
+      timestamp: "2026-06-19T00:00:00.000Z",
+      type: ledgerTypeFor(events[0]!),
+      payload: { ...events[0] },
+    });
+    const parsed = parseEventLog(line);
+
+    expect(parsed).toHaveLength(1);
+    expect(parsed[0]?.kind).toBe("policy");
+    expect(parsed[0]?.decision).toBe("deny");
+    expect(parsed[0]?.risk).toBe("high");
+    expect(parsed[0]?.rules).toEqual(["no-destructive-shell"]);
+  });
+
+  test("legacy flat-format lines still parse (back-compat)", () => {
+    const flat = [
+      JSON.stringify({ kind: "cycle", task: "t", message: "" }),
+      JSON.stringify({ kind: "done", task: "t", message: "" }),
+    ].join("\n");
+    const parsed = parseEventLog(flat);
+
+    expect(parsed.map((e) => e.kind)).toEqual(["cycle", "done"]);
+  });
+});
+
+describe("trace metrics: policy counts", () => {
+  test("analyzeEvents counts denies, asks, and denials by risk", () => {
+    const events: ILoopEvent[] = [
+      {
+        kind: "policy",
+        task: "t",
+        message: "",
+        decision: "deny",
+        risk: "high",
+      },
+      {
+        kind: "policy",
+        task: "t",
+        message: "",
+        decision: "deny",
+        risk: "critical",
+      },
+      {
+        kind: "policy",
+        task: "t",
+        message: "",
+        decision: "ask",
+        risk: "medium",
+      },
+      {
+        kind: "policy",
+        task: "t",
+        message: "",
+        decision: "allow",
+        risk: "low",
+      },
+    ];
+    const m = analyzeEvents(events);
+
+    expect(m.policyDenies).toBe(2);
+    expect(m.policyAsks).toBe(1);
+    expect(m.denialsByRisk).toEqual({ high: 1, critical: 1 });
+  });
+});
+
+describe("trace formatter", () => {
+  test("formatTrace renders the headline run signals", () => {
+    const events: ILoopEvent[] = [
+      {
+        kind: "start",
+        task: "t",
+        message: "",
+        model: "qwen",
+        contextWindow: 8000,
+      },
+      { kind: "cycle", task: "t", message: "", cycle: 1 },
+      {
+        kind: "usage",
+        task: "t",
+        message: "",
+        promptTokens: 500,
+        completionTokens: 120,
+      },
+      {
+        kind: "policy",
+        task: "t",
+        message: "",
+        decision: "deny",
+        risk: "high",
+      },
+      { kind: "done", task: "t", message: "" },
+    ];
+    const out = formatTrace(events);
+
+    expect(out).toContain("qwen");
+    expect(out).toContain("turns");
+    expect(out).toMatch(/den(y|ied|ials)/i);
+    expect(out).toContain("high");
+  });
+});


### PR DESCRIPTION
## Phase 1 of the Codebuff-inspired uplift — trace hygiene

### The bug (two stacked)
The `--log` run **ledger** (shipped earlier today) writes nested lines: `{type, payload:{kind,…}}`. But the eval parser (`parseEventLog`/`coerceEvent`) read **top-level** `record.kind`. So:

1. **Format mismatch** — `parseEventLog` on a real `--log` file yielded **zero** events; `cli-metrics` / `classifyRun` silently analyzed nothing.
2. **Policy dropped** — `KNOWN_KINDS` had no `"policy"`, and `decision`/`risk` were never carried.

`cli-metrics.ts`'s hand-rolled analyzer was broken the same way (top-level field reads).

### The fix
- **`parse-log.ts`** — `coerceEvent` is now format-tolerant (reads through `payload` or flat) and carries the numeric + verdict fields the metrics, classifier, and trace summary consume; `"policy"` added to `KNOWN_KINDS`.
- **`metrics.ts`** — `IRunMetrics` gains `policyDenies`, `policyAsks`, `denialsByRisk`.
- **`tsforge trace [logfile]` / `/trace`** — new deterministic run summary (model/tool calls, policy by risk, gate verdicts, turns-to-green); no model call. Adapts Codebuff's LLM trace-analyzer as a pure function (`formatTrace`).
- **`cli-metrics.ts`** — reads the ledger shape too.
- **Docs** — new `observability/trace` page + `commands`/`metrics` cross-links.

### Tests
`tests/trace.test.ts` locks the **writer↔reader contract** with a real `LedgerWriter` round-trip, plus policy round-trip, legacy back-compat, policy metric counts, and the formatter.

### Verification
- `bun run validate` green (1189 pass, 0 fail).
- Astro docs build green (38 pages).
- Live smoke: `tsforge trace` on a synthetic ledger surfaces `policy denials 1 (1 high)`; `cli-metrics` reads the same file correctly.

> Note: committed unsigned (1Password was locked this session); can re-sign before merge.