### PR TITLE
fix(tools): never throw into the loop + atomic scaffold/LSP writes

### DIFF
--- a/packages/core/src/lib/fs/fs.ts
+++ b/packages/core/src/lib/fs/fs.ts
@@ -1,4 +1,5 @@
 import { join } from "node:path";
+import { rm } from "node:fs/promises";
 import { Glob } from "bun";
 import type { IFileView } from "./fs.types";
 
@@ -96,6 +97,76 @@ export async function readFiles(
   }
 
   return views;
+}
+
+/** One pending write in a batch. */
+export interface IWriteFile {
+  path: string;
+  content: string;
+}
+
+/** Result of a batch write: the paths written on success, or the failure reason. */
+export type IBatchWriteResult =
+  | { ok: true; written: string[] }
+  | { ok: false; reason: string };
+
+/** A file touched by the batch, with the bytes to restore it to on rollback
+ *  (`null` = it didn't exist before, so rollback removes it). */
+interface ITouched {
+  abs: string;
+  prior: Uint8Array | null;
+}
+
+/** Best-effort restore of a partial batch, newest first: bring each touched path
+ *  back to its prior bytes, or remove it if it didn't exist before. A rollback
+ *  failure is swallowed so it can't mask the original write error. */
+async function rollback(done: readonly ITouched[]): Promise<void> {
+  for (const entry of [...done].reverse()) {
+    try {
+      await (entry.prior === null
+        ? rm(entry.abs, { force: true })
+        : Bun.write(entry.abs, entry.prior));
+    } catch {
+      // best-effort
+    }
+  }
+}
+
+/**
+ * Write a batch of files ATOMICALLY: either all land, or NONE do. On any write
+ * failure (e.g. EACCES), every file already written in THIS batch is rolled back
+ * — a path that existed is RESTORED to its previous bytes (never deleted), one
+ * that didn't is removed — so a partial mutation never reaches disk. This is the
+ * contract the scaffolds + semantic edits rely on to emit `mutated` only once,
+ * after a full success. Parent dirs are created as needed (via `Bun.write`).
+ */
+export async function writeFilesOrRollback(
+  cwd: string,
+  files: readonly IWriteFile[]
+): Promise<IBatchWriteResult> {
+  const done: ITouched[] = [];
+
+  try {
+    for (const file of files) {
+      const abs = join(cwd, file.path);
+      const handle = Bun.file(abs);
+      const prior = (await handle.exists())
+        ? new Uint8Array(await handle.arrayBuffer())
+        : null;
+
+      await Bun.write(abs, file.content);
+      done.push({ abs, prior });
+    }
+
+    return { ok: true, written: files.map((f) => f.path) };
+  } catch (err) {
+    await rollback(done);
+
+    return {
+      ok: false,
+      reason: err instanceof Error ? err.message : String(err),
+    };
+  }
 }
 
 /**

--- a/packages/core/src/loop/tools/execute-tool.ts
+++ b/packages/core/src/loop/tools/execute-tool.ts
@@ -135,5 +135,16 @@ export async function executeTool(
     );
   }
 
-  return HANDLERS[call.name](call.arguments, ctx);
+  // Error boundary: a handler must hand the model a tool-error STRING, never throw
+  // into the loop (an unguarded `Bun.write` EACCES, a parse failure, etc. would
+  // otherwise crash `runToolCalls` mid-turn). Catch only the built-in dispatch —
+  // policy/MCP/unknown above already return text. Mutating handlers roll back their
+  // own partial writes (writeFilesOrRollback), so a caught throw left disk clean.
+  try {
+    return await HANDLERS[call.name](call.arguments, ctx);
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+
+    return reject(ctx, call.name, `${call.name} FAILED: ${message}`);
+  }
 }

--- a/packages/core/src/loop/tools/scaffold-routes.ts
+++ b/packages/core/src/loop/tools/scaffold-routes.ts
@@ -52,6 +52,16 @@ export async function doScaffoldRoutes(
     pending.push({ path, content });
   }
 
+  // Nothing in scope at all (no new stubs AND none already exist) → reject
+  // honestly rather than report a misleading "created 0" success.
+  if (pending.length === 0 && kept.length === 0) {
+    return reject(
+      ctx,
+      "scaffold_routes",
+      "no routes are within the editable scope (`--files`) — widen the scope to scaffold these routes."
+    );
+  }
+
   const keptNote =
     kept.length > 0
       ? ` (kept ${String(kept.length)} existing route(s) untouched)`

--- a/packages/core/src/loop/tools/scaffold-routes.ts
+++ b/packages/core/src/loop/tools/scaffold-routes.ts
@@ -1,7 +1,8 @@
 import { join } from "node:path";
 import { writable, normalizeWorkspacePath } from "../../lib/scope";
+import { writeFilesOrRollback, type IWriteFile } from "../../lib/fs";
 import { materializeRoutes, asRoutePaths } from "../../web-routes";
-import { type IToolContext } from "./tool-context";
+import { reject, type IToolContext } from "./tool-context";
 
 /**
  * `scaffold_routes` — materialize ALL of an app's routes as file-based stubs from
@@ -11,6 +12,10 @@ import { type IToolContext } from "./tool-context";
  * owns HOW (correct createFileRoute + $param filename mapping). Like scaffold_ui:
  * overwrites stubs idempotently and reports ONE summary event (not per-file
  * `create`s) so the write-guard doesn't re-check the generated shells.
+ *
+ * Writes are ATOMIC (writeFilesOrRollback) and `mutated` is emitted ONLY after a
+ * full success — a mid-batch failure rolls back, so the workspace never holds a
+ * half-written route set with no re-gate.
  */
 export async function doScaffoldRoutes(
   args: Record<string, unknown>,
@@ -23,16 +28,14 @@ export async function doScaffoldRoutes(
   }
 
   const files = materializeRoutes(paths);
-  const written: string[] = [];
+  const pending: IWriteFile[] = [];
   const kept: string[] = [];
 
   for (const [rel, content] of Object.entries(files)) {
     const path = normalizeWorkspacePath(ctx.cwd, rel);
 
-    // Scope check only — deliberately NOT the vendored guard. This tool's JOB is to
-    // write the generated route shells; gating it on `isVendored` would refuse the
-    // very files it owns if the vendored set ever covered them. (edit/create DO
-    // reject vendored paths — there the model must not rewrite a generated shell.)
+    // Scope check only — deliberately NOT the vendored guard (this tool owns these
+    // generated shells; see scaffold-ui for the rationale).
     if (!writable(path, ctx.files)) {
       continue;
     }
@@ -46,14 +49,31 @@ export async function doScaffoldRoutes(
       continue;
     }
 
-    await Bun.write(join(ctx.cwd, path), content);
-    written.push(path);
+    pending.push({ path, content });
   }
 
   const keptNote =
     kept.length > 0
       ? ` (kept ${String(kept.length)} existing route(s) untouched)`
       : "";
+
+  // Atomic write of the new stubs. A no-op (nothing new in scope) skips the batch
+  // entirely, so it emits no `mutated` and doesn't force a gate run.
+  let written: string[] = [];
+
+  if (pending.length > 0) {
+    const result = await writeFilesOrRollback(ctx.cwd, pending);
+
+    if (!result.ok) {
+      return reject(
+        ctx,
+        "scaffold_routes",
+        `could not write the route stubs (${result.reason}) — disk left unchanged.`
+      );
+    }
+
+    written = result.written;
+  }
 
   ctx.report({
     kind: "tool",

--- a/packages/core/src/loop/tools/scaffold-ui.ts
+++ b/packages/core/src/loop/tools/scaffold-ui.ts
@@ -1,5 +1,5 @@
-import { join } from "node:path";
 import { writable, normalizeWorkspacePath } from "../../lib/scope";
+import { writeFilesOrRollback, type IWriteFile } from "../../lib/fs";
 import {
   materializeComponents,
   asThemeName,
@@ -7,7 +7,7 @@ import {
   COMPONENT_NAMES,
   THEME_NAMES,
 } from "../../web-components";
-import { type IToolContext } from "./tool-context";
+import { reject, type IToolContext } from "./tool-context";
 
 /**
  * `scaffold_ui` — materialize tested, THEMED UI primitives so the model never
@@ -16,6 +16,10 @@ import { type IToolContext } from "./tool-context";
  * with the theme's per-component classes baked in. Overwrites (re-theming is
  * idempotent). Reports ONE summary event — deliberately NOT per-file `create`
  * events, so the write-guard doesn't re-check known-good vendored files.
+ *
+ * The writes are ATOMIC (writeFilesOrRollback): either every primitive lands and
+ * we emit `mutated` once, or none does and we reject — never a half-written set
+ * with no re-gate (the partial-mutation contract break the harness review found).
  */
 export async function doScaffoldUi(
   args: Record<string, unknown>,
@@ -33,36 +37,54 @@ export async function doScaffoldUi(
     return `scaffold_ui REJECTED: \`components\` must be a non-empty array from: ${COMPONENT_NAMES.join(", ")}.`;
   }
 
-  const files = materializeComponents(theme, components);
-  const written: string[] = [];
+  // Plan the writes: scope check only — deliberately NOT the vendored guard. This
+  // tool's JOB is to materialize the generated UI primitives; gating it on
+  // `isVendored` would refuse the very files it owns. (edit/create DO reject
+  // vendored paths — there the model must not rewrite a generated shell.)
+  const pending: IWriteFile[] = [];
 
-  for (const [rel, content] of Object.entries(files)) {
+  for (const [rel, content] of Object.entries(
+    materializeComponents(theme, components)
+  )) {
     const path = normalizeWorkspacePath(ctx.cwd, rel);
 
-    // Scope check only — deliberately NOT the vendored guard. This tool's JOB is to
-    // materialize the generated UI primitives; gating it on `isVendored` would refuse
-    // the very files it owns if the vendored set ever covered them. (edit/create DO
-    // reject vendored paths — there the model must not rewrite a generated shell.)
-    if (!writable(path, ctx.files)) {
-      continue;
+    if (writable(path, ctx.files)) {
+      pending.push({ path, content });
     }
+  }
 
-    await Bun.write(join(ctx.cwd, path), content);
-    written.push(path);
+  // Nothing in scope → reject honestly; do NOT tell the model to import primitives
+  // from @/components/ui that were never written.
+  if (pending.length === 0) {
+    return reject(
+      ctx,
+      "scaffold_ui",
+      "no UI primitives are within the editable scope (`--files`) — widen the scope, or compose the existing components instead."
+    );
+  }
+
+  const result = await writeFilesOrRollback(ctx.cwd, pending);
+
+  if (!result.ok) {
+    return reject(
+      ctx,
+      "scaffold_ui",
+      `could not write the themed files (${result.reason}) — disk left unchanged.`
+    );
   }
 
   ctx.report({
     kind: "tool",
     task: ctx.task,
-    message: `scaffold_ui: wrote ${String(written.length)} themed file(s) [${theme}] — ${components.join(", ")}`,
+    message: `scaffold_ui: wrote ${String(result.written.length)} themed file(s) [${theme}] — ${components.join(", ")}`,
     // Re-gate after mutating the workspace — without write-guarding each generated
-    // (vendored) primitive. Empty when nothing was written.
-    ...(written.length > 0 ? { mutated: written } : {}),
+    // (vendored) primitive. Emitted ONLY after a full, successful batch.
+    mutated: result.written,
   });
 
   return (
-    `scaffold_ui: wrote ${String(written.length)} file(s) with the "${theme}" theme ` +
-    `(${written.join(", ")}). Import these from @/components/ui (e.g. \`import { Button } ` +
+    `scaffold_ui: wrote ${String(result.written.length)} file(s) with the "${theme}" theme ` +
+    `(${result.written.join(", ")}). Import these from @/components/ui (e.g. \`import { Button } ` +
     `from "@/components/ui/button"\`) and COMPOSE them — do NOT re-create any primitive ` +
     `or edit the files under src/components/ui.`
   );

--- a/packages/core/src/lsp/service.ts
+++ b/packages/core/src/lsp/service.ts
@@ -584,7 +584,14 @@ export class TsService {
     // it was — never a half-applied rename with the source already deleted.
     const snapshots = new Map<string, string>();
 
-    for (const target of new Set([...edits.map((e) => e.fileName), fromAbs])) {
+    // Include toAbs: if the destination already exists (an overwriting move), its
+    // prior content must be restorable too. A non-existent dest isn't snapshotted
+    // (readFile → undefined), so restoreMove removes it instead.
+    for (const target of new Set([
+      ...edits.map((e) => e.fileName),
+      fromAbs,
+      toAbs,
+    ])) {
       const prior = ts.sys.readFile(target);
 
       if (prior !== undefined) {

--- a/packages/core/src/lsp/service.ts
+++ b/packages/core/src/lsp/service.ts
@@ -183,29 +183,102 @@ export class TsService {
     return undefined;
   }
 
+  /** Compute the new text for one file's edits (back-to-front so earlier spans
+   *  keep their offsets); null when the file can't be read. */
+  private editedText(fc: ts.FileTextChanges): string | null {
+    const original = ts.sys.readFile(fc.fileName);
+
+    if (original === undefined) {
+      return null;
+    }
+
+    const sorted = [...fc.textChanges].sort(
+      (a, b) => b.span.start - a.span.start
+    );
+    let text = original;
+
+    for (const tc of sorted) {
+      text =
+        text.slice(0, tc.span.start) +
+        tc.newText +
+        text.slice(tc.span.start + tc.span.length);
+    }
+
+    return text;
+  }
+
+  /**
+   * Apply a multi-file edit set ATOMICALLY: compute every new file text first,
+   * then write them; if any write throws (e.g. EACCES), restore the files already
+   * written in this batch to their prior content and re-throw. Without this a
+   * partial rename/organize/quick-fix could leave the tree half-edited (the
+   * partial-mutation contract break). The caller (executeTool's boundary) turns the
+   * re-thrown error into a tool-error string.
+   */
   private applyChanges(changes: readonly ts.FileTextChanges[]): void {
+    const planned: { fileName: string; text: string; prior: string }[] = [];
+
     for (const fc of changes) {
-      const original = ts.sys.readFile(fc.fileName);
+      const text = this.editedText(fc);
+      const prior = ts.sys.readFile(fc.fileName);
 
-      if (original === undefined) {
-        continue;
+      if (text !== null && prior !== undefined) {
+        planned.push({ fileName: fc.fileName, text, prior });
+      }
+    }
+
+    const written: { fileName: string; prior: string }[] = [];
+
+    try {
+      for (const p of planned) {
+        ts.sys.writeFile(p.fileName, p.text);
+        written.push({ fileName: p.fileName, prior: p.prior });
+      }
+    } catch (err) {
+      for (const w of [...written].reverse()) {
+        try {
+          ts.sys.writeFile(w.fileName, w.prior);
+        } catch {
+          // best-effort restore
+        }
       }
 
-      // Apply edits back-to-front so earlier spans keep their offsets.
-      const sorted = [...fc.textChanges].sort(
-        (a, b) => b.span.start - a.span.start
-      );
-      let text = original;
-
-      for (const tc of sorted) {
-        text =
-          text.slice(0, tc.span.start) +
-          tc.newText +
-          text.slice(tc.span.start + tc.span.length);
+      for (const p of planned) {
+        this.refresh(p.fileName);
       }
 
-      ts.sys.writeFile(fc.fileName, text);
-      this.refresh(fc.fileName);
+      throw err;
+    }
+
+    for (const p of planned) {
+      this.refresh(p.fileName);
+    }
+  }
+
+  /** Undo a failed move: restore every snapshotted file to its prior content and
+   *  remove the destination if this move created it. Best-effort; re-grounds each
+   *  touched file so the in-memory service matches disk again. */
+  private restoreMove(
+    snapshots: ReadonlyMap<string, string>,
+    toAbs: string,
+    destExisted: boolean
+  ): void {
+    for (const [file, prior] of snapshots) {
+      try {
+        ts.sys.writeFile(file, prior);
+      } catch {
+        // best-effort
+      }
+
+      this.refresh(file);
+    }
+
+    if (!destExisted) {
+      try {
+        rmSync(toAbs, { force: true });
+      } catch {
+        // best-effort
+      }
     }
   }
 
@@ -506,15 +579,36 @@ export class TsService {
 
     const edits = this.moveEdits(fromAbs, toAbs);
 
-    // Apply the import rewrites (importers + the moved file's own imports) while
-    // the file still lives at its old path, THEN relocate the edited content.
-    this.applyChanges(edits);
+    // Snapshot every file the move touches (import rewrites + the source) so a
+    // failure midway (e.g. an unwritable destination) leaves the tree exactly as
+    // it was — never a half-applied rename with the source already deleted.
+    const snapshots = new Map<string, string>();
 
-    const moved = ts.sys.readFile(fromAbs) ?? original;
+    for (const target of new Set([...edits.map((e) => e.fileName), fromAbs])) {
+      const prior = ts.sys.readFile(target);
 
-    mkdirSync(dirname(toAbs), { recursive: true });
-    ts.sys.writeFile(toAbs, moved);
-    rmSync(fromAbs, { force: true });
+      if (prior !== undefined) {
+        snapshots.set(target, prior);
+      }
+    }
+
+    const destExisted = ts.sys.readFile(toAbs) !== undefined;
+
+    try {
+      // Apply the import rewrites (importers + the moved file's own imports) while
+      // the file still lives at its old path, THEN relocate the edited content.
+      this.applyChanges(edits);
+
+      const moved = ts.sys.readFile(fromAbs) ?? original;
+
+      mkdirSync(dirname(toAbs), { recursive: true });
+      ts.sys.writeFile(toAbs, moved);
+      rmSync(fromAbs, { force: true });
+    } catch (err) {
+      this.restoreMove(snapshots, toAbs, destExisted);
+
+      throw err;
+    }
 
     const stale = this.files.indexOf(fromAbs);
 

--- a/packages/core/tests/fs-write.test.ts
+++ b/packages/core/tests/fs-write.test.ts
@@ -1,0 +1,67 @@
+import { test, expect } from "bun:test";
+import { mkdtemp, rm, mkdir, writeFile, chmod } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { writeFilesOrRollback } from "../src/lib/fs";
+
+test("writeFilesOrRollback writes every file on success (new + overwrite)", async () => {
+  const dir = await mkdtemp(join(tmpdir(), "tsforge-batch-"));
+
+  try {
+    await mkdir(join(dir, "a"), { recursive: true });
+    await writeFile(join(dir, "a/x.ts"), "old");
+
+    const result = await writeFilesOrRollback(dir, [
+      { path: "a/x.ts", content: "new" }, // overwrite
+      { path: "a/y.ts", content: "fresh" }, // create
+    ]);
+
+    expect(result.ok).toBe(true);
+    expect(await Bun.file(join(dir, "a/x.ts")).text()).toBe("new");
+    expect(await Bun.file(join(dir, "a/y.ts")).text()).toBe("fresh");
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test("a mid-batch failure rolls back: overwritten file RESTORED, new file removed", async () => {
+  const dir = await mkdtemp(join(tmpdir(), "tsforge-batch-"));
+
+  try {
+    await mkdir(join(dir, "a"), { recursive: true });
+    await mkdir(join(dir, "b"), { recursive: true });
+    await writeFile(join(dir, "a/x.ts"), "ORIGINAL");
+    await chmod(join(dir, "b"), 0o555); // no write perm → second write throws
+
+    // If perms aren't enforced (e.g. running as root), the failure can't be
+    // simulated — skip the rollback assertions rather than false-pass.
+    let enforced = false;
+
+    try {
+      await Bun.write(join(dir, "b/probe"), "x");
+      await rm(join(dir, "b/probe"), { force: true });
+    } catch {
+      enforced = true;
+    }
+
+    if (!enforced) {
+      return;
+    }
+
+    const result = await writeFilesOrRollback(dir, [
+      { path: "a/x.ts", content: "CHANGED" }, // overwrite (must be restored)
+      { path: "a/z.ts", content: "NEW" }, // create (must be removed)
+      { path: "b/y.ts", content: "blocked" }, // fails → triggers rollback
+    ]);
+
+    expect(result.ok).toBe(false);
+    // The overwritten file is RESTORED to its original (not deleted — no data loss).
+    expect(await Bun.file(join(dir, "a/x.ts")).text()).toBe("ORIGINAL");
+    // The newly-created file is removed (disk unchanged).
+    expect(await Bun.file(join(dir, "a/z.ts")).exists()).toBe(false);
+    expect(await Bun.file(join(dir, "b/y.ts")).exists()).toBe(false);
+  } finally {
+    await chmod(join(dir, "b"), 0o755).catch(() => undefined);
+    await rm(dir, { recursive: true, force: true });
+  }
+});

--- a/packages/core/tests/tool-accounting.test.ts
+++ b/packages/core/tests/tool-accounting.test.ts
@@ -1,5 +1,5 @@
 import { test, expect } from "bun:test";
-import { mkdtemp, rm } from "node:fs/promises";
+import { mkdtemp, rm, mkdir, chmod } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import {
@@ -7,7 +7,9 @@ import {
   countsAsMutation,
   type ILoopCtx,
   type ILoopState,
+  type ILoopEvent,
 } from "../src/loop";
+import { THEME_NAMES, COMPONENT_NAMES } from "../src/web-components";
 import { TsService } from "../src/lsp";
 import { makeFileLinter, WEB_PACKS } from "../src/detect-gate";
 import { TOOL_NAME, READ_ONLY_TOOL_NAMES } from "../src/agent";
@@ -541,6 +543,175 @@ test("scaffold_web that writes nothing does NOT re-gate (no false 'done')", asyn
 
     expect(touched).toBe(false);
     expect(ctx.touched?.size ?? 0).toBe(0);
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+// ── P1/P2 contract regression tests (harness review: tools) ────────────────────
+
+/** A report sink that records every event, plus the ctx wired to it. */
+function collectingCtx(
+  cwd: string,
+  files: string[]
+): { ctx: ILoopCtx; events: ILoopEvent[] } {
+  const events: ILoopEvent[] = [];
+  const ctx: ILoopCtx = {
+    task: { id: "t", accept: "true", files },
+    cwd,
+    tsService: null,
+    parse: undefined,
+    report: (e) => {
+      events.push(e);
+    },
+    messages: [],
+  };
+
+  return { ctx, events };
+}
+
+/** True when the FS enforces a chmod 555 (root bypasses perms → caller skips). */
+async function permsEnforced(dir: string): Promise<boolean> {
+  try {
+    await Bun.write(join(dir, ".probe"), "x");
+    await rm(join(dir, ".probe"), { force: true });
+
+    return false;
+  } catch {
+    return true;
+  }
+}
+
+// P1: a handler that THROWS (here `create` hitting an unwritable dir → EACCES) must
+// be caught at the executeTool boundary and returned as a tool-error string — never
+// thrown into runToolCalls. The write didn't happen, so it isn't counted.
+test("a throwing create is caught (no crash), reported FAILED, and not counted", async () => {
+  const dir = await mkdtemp(join(tmpdir(), "tsforge-acct-"));
+
+  try {
+    await mkdir(join(dir, "ro"), { recursive: true });
+    await chmod(join(dir, "ro"), 0o555);
+
+    if (!(await permsEnforced(join(dir, "ro")))) {
+      return; // running as root — perms not enforced
+    }
+
+    const { ctx } = collectingCtx(dir, ["**/*"]);
+    const state = freshState();
+    const touched = await runToolCalls(
+      [
+        {
+          name: "create",
+          arguments: { file: "ro/x.ts", content: "export const x = 1;\n" },
+        },
+      ],
+      ctx,
+      state
+    );
+
+    expect(touched).toBe(false);
+    expect(state.edits).toBe(0);
+    const msg = ctx.messages.find((m) => m.role === "tool")?.content ?? "";
+
+    expect(msg).toContain("FAILED");
+    expect(await Bun.file(join(dir, "ro/x.ts")).exists()).toBe(false);
+  } finally {
+    await chmod(join(dir, "ro"), 0o755).catch(() => undefined);
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+// P1: scaffold_ui writes are ATOMIC — when a write fails the batch rolls back, so a
+// pre-existing file is left untouched, nothing is counted, and NO `mutated` event
+// fires (a half-written set must never re-gate as if it succeeded).
+test("scaffold_ui rolls back on a write failure: disk unchanged, no mutated event", async () => {
+  const dir = await mkdtemp(join(tmpdir(), "tsforge-acct-"));
+
+  try {
+    await mkdir(join(dir, "src"), { recursive: true });
+    await Bun.write(join(dir, "src/index.css"), "MARKER");
+    await chmod(join(dir, "src"), 0o555);
+
+    if (!(await permsEnforced(join(dir, "src")))) {
+      return;
+    }
+
+    const { ctx, events } = collectingCtx(dir, ["**/*"]);
+    const touched = await runToolCalls(
+      [
+        {
+          name: "scaffold_ui",
+          arguments: {
+            theme: THEME_NAMES[0],
+            components: [COMPONENT_NAMES[0]],
+          },
+        },
+      ],
+      ctx,
+      freshState()
+    );
+
+    expect(touched).toBe(false);
+    expect(events.some((e) => e.mutated !== undefined)).toBe(false);
+    expect(await Bun.file(join(dir, "src/index.css")).text()).toBe("MARKER");
+  } finally {
+    await chmod(join(dir, "src"), 0o755).catch(() => undefined);
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+// P2: scaffold_ui with nothing in the editable scope must REJECT honestly — never
+// emit the success copy that tells the model to import primitives never written.
+test("scaffold_ui out of scope rejects without the import advice", async () => {
+  const dir = await mkdtemp(join(tmpdir(), "tsforge-acct-"));
+
+  try {
+    const { ctx } = collectingCtx(dir, ["src/lib/**"]);
+    const touched = await runToolCalls(
+      [
+        {
+          name: "scaffold_ui",
+          arguments: {
+            theme: THEME_NAMES[0],
+            components: [COMPONENT_NAMES[0]],
+          },
+        },
+      ],
+      ctx,
+      freshState()
+    );
+
+    expect(touched).toBe(false);
+    const msg = ctx.messages.find((m) => m.role === "tool")?.content ?? "";
+
+    expect(msg).not.toContain("Import these from @/components/ui");
+    expect(msg.toLowerCase()).toContain("scope");
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+// add_dependency validates names offline (no network) — an invalid spec rejects and
+// nothing is written/counted.
+test("add_dependency rejects an invalid package spec and does not mutate", async () => {
+  const dir = await mkdtemp(join(tmpdir(), "tsforge-acct-"));
+
+  try {
+    await Bun.write(
+      join(dir, "package.json"),
+      JSON.stringify({ name: "t", version: "1.0.0" })
+    );
+
+    const { ctx } = collectingCtx(dir, ["**/*"]);
+    const state = freshState();
+    const touched = await runToolCalls(
+      [{ name: "add_dependency", arguments: { packages: "../evil" } }],
+      ctx,
+      state
+    );
+
+    expect(touched).toBe(false);
+    expect(state.edits).toBe(0);
   } finally {
     await rm(dir, { recursive: true, force: true });
   }


### PR DESCRIPTION
## Tools-contract hardening (harness review: `tools`)

Fixes the two **P1** contract breaks + the **P2** from the review, plus the related LSP partial-write follow-up. `bun run validate` green (1216 pass; +6 regression tests). Verified each finding against the code first.

### The breaks
1. **P1 — a handler throw escaped the loop.** `executeTool` dispatched `HANDLERS[name](...)` (line 138) with **no try/catch**, and `runToolCalls` doesn't wrap it either; `applyCreate`/scaffolds call `Bun.write` unguarded → an EACCES throw crashed the turn.
2. **P1 — partial scaffold mutations.** `scaffold_ui`/`scaffold_routes` wrote files one-by-one and emitted `mutated` only *after* the loop → a mid-loop throw left orphan files **and** no re-gate.
3. **P2 — misleading zero-write copy.** `scaffold_ui` returned "Import these from `@/components/ui`" even when `written.length === 0` (everything out of scope).

### Fixes
- **`executeTool` error boundary** — the built-in dispatch is wrapped; a throw becomes a `reject()` tool-error string (policy/MCP/unknown already return text). One choke point covers create/edit/scaffold/lsp.
- **`lib/fs` `writeFilesOrRollback`** — atomic batch write with **snapshot/restore**: on failure an *overwritten* file is restored to its prior bytes and a *new* file removed. (Corrects the original plan's blind-`rm` rollback, which would have **deleted** a pre-existing `src/index.css` — data loss.)
- **scaffolds** — plan → batch → emit `mutated` **once** on full success; reject (no import advice) when nothing's in scope or the write fails. `scaffold_routes` keeps its additive `exists()`-skip.
- **LSP `applyChanges`** (the "out of scope" follow-up — included per request) — now atomic: compute all texts, write, **restore + rethrow** on failure (covers `fixAll`/`rename`/`organizeImports`). `moveFile` is wrapped as a transaction (snapshot every touched file; on failure restore them + remove a newly-created destination).

### Tests
- `tests/fs-write.test.ts` — success path + **restore-on-failure** rollback (overwritten file restored, new file removed; root-guarded via a perms probe).
- `tool-accounting.test.ts` — throwing `create` is caught/uncounted/`FAILED`; `scaffold_ui` rollback leaves disk unchanged with **no `mutated`**; out-of-scope `scaffold_ui` rejects **without** the import advice; `add_dependency` invalid spec rejects (offline). Dropped the plan's network-dependent valid-package test per review.

### Notes
- chmod-based EACCES tests skip cleanly when run as root (perms not enforced).
- `docs/harness-subsystems.md` unchanged — the `tools` invariants these tests enforce are already listed.