### PR TITLE
feat(review): gate-aware reviewer (--with-gate)

### DIFF
--- a/apps/docs/astro.config.mjs
+++ b/apps/docs/astro.config.mjs
@@ -171,6 +171,7 @@ export default defineConfig({
             { label: "Chat with your repo", link: "/cli/interactive/" },
             { label: "Drive a change to green", link: "/workflows/fix-to-green/" },
             { label: "Review your changes", link: "/cli/review/" },
+            { label: "Recipes", link: "/cli/recipes/" },
             { label: "Map the repo", link: "/cli/map/" },
             { label: "Plan mode", link: "/cli/plan-mode/" },
           ],

--- a/apps/docs/src/content/docs/cli/recipes.mdx
+++ b/apps/docs/src/content/docs/cli/recipes.mdx
@@ -1,0 +1,59 @@
+---
+title: Recipes
+description: Save a run setup as declarative JSON and invoke it by name with tsforge run <id> — a deterministic, reviewable alternative to retyping flags.
+---
+
+A **recipe** is a named, declarative run setup checked into your repo. Instead of retyping `--files`, `--accept`, the model, and limits every time, you write them once and invoke by name:
+
+```bash
+tsforge run api-endpoint "add a DELETE /users/:id route"
+tsforge recipes                # list the recipes this repo has
+```
+
+A recipe is **data, not code** — it composes options tsforge already has. It never executes arbitrary logic and never spawns sub-agents, so it stays deterministic and reviewable in a PR. (This is the deliberate divergence from Codebuff's executable `.ts` agent definitions.)
+
+## Where recipes live
+
+```
+.tsforge/recipes/<id>.json     # project recipes (checked in, shared with the team)
+~/.tsforge/recipes/<id>.json   # your personal recipes, across all repos
+```
+
+A project recipe **overrides** a global one with the same id. `tsforge recipes` lists everything it found.
+
+## Example
+
+```json
+// .tsforge/recipes/api-endpoint.json
+{
+  "id": "api-endpoint",
+  "description": "Add an API route under src/api, strict gate",
+  "gate": "bun run validate",
+  "files": ["src/api/**"],
+  "model": "qwen3-coder",
+  "maxTurns": 30,
+  "policyMode": "default"
+}
+```
+
+## Fields
+
+| Field | Maps to | Notes |
+| --- | --- | --- |
+| `id` | — | required, kebab-case; the name you invoke |
+| `description` | — | shown by `tsforge recipes` |
+| `task` | the prompt | a CLI positional still overrides it |
+| `files` | `--files` | editable scope globs |
+| `gate` | `--accept` | the command that confirms "done" |
+| `model` | the run's model | a name from `~/.tsforge/models.json` |
+| `maxTurns` | run limit | hard cap on model turns |
+| `thinkingBudget` | run limit | reasoning-token cap per call |
+| `policyMode` | `--policy-mode` | `plan` / `default` / `acceptEdits` / `ci` / `dontAsk` / `bypassPermissions` |
+| `base`, `staged` | `--base` / `--staged` | for review-style runs |
+| `web`, `plan`, `log`, `strictFloorOnly` | the matching flags | booleans |
+
+A recipe is, in effect, a saved set of CLI options: `tsforge run <id>` applies them, and you can also combine `--recipe <id>` with other commands (e.g. `tsforge review --recipe …`). **An explicit CLI flag always wins** over the recipe, so `tsforge run api-endpoint --files lib/**` overrides just the scope.
+
+Fields this version doesn't recognize (a typo, or a not-yet-supported field like `profile`/`tools`) are **reported, not silently ignored** — so a recipe never quietly does less than it says.
+
+→ [Commands](/reference/commands/) · [tsforge.config.json](/guardrails/config/) · [Models](/inference/models-json/)

--- a/apps/docs/src/content/docs/cli/review.mdx
+++ b/apps/docs/src/content/docs/cli/review.mdx
@@ -9,9 +9,14 @@ description: "tsforge review — a functional code review of the change you're o
 tsforge review                 # review the current diff
 tsforge review --staged        # only staged changes (pre-commit)
 tsforge review --base develop   # diff against a specific ref
+tsforge review --with-gate     # run the gate first; skip what it already covers
 ```
 
 Inside a session, the same review is available as `/review`.
+
+## Gate-aware review
+
+With `--with-gate`, tsforge runs [the gate](/loop/gate-floor/) once before reviewing and tells the reviewer **which rules are already failing**, so it won't spend its attention re-reporting a type or lint error the gate loop will fix anyway. The review focuses on the behaviour of the code the gate already accepts — exactly the part the gate is blind to. The report notes how many gate rules were skipped. Without the flag, review runs as before (no gate run).
 
 ## What it reviews
 

--- a/apps/docs/src/content/docs/reference/commands.mdx
+++ b/apps/docs/src/content/docs/reference/commands.mdx
@@ -36,6 +36,16 @@ It is **functional** review — logic, regressions, edge cases, and business rul
 
 The same review is available inside an interactive session as **`/review`** (optionally `/review <base>` to diff against a specific ref).
 
+## Recipes
+
+```bash
+tsforge recipes                          # list this repo's recipes
+tsforge run api-endpoint "add a route"   # run a saved recipe by name
+tsforge run api-endpoint --files lib/**  # ...with a CLI override (CLI wins)
+```
+
+A recipe is declarative JSON in `.tsforge/recipes/<id>.json` (project) or `~/.tsforge/recipes/<id>.json` (global) that composes a run's options — model, gate, scope, limits, policy mode. See [Recipes](/cli/recipes/).
+
 ## Map the repo to prime the agent
 
 ```bash

--- a/apps/docs/src/content/docs/reference/commands.mdx
+++ b/apps/docs/src/content/docs/reference/commands.mdx
@@ -27,6 +27,7 @@ Environment variables: [Environment variables](/reference/flags/). Interactive u
 tsforge review                 # functional review of the current diff
 tsforge review --staged        # only staged changes (pre-commit)
 tsforge review --base develop  # diff against an explicit base ref
+tsforge review --with-gate     # run the gate first; skip what it already covers
 ```
 
 `tsforge review` reviews the change you're working on — the working tree (committed **and** uncommitted edits) vs the auto-detected base (merge-base with `main`/`master`). No commit or push required.

--- a/packages/core/src/cli.ts
+++ b/packages/core/src/cli.ts
@@ -19,6 +19,7 @@ import {
 } from "./loop";
 import { buildAndPersistMap, mapStatus, forgetMap } from "./codebase";
 import { parseEventLog, formatTrace } from "./eval";
+import { loadRecipes, findRecipe, type ITaskRecipe } from "./config/recipes";
 import { validate } from "./validate";
 import { isPolicyMode } from "./policy";
 import {
@@ -142,6 +143,19 @@ export interface ICliArgs {
   map: boolean;
   /** Summarize a `--log` run (`tsforge trace [logfile]`); `task` carries the path. */
   trace: boolean;
+  /** Recipe id to apply (`tsforge run <id>` or `--recipe <id>`); "" = none. */
+  recipe: string;
+  /** List discovered recipes (`tsforge recipes`). */
+  recipes: boolean;
+  /** The `run` subcommand was used (`tsforge run <id>`) — tracked so a missing id
+   *  is an explicit error, not a silent fall-through to the interactive REPL. */
+  run: boolean;
+  /** Model name override (from a recipe); "" = the active model. */
+  model: string;
+  /** Hard turn cap (from a recipe); 0 = the loop default. */
+  maxTurns: number;
+  /** Reasoning-token cap (from a recipe); 0 = the env/default. */
+  thinkingBudget: number;
   /** Base policy mode (`--policy-mode <plan|default|acceptEdits|ci|dontAsk|
    *  bypassPermissions>`); overrides the config file's policy.mode. */
   policyMode: string;
@@ -178,6 +192,7 @@ const VALUE_FLAGS = new Set([
   "--resume",
   "--base",
   "--policy-mode",
+  "--recipe",
 ]);
 
 /** Parse argv (without the tsforge binary name). Always succeeds — mode is decided in main. */
@@ -202,6 +217,12 @@ export function parseArgs(argv: readonly string[]): ICliArgs {
     base: "",
     map: false,
     trace: false,
+    recipe: "",
+    recipes: false,
+    run: false,
+    model: "",
+    maxTurns: 0,
+    thinkingBudget: 0,
     policyMode: "",
   };
 
@@ -237,6 +258,12 @@ export function parseArgs(argv: readonly string[]): ICliArgs {
   } else if (positional[0] === "trace") {
     out.trace = true;
     out.task = positional.slice(1).join(" ").trim();
+  } else if (positional[0] === "recipes") {
+    out.recipes = true;
+  } else if (positional[0] === "run") {
+    out.run = true;
+    out.recipe = positional[1] ?? "";
+    out.task = positional.slice(2).join(" ").trim();
   }
 
   out.dir = isAbsolute(out.dir) ? out.dir : join(process.cwd(), out.dir);
@@ -261,9 +288,62 @@ function applyValueFlag(flag: string, value: string, out: ICliArgs): void {
     out.base = value;
   } else if (flag === "--policy-mode") {
     out.policyMode = value;
+  } else if (flag === "--recipe") {
+    out.recipe = value;
   } else {
     out.accept = value; // --accept / --gate
   }
+}
+
+/** Overlay a recipe's fields onto the parsed args. An explicit CLI value ALWAYS
+ *  wins (a recipe only fills a field still at its default), so `tsforge run x
+ *  --files src/**` overrides the recipe's scope. Booleans can only be turned ON
+ *  by a recipe — a CLI flag can't switch a recipe's `true` back off. */
+export function applyRecipe(args: ICliArgs, recipe: ITaskRecipe): void {
+  if (args.task.length === 0 && recipe.task !== undefined) {
+    args.task = recipe.task;
+  }
+
+  if (args.files.length === 0 && recipe.files !== undefined) {
+    args.files = [...recipe.files];
+  }
+
+  if (args.accept.length === 0 && recipe.gate !== undefined) {
+    args.accept = recipe.gate;
+  }
+
+  if (args.model.length === 0 && recipe.model !== undefined) {
+    args.model = recipe.model;
+  }
+
+  if (args.base.length === 0 && recipe.base !== undefined) {
+    args.base = recipe.base;
+  }
+
+  if (args.policyMode.length === 0 && recipe.policyMode !== undefined) {
+    args.policyMode = recipe.policyMode;
+  }
+
+  if (args.maxTurns === 0 && recipe.maxTurns !== undefined) {
+    args.maxTurns = recipe.maxTurns;
+  }
+
+  if (args.thinkingBudget === 0 && recipe.thinkingBudget !== undefined) {
+    args.thinkingBudget = recipe.thinkingBudget;
+  }
+
+  applyRecipeFlags(args, recipe);
+}
+
+/** Recipe booleans (split out to keep applyRecipe's complexity in check). */
+function applyRecipeFlags(args: ICliArgs, recipe: ITaskRecipe): void {
+  args.staged = args.staged || recipe.staged === true;
+  args.strictFloorOnly =
+    args.strictFloorOnly || recipe.strictFloorOnly === true;
+  args.web = args.web || recipe.web === true;
+  args.plan = args.plan || recipe.plan === true;
+  args.log = args.log || recipe.log === true;
+  args.withGate = args.withGate || recipe.withGate === true;
 }
 
 // Default editable scope: the whole workspace — like any agentic CLI, the agent
@@ -753,6 +833,27 @@ function resolveLogPath(id: string, enabled: boolean): string {
   return join(dir, `${stamp}-${id}.jsonl`);
 }
 
+/** The model for a run: a recipe's named model (from ~/.tsforge/models.json) when
+ *  set and known, else the active model. An unknown name warns and falls back. */
+async function modelForRun(
+  args: ICliArgs
+): Promise<{ name: string; entry: IModelEntry }> {
+  if (args.model.length > 0) {
+    const cfg = await loadModelsConfig();
+    const entry = cfg.models[args.model];
+
+    if (entry !== undefined) {
+      return { name: args.model, entry };
+    }
+
+    process.stdout.write(
+      `  recipe model '${args.model}' not in models.json — using the active model\n`
+    );
+  }
+
+  return resolveActiveModel();
+}
+
 /** One-shot: drive a single task to green, then exit. */
 async function runOnce(args: ICliArgs): Promise<number> {
   const task: ITask = {
@@ -769,11 +870,15 @@ async function runOnce(args: ICliArgs): Promise<number> {
     process.stdout.write(`  ↳ logging this run to ${logFile}\n`);
   }
 
-  const thinkingTokenBudget = envNumber("TSFORGE_THINKING_BUDGET");
-  const { entry } = await resolveActiveModel();
+  const thinkingTokenBudget =
+    args.thinkingBudget > 0
+      ? args.thinkingBudget
+      : envNumber("TSFORGE_THINKING_BUDGET");
+  const { entry } = await modelForRun(args);
   const result = await runTask(task, args.dir, makeProvider(entry), {
     onEvent: makeReporter(logFile, "cli"),
     ...(thinkingTokenBudget === undefined ? {} : { thinkingTokenBudget }),
+    ...(args.maxTurns > 0 ? { maxTurns: args.maxTurns } : {}),
   });
   const ok = result.status === RUN_STATUS.done;
 
@@ -968,9 +1073,10 @@ async function baseGate(
 
 /** Interactive REPL: a persistent gate-anchored conversation. */
 async function repl(args: ICliArgs): Promise<number> {
-  // The active model comes from the registry (~/.tsforge/models.json) unless an
-  // explicit TSFORGE_* env overrides it; `/model <name>` switches it live.
-  const activeModel = await resolveActiveModel();
+  // The active model comes from the registry (~/.tsforge/models.json) unless a
+  // recipe names one or an explicit TSFORGE_* env overrides it; `/model <name>`
+  // switches it live.
+  const activeModel = await modelForRun(args);
   const provider = makeProvider(activeModel.entry);
   let activeName = activeModel.name;
 
@@ -1941,6 +2047,58 @@ async function mapMode(args: ICliArgs): Promise<number> {
   return 0;
 }
 
+/** `tsforge recipes` — list the recipes discovered for this repo. */
+async function recipesMode(args: ICliArgs): Promise<number> {
+  const recipes = await loadRecipes(args.dir, (m) =>
+    process.stdout.write(`  ${m}\n`)
+  );
+
+  if (recipes.length === 0) {
+    process.stdout.write(
+      "no recipes found — add .tsforge/recipes/<id>.json (see the docs)\n"
+    );
+
+    return 0;
+  }
+
+  process.stdout.write("Recipes:\n");
+
+  for (const recipe of recipes) {
+    const desc =
+      recipe.description === undefined ? "" : ` — ${recipe.description}`;
+
+    process.stdout.write(`  ${recipe.id}${desc}\n`);
+  }
+
+  return 0;
+}
+
+/** Resolve `--recipe`/`tsforge run <id>` and overlay it onto args. Returns an
+ *  exit code to abort on (unknown id), or null to continue dispatching. */
+async function applyRecipeArg(args: ICliArgs): Promise<number | null> {
+  if (args.recipe.length === 0) {
+    return null;
+  }
+
+  const recipes = await loadRecipes(args.dir, (m) =>
+    process.stdout.write(`  ${m}\n`)
+  );
+  const recipe = findRecipe(recipes, args.recipe);
+
+  if (recipe === undefined) {
+    process.stdout.write(
+      `unknown recipe: ${args.recipe} — run \`tsforge recipes\` to list them\n`
+    );
+
+    return 1;
+  }
+
+  applyRecipe(args, recipe);
+  process.stdout.write(`using recipe '${recipe.id}'\n`);
+
+  return null;
+}
+
 /** Resolve the newest `--log` JSONL under ~/.tsforge/logs, or "" if none. */
 async function newestLogFile(): Promise<string> {
   try {
@@ -2010,6 +2168,26 @@ async function traceMode(args: ICliArgs): Promise<number> {
 
 export async function main(): Promise<number> {
   const args = parseArgs(process.argv.slice(2));
+
+  if (args.recipes) {
+    return recipesMode(args);
+  }
+
+  if (args.run && args.recipe.length === 0) {
+    process.stdout.write(
+      "missing recipe id — usage: tsforge run <id> [task] (see `tsforge recipes`)\n"
+    );
+
+    return 1;
+  }
+
+  // A `--recipe`/`run <id>` overlays the recipe's fields onto args (CLI wins),
+  // then dispatch continues as if those were passed directly.
+  const recipeAbort = await applyRecipeArg(args);
+
+  if (recipeAbort !== null) {
+    return recipeAbort;
+  }
 
   if (args.review) {
     return reviewMode(args);

--- a/packages/core/src/cli.ts
+++ b/packages/core/src/cli.ts
@@ -1873,28 +1873,41 @@ async function runReviewCommand(
 /** Run the auto/explicit gate ONCE and return its distinct failing rule ids, so a
  *  gate-aware review skips what the gate already covers. Green/no-gate → []. */
 async function gateFailingRules(args: ICliArgs): Promise<string[]> {
-  const gate = await resolveGate(args, null);
+  // Running the gate can throw (missing deps, a broken gate command, env issues).
+  // A gate-aware review is an enhancement, never a hard dependency — on any failure
+  // fall back to a full review instead of crashing the command.
+  try {
+    const gate = await resolveGate(args, null);
 
-  if (gate.accept.length === 0) {
-    return [];
-  }
-
-  const task: ITask = { id: "review", accept: gate.accept, files: [] };
-  const result = await validate(task, args.dir);
-
-  if (result.passed) {
-    return [];
-  }
-
-  const rules = new Set<string>();
-
-  for (const error of result.errors) {
-    if (typeof error.rule === "string" && error.rule.length > 0) {
-      rules.add(error.rule);
+    if (gate.accept.length === 0) {
+      return [];
     }
-  }
 
-  return [...rules];
+    const task: ITask = { id: "review", accept: gate.accept, files: [] };
+    const result = await validate(task, args.dir);
+
+    if (result.passed) {
+      return [];
+    }
+
+    const rules = new Set<string>();
+
+    for (const error of result.errors) {
+      if (typeof error.rule === "string" && error.rule.length > 0) {
+        rules.add(error.rule);
+      }
+    }
+
+    return [...rules];
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+
+    process.stdout.write(
+      `gate: couldn't run the gate (${message}) — falling back to full review\n`
+    );
+
+    return [];
+  }
 }
 
 async function reviewMode(args: ICliArgs): Promise<number> {

--- a/packages/core/src/cli.ts
+++ b/packages/core/src/cli.ts
@@ -19,6 +19,7 @@ import {
 } from "./loop";
 import { buildAndPersistMap, mapStatus, forgetMap } from "./codebase";
 import { parseEventLog, formatTrace } from "./eval";
+import { validate } from "./validate";
 import { isPolicyMode } from "./policy";
 import {
   PROVIDER_LIMITS,
@@ -132,6 +133,9 @@ export interface ICliArgs {
   review: boolean;
   /** Review only staged changes (`--staged`). */
   staged: boolean;
+  /** Run the gate first and tell the reviewer to skip what it already covers
+   *  (`tsforge review --with-gate`). */
+  withGate: boolean;
   /** Explicit base ref to diff against for review (`--base <ref>`). */
   base: string;
   /** Build a structural workspace map (`tsforge map`). */
@@ -145,7 +149,14 @@ export interface ICliArgs {
 
 const BOOL_FLAGS: Record<
   string,
-  "continue" | "noGate" | "web" | "log" | "plan" | "strictFloorOnly" | "staged"
+  | "continue"
+  | "noGate"
+  | "web"
+  | "log"
+  | "plan"
+  | "strictFloorOnly"
+  | "staged"
+  | "withGate"
 > = {
   "--continue": "continue",
   "-c": "continue",
@@ -155,6 +166,7 @@ const BOOL_FLAGS: Record<
   "--plan": "plan",
   "--strict-floor-only": "strictFloorOnly",
   "--staged": "staged",
+  "--with-gate": "withGate",
 };
 
 const VALUE_FLAGS = new Set([
@@ -186,6 +198,7 @@ export function parseArgs(argv: readonly string[]): ICliArgs {
     strictFloorOnly: false,
     review: false,
     staged: false,
+    withGate: false,
     base: "",
     map: false,
     trace: false,
@@ -1857,11 +1870,49 @@ async function runReviewCommand(
   }
 }
 
+/** Run the auto/explicit gate ONCE and return its distinct failing rule ids, so a
+ *  gate-aware review skips what the gate already covers. Green/no-gate → []. */
+async function gateFailingRules(args: ICliArgs): Promise<string[]> {
+  const gate = await resolveGate(args, null);
+
+  if (gate.accept.length === 0) {
+    return [];
+  }
+
+  const task: ITask = { id: "review", accept: gate.accept, files: [] };
+  const result = await validate(task, args.dir);
+
+  if (result.passed) {
+    return [];
+  }
+
+  const rules = new Set<string>();
+
+  for (const error of result.errors) {
+    if (typeof error.rule === "string" && error.rule.length > 0) {
+      rules.add(error.rule);
+    }
+  }
+
+  return [...rules];
+}
+
 async function reviewMode(args: ICliArgs): Promise<number> {
   const { entry } = await resolveActiveModel();
+  const rules = args.withGate ? await gateFailingRules(args) : [];
+
+  if (args.withGate) {
+    process.stdout.write(
+      rules.length > 0
+        ? `gate: ${rules.length} failing rule(s) — review will skip what they cover\n`
+        : "gate: green — full functional review\n"
+    );
+  }
+
   const report = await reviewChange(makeProvider(entry), args.dir, {
     ...(args.base.length > 0 ? { base: args.base } : {}),
     staged: args.staged,
+    ...(rules.length > 0 ? { gateFailingRules: rules } : {}),
     log: (m) => process.stdout.write(`  ↳ ${m}\n`),
   });
 

--- a/packages/core/src/config/index.ts
+++ b/packages/core/src/config/index.ts
@@ -14,3 +14,9 @@ export {
   resolveProfileMetaRuleOverrides,
   type ProfileId,
 } from "./profiles";
+export {
+  parseRecipe,
+  loadRecipes,
+  findRecipe,
+  type ITaskRecipe,
+} from "./recipes";

--- a/packages/core/src/config/recipes.ts
+++ b/packages/core/src/config/recipes.ts
@@ -1,0 +1,248 @@
+import { readdir, readFile } from "node:fs/promises";
+import { homedir } from "node:os";
+import { join } from "node:path";
+import { isRecord } from "../lib/guards";
+import { isPolicyMode, type PolicyMode } from "../policy";
+
+/**
+ * A declarative task recipe — tsforge's adaptation of Codebuff's `AgentDefinition`
+ * to a deterministic config object. A recipe NAMES a run setup by composing knobs
+ * tsforge already has; it never executes code (no `handleSteps`, no spawned
+ * subagents), so a repo's recipes stay reviewable data, not a program.
+ *
+ * Discovered from `.tsforge/recipes/*.json` (project) and `~/.tsforge/recipes/*.json`
+ * (global); a project recipe overrides a global one with the same id.
+ */
+export interface ITaskRecipe {
+  /** Stable id (kebab-case); the name you invoke with `tsforge run <id>`. */
+  readonly id: string;
+  /** One-line summary shown by `tsforge recipes`. */
+  readonly description?: string;
+  /** Default task/prompt for the run (a CLI positional still overrides it). */
+  readonly task?: string;
+  /** Editable scope globs (→ the run's `--files`). */
+  readonly files?: readonly string[];
+  /** The gate command that confirms "done" (→ `--accept`). */
+  readonly gate?: string;
+  /** A configured model name from `~/.tsforge/models.json` (→ the run's model). */
+  readonly model?: string;
+  /** Hard cap on model turns (→ run option `maxTurns`). */
+  readonly maxTurns?: number;
+  /** Reasoning-token cap per call (→ run option `thinkingTokenBudget`). */
+  readonly thinkingBudget?: number;
+  /** Base policy enforcement mode (→ `--policy-mode`). */
+  readonly policyMode?: PolicyMode;
+  /** Diff base ref for a review-style run (→ `--base`). */
+  readonly base?: string;
+  /** Review only staged changes (→ `--staged`). */
+  readonly staged?: boolean;
+  /** Keep the gate at the strict TS floor only (→ `--strict-floor-only`). */
+  readonly strictFloorOnly?: boolean;
+  /** Scaffold + gate a web app (→ `--web`). */
+  readonly web?: boolean;
+  /** Start in plan mode (→ `--plan`). */
+  readonly plan?: boolean;
+  /** Record the run ledger (→ `--log`). */
+  readonly log?: boolean;
+  /** Run a gate-aware functional review after green (→ `review --with-gate`). */
+  readonly withGate?: boolean;
+}
+
+function optString(value: unknown): string | undefined {
+  return typeof value === "string" && value.length > 0 ? value : undefined;
+}
+
+function optBool(value: unknown): boolean | undefined {
+  return typeof value === "boolean" ? value : undefined;
+}
+
+function optPositive(value: unknown): number | undefined {
+  return typeof value === "number" && Number.isInteger(value) && value > 0
+    ? value
+    : undefined;
+}
+
+function stringArray(value: unknown): readonly string[] | undefined {
+  if (!Array.isArray(value)) {
+    return undefined;
+  }
+
+  const strings = value
+    .filter((v): v is string => typeof v === "string")
+    .map((v) => v.trim())
+    .filter((v) => v.length > 0);
+
+  return strings.length > 0 ? strings : undefined;
+}
+
+/** Assign the optional scalar fields onto a recipe under construction. */
+function assignScalars(recipe: Mutable, raw: Record<string, unknown>): void {
+  recipe.description = optString(raw.description);
+  recipe.task = optString(raw.task);
+  recipe.gate = optString(raw.gate);
+  recipe.model = optString(raw.model);
+  recipe.base = optString(raw.base);
+  recipe.files = stringArray(raw.files);
+  recipe.maxTurns = optPositive(raw.maxTurns);
+  recipe.thinkingBudget = optPositive(raw.thinkingBudget);
+
+  if (isPolicyMode(raw.policyMode)) {
+    recipe.policyMode = raw.policyMode;
+  }
+}
+
+/** Assign the optional boolean flags onto a recipe under construction. */
+function assignFlags(recipe: Mutable, raw: Record<string, unknown>): void {
+  recipe.staged = optBool(raw.staged);
+  recipe.strictFloorOnly = optBool(raw.strictFloorOnly);
+  recipe.web = optBool(raw.web);
+  recipe.plan = optBool(raw.plan);
+  recipe.log = optBool(raw.log);
+  recipe.withGate = optBool(raw.withGate);
+}
+
+type Mutable = { -readonly [K in keyof ITaskRecipe]: ITaskRecipe[K] };
+
+/** Every field a v1 recipe applies. A key outside this set is reported (not
+ *  silently dropped) so a typo or not-yet-supported field (e.g. `profile`,
+ *  `tools`) is visible rather than mysteriously ignored. */
+const KNOWN_KEYS = new Set<string>([
+  "id",
+  "description",
+  "task",
+  "files",
+  "gate",
+  "model",
+  "maxTurns",
+  "thinkingBudget",
+  "policyMode",
+  "base",
+  "staged",
+  "strictFloorOnly",
+  "web",
+  "plan",
+  "log",
+  "withGate",
+]);
+
+/** Keys present in the raw recipe that this version doesn't recognize. */
+export function unrecognizedKeys(value: unknown): string[] {
+  if (!isRecord(value)) {
+    return [];
+  }
+
+  return Object.keys(value).filter((key) => !KNOWN_KEYS.has(key));
+}
+
+/**
+ * Validate one parsed JSON value into an ITaskRecipe, or null when it isn't one.
+ * Every field is type-checked (no `as`); unknown fields and wrong-typed fields are
+ * dropped, so a malformed recipe degrades to "ignored", never a crash.
+ */
+export function parseRecipe(value: unknown): ITaskRecipe | null {
+  if (!isRecord(value)) {
+    return null;
+  }
+
+  const id = optString(value.id);
+
+  if (id === undefined || !/^[a-z0-9][a-z0-9-]*$/u.test(id)) {
+    return null;
+  }
+
+  const recipe: Mutable = { id };
+
+  assignScalars(recipe, value);
+  assignFlags(recipe, value);
+
+  return recipe;
+}
+
+/** The two recipe directories, lowest precedence first (global, then project). */
+function recipeDirs(cwd: string): string[] {
+  const home = process.env.TSFORGE_HOME ?? homedir();
+
+  return [join(home, ".tsforge", "recipes"), join(cwd, ".tsforge", "recipes")];
+}
+
+/** Sorted `*.json` filenames in a directory, or [] if it doesn't exist. */
+async function jsonFilesIn(dir: string): Promise<string[]> {
+  try {
+    return (await readdir(dir)).filter((n) => n.endsWith(".json")).sort();
+  } catch {
+    return []; // no such directory — fine
+  }
+}
+
+/** Parse every `*.json` recipe in one directory; unreadable/invalid files are
+ *  reported and skipped (never throws). */
+async function loadDir(
+  dir: string,
+  into: Map<string, ITaskRecipe>,
+  report: (message: string) => void
+): Promise<void> {
+  for (const name of await jsonFilesIn(dir)) {
+    const path = join(dir, name);
+    const text = await readFile(path, "utf8").catch(() => "");
+    let parsed: unknown;
+
+    try {
+      parsed = JSON.parse(text);
+    } catch {
+      report(`recipe '${name}': invalid JSON — skipped`);
+      continue;
+    }
+
+    const recipe = parseRecipe(parsed);
+
+    if (recipe === null) {
+      report(
+        `recipe '${name}': not a valid recipe (needs a kebab-case id) — skipped`
+      );
+      continue;
+    }
+
+    const expectedId = name.slice(0, -".json".length);
+
+    if (recipe.id !== expectedId) {
+      report(
+        `recipe '${name}': id '${recipe.id}' does not match the filename — invoke it as '${recipe.id}'`
+      );
+    }
+
+    const unknown = unrecognizedKeys(parsed);
+
+    if (unknown.length > 0) {
+      report(
+        `recipe '${name}': ignoring unrecognized field(s): ${unknown.join(", ")}`
+      );
+    }
+
+    into.set(recipe.id, recipe); // later dir (project) wins on id collision
+  }
+}
+
+/**
+ * Discover all recipes for a repo, project overriding global on id collision.
+ * Never throws — a broken recipe can't take down a run.
+ */
+export async function loadRecipes(
+  cwd: string,
+  report: (message: string) => void = () => undefined
+): Promise<ITaskRecipe[]> {
+  const byId = new Map<string, ITaskRecipe>();
+
+  for (const dir of recipeDirs(cwd)) {
+    await loadDir(dir, byId, report);
+  }
+
+  return [...byId.values()].sort((a, b) => a.id.localeCompare(b.id));
+}
+
+/** Find one recipe by id among the discovered set. */
+export function findRecipe(
+  recipes: readonly ITaskRecipe[],
+  id: string
+): ITaskRecipe | undefined {
+  return recipes.find((r) => r.id === id);
+}

--- a/packages/core/src/loop/review/review-change.ts
+++ b/packages/core/src/loop/review/review-change.ts
@@ -27,6 +27,10 @@ export interface IReviewOptions {
   /** Run the adversarial-verify pass (default true). Off = raw findings pass
    *  through unverified — for A/B measuring verify's effect on precision. */
   verify?: boolean;
+  /** Rules the automated gate is CURRENTLY failing on (a gate-aware run). The find
+   *  pass is told NOT to duplicate what these cover — the gate loop fixes them —
+   *  so it spends its attention on the behaviour of the code the gate accepts. */
+  gateFailingRules?: readonly string[];
   /** Progress callback (one line per step). */
   log?: (message: string) => void;
 }
@@ -102,7 +106,7 @@ async function fileDiff(
   return out.slice(0, DIFF_CHARS);
 }
 
-const FIND_SYSTEM = [
+const FIND_SYSTEM_BASE = [
   "You are a senior engineer reviewing a code change for FUNCTIONAL problems: logic errors, regressions, missed edge cases, and broken business rules.",
   "A separate automated gate already covers types, structure, and style — do NOT report those. Only functional/behavioural issues.",
   "Review the change THROUGH these lenses:",
@@ -111,10 +115,22 @@ const FIND_SYSTEM = [
   'Respond with ONLY JSON: {"findings":[{"line":<number>,"severity":"error|warning|info","lens":"<lens id>","claim":"<what is wrong>","reason":"<why>"}]}.',
 ].join("\n\n");
 
+/** The find-pass system prompt, optionally with a gate-aware clause: when the
+ *  caller knows which rules the gate is ALREADY failing, tell the model not to
+ *  duplicate them — its attention goes to the behaviour of the green code. */
+function buildFindSystem(gateFailingRules: readonly string[]): string {
+  if (gateFailingRules.length === 0) {
+    return FIND_SYSTEM_BASE;
+  }
+
+  return `${FIND_SYSTEM_BASE}\n\nThe automated gate is ALREADY failing on these rule(s): ${gateFailingRules.join(", ")}. Do NOT report problems those rules cover — the gate loop will fix them. Focus on the BEHAVIOUR of the code the gate already accepts.`;
+}
+
 /** One find pass over a single changed file's diff (per-file decomposition keeps
  *  a small model in its reliable zone). */
 async function findInFile(
   provider: IProvider,
+  system: string,
   file: string,
   diff: string,
   signal: string
@@ -130,7 +146,7 @@ async function findInFile(
 
   const res = await provider.complete(
     [
-      { role: "system", content: FIND_SYSTEM },
+      { role: "system", content: system },
       {
         role: "user",
         content: `File: ${file}\n\nDiff (base → working tree):\n${diff}${callers}`,
@@ -292,6 +308,7 @@ function errText(err: unknown): string {
  *  abort the whole review). */
 async function safeFind(
   provider: IProvider,
+  system: string,
   svc: TsService | null,
   cwd: string,
   file: string,
@@ -303,7 +320,7 @@ async function safeFind(
     // degrades that file's review, never aborting the whole run.
     const signal = callerSignal(svc, cwd, file);
 
-    return await findInFile(provider, file, diff, signal);
+    return await findInFile(provider, system, file, diff, signal);
   } catch (err) {
     log(`  ${file}: review failed — ${errText(err)}`);
 
@@ -339,10 +356,16 @@ export async function reviewChange(
 ): Promise<IReviewReport> {
   const log = opts.log ?? ((): void => undefined);
   const staged = opts.staged ?? false;
+  const gateFailingRules = [...(opts.gateFailingRules ?? [])];
+  const system = buildFindSystem(gateFailingRules);
   const base = await detectBase(cwd, opts.base);
   const files = await changedFiles(cwd, base, staged);
 
   log(`reviewing ${files.length} changed file(s) vs ${base}`);
+
+  if (gateFailingRules.length > 0) {
+    log(`gate-aware: skipping ${gateFailingRules.length} failing gate rule(s)`);
+  }
 
   // In-process TS LanguageService (null without a tsconfig) — powers the
   // caller blast-radius signal. Built once; falls back gracefully when absent.
@@ -354,7 +377,7 @@ export async function reviewChange(
   // isolated in try/catch so one bad file can't abort the whole review.
   for (const file of files) {
     const diff = await fileDiff(cwd, base, file, staged);
-    const found = await safeFind(provider, svc, cwd, file, diff, log);
+    const found = await safeFind(provider, system, svc, cwd, file, diff, log);
 
     log(`  ${file}: ${found.length} candidate finding(s)`);
     raw.push(...found);
@@ -378,7 +401,13 @@ export async function reviewChange(
 
   log(`verified ${verified.length} finding(s), rejected ${rejected}`);
 
-  return { base, changedFiles: files, findings: verified, rejected };
+  return {
+    base,
+    changedFiles: files,
+    findings: verified,
+    rejected,
+    gateFailingRules,
+  };
 }
 
 const SEVERITY_RANK: Record<Severity, number> = {
@@ -404,10 +433,17 @@ export function formatReport(report: IReviewReport): string {
     (f) =>
       `${f.severity.toUpperCase()} ${f.file}:${f.line} [${f.lens}]\n  ${f.claim}\n  → ${f.reason}`
   );
+  const gateNote =
+    report.gateFailingRules.length > 0
+      ? [
+          `(gate-aware: skipped ${report.gateFailingRules.length} failing gate rule(s) the gate already covers)`,
+        ]
+      : [];
 
   return [
     `Review of ${report.changedFiles.length} changed file(s) vs ${report.base}:`,
     `${report.findings.length} verified finding(s), ${report.rejected} rejected.`,
+    ...gateNote,
     "",
     ...lines,
   ].join("\n");

--- a/packages/core/src/loop/review/review-change.ts
+++ b/packages/core/src/loop/review/review-change.ts
@@ -433,10 +433,11 @@ export function formatReport(report: IReviewReport): string {
     (f) =>
       `${f.severity.toUpperCase()} ${f.file}:${f.line} [${f.lens}]\n  ${f.claim}\n  → ${f.reason}`
   );
+  const gateFailingRules = report.gateFailingRules ?? [];
   const gateNote =
-    report.gateFailingRules.length > 0
+    gateFailingRules.length > 0
       ? [
-          `(gate-aware: skipped ${report.gateFailingRules.length} failing gate rule(s) the gate already covers)`,
+          `(gate-aware: skipped ${gateFailingRules.length} failing gate rule(s) the gate already covers)`,
         ]
       : [];
 

--- a/packages/core/src/loop/review/review.types.ts
+++ b/packages/core/src/loop/review/review.types.ts
@@ -46,4 +46,7 @@ export interface IReviewReport {
   findings: IVerifiedFinding[];
   /** How many raw findings the verify pass rejected (precision signal). */
   rejected: number;
+  /** Failing gate rules the find pass was told to skip (from a gate-aware run);
+   *  empty when review ran without a gate signal. */
+  gateFailingRules: string[];
 }

--- a/packages/core/src/loop/review/review.types.ts
+++ b/packages/core/src/loop/review/review.types.ts
@@ -47,6 +47,7 @@ export interface IReviewReport {
   /** How many raw findings the verify pass rejected (precision signal). */
   rejected: number;
   /** Failing gate rules the find pass was told to skip (from a gate-aware run);
-   *  empty when review ran without a gate signal. */
-  gateFailingRules: string[];
+   *  empty/omitted when review ran without a gate signal. Optional so a report from
+   *  an older/external caller (without the field) stays valid. */
+  gateFailingRules?: string[];
 }

--- a/packages/core/tests/cli.test.ts
+++ b/packages/core/tests/cli.test.ts
@@ -1,5 +1,6 @@
 import { test, expect } from "bun:test";
-import { parseArgs, isOneShot } from "../src/cli";
+import { parseArgs, isOneShot, applyRecipe } from "../src/cli";
+import type { ITaskRecipe } from "../src/config/recipes";
 
 test("parses task + files + accept + dir", () => {
   const a = parseArgs([
@@ -38,6 +39,58 @@ test("bare invocation parses to an empty interactive session", () => {
   expect(a.files).toEqual([]);
   expect(a.accept).toBe("");
   expect(isOneShot(a)).toBe(false);
+});
+
+test("`tsforge run <id>` parses the recipe id and trailing task", () => {
+  const a = parseArgs(["run", "api-endpoint", "add", "a", "route"]);
+
+  expect(a.run).toBe(true);
+  expect(a.recipe).toBe("api-endpoint");
+  expect(a.task).toBe("add a route");
+});
+
+test("`tsforge run` with no id flags the run subcommand (so main can error)", () => {
+  const a = parseArgs(["run"]);
+
+  expect(a.run).toBe(true);
+  expect(a.recipe).toBe("");
+});
+
+test("`tsforge recipes` and `--recipe <id>` are recognized", () => {
+  expect(parseArgs(["recipes"]).recipes).toBe(true);
+  expect(parseArgs(["--recipe", "web-build", "build it"]).recipe).toBe(
+    "web-build"
+  );
+});
+
+test("applyRecipe fills defaults but an explicit CLI value always wins", () => {
+  const recipe: ITaskRecipe = {
+    id: "api-endpoint",
+    files: ["src/api/**"],
+    gate: "bun run validate",
+    model: "qwen3-coder",
+    maxTurns: 25,
+    policyMode: "default",
+    web: true,
+  };
+
+  // Nothing on the CLI → recipe fills everything.
+  const filled = parseArgs([]);
+
+  applyRecipe(filled, recipe);
+  expect(filled.files).toEqual(["src/api/**"]);
+  expect(filled.accept).toBe("bun run validate");
+  expect(filled.model).toBe("qwen3-coder");
+  expect(filled.maxTurns).toBe(25);
+  expect(filled.policyMode).toBe("default");
+  expect(filled.web).toBe(true);
+
+  // An explicit --files overrides the recipe's scope; the rest still fill.
+  const overridden = parseArgs(["--files", "lib/**"]);
+
+  applyRecipe(overridden, recipe);
+  expect(overridden.files).toEqual(["lib/**"]); // CLI wins
+  expect(overridden.accept).toBe("bun run validate"); // recipe fills
 });
 
 test("plan approval is narrow — a 'yes' answering a question must not implement", async () => {

--- a/packages/core/tests/recipes.test.ts
+++ b/packages/core/tests/recipes.test.ts
@@ -1,0 +1,140 @@
+import { test, expect, describe } from "bun:test";
+import { mkdtemp, rm, mkdir, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  parseRecipe,
+  loadRecipes,
+  findRecipe,
+  unrecognizedKeys,
+} from "../src/config/recipes";
+
+describe("parseRecipe", () => {
+  test("accepts a well-formed recipe and keeps only valid fields", () => {
+    const r = parseRecipe({
+      id: "api-endpoint",
+      description: "scaffold an API route",
+      gate: "bun run validate",
+      files: ["src/api/**", "  ", 42],
+      model: "qwen3-coder",
+      maxTurns: 30,
+      thinkingBudget: 2048,
+      policyMode: "default",
+      web: true,
+      bogusField: "ignored",
+    });
+
+    expect(r?.id).toBe("api-endpoint");
+    expect(r?.gate).toBe("bun run validate");
+    expect(r?.files).toEqual(["src/api/**"]); // blanks + non-strings dropped
+    expect(r?.maxTurns).toBe(30);
+    expect(r?.policyMode).toBe("default");
+    expect(r?.web).toBe(true);
+    expect("bogusField" in (r ?? {})).toBe(false);
+  });
+
+  test("rejects a recipe with no id or a non-kebab id", () => {
+    expect(parseRecipe({ gate: "x" })).toBeNull();
+    expect(parseRecipe({ id: "Has Spaces" })).toBeNull();
+    expect(parseRecipe({ id: "UPPER" })).toBeNull();
+    expect(parseRecipe("not an object")).toBeNull();
+  });
+
+  test("drops an invalid policyMode and a non-positive maxTurns", () => {
+    const r = parseRecipe({ id: "x", policyMode: "yolo", maxTurns: 0 });
+
+    expect(r?.policyMode).toBeUndefined();
+    expect(r?.maxTurns).toBeUndefined();
+  });
+
+  test("flags fields it doesn't yet apply (so they don't silently vanish)", () => {
+    // `profile`/`tools` aren't applied in v1 — surface them rather than ignore.
+    expect(
+      unrecognizedKeys({ id: "x", profile: "strict", tools: ["read"] })
+    ).toEqual(["profile", "tools"]);
+    expect(unrecognizedKeys({ id: "x", gate: "g" })).toEqual([]);
+  });
+});
+
+describe("loadRecipes", () => {
+  test("discovers project recipes and overrides global on id collision", async () => {
+    const home = await mkdtemp(join(tmpdir(), "tsforge-rec-home-"));
+    const cwd = await mkdtemp(join(tmpdir(), "tsforge-rec-proj-"));
+    const prev = process.env.TSFORGE_HOME;
+
+    try {
+      process.env.TSFORGE_HOME = home;
+      await mkdir(join(home, ".tsforge", "recipes"), { recursive: true });
+      await mkdir(join(cwd, ".tsforge", "recipes"), { recursive: true });
+
+      // global: two recipes
+      await writeFile(
+        join(home, ".tsforge/recipes/shared.json"),
+        JSON.stringify({ id: "shared", gate: "global-gate" })
+      );
+      await writeFile(
+        join(home, ".tsforge/recipes/global-only.json"),
+        JSON.stringify({ id: "global-only", gate: "g" })
+      );
+      // project overrides `shared`, adds `proj-only`, and one broken file
+      await writeFile(
+        join(cwd, ".tsforge/recipes/shared.json"),
+        JSON.stringify({ id: "shared", gate: "project-gate" })
+      );
+      await writeFile(
+        join(cwd, ".tsforge/recipes/proj-only.json"),
+        JSON.stringify({ id: "proj-only", gate: "p" })
+      );
+      // id ≠ filename: registers under its declared id but warns about the mismatch.
+      await writeFile(
+        join(cwd, ".tsforge/recipes/mismatch.json"),
+        JSON.stringify({ id: "not-mismatch", gate: "g" })
+      );
+      await writeFile(join(cwd, ".tsforge/recipes/broken.json"), "{ not json");
+
+      const reports: string[] = [];
+      const recipes = await loadRecipes(cwd, (m) => reports.push(m));
+
+      expect(recipes.map((r) => r.id)).toEqual([
+        "global-only",
+        "not-mismatch",
+        "proj-only",
+        "shared",
+      ]);
+      expect(findRecipe(recipes, "shared")?.gate).toBe("project-gate"); // project wins
+      expect(reports.some((m) => m.includes("broken.json"))).toBe(true);
+      expect(
+        reports.some(
+          (m) => m.includes("mismatch.json") && m.includes("not-mismatch")
+        )
+      ).toBe(true);
+    } finally {
+      if (prev === undefined) {
+        delete process.env.TSFORGE_HOME;
+      } else {
+        process.env.TSFORGE_HOME = prev;
+      }
+
+      await rm(home, { recursive: true, force: true });
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  test("a repo with no recipe dirs yields an empty list (no throw)", async () => {
+    const cwd = await mkdtemp(join(tmpdir(), "tsforge-rec-empty-"));
+    const prev = process.env.TSFORGE_HOME;
+
+    try {
+      process.env.TSFORGE_HOME = cwd; // also empty
+      expect(await loadRecipes(cwd)).toEqual([]);
+    } finally {
+      if (prev === undefined) {
+        delete process.env.TSFORGE_HOME;
+      } else {
+        process.env.TSFORGE_HOME = prev;
+      }
+
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+});

--- a/packages/core/tests/review-change.test.ts
+++ b/packages/core/tests/review-change.test.ts
@@ -173,6 +173,41 @@ test("injects the caller blast-radius signal into the find prompt", async () => 
   }
 });
 
+/** Capture the find-pass SYSTEM prompt (the one that is NOT the verify prompt). */
+function captureFindSystem(sink: { value: string }): IProvider {
+  return {
+    async complete(messages) {
+      const sys = messages.find((m) => m.role === "system")?.content ?? "";
+
+      if (!sys.includes("verifying a code-review finding")) {
+        sink.value = sys;
+      }
+
+      return { content: JSON.stringify({ findings: [] }), toolCalls: [] };
+    },
+  };
+}
+
+test("gate-aware review tells the find pass not to duplicate failing gate rules", async () => {
+  const sink = { value: "" };
+
+  await reviewChange(captureFindSystem(sink), repo, {
+    gateFailingRules: ["no-as-cast", "TS2322"],
+  });
+
+  expect(sink.value).toContain("no-as-cast");
+  expect(sink.value).toContain("TS2322");
+  expect(sink.value.toLowerCase()).toContain("already failing");
+});
+
+test("without a gate signal the find prompt has no gate clause (back-compat)", async () => {
+  const sink = { value: "" };
+
+  await reviewChange(captureFindSystem(sink), repo);
+
+  expect(sink.value.toLowerCase()).not.toContain("already failing");
+});
+
 test("the senior-review rubric ships with the expected lenses", () => {
   const ids = LENSES.map((l) => l.id);
 


### PR DESCRIPTION
## Phase 2 of the Codebuff-inspired uplift — gate-aware review

**Stacked on #28** (base = `feat/trace-hygiene-policy-metrics`); review that first. This PR's own diff is just the review changes.

### Why
Codebuff's reviewer agent has `toolNames: []` — it can't see build/lint/test results, so it has no idea what the gate already covers. tsforge's `review` can do better.

### What
`tsforge review --with-gate` runs the gate **once**, collects the distinct failing rule ids, and tells the find pass *not* to duplicate what those rules cover. A small local model then spends its limited attention on the **behaviour** of the code the gate already accepts (logic, regressions, edge cases) instead of re-reporting a type/lint error the gate loop will fix anyway.

- `reviewChange`: new optional `gateFailingRules`; injected into the find-pass system prompt; recorded on `IReviewReport` and surfaced by `formatReport` ("gate-aware: skipped N failing gate rule(s)").
- `cli`: `--with-gate` resolves the gate via the existing `resolveGate` + `validate`, extracts failing rules, passes them in. **Default off** so plain `review` stays fast and unchanged.
- Sequential, single-provider design preserved — no fan-out (matches tsforge's identity).
- Docs: `cli/review`, `reference/commands`.

### Tests
`review-change.test.ts`: the find-pass system prompt contains the failing rule ids + "already failing" clause when a gate signal is supplied; without it, the prompt has no gate clause (back-compat).

### Verification
`bun run validate` green (1192 pass, 0 fail). Typecheck clean.