### PR TITLE
feat(loop): deterministic pre-edit scout (--scout)

### DIFF
--- a/apps/docs/astro.config.mjs
+++ b/apps/docs/astro.config.mjs
@@ -172,6 +172,7 @@ export default defineConfig({
             { label: "Drive a change to green", link: "/workflows/fix-to-green/" },
             { label: "Review your changes", link: "/cli/review/" },
             { label: "Recipes", link: "/cli/recipes/" },
+            { label: "Pre-edit scout", link: "/loop/scout/" },
             { label: "Map the repo", link: "/cli/map/" },
             { label: "Plan mode", link: "/cli/plan-mode/" },
           ],

--- a/apps/docs/src/content/docs/cli/recipes.mdx
+++ b/apps/docs/src/content/docs/cli/recipes.mdx
@@ -50,6 +50,7 @@ A project recipe **overrides** a global one with the same id. `tsforge recipes` 
 | `thinkingBudget` | run limit | reasoning-token cap per call |
 | `policyMode` | `--policy-mode` | `plan` / `default` / `acceptEdits` / `ci` / `dontAsk` / `bypassPermissions` |
 | `base`, `staged` | `--base` / `--staged` | for review-style runs |
+| `scout` | `--scout` | seed a [pre-edit blast-radius scout](/loop/scout/) |
 | `web`, `plan`, `log`, `strictFloorOnly` | the matching flags | booleans |
 
 A recipe is, in effect, a saved set of CLI options: `tsforge run <id>` applies them, and you can also combine `--recipe <id>` with other commands (e.g. `tsforge review --recipe …`). **An explicit CLI flag always wins** over the recipe, so `tsforge run api-endpoint --files lib/**` overrides just the scope.

--- a/apps/docs/src/content/docs/loop/scout.mdx
+++ b/apps/docs/src/content/docs/loop/scout.mdx
@@ -1,0 +1,32 @@
+---
+title: Pre-edit scout
+description: Before editing existing code, tsforge can seed the run with a deterministic caller blast-radius — who depends on the files about to change — so a small model edits with awareness instead of blind.
+---
+
+A small local model editing brownfield code can't see what depends on it, so it breaks callers it never read — and then burns repair turns fixing the regressions. The **scout** removes that blind spot: before the first edit, it hands the model the **blast radius** of the files it's about to change.
+
+```bash
+tsforge "rename area() to rect()" --files "src/geometry.ts" --scout
+```
+
+## What it adds
+
+For each editable file that already exists, scout computes — **type-exactly, from the TypeScript LanguageService** — who calls that file's exports, and seeds it into the opening context:
+
+```
+Blast radius — who calls the files you're about to change (type-exact; check these for regressions before editing):
+src/geometry.ts:
+- area → src/floorplan.ts:12; src/report.ts:48
+```
+
+That's the same caller signal [`tsforge review`](/cli/review/) uses, applied **before** the edit instead of after.
+
+## Deterministic by design
+
+Scout makes **no model call** — it's pure compiler facts (the divergence from Codebuff's LLM file-picker). It's:
+
+- **Opt-in** — off unless you pass `--scout` (or a [recipe](/cli/recipes/) sets `"scout": true`). One-shots stay fast by default.
+- **Brownfield only** — it does nothing on a from-scratch build (there are no callers yet) or when there's no `tsconfig.json`.
+- **Bounded** — capped in files probed and total size, so it primes context without flooding it.
+
+→ [Review your changes](/cli/review/) · [Recipes](/cli/recipes/) · [Map the repo](/cli/map/)

--- a/apps/docs/src/content/docs/loop/scout.mdx
+++ b/apps/docs/src/content/docs/loop/scout.mdx
@@ -25,8 +25,12 @@ That's the same caller signal [`tsforge review`](/cli/review/) uses, applied **b
 
 Scout makes **no model call** — it's pure compiler facts (the divergence from Codebuff's LLM file-picker). It's:
 
-- **Opt-in** — off unless you pass `--scout` (or a [recipe](/cli/recipes/) sets `"scout": true`). One-shots stay fast by default.
-- **Brownfield only** — it does nothing on a from-scratch build (there are no callers yet) or when there's no `tsconfig.json`.
-- **Bounded** — capped in files probed and total size, so it primes context without flooding it.
+- **Opt-in** — off unless you pass `--scout` (or a [recipe](/cli/recipes/) sets `"scout": true`). Runs stay fast by default.
+- **Brownfield only** — it does nothing on a from-scratch build (there are no callers yet) or when there's no `tsconfig.json`. A non-TS editable file (`.json`, `.md`) is skipped, never a crash.
+- **Bounded** — capped in files probed and total size; if it hits the size cap it trims to the last whole line and appends `… [scout truncated]`, so the model never sees a half-written call site.
+
+## Scope
+
+Scout seeds the opening prompt of a **one-shot** drive-to-green run (`tsforge "task" --files … --scout`, or a recipe run with `"scout": true`). Interactive sessions gather context conversationally, so the flag doesn't apply there — passing `--scout` to an interactive session prints a note saying so rather than silently ignoring it.
 
 → [Review your changes](/cli/review/) · [Recipes](/cli/recipes/) · [Map the repo](/cli/map/)

--- a/packages/core/scripts/cli-metrics.ts
+++ b/packages/core/scripts/cli-metrics.ts
@@ -48,6 +48,8 @@ interface IMetrics {
   buildNudges: number;
   salvaged: number;
   hallucinatedImports: string[];
+  policyDenies: number;
+  policyAsks: number;
   wallClockSeconds: number;
 }
 
@@ -86,7 +88,9 @@ const HANDLERS: Record<
     m.edits += 1;
   },
   timing: (m, e) => {
-    m.wallClockSeconds += Math.round(num(e.ms) / 1000);
+    // Accumulate raw ms; analyze() rounds ONCE at the end (per-event rounding
+    // would floor sub-second turns to 0s).
+    m.wallClockSeconds += num(e.ms);
   },
   validated: (m) => {
     m.gateRuns += 1;
@@ -96,6 +100,12 @@ const HANDLERS: Record<
   },
   stuck: (m) => {
     m.finalStatus = "stuck";
+  },
+  policy: (m, e) => {
+    const decision = str(e.decision);
+
+    m.policyDenies += decision === "deny" ? 1 : 0;
+    m.policyAsks += decision === "ask" ? 1 : 0;
   },
   tool: (m, e) => {
     const msg = str(e.message);
@@ -122,6 +132,8 @@ function emptyMetrics(): IMetrics {
     buildNudges: 0,
     salvaged: 0,
     hallucinatedImports: [],
+    policyDenies: 0,
+    policyAsks: 0,
     wallClockSeconds: 0,
   };
 }
@@ -168,6 +180,8 @@ function analyze(lines: string[]): IMetrics {
 
   m.filesCreated = created.size;
   m.hallucinatedImports = [...hallucinated];
+  // wallClockSeconds accumulated raw ms above — convert to seconds once.
+  m.wallClockSeconds = Math.round(m.wallClockSeconds / 1000);
 
   return m;
 }
@@ -206,6 +220,7 @@ async function main(): Promise<void> {
     ["peak context", `${m.peakContext} (${pct}% of window)`],
     ["edits/creates", `${m.edits} (${m.filesCreated} files created)`],
     ["gate runs", String(m.gateRuns)],
+    ["policy denials/asks", `${m.policyDenies} / ${m.policyAsks}`],
     ["auto-compactions", String(m.compactions)],
     ["build nudges", String(m.buildNudges)],
     ["salvaged tool calls", String(m.salvaged)],

--- a/packages/core/src/cli.ts
+++ b/packages/core/src/cli.ts
@@ -1119,6 +1119,15 @@ async function repl(args: ICliArgs): Promise<number> {
     process.stdout.write(`  ↳ logging this run to ${logFile}\n`);
   }
 
+  // Scout seeds a one-shot drive-to-green run's first prompt; interactive sessions
+  // gather context conversationally, so it doesn't apply here. Say so rather than
+  // silently ignore the flag.
+  if (args.scout) {
+    process.stdout.write(
+      '  ↳ note: --scout applies to one-shot runs (tsforge "task" --files … --scout); ignored in interactive mode\n'
+    );
+  }
+
   const thinkingTokenBudget = envNumber("TSFORGE_THINKING_BUDGET");
   // Auto-compaction threshold (fraction of the window); session default 0.8.
   const autoCompactAt = envNumber("TSFORGE_COMPACT_AT");

--- a/packages/core/src/cli.ts
+++ b/packages/core/src/cli.ts
@@ -137,6 +137,9 @@ export interface ICliArgs {
   /** Run the gate first and tell the reviewer to skip what it already covers
    *  (`tsforge review --with-gate`). */
   withGate: boolean;
+  /** Seed a brownfield run with a deterministic caller blast-radius scout
+   *  (`--scout`). */
+  scout: boolean;
   /** Explicit base ref to diff against for review (`--base <ref>`). */
   base: string;
   /** Build a structural workspace map (`tsforge map`). */
@@ -171,6 +174,7 @@ const BOOL_FLAGS: Record<
   | "strictFloorOnly"
   | "staged"
   | "withGate"
+  | "scout"
 > = {
   "--continue": "continue",
   "-c": "continue",
@@ -181,6 +185,7 @@ const BOOL_FLAGS: Record<
   "--strict-floor-only": "strictFloorOnly",
   "--staged": "staged",
   "--with-gate": "withGate",
+  "--scout": "scout",
 };
 
 const VALUE_FLAGS = new Set([
@@ -214,6 +219,7 @@ export function parseArgs(argv: readonly string[]): ICliArgs {
     review: false,
     staged: false,
     withGate: false,
+    scout: false,
     base: "",
     map: false,
     trace: false,
@@ -344,6 +350,7 @@ function applyRecipeFlags(args: ICliArgs, recipe: ITaskRecipe): void {
   args.plan = args.plan || recipe.plan === true;
   args.log = args.log || recipe.log === true;
   args.withGate = args.withGate || recipe.withGate === true;
+  args.scout = args.scout || recipe.scout === true;
 }
 
 // Default editable scope: the whole workspace — like any agentic CLI, the agent
@@ -879,6 +886,7 @@ async function runOnce(args: ICliArgs): Promise<number> {
     onEvent: makeReporter(logFile, "cli"),
     ...(thinkingTokenBudget === undefined ? {} : { thinkingTokenBudget }),
     ...(args.maxTurns > 0 ? { maxTurns: args.maxTurns } : {}),
+    ...(args.scout ? { scout: true } : {}),
   });
   const ok = result.status === RUN_STATUS.done;
 

--- a/packages/core/src/config/recipes.ts
+++ b/packages/core/src/config/recipes.ts
@@ -51,7 +51,13 @@ export interface ITaskRecipe {
 }
 
 function optString(value: unknown): string | undefined {
-  return typeof value === "string" && value.length > 0 ? value : undefined;
+  if (typeof value !== "string") {
+    return undefined;
+  }
+
+  const trimmed = value.trim();
+
+  return trimmed.length > 0 ? trimmed : undefined;
 }
 
 function optBool(value: unknown): boolean | undefined {

--- a/packages/core/src/config/recipes.ts
+++ b/packages/core/src/config/recipes.ts
@@ -46,6 +46,8 @@ export interface ITaskRecipe {
   readonly log?: boolean;
   /** Run a gate-aware functional review after green (→ `review --with-gate`). */
   readonly withGate?: boolean;
+  /** Seed a deterministic pre-edit caller blast-radius scout (→ `--scout`). */
+  readonly scout?: boolean;
 }
 
 function optString(value: unknown): string | undefined {
@@ -99,6 +101,7 @@ function assignFlags(recipe: Mutable, raw: Record<string, unknown>): void {
   recipe.plan = optBool(raw.plan);
   recipe.log = optBool(raw.log);
   recipe.withGate = optBool(raw.withGate);
+  recipe.scout = optBool(raw.scout);
 }
 
 type Mutable = { -readonly [K in keyof ITaskRecipe]: ITaskRecipe[K] };
@@ -123,6 +126,7 @@ const KNOWN_KEYS = new Set<string>([
   "plan",
   "log",
   "withGate",
+  "scout",
 ]);
 
 /** Keys present in the raw recipe that this version doesn't recognize. */

--- a/packages/core/src/eval/metrics.ts
+++ b/packages/core/src/eval/metrics.ts
@@ -82,6 +82,9 @@ export function analyzeEvents(events: readonly ILoopEvent[]): IRunMetrics {
   const created = new Set<string>();
   let tpsSum = 0;
   let tpsCount = 0;
+  // Accumulate raw ms and round ONCE at the end: rounding each timing event
+  // would floor sub-second turns to 0s (400+400+400ms → 0s instead of 1s).
+  let wallMs = 0;
 
   for (const event of events) {
     if (event.kind === "cycle") {
@@ -104,7 +107,7 @@ export function analyzeEvents(events: readonly ILoopEvent[]): IRunMetrics {
     } else if (event.kind === "edit") {
       m.edits += 1;
     } else if (event.kind === "timing") {
-      m.wallClockSeconds += Math.round((event.ms ?? 0) / 1000);
+      wallMs += event.ms ?? 0;
     } else if (event.kind === "validated") {
       m.gateRuns += 1;
     } else if (event.kind === "done") {
@@ -119,6 +122,7 @@ export function analyzeEvents(events: readonly ILoopEvent[]): IRunMetrics {
 
   m.filesCreated = created.size;
   m.avgTokensPerSecond = tpsCount > 0 ? Math.round(tpsSum / tpsCount) : 0;
+  m.wallClockSeconds = Math.round(wallMs / 1000);
   m.failureClass = classifyRun(events).failureClass;
 
   return m;

--- a/packages/core/src/loop/loop.types.ts
+++ b/packages/core/src/loop/loop.types.ts
@@ -117,6 +117,9 @@ export interface IRunOptions {
   thinkingTokenBudget?: number;
   /** Hard backstop on model turns (default LOOP_LIMITS.maxTurns). */
   maxTurns?: number;
+  /** Seed the run with a deterministic pre-edit scout bundle (caller blast-radius
+   *  of the editable files). Opt-in; only fires on brownfield (existing-code) runs. */
+  scout?: boolean;
 }
 
 export interface ISpecResult {

--- a/packages/core/src/loop/prompt/prompt.ts
+++ b/packages/core/src/loop/prompt/prompt.ts
@@ -133,7 +133,8 @@ export function seedPrompt(
   task: ITask,
   editable: IFileView[],
   context: IFileView[],
-  stack?: IStackProfile
+  stack?: IStackProfile,
+  scout?: string
 ): string {
   const intent =
     task.intent !== undefined && task.intent.length > 0
@@ -155,11 +156,13 @@ export function seedPrompt(
       : `Read-only context (do NOT edit)${ctx.mapped ? " — MAP; read specifics on demand" : ""}:\n${ctx.text}`;
 
   const stackText = stack !== undefined ? buildStackGuidance(stack) : "";
+  const scoutText = scout !== undefined && scout.length > 0 ? scout : "";
 
   return [
     `Task ${task.id}.`,
     intent,
     stackText,
+    scoutText,
     `Acceptance command (run this to verify — it must exit 0): ${task.accept}`,
     `Editable files: ${task.files.join(", ")}`,
     `Current editable contents:\n${editableText}`,

--- a/packages/core/src/loop/review/review-change.ts
+++ b/packages/core/src/loop/review/review-change.ts
@@ -422,8 +422,21 @@ export function formatReport(report: IReviewReport): string {
     return "No changed source files to review.";
   }
 
+  // The gate-aware note must show even when nothing was found — otherwise a
+  // `--with-gate` run that skipped rules reads as "all clear" with no hint why.
+  const gateFailingRules = report.gateFailingRules ?? [];
+  const gateNote =
+    gateFailingRules.length > 0
+      ? [
+          `(gate-aware: skipped ${gateFailingRules.length} failing gate rule(s) the gate already covers)`,
+        ]
+      : [];
+
   if (report.findings.length === 0) {
-    return `No functional issues found across ${report.changedFiles.length} changed file(s) (${report.rejected} candidate(s) rejected on verification).`;
+    return [
+      `No functional issues found across ${report.changedFiles.length} changed file(s) (${report.rejected} candidate(s) rejected on verification).`,
+      ...gateNote,
+    ].join("\n");
   }
 
   const sorted = [...report.findings].sort(
@@ -433,13 +446,6 @@ export function formatReport(report: IReviewReport): string {
     (f) =>
       `${f.severity.toUpperCase()} ${f.file}:${f.line} [${f.lens}]\n  ${f.claim}\n  → ${f.reason}`
   );
-  const gateFailingRules = report.gateFailingRules ?? [];
-  const gateNote =
-    gateFailingRules.length > 0
-      ? [
-          `(gate-aware: skipped ${gateFailingRules.length} failing gate rule(s) the gate already covers)`,
-        ]
-      : [];
 
   return [
     `Review of ${report.changedFiles.length} changed file(s) vs ${report.base}:`,

--- a/packages/core/src/loop/run.ts
+++ b/packages/core/src/loop/run.ts
@@ -2,7 +2,7 @@ import type { ITask } from "../spec";
 import type { IChatMessage, IModelResponse, IProvider } from "../inference";
 import { validate, type ErrorParser } from "../validate";
 import { parseEslintJson } from "../validate";
-import { readFiles } from "../lib/fs";
+import { readFiles, type IFileView } from "../lib/fs";
 import {
   DEFAULT_TEMPERATURE,
   RUN_STATUS,
@@ -20,6 +20,7 @@ import { flags } from "../config";
 import type { ITsforgeProjectConfig } from "../config";
 import type { PolicyMode, IPolicyRules } from "../policy";
 import { buildSystemPrompt, seedPrompt } from "./prompt";
+import { buildScoutContext } from "./scout";
 import { detectStack } from "../stack-detection";
 import type { TtsrManager } from "./ttsr";
 import {
@@ -228,6 +229,22 @@ async function resolveStackForRun(
  * This is the RED-first, drive-to-green wrapper the EVAL harness uses; the
  * interactive CLI composes the same `turn.ts` primitives via `Session`.
  */
+function scoutSeed(
+  opts: IRunOptions,
+  tsService: Parameters<typeof buildScoutContext>[0],
+  cwd: string,
+  editable: readonly IFileView[],
+  hasExistingCode: boolean
+): string {
+  // Opt-in, brownfield-only (a from-scratch build has no callers to map). Kept out
+  // of runTask so its branch doesn't add to that function's complexity.
+  if (opts.scout !== true || !hasExistingCode) {
+    return "";
+  }
+
+  return buildScoutContext(tsService, cwd, editable);
+}
+
 export async function runTask(
   task: ITask,
   cwd: string,
@@ -317,6 +334,11 @@ export async function runTask(
   // gates the scratch-simplicity guidance (from-scratch builds only).
   const hasExistingCode = editable.some((f) => f.content.trim().length > 0);
 
+  // Build the LanguageService once, up front: scout needs it to seed the prompt,
+  // and the loop reuses it (don't build twice).
+  const tsService = await buildTsService(cwd);
+  const scout = scoutSeed(opts, tsService, cwd, editable, hasExistingCode);
+
   const messages: IChatMessage[] = [
     {
       role: "system",
@@ -324,7 +346,7 @@ export async function runTask(
     },
     {
       role: "user",
-      content: seedPrompt(task, editable, context, stackProfile),
+      content: seedPrompt(task, editable, context, stackProfile, scout),
     },
   ];
 
@@ -342,7 +364,7 @@ export async function runTask(
   const ctx: ILoopCtx = {
     task,
     cwd,
-    tsService: await buildTsService(cwd),
+    tsService,
     parse: effectiveParse,
     report,
     messages,

--- a/packages/core/src/loop/scout.ts
+++ b/packages/core/src/loop/scout.ts
@@ -1,0 +1,52 @@
+import type { TsService } from "../lsp";
+import type { IFileView } from "../lib/fs";
+import { callerSignal } from "./review/signals";
+
+/** Cap the files probed and the bundle size — a pre-edit primer, not a dump. */
+const MAX_SCOUT_FILES = 8;
+const SCOUT_CHARS = 4000;
+
+/**
+ * A DETERMINISTIC pre-edit context bundle: for each editable file that already
+ * exists, who calls its exports (type-exact, from the TypeScript LanguageService).
+ * Injected before the model edits brownfield code so it changes with blast-radius
+ * awareness instead of blind. No model call — the divergence from Codebuff's LLM
+ * file-picker. Returns "" when there's no tsconfig/service or nothing depends on
+ * the targets (e.g. a from-scratch build).
+ */
+export function buildScoutContext(
+  svc: TsService | null,
+  cwd: string,
+  editable: readonly IFileView[]
+): string {
+  if (svc === null) {
+    return "";
+  }
+
+  const sections: string[] = [];
+
+  for (const file of editable) {
+    if (sections.length >= MAX_SCOUT_FILES) {
+      break;
+    }
+
+    // A not-yet-created (empty) editable file has no callers to map.
+    if (file.content.trim().length === 0) {
+      continue;
+    }
+
+    const signal = callerSignal(svc, cwd, file.path);
+
+    if (signal.length > 0) {
+      sections.push(`${file.path}:\n${signal}`);
+    }
+  }
+
+  if (sections.length === 0) {
+    return "";
+  }
+
+  const bundle = `Blast radius — who calls the files you're about to change (type-exact; check these for regressions before editing):\n${sections.join("\n\n")}`;
+
+  return bundle.slice(0, SCOUT_CHARS);
+}

--- a/packages/core/src/loop/scout.ts
+++ b/packages/core/src/loop/scout.ts
@@ -35,7 +35,7 @@ export function buildScoutContext(
       continue;
     }
 
-    const signal = callerSignal(svc, cwd, file.path);
+    const signal = safeCallerSignal(svc, cwd, file.path);
 
     if (signal.length > 0) {
       sections.push(`${file.path}:\n${signal}`);
@@ -48,5 +48,30 @@ export function buildScoutContext(
 
   const bundle = `Blast radius — who calls the files you're about to change (type-exact; check these for regressions before editing):\n${sections.join("\n\n")}`;
 
-  return bundle.slice(0, SCOUT_CHARS);
+  return capBundle(bundle);
+}
+
+/** callerSignal, but a throw (a non-TS editable file the service can't analyze,
+ *  e.g. .json/.md) degrades to "" so scout skips that file instead of aborting. */
+function safeCallerSignal(svc: TsService, cwd: string, file: string): string {
+  try {
+    return callerSignal(svc, cwd, file);
+  } catch {
+    return "";
+  }
+}
+
+/** Cap the bundle at SCOUT_CHARS, trimming to the last whole line and flagging the
+ *  cut — so the model never sees a path/call site sliced mid-word with no signal
+ *  that more was dropped. */
+function capBundle(bundle: string): string {
+  if (bundle.length <= SCOUT_CHARS) {
+    return bundle;
+  }
+
+  const cut = bundle.slice(0, SCOUT_CHARS);
+  const lastNewline = cut.lastIndexOf("\n");
+  const trimmed = lastNewline > 0 ? cut.slice(0, lastNewline) : cut;
+
+  return `${trimmed}\n… [scout truncated]`;
 }

--- a/packages/core/tests/cli.test.ts
+++ b/packages/core/tests/cli.test.ts
@@ -63,6 +63,16 @@ test("`tsforge recipes` and `--recipe <id>` are recognized", () => {
   );
 });
 
+test("--scout parses, and a recipe can turn scout on", () => {
+  expect(parseArgs(["fix it", "--scout"]).scout).toBe(true);
+  expect(parseArgs(["fix it"]).scout).toBe(false);
+
+  const args = parseArgs(["fix it"]);
+
+  applyRecipe(args, { id: "brownfield", scout: true });
+  expect(args.scout).toBe(true);
+});
+
 test("applyRecipe fills defaults but an explicit CLI value always wins", () => {
   const recipe: ITaskRecipe = {
     id: "api-endpoint",

--- a/packages/core/tests/eval-infra.test.ts
+++ b/packages/core/tests/eval-infra.test.ts
@@ -116,4 +116,16 @@ describe("eval metrics: analyzeEvents", () => {
     expect(m.finalStatus).toBe("done");
     expect(m.avgTokensPerSecond).toBe(40);
   });
+
+  test("wall-clock accumulates ms then rounds once (sub-second turns don't vanish)", () => {
+    // Three 400ms turns = 1200ms. Per-event rounding floored each to 0s (→ 0s
+    // total); accumulate-then-round gives the correct 1s.
+    const subSecond: ILoopEvent[] = [
+      { kind: "timing", task: "1", message: "", ms: 400 },
+      { kind: "timing", task: "1", message: "", ms: 400 },
+      { kind: "timing", task: "1", message: "", ms: 400 },
+    ];
+
+    expect(analyzeEvents(subSecond).wallClockSeconds).toBe(1);
+  });
 });

--- a/packages/core/tests/recipes.test.ts
+++ b/packages/core/tests/recipes.test.ts
@@ -47,6 +47,18 @@ describe("parseRecipe", () => {
     expect(r?.maxTurns).toBeUndefined();
   });
 
+  test("a whitespace-only string field becomes undefined (not a broken value)", () => {
+    const r = parseRecipe({ id: "x", gate: "   ", model: "\t", base: "\n" });
+
+    expect(r?.gate).toBeUndefined();
+    expect(r?.model).toBeUndefined();
+    expect(r?.base).toBeUndefined();
+    // and a real value is trimmed
+    expect(parseRecipe({ id: "x", gate: "  bun test  " })?.gate).toBe(
+      "bun test"
+    );
+  });
+
   test("flags fields it doesn't yet apply (so they don't silently vanish)", () => {
     // `profile`/`tools` aren't applied in v1 — surface them rather than ignore.
     expect(

--- a/packages/core/tests/review-change.test.ts
+++ b/packages/core/tests/review-change.test.ts
@@ -208,6 +208,21 @@ test("without a gate signal the find prompt has no gate clause (back-compat)", a
   expect(sink.value.toLowerCase()).not.toContain("already failing");
 });
 
+test("formatReport shows the gate-aware note even when 0 findings", () => {
+  // A --with-gate run that skipped rules but found nothing must still say so —
+  // otherwise it reads as "all clear" with no hint the gate had failures.
+  const text = formatReport({
+    base: "HEAD",
+    changedFiles: ["a.ts"],
+    findings: [],
+    rejected: 3,
+    gateFailingRules: ["TS2322", "no-as-cast"],
+  });
+
+  expect(text).toContain("No functional issues found");
+  expect(text).toContain("gate-aware: skipped 2");
+});
+
 test("the senior-review rubric ships with the expected lenses", () => {
   const ids = LENSES.map((l) => l.id);
 

--- a/packages/core/tests/scout.test.ts
+++ b/packages/core/tests/scout.test.ts
@@ -61,3 +61,22 @@ test("scout is empty with no LanguageService (no tsconfig)", () => {
     buildScoutContext(null, "/tmp", [{ path: "a.ts", content: "x" }])
   ).toBe("");
 });
+
+test("a non-TS editable file is skipped, not crashed on", async () => {
+  const dir = fixture();
+
+  try {
+    writeFileSync(join(dir, "data.json"), '{"a":1}\n');
+    const svc = await buildTsService(dir);
+    // util.ts (has callers) + a .json file the service can't analyze.
+    const out = buildScoutContext(svc, dir, [
+      { path: "data.json", content: '{"a":1}' },
+      { path: "util.ts", content: "export function area(){}" },
+    ]);
+
+    // No throw; the TS file still contributes its blast radius.
+    expect(out).toContain("caller.ts");
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});

--- a/packages/core/tests/scout.test.ts
+++ b/packages/core/tests/scout.test.ts
@@ -1,0 +1,63 @@
+import { test, expect } from "bun:test";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { buildScoutContext } from "../src/loop/scout";
+import { buildTsService } from "../src/loop/turn";
+import type { IFileView } from "../src/lib/fs";
+
+function fixture(): string {
+  const dir = mkdtempSync(join(tmpdir(), "tsforge-scout-"));
+
+  writeFileSync(
+    join(dir, "tsconfig.json"),
+    '{"compilerOptions":{"strict":true,"skipLibCheck":true},"include":["*.ts"]}'
+  );
+  writeFileSync(
+    join(dir, "util.ts"),
+    "export function area(w: number, h: number): number {\n  return w * h;\n}\n"
+  );
+  writeFileSync(
+    join(dir, "caller.ts"),
+    'import { area } from "./util";\nexport const room = area(3, 4);\n'
+  );
+
+  return dir;
+}
+
+test("scout names the callers of an editable file (the blast radius)", async () => {
+  const dir = fixture();
+
+  try {
+    const svc = await buildTsService(dir);
+    const editable: IFileView[] = [
+      { path: "util.ts", content: "export function area(){}" },
+    ];
+    const out = buildScoutContext(svc, dir, editable);
+
+    expect(out.toLowerCase()).toContain("blast radius");
+    expect(out).toContain("area");
+    expect(out).toContain("caller.ts");
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("scout is empty for a not-yet-created (empty) editable file", async () => {
+  const dir = fixture();
+
+  try {
+    const svc = await buildTsService(dir);
+    const out = buildScoutContext(svc, dir, [{ path: "new.ts", content: "" }]);
+
+    expect(out).toBe("");
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("scout is empty with no LanguageService (no tsconfig)", () => {
+  expect(
+    buildScoutContext(null, "/tmp", [{ path: "a.ts", content: "x" }])
+  ).toBe("");
+});


### PR DESCRIPTION
## Phase 4 (final) of the Codebuff-inspired uplift — deterministic pre-edit scout

Based on `main` (Phases 1–3 already merged).

### Why
A small local model editing existing code can't see what depends on it, so it breaks callers it never read — then spends repair turns fixing the regressions. Scout removes that blind spot.

### What
```bash
tsforge "rename area() to rect()" --files src/geometry.ts --scout
```
Before the first edit, scout seeds the run with the **caller blast-radius** of the editable files — who calls their exports, computed **type-exactly from the TypeScript LanguageService**:

```
Blast radius — who calls the files you're about to change (type-exact; check these for regressions before editing):
src/geometry.ts:
- area → src/floorplan.ts:12; src/report.ts:48
```

It's the same caller signal `tsforge review` uses, applied **before** the edit instead of after.

### Design
- **`loop/scout.ts`** — `buildScoutContext` reuses `buildTsService` + `callerSignal`. **No model call** (the divergence from Codebuff's LLM file-picker — tsforge stays deterministic). Bounded by file count + char cap.
- **`run.ts`** — builds the LanguageService **once** and reuses it for both scout and the loop ctx (was built twice before — net no extra cost). Seeds via `seedPrompt`'s new optional `scout` section.
- **Opt-in & brownfield-only** — `--scout` (or a recipe `scout: true`); does nothing on a from-scratch build or with no `tsconfig.json`. One-shots stay fast by default.
- Recipe `scout` field is now applied (added to the recipe's known keys).
- Docs: `loop/scout`, recipes/commands cross-links.

### Tests
`scout.test.ts` (names callers, skips empty/new files, empty without a LanguageService) + `cli.test.ts` (`--scout` parse, recipe overlay).

### Verification
`bun run validate` green (1206 pass, 0 fail). Docs build green (40 pages).