### PR TITLE
feat(setup): tsforge setup — conventions onboarding wizard

### DIFF
--- a/apps/docs/astro.config.mjs
+++ b/apps/docs/astro.config.mjs
@@ -168,6 +168,7 @@ export default defineConfig({
         {
           label: "Everyday use",
           items: [
+            { label: "Set up a repo", link: "/cli/setup/" },
             { label: "Chat with your repo", link: "/cli/interactive/" },
             { label: "Drive a change to green", link: "/workflows/fix-to-green/" },
             { label: "Review your changes", link: "/cli/review/" },

--- a/apps/docs/src/content/docs/cli/setup.mdx
+++ b/apps/docs/src/content/docs/cli/setup.mdx
@@ -42,7 +42,9 @@ One choice drives both halves of the harness, so they can never disagree:
 - **The gate** stops failing your code on a convention you opted out of (choose `bare-pascal-case` and `eslint` no longer demands the `I`).
 - **The prompts** tell the model to write your style from the start, instead of writing `IFoo` and getting corrected.
 
-Setup writes `tsforge.config.json` (merged — your `mcpServers`, `plugins`, and `policy` are preserved) plus `.tsforge/setup-evidence.json` for audit. Only the choices that differ from the defaults are written, so the file stays minimal.
+Setup writes `tsforge.config.json` (merged — your `mcpServers`, `plugins`, and `policy` are preserved) plus `.tsforge/setup-evidence.json` for audit. Only the choices that differ from the defaults are written, so the file stays minimal. Re-running setup re-decides all four conventions, so the file always matches what the overview showed.
+
+Conventions govern your everyday sessions (the auto gate, the write-time linter, and the prompts). Scaffolding a brand-new app with `--web` uses tsforge's house style for the generated skeleton, regardless of `conventions` — it's greenfield code tsforge writes itself.
 
 ## Non-interactive use
 

--- a/apps/docs/src/content/docs/cli/setup.mdx
+++ b/apps/docs/src/content/docs/cli/setup.mdx
@@ -1,0 +1,51 @@
+---
+title: Set up a repo
+description: "tsforge setup — a wizard that infers your repo's conventions and writes tsforge.config.json so the guardrails match your style, without weakening the safety floor."
+---
+
+By default tsforge brings one opinion: `I`-prefixed interfaces, no enums, tests beside their source, the `src/views/` layout. That's right for a fresh project tsforge scaffolds, but an existing repo usually has its own conventions. `tsforge setup` scans your repo, shows you what it found, and writes those preferences into `tsforge.config.json` so tsforge adapts to your style instead of imposing its own.
+
+```bash
+tsforge setup          # the interactive wizard
+tsforge setup --yes    # write the scan's recommendations, no prompts
+```
+
+Inside a session, the same wizard is available as `/setup`. tsforge never runs it for you — if a repo has no config, you'll just see a one-line hint suggesting it.
+
+## What it can change — and what it can't
+
+There are two kinds of rules, and setup only touches one of them.
+
+**The safety floor is never negotiable.** No `any`, no `as`/`<>` casts, no non-null `!`, `===`, no `var`, the complexity cap — these catch real bugs and unsafe code. The wizard physically cannot turn them off, and a hand-edited config can't either.
+
+**Conventions are taste**, and these are what setup adapts:
+
+| Convention | Choices |
+| --- | --- |
+| `interfaces` | `i-prefix` · `bare-pascal-case` · `off` |
+| `enums` | `ban` · `allow` |
+| `tests` | `co-located` · `mirrored` · `either` |
+| `componentFolders` | `tsforge-views` · `repo` · `warn` |
+
+Allowing enums removes only the enum ban — the separate `as`-cast ban stays intact. Relaxing a convention never relaxes safety.
+
+## How the wizard works
+
+Each step shows the evidence the scan found (e.g. "300 bare PascalCase, 12 I-prefixed"), the recommended choice, and exactly which config field it sets. Arrow keys to move, Enter to choose, `b` to go back, `q` to cancel. A final overview shows the exact `tsforge.config.json` fragment that will be written — **nothing is written until you Apply**, and Cancel writes nothing.
+
+The scan is read-only: it parses your TypeScript via the compiler's AST and never executes your `eslint.config.*`, `prettier.config.*`, or any project JavaScript.
+
+## Where the choices take effect
+
+One choice drives both halves of the harness, so they can never disagree:
+
+- **The gate** stops failing your code on a convention you opted out of (choose `bare-pascal-case` and `eslint` no longer demands the `I`).
+- **The prompts** tell the model to write your style from the start, instead of writing `IFoo` and getting corrected.
+
+Setup writes `tsforge.config.json` (merged — your `mcpServers`, `plugins`, and `policy` are preserved) plus `.tsforge/setup-evidence.json` for audit. Only the choices that differ from the defaults are written, so the file stays minimal.
+
+## Non-interactive use
+
+Outside a terminal, `tsforge setup` prints the scan and the proposed config and writes nothing — re-run it in a terminal, or pass `--yes` to write the recommendations. If an existing `tsforge.config.json` is invalid JSON, setup refuses to overwrite it and tells you to fix it first.
+
+→ [tsforge.config.json](/guardrails/config/) · [Commands](/reference/commands/) · [Map the repo](/cli/map/)

--- a/apps/docs/src/content/docs/guardrails/config.mdx
+++ b/apps/docs/src/content/docs/guardrails/config.mdx
@@ -16,6 +16,7 @@ Add **`tsforge.config.json`** at your repo root when you want to override what t
 | `packs.include` | string[] | Add packs after detection |
 | `packs.exclude` | string[] | Remove packs after detection |
 | `rules` | object | Per-rule severity: `"error"`, `"warn"`, or `"off"` (overrides profile defaults) |
+| `conventions` | object | Project taste tsforge adapts to: `interfaces`, `enums`, `tests`, `componentFolders` — written by [`tsforge setup`](/cli/setup/) |
 | `plugins` | object[] | External modules providing extra rule packs (see below) |
 | `mcpServers` | object | External [MCP servers](/integrations/mcp/) whose tools the agent can call |
 

--- a/apps/docs/src/content/docs/reference/commands.mdx
+++ b/apps/docs/src/content/docs/reference/commands.mdx
@@ -21,6 +21,15 @@ bun run tsforge
 
 Environment variables: [Environment variables](/reference/flags/). Interactive usage: [Interactive CLI](/cli/interactive/).
 
+## Set up a repo
+
+```bash
+tsforge setup          # the interactive conventions wizard
+tsforge setup --yes    # write the scan's recommendations, no prompts
+```
+
+`tsforge setup` (or `/setup` in a session) scans the repo and writes a `conventions` block to `tsforge.config.json` so the guardrails match your repo's taste — interface naming, enums, test layout, component folders. It never weakens the safety floor (no `any`/`as`/`!`, complexity cap, `===`), and writes nothing until you Apply. Outside a terminal it prints the proposal and writes nothing unless you pass `--yes`. See [Set up a repo](/cli/setup/).
+
 ## Review the change you're on
 
 ```bash

--- a/docs/harness-subsystems.md
+++ b/docs/harness-subsystems.md
@@ -130,6 +130,48 @@ Vite/React/vanilla templates, the vendored guard, the web gate.
 **Invariants** only `*.gen.ts`/vendored shells are write-guard-exempt; scaffold is
 non-destructive (only missing files); a scaffold reports its writes (re-gate).
 
+## setup / conventions — `src/infer-rules/*`, `src/setup/*`, `src/render/wizard.ts`, the bundled `.mjs` configs
+
+`tsforge setup` infers a repo's conventions (interface naming, enums, test layout,
+component folders) and writes them to `tsforge.config.json`. The contract is that
+conventions are **taste only** and a single source drives BOTH enforcement and
+guidance, so the gate and the prompts can never disagree.
+
+**Invariants**
+- The safety floor (no `any`/`as`/`!`, complexity cap, `eqeqeq`, `no-var`,
+  `prefer-const`) can NEVER be relaxed through `conventions` OR `TSFORGE_RULE_OVERRIDES`,
+  on either bundled surface — enforced by `PROTECTED_BUNDLED_RULES` +
+  `applyBundledOverrides`, surface-aware (only protects a rule the surface already has).
+- Allowing enums removes ONLY the enum selector; the `as`/`<>` cast bans stay.
+- A DEFAULT convention set emits no `TSFORGE_CONVENTIONS` and the `.mjs` fallback equals
+  the old hardcoded rules — a default project is byte-identical to pre-feature.
+- A failed import of the convention builder inside a `.mjs` falls back to the hardcoded
+  house-style rules (never silently drops the enum/cast/naming bans).
+- The gate (`TSFORGE_CONVENTIONS` env via `packEnvPrefix`) and the write-time linter
+  (`makeFileLinter` overrideConfig) resolve the SAME conventions.
+- The wizard writes nothing until Apply; cancel/back writes nothing; the interactive
+  driver restores keypress listeners + cursor on every exit path (no terminal wedge).
+- The writer preserves unrelated config keys; the conventions block is wholly
+  setup-owned (a re-run replaces it, or removes it when all choices are default).
+- The scanner is read-only (TS AST only) and never executes a target's config; bounded
+  by MAX_FILES/MAX_BYTES.
+
+**Scope note (deliberate, documented)** Conventions govern the CORE/brownfield path
+(auto gate + `buildSystemPrompt`/chat/TDD + write-time linter). The `--web` SCAFFOLD
+path (`buildWebGate`/`configureWeb` + `REACT_GUIDANCE`/`webGuidance`/`BUILD_PREAMBLE`)
+intentionally uses tsforge's house style — it's greenfield, and its gate + guidance are
+consistent with each other. The eval-sweep agent (`src/agent/model-agent.ts`) also still
+carries house-style guidance (eval-only path). Both are tracked follow-ups, not bugs.
+
+**Risk areas** an override key slipping past the protected set; a `.mjs` rebuild that
+drops a ban; the gate honoring a convention the prompt contradicts; a wizard exit path
+that leaks keypress listeners.
+
+**Checklist** `tests/eslint-conventions.test.ts` (guard + split), `tests/gate-conventions.test.ts`
+(real spawned gate), `tests/prompt-conventions.test.ts` (no stale I-prefix),
+`tests/wizard.test.ts` (reducer/render/lifecycle), `tests/write-config.test.ts` (merge),
+`tests/scan.test.ts` (read-only + caps).
+
 ## lib/fs — `src/lib/fs/process.ts`, fs helpers, `src/lib/scope.ts`
 
 The ONE shared command runner; path normalization; scope checks.

--- a/packages/core/src/cli.ts
+++ b/packages/core/src/cli.ts
@@ -653,6 +653,11 @@ async function baseGate(
   }
 
   if (args.web) {
+    // The --web SCAFFOLD path is greenfield: tsforge writes the skeleton in its
+    // own house style, so the web gate + web guidance deliberately stay on the
+    // defaults and do NOT thread project `conventions` (which govern the core
+    // brownfield path). Keeping both on house style avoids a gate/guidance
+    // contradiction. See docs/harness-subsystems.md "setup / conventions".
     const web = buildWebGate("react", undefined, args.dir);
 
     // PER-WRITE lint moat: the web gate's eslint rules applied to each file as the

--- a/packages/core/src/cli.ts
+++ b/packages/core/src/cli.ts
@@ -1,6 +1,6 @@
 #!/usr/bin/env bun
 import { join, isAbsolute } from "node:path";
-import { mkdirSync } from "node:fs";
+import { mkdirSync, existsSync } from "node:fs";
 import { readdir } from "node:fs/promises";
 import { Writable } from "node:stream";
 import { createInterface } from "node:readline/promises";
@@ -712,6 +712,19 @@ async function baseGate(
   };
 }
 
+/** One-line nudge when the repo has no config yet — setup adapts the guardrails
+ *  to this repo's conventions. Just a hint; never auto-runs. */
+function maybePrintNoConfigHint(
+  dir: string,
+  resumed: ISessionRecord | null
+): void {
+  if (resumed === null && !existsSync(join(dir, "tsforge.config.json"))) {
+    process.stdout.write(
+      "No project config. Run tsforge setup (or /setup) to adapt guardrails to this repo.\n"
+    );
+  }
+}
+
 /** Interactive REPL: a persistent gate-anchored conversation. */
 async function repl(args: ICliArgs): Promise<number> {
   // The active model comes from the registry (~/.tsforge/models.json) unless a
@@ -858,6 +871,8 @@ async function repl(args: ICliArgs): Promise<number> {
     model: modelInfo(provider.config),
     updateNotice,
   });
+
+  maybePrintNoConfigHint(args.dir, resumed);
 
   // Pin an editable input row only on a real TTY tall enough to host the bar.
   // In that mode readline does line-EDITING but must not RENDER (we paint the
@@ -1183,6 +1198,20 @@ async function repl(args: ICliArgs): Promise<number> {
       case "trace":
         await runTraceCommand(arg, logFile);
         break;
+
+      case "setup": {
+        const { runSetup } = await import("./setup/run-setup");
+
+        await runSetup({
+          cwd: args.dir,
+          yes: false,
+          color: process.stdout.isTTY,
+        });
+        process.stdout.write(
+          "(conventions written — they apply to the next session)\n"
+        );
+        break;
+      }
 
       case "files": {
         const globs = arg
@@ -1697,6 +1726,18 @@ async function mapMode(args: ICliArgs): Promise<number> {
   return 0;
 }
 
+/** `tsforge setup` — the onboarding wizard that infers + writes project
+ *  conventions. `--yes` writes the recommendations non-interactively. */
+async function setupMode(args: ICliArgs): Promise<number> {
+  const { runSetup } = await import("./setup/run-setup");
+
+  return runSetup({
+    cwd: args.dir,
+    yes: args.setupYes,
+    color: process.stdout.isTTY,
+  });
+}
+
 /** `tsforge recipes` — list the recipes discovered for this repo. */
 async function recipesMode(args: ICliArgs): Promise<number> {
   const recipes = await loadRecipes(args.dir, (m) =>
@@ -1849,6 +1890,10 @@ export async function main(): Promise<number> {
 
   if (args.trace) {
     return traceMode(args);
+  }
+
+  if (args.setup) {
+    return setupMode(args);
   }
 
   // A positional task with a scope + gate ⇒ one-shot; otherwise interactive.

--- a/packages/core/src/cli.ts
+++ b/packages/core/src/cli.ts
@@ -1207,14 +1207,13 @@ async function repl(args: ICliArgs): Promise<number> {
       case "setup": {
         const { runSetup } = await import("./setup/run-setup");
 
+        // runSetup prints its own apply/cancel summary — don't add a second,
+        // possibly-misleading line (it would claim success even on cancel).
         await runSetup({
           cwd: args.dir,
           yes: false,
           color: process.stdout.isTTY,
         });
-        process.stdout.write(
-          "(conventions written — they apply to the next session)\n"
-        );
         break;
       }
 

--- a/packages/core/src/cli.ts
+++ b/packages/core/src/cli.ts
@@ -676,12 +676,14 @@ async function baseGate(
     normalizeRuleOverrides,
     resolveProjectProfile,
   } = await import("./config/tsforge-config");
+  const { resolveConventions } = await import("./infer-rules/conventions");
 
   const stackProfile = await detectStack(args.dir);
   const config = await loadTsforgeConfig(args.dir);
   const activePacks = resolveActivePacks(stackProfile.packs, config);
   const ruleOverrides = normalizeRuleOverrides(config);
   const profile = resolveProjectProfile(config);
+  const conventions = resolveConventions(config.conventions);
 
   const auto = await buildGate(
     args.dir,
@@ -693,6 +695,7 @@ async function baseGate(
       // not just that it type-checks and lints. discoverTestCommand appends them
       // only when the project actually has tests; --strict-floor-only opts out.
       includeTests: !args.strictFloorOnly,
+      conventions,
     }
   );
 
@@ -703,7 +706,8 @@ async function baseGate(
       "core",
       args.dir,
       activePacks,
-      Object.keys(ruleOverrides).length > 0 ? ruleOverrides : undefined
+      Object.keys(ruleOverrides).length > 0 ? ruleOverrides : undefined,
+      conventions
     ),
   };
 }

--- a/packages/core/src/cli/args.ts
+++ b/packages/core/src/cli/args.ts
@@ -64,6 +64,12 @@ export interface ICliArgs {
   /** Base policy mode (`--policy-mode <plan|default|acceptEdits|ci|dontAsk|
    *  bypassPermissions>`); overrides the config file's policy.mode. */
   policyMode: string;
+  /** Run the onboarding wizard that infers + writes project conventions
+   *  (`tsforge setup`). */
+  setup: boolean;
+  /** Write the scan's recommended conventions non-interactively (`tsforge setup
+   *  --yes`). */
+  setupYes: boolean;
 }
 
 const BOOL_FLAGS: Record<
@@ -77,6 +83,7 @@ const BOOL_FLAGS: Record<
   | "staged"
   | "withGate"
   | "scout"
+  | "setupYes"
 > = {
   "--continue": "continue",
   "-c": "continue",
@@ -88,6 +95,7 @@ const BOOL_FLAGS: Record<
   "--staged": "staged",
   "--with-gate": "withGate",
   "--scout": "scout",
+  "--yes": "setupYes",
 };
 
 const VALUE_FLAGS = new Set([
@@ -132,6 +140,8 @@ export function parseArgs(argv: readonly string[]): ICliArgs {
     maxTurns: 0,
     thinkingBudget: 0,
     policyMode: "",
+    setup: false,
+    setupYes: false,
   };
 
   for (let i = 0; i < argv.length; i += 1) {
@@ -168,6 +178,8 @@ export function parseArgs(argv: readonly string[]): ICliArgs {
     out.task = positional.slice(1).join(" ").trim();
   } else if (positional[0] === "recipes") {
     out.recipes = true;
+  } else if (positional[0] === "setup") {
+    out.setup = true;
   } else if (positional[0] === "run") {
     out.run = true;
     out.recipe = positional[1] ?? "";

--- a/packages/core/src/cli/commands.ts
+++ b/packages/core/src/cli/commands.ts
@@ -69,6 +69,10 @@ export const COMMANDS: readonly ICommandSpec[] = [
     arg: "[forget]",
     summary: "show learned failure→fix lessons (forget to clear)",
   },
+  {
+    name: "/setup",
+    summary: "infer + write project conventions (the setup wizard)",
+  },
   { name: "/exit", summary: "leave the session" },
 ] as const;
 

--- a/packages/core/src/config/tsforge-config.ts
+++ b/packages/core/src/config/tsforge-config.ts
@@ -10,6 +10,13 @@ import {
   type IPolicyRule,
   type IPolicyRules,
 } from "../policy";
+import {
+  isComponentFoldersConvention,
+  isEnumConvention,
+  isInterfaceConvention,
+  isTestConvention,
+} from "../infer-rules/conventions";
+import type { IConventions } from "../infer-rules/conventions.types";
 import { parsePlugins, type IExternalPlugin } from "./external-plugins";
 import {
   DEFAULT_PROFILE,
@@ -69,6 +76,15 @@ export interface ITsforgeProjectConfig {
     readonly mode?: PolicyMode;
     readonly rules?: IPolicyRules;
   };
+
+  /**
+   * Project conventions inferred by `tsforge setup` — TASTE only (interface
+   * naming, enums, test layout, component folders). Each field tunes a stylistic
+   * rule; unset fields fall back to tsforge's house defaults. These can NEVER
+   * relax the safety floor (no `any`/`as`/`!`, complexity, etc.). Opt-in: absent
+   * ⇒ tsforge's default house style.
+   */
+  readonly conventions?: Readonly<Partial<IConventions>>;
 }
 
 function warnConfig(msg: string): void {
@@ -105,6 +121,18 @@ function warnInvalidRuleSeverity(key: string, value: unknown): void {
   const msg = `tsforge.config.json: rule "${key}" severity must be "error", "warn", or "off", got "${String(value)}"`;
 
   warnConfig(msg);
+}
+
+function warnInvalidConventionsType(value: unknown): void {
+  warnConfig(
+    `tsforge.config.json: "conventions" must be an object, got ${typeof value}`
+  );
+}
+
+function warnInvalidConvention(key: string, value: unknown): void {
+  warnConfig(
+    `tsforge.config.json: conventions.${key} has invalid value "${String(value)}" (ignored)`
+  );
 }
 
 function warnInvalidJsonRoot(rootValue: unknown): void {
@@ -227,6 +255,55 @@ function validateRules(
   }
 
   return Object.keys(rulesFields).length > 0 ? rulesFields : undefined;
+}
+
+/** Validate the `conventions` block — warn-and-drop per sub-field. Each field is
+ *  optional taste (interface naming, enums, test layout, component folders); an
+ *  invalid value is warned and dropped so the resolved default applies. */
+function validateConventions(
+  parsed: unknown
+): Readonly<Partial<IConventions>> | undefined {
+  if (!isRecord(parsed)) {
+    warnInvalidConventionsType(parsed);
+
+    return undefined;
+  }
+
+  const out: { -readonly [K in keyof IConventions]?: IConventions[K] } = {};
+
+  if (parsed.interfaces !== undefined) {
+    if (isInterfaceConvention(parsed.interfaces)) {
+      out.interfaces = parsed.interfaces;
+    } else {
+      warnInvalidConvention("interfaces", parsed.interfaces);
+    }
+  }
+
+  if (parsed.enums !== undefined) {
+    if (isEnumConvention(parsed.enums)) {
+      out.enums = parsed.enums;
+    } else {
+      warnInvalidConvention("enums", parsed.enums);
+    }
+  }
+
+  if (parsed.tests !== undefined) {
+    if (isTestConvention(parsed.tests)) {
+      out.tests = parsed.tests;
+    } else {
+      warnInvalidConvention("tests", parsed.tests);
+    }
+  }
+
+  if (parsed.componentFolders !== undefined) {
+    if (isComponentFoldersConvention(parsed.componentFolders)) {
+      out.componentFolders = parsed.componentFolders;
+    } else {
+      warnInvalidConvention("componentFolders", parsed.componentFolders);
+    }
+  }
+
+  return Object.keys(out).length > 0 ? out : undefined;
 }
 
 /** Validate each known field of an already-parsed config object, dropping any
@@ -372,6 +449,24 @@ function assignPolicy(
   }
 }
 
+/** Validate + assign the optional `conventions` block (kept off
+ *  `buildConfigFields` so its per-field branches don't push it over the
+ *  complexity cap — mirrors `assignPolicy`). */
+function assignConventions(
+  parsed: Record<string, unknown>,
+  configFields: { conventions?: Readonly<Partial<IConventions>> }
+): void {
+  if (parsed.conventions === undefined) {
+    return;
+  }
+
+  const conventions = validateConventions(parsed.conventions);
+
+  if (conventions !== undefined) {
+    configFields.conventions = conventions;
+  }
+}
+
 function buildConfigFields(
   parsed: Record<string, unknown>
 ): ITsforgeProjectConfig {
@@ -383,6 +478,7 @@ function buildConfigFields(
     mcpServers?: Record<string, IMcpServerConfig>;
     plugins?: readonly IExternalPlugin[];
     policy?: { mode?: PolicyMode; rules?: IPolicyRules };
+    conventions?: Readonly<Partial<IConventions>>;
   } = {};
 
   if (parsed.profile !== undefined) {
@@ -434,6 +530,7 @@ function buildConfigFields(
   }
 
   assignPolicy(parsed, configFields);
+  assignConventions(parsed, configFields);
 
   return configFields;
 }

--- a/packages/core/src/constitution/baseline.ts
+++ b/packages/core/src/constitution/baseline.ts
@@ -46,6 +46,15 @@ const PRETTIER = `{
 }
 `;
 
+// This is the BROWNFIELD floor written into a target repo's own eslint.config.js
+// (a serialized source string, not an in-memory config). Its interface-naming +
+// no-enum rules below encode the DEFAULT conventions (I-prefix, enum ban) — the
+// same values infer-rules/conventions DEFAULT_CONVENTIONS produces. The live gate,
+// the write-time linter, and the prompts read project conventions DYNAMICALLY
+// (TSFORGE_CONVENTIONS); this brought floor intentionally uses the defaults for
+// V1 (per the setup plan: honoring per-repo conventions here is secondary to a
+// drift-free runtime). Changing DEFAULT_CONVENTIONS trips the conventions tests,
+// which is the reminder to revisit this block.
 const ESLINT = `import pluginJs from "@eslint/js";
 import tseslint from "typescript-eslint";
 import configPrettier from "eslint-config-prettier";

--- a/packages/core/src/detect-gate.ts
+++ b/packages/core/src/detect-gate.ts
@@ -4,6 +4,11 @@ import { ESLint } from "eslint";
 import { WEB_TEMPLATES, type WebFramework } from "./web-templates";
 import { isRecord } from "./lib/guards";
 import { runArgvCommand } from "./lib/fs/process";
+import {
+  conventionOverrideRules,
+  conventionsEnvValue,
+} from "./infer-rules/eslint-conventions";
+import type { IConventions } from "./infer-rules/conventions.types";
 
 /** Hard ceiling for `bun install` during web scaffolding (5 min) — long enough for
  *  a cold registry, short enough that a wedged install can't hang the session. */
@@ -299,7 +304,8 @@ export function makeFileLinter(
   framework: WebFramework | "core",
   cwd: string,
   packIds?: readonly string[],
-  ruleOverrides?: Readonly<Record<string, "error" | "warn" | "off">>
+  ruleOverrides?: Readonly<Record<string, "error" | "warn" | "off">>,
+  conventions?: IConventions
 ): FileLinter {
   const overrideConfigFile =
     framework === "core" ? STRICT_CONFIG : STRICT_WEB_CONFIG;
@@ -324,6 +330,25 @@ export function makeFileLinter(
         // Add ignores config if needed
         if (ignores.length > 0) {
           eOpts.overrideConfig = [{ ignores }];
+        }
+
+        // Conventions OVERRIDE the bundled config's naming/no-restricted-syntax in
+        // process — so write-time feedback matches the gate (which gets the same
+        // choice via TSFORGE_CONVENTIONS). A disabled rule is set "off" here, not
+        // omitted, so it actually disables the bundled copy.
+        if (conventions !== undefined) {
+          const convConfig: Record<string, unknown> = {
+            files: ["**/*.ts", "**/*.tsx"],
+            rules: conventionOverrideRules(
+              conventions,
+              framework === "core" ? "core" : "web"
+            ),
+          };
+
+          eOpts.overrideConfig =
+            eOpts.overrideConfig !== undefined
+              ? [...eOpts.overrideConfig, convConfig]
+              : [convConfig];
         }
 
         // Add pack rules if provided
@@ -527,7 +552,8 @@ function shSingleQuote(value: string): string {
  *  bundled eslint config, which reads them from the environment at load time. */
 function packEnvPrefix(
   packs?: readonly string[],
-  ruleOverrides?: Readonly<Record<string, "error" | "warn" | "off">>
+  ruleOverrides?: Readonly<Record<string, "error" | "warn" | "off">>,
+  conventions?: IConventions
 ): string {
   const envParts: string[] = [];
 
@@ -541,13 +567,21 @@ function packEnvPrefix(
     );
   }
 
+  const conv = conventionsEnvValue(conventions);
+
+  if (conv !== undefined) {
+    envParts.push(`TSFORGE_CONVENTIONS=${shSingleQuote(conv)}`);
+  }
+
   return envParts.length > 0 ? `${envParts.join(" ")} ` : "";
 }
 
 export function buildWebGate(
   framework: WebFramework,
   packs: readonly string[] = WEB_PACKS,
-  cwd: string = process.cwd()
+  cwd: string = process.cwd(),
+  ruleOverrides?: Readonly<Record<string, "error" | "warn" | "off">>,
+  conventions?: IConventions
 ): IGate {
   const template = WEB_TEMPLATES[framework];
   const ignores = template.eslintIgnore
@@ -556,7 +590,7 @@ export function buildWebGate(
   const build = `bun run build`;
   const tsc = `"${TSC_BIN}" --noEmit -p ${ensureWebGateTsconfig(cwd)}`;
   const lint =
-    `${packEnvPrefix(packs)}bun "${ESLINT_BIN}" --no-config-lookup -c "${STRICT_WEB_CONFIG}" ${ignores} --format json .`.replace(
+    `${packEnvPrefix(packs, ruleOverrides, conventions)}bun "${ESLINT_BIN}" --no-config-lookup -c "${STRICT_WEB_CONFIG}" ${ignores} --format json .`.replace(
       /\s+/g,
       " "
     );
@@ -755,7 +789,11 @@ export async function buildGate(
   cwd: string,
   packs?: readonly string[],
   ruleOverrides?: Readonly<Record<string, "error" | "warn" | "off">>,
-  options?: { enableTypeAware?: boolean; includeTests?: boolean }
+  options?: {
+    enableTypeAware?: boolean;
+    includeTests?: boolean;
+    conventions?: IConventions;
+  }
 ): Promise<IGate> {
   const parts: string[] = [];
   const labels: string[] = [];
@@ -767,7 +805,7 @@ export async function buildGate(
     labels.push("tsc --strict");
   }
 
-  const lint = lintPart(packs, ruleOverrides);
+  const lint = lintPart(packs, ruleOverrides, options?.conventions);
 
   parts.push(lint.command);
   labels.push(lint.label);
@@ -946,10 +984,11 @@ async function ignoreGateArtifact(cwd: string): Promise<void> {
  *  overrides are passed via TSFORGE_RULE_OVERRIDES (JSON-encoded map). */
 function lintPart(
   packs?: readonly string[],
-  ruleOverrides?: Readonly<Record<string, "error" | "warn" | "off">>
+  ruleOverrides?: Readonly<Record<string, "error" | "warn" | "off">>,
+  conventions?: IConventions
 ): IGate {
   return {
-    command: `${packEnvPrefix(packs, ruleOverrides)}bun "${ESLINT_BIN}" --no-config-lookup -c "${STRICT_CONFIG}" --format json .`,
+    command: `${packEnvPrefix(packs, ruleOverrides, conventions)}bun "${ESLINT_BIN}" --no-config-lookup -c "${STRICT_CONFIG}" --format json .`,
     label: "strict TypeScript (tsforge)",
   };
 }

--- a/packages/core/src/infer-rules/conventions.ts
+++ b/packages/core/src/infer-rules/conventions.ts
@@ -65,3 +65,15 @@ export function resolveConventions(
 ): IConventions {
   return { ...DEFAULT_CONVENTIONS, ...partial };
 }
+
+/** True when every field equals the house default — used to SKIP emitting the
+ *  `TSFORGE_CONVENTIONS` env/override, so a default project's gate command and
+ *  prompts are byte-identical to before this feature existed. */
+export function isDefaultConventions(conventions: IConventions): boolean {
+  return (
+    conventions.interfaces === DEFAULT_CONVENTIONS.interfaces &&
+    conventions.enums === DEFAULT_CONVENTIONS.enums &&
+    conventions.tests === DEFAULT_CONVENTIONS.tests &&
+    conventions.componentFolders === DEFAULT_CONVENTIONS.componentFolders
+  );
+}

--- a/packages/core/src/infer-rules/conventions.ts
+++ b/packages/core/src/infer-rules/conventions.ts
@@ -1,0 +1,67 @@
+import type {
+  ComponentFoldersConvention,
+  EnumConvention,
+  IConventions,
+  InterfaceConvention,
+  TestConvention,
+} from "./conventions.types";
+
+/** Allowed values per field — the single source for validation AND wizard menus. */
+export const INTERFACE_CONVENTIONS = [
+  "i-prefix",
+  "bare-pascal-case",
+  "off",
+] as const;
+export const ENUM_CONVENTIONS = ["ban", "allow"] as const;
+export const TEST_CONVENTIONS = ["co-located", "mirrored", "either"] as const;
+export const COMPONENT_FOLDER_CONVENTIONS = [
+  "tsforge-views",
+  "repo",
+  "warn",
+] as const;
+
+/**
+ * The defaults that REPRODUCE tsforge's current house style exactly, so a repo
+ * with no `conventions` block behaves identically to before this feature:
+ * I-prefixed interfaces, enums banned, the React `src/views/` layout. `tests` is
+ * `either` because the test-sibling gate already accepts both a co-located sibling
+ * and a `tests/` mirror — defaulting to a single layout would TIGHTEN the gate.
+ */
+export const DEFAULT_CONVENTIONS: IConventions = {
+  interfaces: "i-prefix",
+  enums: "ban",
+  tests: "either",
+  componentFolders: "tsforge-views",
+};
+
+const INTERFACE_SET = new Set<string>(INTERFACE_CONVENTIONS);
+const ENUM_SET = new Set<string>(ENUM_CONVENTIONS);
+const TEST_SET = new Set<string>(TEST_CONVENTIONS);
+const COMPONENT_FOLDER_SET = new Set<string>(COMPONENT_FOLDER_CONVENTIONS);
+
+export function isInterfaceConvention(v: unknown): v is InterfaceConvention {
+  return typeof v === "string" && INTERFACE_SET.has(v);
+}
+
+export function isEnumConvention(v: unknown): v is EnumConvention {
+  return typeof v === "string" && ENUM_SET.has(v);
+}
+
+export function isTestConvention(v: unknown): v is TestConvention {
+  return typeof v === "string" && TEST_SET.has(v);
+}
+
+export function isComponentFoldersConvention(
+  v: unknown
+): v is ComponentFoldersConvention {
+  return typeof v === "string" && COMPONENT_FOLDER_SET.has(v);
+}
+
+/** Fill any unset field from {@link DEFAULT_CONVENTIONS}, yielding a fully-decided
+ *  set. This is THE function every consumer (gate, linter, prompts) calls so they
+ *  all agree on the same resolved choices. */
+export function resolveConventions(
+  partial: Readonly<Partial<IConventions>> | undefined
+): IConventions {
+  return { ...DEFAULT_CONVENTIONS, ...partial };
+}

--- a/packages/core/src/infer-rules/conventions.types.ts
+++ b/packages/core/src/infer-rules/conventions.types.ts
@@ -1,0 +1,34 @@
+/**
+ * The four convention choices `tsforge setup` infers from a repo and writes to
+ * `tsforge.config.json`. These are TASTE, not safety: each governs a stylistic
+ * rule that has no single right answer (interface naming, enums, test layout,
+ * component folders). The safety floor (`no any`/`as`/`!`, complexity, etc.) is
+ * NEVER expressed here and can never be relaxed through conventions.
+ *
+ * One resolved `IConventions` object is the single source every surface reads —
+ * the gate (eslint rule OPTIONS), the write-time linter, and every prompt — so a
+ * choice like "bare PascalCase" can never disagree between what the model is told
+ * and what the gate enforces.
+ */
+
+/** How interface names are enforced: `IUser` / `User` / no enforcement. */
+export type InterfaceConvention = "i-prefix" | "bare-pascal-case" | "off";
+
+/** Whether `enum` declarations are banned (use `as const`) or allowed. Banning
+ *  enums NEVER affects the separate `as`-cast ban — they are split deliberately. */
+export type EnumConvention = "ban" | "allow";
+
+/** Where a logic file's test lives: beside it, in a `tests/` mirror, or either. */
+export type TestConvention = "co-located" | "mirrored" | "either";
+
+/** Frontend component layout: tsforge's `src/views/<Feature>/`, the repo's own
+ *  layout, or warn-only. */
+export type ComponentFoldersConvention = "tsforge-views" | "repo" | "warn";
+
+/** The fully-resolved convention set (every field decided — defaults applied). */
+export interface IConventions {
+  readonly interfaces: InterfaceConvention;
+  readonly enums: EnumConvention;
+  readonly tests: TestConvention;
+  readonly componentFolders: ComponentFoldersConvention;
+}

--- a/packages/core/src/infer-rules/eslint-conventions.ts
+++ b/packages/core/src/infer-rules/eslint-conventions.ts
@@ -1,0 +1,195 @@
+import { resolveConventions } from "./conventions";
+import type { IConventions } from "./conventions.types";
+import type {
+  EslintSurface,
+  IConventionRuleEntries,
+  RuleEntry,
+  RuleSeverity,
+} from "./eslint-conventions.types";
+import { isRecord } from "../lib/guards";
+
+/**
+ * The single builder that turns resolved {@link IConventions} into the ESLint rule
+ * OPTIONS the bundled `.mjs` configs (and the brought constitution) splice in. This
+ * is why "bare PascalCase" or "allow enums" can be expressed at all: `applyOverrides`
+ * (rule-packs) is severity-only and CANNOT rewrite a rule's options — only this
+ * builder can. Every gate surface calls it, so the gate, the write-time linter, and
+ * the brought constitution can never disagree on what a convention means.
+ *
+ * SAFETY IS STRUCTURAL HERE: the `as`/`<>` cast bans on the web surface live inside
+ * `no-restricted-syntax`, and this builder ALWAYS emits them regardless of the enum
+ * choice — so "allow enums" can never remove a cast ban. The core surface bans casts
+ * via the separate `consistent-type-assertions` rule, which this builder never touches.
+ */
+
+// Exact messages preserved from the bundled configs so gate output is unchanged.
+const ENUM_MESSAGE = "Use 'as const' object literals instead of enums.";
+const AS_CAST_MESSAGE =
+  "No `as` type casts — type it properly (annotate, narrow, or guard). `as const` is allowed.";
+const ANGLE_CAST_MESSAGE =
+  "No angle-bracket type assertions — type it properly. `as const` is allowed.";
+
+// The value-changing cast selectors — SAFETY, always on the web surface.
+const CAST_SELECTORS: readonly unknown[] = [
+  {
+    selector: "TSAsExpression[typeAnnotation.typeName.name!='const']",
+    message: AS_CAST_MESSAGE,
+  },
+  { selector: "TSTypeAssertion", message: ANGLE_CAST_MESSAGE },
+];
+
+const ENUM_SELECTOR = { selector: "TSEnumDeclaration", message: ENUM_MESSAGE };
+
+/** Build the `@typescript-eslint/naming-convention` entry, or undefined to omit it
+ *  (interface naming "off"). The web surface exempts library-mandated `Register`. */
+function namingRule(
+  conventions: IConventions,
+  surface: EslintSurface
+): RuleEntry | undefined {
+  if (conventions.interfaces === "off") {
+    return undefined;
+  }
+
+  const selector: Record<string, unknown> = {
+    selector: "interface",
+    format: ["PascalCase"],
+  };
+
+  if (conventions.interfaces === "i-prefix") {
+    selector.prefix = ["I"];
+  }
+
+  if (surface === "web") {
+    selector.filter = { regex: "^(Register)$", match: false };
+  }
+
+  return ["error", selector];
+}
+
+/** Build the `no-restricted-syntax` entry, or undefined to omit it. Enum ban is the
+ *  taste part; the web cast selectors are the SAFETY part and are always included. */
+function noRestrictedSyntaxRule(
+  conventions: IConventions,
+  surface: EslintSurface
+): RuleEntry | undefined {
+  const selectors: unknown[] = [];
+
+  if (conventions.enums === "ban") {
+    selectors.push(ENUM_SELECTOR);
+  }
+
+  if (surface === "web") {
+    selectors.push(...CAST_SELECTORS);
+  }
+
+  if (selectors.length === 0) {
+    return undefined;
+  }
+
+  return ["error", ...selectors];
+}
+
+/** The two convention-managed rule entries for a surface — keys present only when
+ *  the convention keeps that rule on. The bundled config must NOT carry its own
+ *  hardcoded `naming-convention`/`no-restricted-syntax`; it splices these instead. */
+export function conventionRuleEntries(
+  conventions: IConventions,
+  surface: EslintSurface
+): IConventionRuleEntries {
+  const entries: {
+    "@typescript-eslint/naming-convention"?: RuleEntry;
+    "no-restricted-syntax"?: RuleEntry;
+  } = {};
+
+  const naming = namingRule(conventions, surface);
+
+  if (naming !== undefined) {
+    entries["@typescript-eslint/naming-convention"] = naming;
+  }
+
+  const nrs = noRestrictedSyntaxRule(conventions, surface);
+
+  if (nrs !== undefined) {
+    entries["no-restricted-syntax"] = nrs;
+  }
+
+  return entries;
+}
+
+/** Parse the JSON `TSFORGE_CONVENTIONS` env channel into a fully-resolved set,
+ *  tolerating junk (any unset/invalid field falls back to the house default). */
+export function parseConventionsEnv(raw: string | undefined): IConventions {
+  if (raw === undefined || raw.length === 0) {
+    return resolveConventions(undefined);
+  }
+
+  try {
+    const parsed: unknown = JSON.parse(raw);
+
+    return resolveConventions(isRecord(parsed) ? parsed : undefined);
+  } catch {
+    return resolveConventions(undefined);
+  }
+}
+
+/**
+ * Bundled safety/convention rules that the severity channel (`TSFORGE_RULE_OVERRIDES`)
+ * may NEVER weaken or disable. Two groups, one guarantee — overrides can't touch them:
+ *  • Safety floor: real-bug catchers (`any`, casts, `!`, complexity, `===`, var/const).
+ *  • Convention-managed: naming + `no-restricted-syntax` are tuned via conventions,
+ *    not by disabling the whole rule (which would also drop the cast ban).
+ * The guard is SURFACE-AWARE: it only protects a rule that the surface already has;
+ * it never ADDS a rule a surface lacks (e.g. type-aware rules absent from the `.mjs`).
+ */
+export const PROTECTED_BUNDLED_RULES: ReadonlySet<string> = new Set([
+  "@typescript-eslint/no-explicit-any",
+  "@typescript-eslint/no-non-null-assertion",
+  "@typescript-eslint/consistent-type-assertions",
+  "@typescript-eslint/strict-boolean-expressions",
+  "@typescript-eslint/naming-convention",
+  "eqeqeq",
+  "no-var",
+  "prefer-const",
+  "no-restricted-syntax",
+  "sonarjs/cognitive-complexity",
+]);
+
+function withSeverity(entry: RuleEntry, severity: RuleSeverity): RuleEntry {
+  if (typeof entry === "string") {
+    return severity;
+  }
+
+  return [severity, ...entry.slice(1)];
+}
+
+/**
+ * Apply `TSFORGE_RULE_OVERRIDES` to a surface's BUNDLED rules, honoring the
+ * protected set. A protected rule's override is ignored (safety/conventions stay
+ * intact); any other rule may be downgraded or dropped (`"off"`). Override keys are
+ * matched bare or `tsforge/`-prefixed. Unknown override keys (rules not on this
+ * surface) are simply not applied — never added.
+ */
+export function applyBundledOverrides(
+  rules: Readonly<Record<string, RuleEntry>>,
+  overrides: Readonly<Record<string, RuleSeverity>> | undefined
+): Record<string, RuleEntry> {
+  if (overrides === undefined) {
+    return { ...rules };
+  }
+
+  const out: Record<string, RuleEntry> = {};
+
+  for (const [name, entry] of Object.entries(rules)) {
+    const bare = name.startsWith("tsforge/") ? name.slice(8) : name;
+    const override = overrides[name] ?? overrides[bare];
+
+    if (override === undefined || PROTECTED_BUNDLED_RULES.has(name)) {
+      out[name] = entry;
+    } else if (override !== "off") {
+      // "off" drops the rule by omission; protected rules never reach here.
+      out[name] = withSeverity(entry, override);
+    }
+  }
+
+  return out;
+}

--- a/packages/core/src/infer-rules/eslint-conventions.ts
+++ b/packages/core/src/infer-rules/eslint-conventions.ts
@@ -1,4 +1,4 @@
-import { resolveConventions } from "./conventions";
+import { isDefaultConventions, resolveConventions } from "./conventions";
 import type { IConventions } from "./conventions.types";
 import type {
   EslintSurface,
@@ -114,6 +114,36 @@ export function conventionRuleEntries(
   }
 
   return entries;
+}
+
+/** The JSON value for the `TSFORGE_CONVENTIONS` gate-command env, or undefined to
+ *  OMIT it — a default convention set emits nothing, so a default project's gate
+ *  command is unchanged. The bundled `.mjs` parses this with {@link parseConventionsEnv}. */
+export function conventionsEnvValue(
+  conventions: IConventions | undefined
+): string | undefined {
+  if (conventions === undefined || isDefaultConventions(conventions)) {
+    return undefined;
+  }
+
+  return JSON.stringify(conventions);
+}
+
+/** The convention-managed rules as an EXPLICIT record for the in-process write-time
+ *  linter's `overrideConfig` (which layers over the bundled `.mjs`). Unlike
+ *  {@link conventionRuleEntries}, a disabled rule is set to `"off"` (not omitted) so
+ *  the override actually disables the bundled config's copy. */
+export function conventionOverrideRules(
+  conventions: IConventions,
+  surface: EslintSurface
+): Record<string, RuleEntry> {
+  const entries = conventionRuleEntries(conventions, surface);
+
+  return {
+    "@typescript-eslint/naming-convention":
+      entries["@typescript-eslint/naming-convention"] ?? "off",
+    "no-restricted-syntax": entries["no-restricted-syntax"] ?? "off",
+  };
 }
 
 /** Parse the JSON `TSFORGE_CONVENTIONS` env channel into a fully-resolved set,

--- a/packages/core/src/infer-rules/eslint-conventions.types.ts
+++ b/packages/core/src/infer-rules/eslint-conventions.types.ts
@@ -1,0 +1,17 @@
+/** Which bundled config a rule set is being built for. The web surface keeps its
+ *  `as`-cast bans inside `no-restricted-syntax` and exempts TanStack's `Register`
+ *  interface; the core surface bans casts via `consistent-type-assertions`. */
+export type EslintSurface = "core" | "web";
+
+export type RuleSeverity = "error" | "warn" | "off";
+
+/** An ESLint rule entry: a bare severity, or `[severity, ...options]`. */
+export type RuleEntry = RuleSeverity | readonly [RuleSeverity, ...unknown[]];
+
+/** The two convention-managed rule entries the bundled `.mjs` configs splice in.
+ *  A key is ABSENT when the convention turns that rule off (so the bundled config
+ *  must omit its own hardcoded copy and rely entirely on these). */
+export interface IConventionRuleEntries {
+  readonly "@typescript-eslint/naming-convention"?: RuleEntry;
+  readonly "no-restricted-syntax"?: RuleEntry;
+}

--- a/packages/core/src/infer-rules/guidance.ts
+++ b/packages/core/src/infer-rules/guidance.ts
@@ -1,0 +1,38 @@
+import type { IConventions } from "./conventions.types";
+
+/**
+ * Convention → PROMPT phrasing. The gate channel (eslint-conventions) decides what
+ * PASSES; this decides what the model is TOLD. Both read the same resolved
+ * {@link IConventions}, so the model is never told "I-prefix" while the gate accepts
+ * bare names (the inconsistency the setup feature exists to remove). Safety rules
+ * (`as`/`any`/`!`, complexity) are NOT expressed here — they are unconditional in
+ * the prompts and never vary by convention.
+ */
+
+/** The interface-naming clause for prompts, or null when naming is unenforced
+ *  ("off") so the prompt simply omits any interface-naming instruction. */
+export function interfaceNamingPhrase(
+  conventions: IConventions
+): string | null {
+  switch (conventions.interfaces) {
+    case "i-prefix":
+      return "interfaces are `I`-prefixed";
+    case "bare-pascal-case":
+      return "interfaces are PascalCase with NO `I` prefix";
+    case "off":
+      return null;
+  }
+}
+
+/** Where a logic file's test must live — used by the TDD/test guidance so the
+ *  model writes the test in the layout the gate actually accepts. */
+export function testLayoutPhrase(conventions: IConventions): string {
+  switch (conventions.tests) {
+    case "co-located":
+      return "a co-located `*.test.ts` sibling";
+    case "mirrored":
+      return "a mirrored `tests/` file";
+    case "either":
+      return "a co-located `*.test.ts` sibling (or a mirrored `tests/` file)";
+  }
+}

--- a/packages/core/src/infer-rules/scan.ts
+++ b/packages/core/src/infer-rules/scan.ts
@@ -1,0 +1,282 @@
+import { join } from "node:path";
+import { existsSync } from "node:fs";
+import { Glob } from "bun";
+import ts from "typescript";
+import { detectStack } from "../stack-detection";
+import { resolveConventions } from "./conventions";
+import type {
+  IFolderScan,
+  IInterfaceScan,
+  IScanReport,
+  ITestScan,
+  IToolingScan,
+  IWizardDefaults,
+} from "./scan.types";
+import type { IConventions } from "./conventions.types";
+
+/** Dirs never worth scanning (deps, build output, vcs, tsforge's own state). */
+const IGNORE = new Set([
+  "node_modules",
+  "dist",
+  "build",
+  ".git",
+  ".tsforge",
+  "coverage",
+  ".next",
+  ".turbo",
+  ".cache",
+  ".vite",
+  "scratch",
+]);
+/** Bound the scan so a huge tree can't stall the wizard. */
+const MAX_FILES = 800;
+const MAX_BYTES = 262_144;
+/** A name like `IUser`/`IButtonProps` (capital after the leading I), NOT `Issue`. */
+const I_PREFIXED = /^I[A-Z]/u;
+/** Library-mandated augmentation names we never count as a naming signal. */
+const NAMING_EXEMPT = new Set(["Register"]);
+
+interface IMutableInterfaceScan {
+  iPrefixed: number;
+  bare: number;
+  total: number;
+  iExamples: string[];
+  bareExamples: string[];
+}
+
+function ignored(rel: string): boolean {
+  return rel.split("/").some((seg) => IGNORE.has(seg));
+}
+
+/** Walk one source file, tallying interface naming + whether it declares an enum. */
+function tallyFile(
+  text: string,
+  path: string,
+  acc: IMutableInterfaceScan
+): boolean {
+  const sf = ts.createSourceFile(
+    path,
+    text,
+    ts.ScriptTarget.Latest,
+    /*setParentNodes*/ false
+  );
+  let hasEnum = false;
+
+  const visit = (node: ts.Node): void => {
+    if (ts.isEnumDeclaration(node)) {
+      hasEnum = true;
+    } else if (ts.isInterfaceDeclaration(node)) {
+      countInterface(node.name.text, acc);
+    }
+
+    node.forEachChild(visit);
+  };
+
+  sf.forEachChild(visit);
+
+  return hasEnum;
+}
+
+function countInterface(name: string, acc: IMutableInterfaceScan): void {
+  if (NAMING_EXEMPT.has(name)) {
+    return;
+  }
+
+  acc.total += 1;
+
+  if (I_PREFIXED.test(name)) {
+    acc.iPrefixed += 1;
+
+    if (acc.iExamples.length < 3) {
+      acc.iExamples.push(name);
+    }
+  } else {
+    acc.bare += 1;
+
+    if (acc.bareExamples.length < 3) {
+      acc.bareExamples.push(name);
+    }
+  }
+}
+
+/** Classify a test file by layout: under a `tests/` segment ⇒ mirrored, else
+ *  co-located beside its source. */
+function classifyTest(
+  rel: string,
+  tests: { co: number; mirror: number }
+): void {
+  if (rel.split("/").includes("tests")) {
+    tests.mirror += 1;
+  } else {
+    tests.co += 1;
+  }
+}
+
+const TEST_FILE = /\.(test|spec)\.tsx?$/u;
+
+/** Read-only scan of the whole codebase, capped. Parses TS/TSX via the compiler's
+ *  AST (no project, no execution of any repo config) and globs for layout signals. */
+export async function scanRepo(cwd: string): Promise<IScanReport> {
+  const stack = await detectStack(cwd);
+  const iface: IMutableInterfaceScan = {
+    iPrefixed: 0,
+    bare: 0,
+    total: 0,
+    iExamples: [],
+    bareExamples: [],
+  };
+  const tests = { co: 0, mirror: 0 };
+  let enumFiles = 0;
+  let filesScanned = 0;
+
+  for await (const rel of new Glob("**/*.{ts,tsx}").scan({
+    cwd,
+    onlyFiles: true,
+  })) {
+    if (ignored(rel)) {
+      continue;
+    }
+
+    if (TEST_FILE.test(rel)) {
+      classifyTest(rel, tests);
+    }
+
+    const file = Bun.file(join(cwd, rel));
+
+    if (file.size > MAX_BYTES) {
+      continue;
+    }
+
+    if (tallyFile(await file.text(), rel, iface)) {
+      enumFiles += 1;
+    }
+
+    filesScanned += 1;
+
+    if (filesScanned >= MAX_FILES) {
+      break;
+    }
+  }
+
+  const interfaces: IInterfaceScan = { ...iface };
+
+  return {
+    stack,
+    interfaces,
+    enums: { fileCount: enumFiles },
+    tests: { coLocated: tests.co, mirrored: tests.mirror },
+    folders: scanFolders(cwd),
+    tooling: scanTooling(cwd),
+    filesScanned,
+  };
+}
+
+function dirExists(cwd: string, rel: string): boolean {
+  return existsSync(join(cwd, rel));
+}
+
+function scanFolders(cwd: string): IFolderScan {
+  return {
+    views: dirExists(cwd, "src/views"),
+    features: dirExists(cwd, "src/features"),
+    flatComponents: dirExists(cwd, "src/components"),
+    routeFolders: dirExists(cwd, "src/routes") || dirExists(cwd, "app"),
+  };
+}
+
+function anyExists(cwd: string, names: readonly string[]): boolean {
+  return names.some((n) => existsSync(join(cwd, n)));
+}
+
+function scanTooling(cwd: string): IToolingScan {
+  return {
+    tsconfig: existsSync(join(cwd, "tsconfig.json")),
+    eslint: anyExists(cwd, [
+      "eslint.config.js",
+      "eslint.config.mjs",
+      "eslint.config.cjs",
+      "eslint.config.ts",
+      ".eslintrc",
+      ".eslintrc.js",
+      ".eslintrc.cjs",
+      ".eslintrc.json",
+    ]),
+    prettier: anyExists(cwd, [
+      ".prettierrc",
+      ".prettierrc.json",
+      ".prettierrc.js",
+      ".prettierrc.cjs",
+      "prettier.config.js",
+      "prettier.config.mjs",
+    ]),
+  };
+}
+
+/** The dominant value when one side is clearly ahead (>= 60% and ahead of the
+ *  other), else null (contested/empty → caller picks a neutral default). */
+function dominant<T>(a: { v: T; n: number }, b: { v: T; n: number }): T | null {
+  const total = a.n + b.n;
+
+  if (total === 0) {
+    return null;
+  }
+
+  if (a.n > b.n && a.n / total >= 0.6) {
+    return a.v;
+  }
+
+  if (b.n > a.n && b.n / total >= 0.6) {
+    return b.v;
+  }
+
+  return null;
+}
+
+function recommendInterfaces(scan: IInterfaceScan): IConventions["interfaces"] {
+  if (scan.total === 0) {
+    return "i-prefix"; // greenfield → tsforge house style
+  }
+
+  const winner = dominant<IConventions["interfaces"]>(
+    { v: "i-prefix", n: scan.iPrefixed },
+    { v: "bare-pascal-case", n: scan.bare }
+  );
+
+  // A genuinely split repo: don't impose a contested naming rule.
+  return winner ?? "off";
+}
+
+function recommendTests(scan: ITestScan): IConventions["tests"] {
+  return (
+    dominant<IConventions["tests"]>(
+      { v: "co-located", n: scan.coLocated },
+      { v: "mirrored", n: scan.mirrored }
+    ) ?? "either"
+  );
+}
+
+function recommendFolders(scan: IFolderScan): IConventions["componentFolders"] {
+  if (scan.views) {
+    return "tsforge-views";
+  }
+
+  if (scan.features || scan.flatComponents || scan.routeFolders) {
+    return "repo";
+  }
+
+  return "tsforge-views"; // greenfield default
+}
+
+/** Map a scan to the RECOMMENDED conventions the wizard preselects. */
+export function recommendConventions(report: IScanReport): IConventions {
+  return resolveConventions({
+    interfaces: recommendInterfaces(report.interfaces),
+    enums: report.enums.fileCount > 0 ? "allow" : "ban",
+    tests: recommendTests(report.tests),
+    componentFolders: recommendFolders(report.folders),
+  });
+}
+
+export function wizardDefaults(report: IScanReport): IWizardDefaults {
+  return { conventions: recommendConventions(report) };
+}

--- a/packages/core/src/infer-rules/scan.ts
+++ b/packages/core/src/infer-rules/scan.ts
@@ -147,8 +147,14 @@ export async function scanRepo(cwd: string): Promise<IScanReport> {
       continue;
     }
 
-    if (tallyFile(await file.text(), rel, iface)) {
-      enumFiles += 1;
+    try {
+      if (tallyFile(await file.text(), rel, iface)) {
+        enumFiles += 1;
+      }
+    } catch {
+      // A file deleted/locked/permission-denied mid-scan must not crash the
+      // wizard — skip it and keep scanning.
+      continue;
     }
 
     filesScanned += 1;

--- a/packages/core/src/infer-rules/scan.types.ts
+++ b/packages/core/src/infer-rules/scan.types.ts
@@ -1,0 +1,55 @@
+import type { IStackProfile } from "../stack-detection";
+import type { IConventions } from "./conventions.types";
+
+/** Interface-naming evidence: how many declared interfaces are `I`-prefixed vs
+ *  bare PascalCase, with a few example names for the wizard's evidence block. */
+export interface IInterfaceScan {
+  readonly iPrefixed: number;
+  readonly bare: number;
+  readonly total: number;
+  readonly iExamples: readonly string[];
+  readonly bareExamples: readonly string[];
+}
+
+/** Enum evidence: how many files declare at least one `enum`. */
+export interface IEnumScan {
+  readonly fileCount: number;
+}
+
+/** Test-layout evidence: tests sitting beside their source vs in a `tests/` mirror. */
+export interface ITestScan {
+  readonly coLocated: number;
+  readonly mirrored: number;
+}
+
+/** Frontend folder-layout evidence (presence signals, not counts). */
+export interface IFolderScan {
+  readonly views: boolean;
+  readonly features: boolean;
+  readonly flatComponents: boolean;
+  readonly routeFolders: boolean;
+}
+
+/** Which config files the repo already ships (evidence only — never executed). */
+export interface IToolingScan {
+  readonly tsconfig: boolean;
+  readonly eslint: boolean;
+  readonly prettier: boolean;
+}
+
+/** The full read-only scan of a repository the wizard presents as evidence. */
+export interface IScanReport {
+  readonly stack: IStackProfile;
+  readonly interfaces: IInterfaceScan;
+  readonly enums: IEnumScan;
+  readonly tests: ITestScan;
+  readonly folders: IFolderScan;
+  readonly tooling: IToolingScan;
+  readonly filesScanned: number;
+}
+
+/** The conventions the scan RECOMMENDS (preselected in the wizard, written by
+ *  `--yes`). Always a fully-resolved set. */
+export interface IWizardDefaults {
+  readonly conventions: IConventions;
+}

--- a/packages/core/src/loop/prompt/index.ts
+++ b/packages/core/src/loop/prompt/index.ts
@@ -4,6 +4,8 @@ export {
   COMPACT_SYSTEM,
   SCRATCH_SIMPLICITY_GUIDANCE,
   TDD_GUIDANCE,
+  buildChatSystem,
+  buildTddGuidance,
   buildSystemPrompt,
   seedPrompt,
 } from "./prompt";

--- a/packages/core/src/loop/prompt/prompt.ts
+++ b/packages/core/src/loop/prompt/prompt.ts
@@ -3,76 +3,116 @@ import type { IFileView } from "../../lib/fs";
 import { PACK_REGISTRY, isWebStack } from "../../stack-detection";
 import type { IStackProfile } from "../../stack-detection";
 import { flags } from "../../config";
+import { DEFAULT_CONVENTIONS } from "../../infer-rules/conventions";
+import type { IConventions } from "../../infer-rules/conventions.types";
+import {
+  interfaceNamingPhrase,
+  testLayoutPhrase,
+} from "../../infer-rules/guidance";
 import { renderFileSection } from "./project-map";
 
+/** The strict-TS house-rules line, with the interface-naming clause tuned to the
+ *  project's convention (omitted entirely when naming is "off"). The safety rules
+ *  (`as`/`any`/`!`, `===`) are unconditional. */
+function gateRulesSentence(conventions: IConventions): string {
+  const naming = interfaceNamingPhrase(conventions);
+  const namingPart = naming === null ? "" : `${naming}; `;
+
+  return `The gate is \`tsc\` strict + eslint with every rule an error, so write TypeScript that satisfies it: ${namingPart}\`===\`; no \`var\`; never the non-null \`!\` — guard index access (\`const x = arr[i]; if (x === undefined) {...}\`); no \`any\` and no \`as\` — type every parameter (e.g. \`.reduce((acc: number, r: number) => …, 0)\`); explicit boolean conditions. When the gate flags errors in read-only files (tests/types), they come from your editable file being missing or wrong-shaped and vanish once it's correct — don't edit them.`;
+}
+
 /** The implement-agent system prompt: who it is, the tools, and the strict-TS
- *  house rules the gate enforces. */
-export const SYSTEM = [
-  "You are an expert TypeScript engineer working inside tsforge, a harness specialized for STRICT TypeScript. Implement the task by editing code until the gate passes.",
-  "Tools: `read` (inspect a file), `edit` (replace an exact, unique snippet), `create` (a new file), `run` (execute any shell command and see its output).",
-  "Lead with action: start writing code right away (one `create`/`edit`) — do NOT deliberate at length before writing any code. (In TDD mode the test comes first; see the test-first guidance below.)",
-  "After every edit the harness AUTOMATICALLY runs the gate and gives you the result (the errors + fix guidance for the failing rules). You do NOT need to run the acceptance command yourself — read that result and fix exactly what it reports, then edit again. Keep going until it reports green; the harness ends the task at that point.",
-  "The harness also AUTO-FIXES mechanical formatting on every file you write — blank lines, braces, quotes, semicolons, import order, `prefer-template`. NEVER hand-fix or chase those, and do NOT run `tsc`/`eslint`/the gate yourself to look for them. Fix only what the gate explicitly hands back (`as`/`any`/`!`, `I`-prefix, real type errors), then stop.",
-  "Test hypotheses by RUNNING them, never by reasoning them out. Unsure about an edge case, rounding, or ordering (`Math.floor(100/3)`, largest-remainder ties)? `run` a quick `bun -e '…console.log(…)'`, or write a throwaway `scratch/check.ts` importing your impl and `run` it. `scratch/` is yours — the gate ignores it.",
-  "The gate is `tsc` strict + eslint with every rule an error, so write TypeScript that satisfies it: interfaces are `I`-prefixed; `===`; no `var`; never the non-null `!` — guard index access (`const x = arr[i]; if (x === undefined) {...}`); no `any` and no `as` — type every parameter (e.g. `.reduce((acc: number, r: number) => …, 0)`); explicit boolean conditions. When the gate flags errors in read-only files (tests/types), they come from your editable file being missing or wrong-shaped and vanish once it's correct — don't edit them.",
-  "Keep functions small: the gate caps cognitive complexity at 20 and nesting depth at 4. If a function grows long or deeply nested, extract named helpers instead of one sprawling block. Always `await` promises (or `void` them deliberately) — a floating promise is a gate error.",
-].join("\n");
+ *  house rules the gate enforces (the naming clause follows the project's
+ *  conventions so the prompt never contradicts the gate). */
+export function buildSystem(conventions: IConventions): string {
+  return [
+    "You are an expert TypeScript engineer working inside tsforge, a harness specialized for STRICT TypeScript. Implement the task by editing code until the gate passes.",
+    "Tools: `read` (inspect a file), `edit` (replace an exact, unique snippet), `create` (a new file), `run` (execute any shell command and see its output).",
+    "Lead with action: start writing code right away (one `create`/`edit`) — do NOT deliberate at length before writing any code. (In TDD mode the test comes first; see the test-first guidance below.)",
+    "After every edit the harness AUTOMATICALLY runs the gate and gives you the result (the errors + fix guidance for the failing rules). You do NOT need to run the acceptance command yourself — read that result and fix exactly what it reports, then edit again. Keep going until it reports green; the harness ends the task at that point.",
+    "The harness also AUTO-FIXES mechanical formatting on every file you write — blank lines, braces, quotes, semicolons, import order, `prefer-template`. NEVER hand-fix or chase those, and do NOT run `tsc`/`eslint`/the gate yourself to look for them. Fix only what the gate explicitly hands back (`as`/`any`/`!`, real type errors), then stop.",
+    "Test hypotheses by RUNNING them, never by reasoning them out. Unsure about an edge case, rounding, or ordering (`Math.floor(100/3)`, largest-remainder ties)? `run` a quick `bun -e '…console.log(…)'`, or write a throwaway `scratch/check.ts` importing your impl and `run` it. `scratch/` is yours — the gate ignores it.",
+    gateRulesSentence(conventions),
+    "Keep functions small: the gate caps cognitive complexity at 20 and nesting depth at 4. If a function grows long or deeply nested, extract named helpers instead of one sprawling block. Always `await` promises (or `void` them deliberately) — a floating promise is a gate error.",
+  ].join("\n");
+}
+
+/** Default (house-style) implement-agent prompt — preserved for callers/tests that
+ *  don't thread conventions; the dynamic path uses {@link buildSystem}. */
+export const SYSTEM = buildSystem(DEFAULT_CONVENTIONS);
 
 /** Appended to SYSTEM for from-scratch, NON-web utility builds when the simplicity
  *  flag is on. Pushes the model toward the shortest correct solution — the axis the
  *  gate is blind to (it checks correctness, never concision). Carve-outs keep it
  *  from fighting the gate's hard rules. NOT for web builds (the views/components
  *  architecture legitimately needs many small files). */
-export const SCRATCH_SIMPLICITY_GUIDANCE = [
-  "SIMPLICITY — write the SHORTEST correct solution that passes the gate:",
-  "  • The task's `files:` are the ceiling — do NOT add modules, classes, or",
-  "    abstractions the task didn't ask for. One focused implementation.",
-  "  • Prefer built-ins and a direct expression over step-by-step temporaries:",
-  "    chain the transforms (`xs.filter(...).map(...)`) instead of naming each",
-  "    intermediate, when it stays readable.",
-  "  • NO narration/step comments ('// Step 1', '// first we…') — the code is the",
-  "    explanation. A comment earns its place only for a non-obvious WHY.",
-  "  • This NEVER overrides the gate: keep `I`-prefixed interfaces, no `as`/`any`/`!`,",
-  "    real validation at trust boundaries, and any test siblings the gate requires.",
-].join("\n");
+export function buildScratchSimplicityGuidance(
+  conventions: IConventions
+): string {
+  const naming = interfaceNamingPhrase(conventions);
+  const keepNaming = naming === null ? "" : `keep ${naming}, `;
+
+  return [
+    "SIMPLICITY — write the SHORTEST correct solution that passes the gate:",
+    "  • The task's `files:` are the ceiling — do NOT add modules, classes, or",
+    "    abstractions the task didn't ask for. One focused implementation.",
+    "  • Prefer built-ins and a direct expression over step-by-step temporaries:",
+    "    chain the transforms (`xs.filter(...).map(...)`) instead of naming each",
+    "    intermediate, when it stays readable.",
+    "  • NO narration/step comments ('// Step 1', '// first we…') — the code is the",
+    "    explanation. A comment earns its place only for a non-obvious WHY.",
+    `  • This NEVER overrides the gate: ${keepNaming}no \`as\`/\`any\`/\`!\`,`,
+    "    real validation at trust boundaries, and any test siblings the gate requires.",
+  ].join("\n");
+}
+
+/** Default-conventions simplicity block (back-compat constant). */
+export const SCRATCH_SIMPLICITY_GUIDANCE =
+  buildScratchSimplicityGuidance(DEFAULT_CONVENTIONS);
 
 /** Appended to SYSTEM when TDD mode is on. Drives test-FIRST development: the
  *  model writes a failing test that pins the behavior, runs it to see it fail for
  *  the right reason, THEN implements to green — and adds a test for every logic
  *  module (the gate elevates `test-sibling-required` to an error in this mode, so
  *  a missing test fails the build, not just warns). */
-export const TDD_GUIDANCE = [
-  "TEST-FIRST (TDD) — write the test BEFORE the implementation:",
-  "  • For each unit of behavior, first `create` a `*.test.ts` that asserts the",
-  "    expected result, then `run` it and SEE IT FAIL for the right reason (the",
-  "    function is missing/wrong) — not a typo or import error.",
-  "  • Only then write the implementation, and keep editing until that test (and",
-  "    the gate) is green. Do NOT write implementation code with no test covering it.",
-  "  • Every logic module (`*.service.ts`, `*.utils.ts`, `lib/…`) MUST have a",
-  "    co-located test — the gate enforces it as an ERROR in this mode.",
-  "  • Cover the real edge cases you'd expect to break it (empty, zero, boundary,",
-  "    error paths), not just the happy path. Tests are part of the deliverable.",
-].join("\n");
+export function buildTddGuidance(conventions: IConventions): string {
+  return [
+    "TEST-FIRST (TDD) — write the test BEFORE the implementation:",
+    "  • For each unit of behavior, first `create` a `*.test.ts` that asserts the",
+    "    expected result, then `run` it and SEE IT FAIL for the right reason (the",
+    "    function is missing/wrong) — not a typo or import error.",
+    "  • Only then write the implementation, and keep editing until that test (and",
+    "    the gate) is green. Do NOT write implementation code with no test covering it.",
+    "  • Every logic module (`*.service.ts`, `*.utils.ts`, `lib/…`) MUST have",
+    `    ${testLayoutPhrase(conventions)} — the gate enforces it as an ERROR in this mode.`,
+    "  • Cover the real edge cases you'd expect to break it (empty, zero, boundary,",
+    "    error paths), not just the happy path. Tests are part of the deliverable.",
+  ].join("\n");
+}
+
+/** Default-conventions TDD block (back-compat constant). */
+export const TDD_GUIDANCE = buildTddGuidance(DEFAULT_CONVENTIONS);
 
 /** SYSTEM + the simplicity block when it applies, else SYSTEM unchanged. Gated on
  *  the `simplicity` flag AND a from-scratch (`!hasExistingCode`) NON-web build —
  *  so it never touches existing-repo edits or web/UI apps. */
 export function buildSystemPrompt(
   hasExistingCode: boolean,
-  stack: IStackProfile | undefined
+  stack: IStackProfile | undefined,
+  conventions: IConventions = DEFAULT_CONVENTIONS
 ): string {
   const webish = stack !== undefined && isWebStack(stack);
-  const blocks: string[] = [SYSTEM];
+  const blocks: string[] = [buildSystem(conventions)];
 
   // Simplicity: from-scratch, non-web only (an A/B-gated concision push).
   if (flags.simplicity() && !hasExistingCode && !webish) {
-    blocks.push(SCRATCH_SIMPLICITY_GUIDANCE);
+    blocks.push(buildScratchSimplicityGuidance(conventions));
   }
 
   // TDD-first: applies on any stack/mode (write the failing test first), paired
   // with the gate elevating test-sibling-required to an error.
   if (flags.tdd()) {
-    blocks.push(TDD_GUIDANCE);
+    blocks.push(buildTddGuidance(conventions));
   }
 
   return blocks.join("\n\n");
@@ -85,16 +125,24 @@ export function buildSystemPrompt(
  * and STOP. Without this framing the model treats every message as implement-to-
  * green and scans the repo forever when asked a question (there's no gate to hit).
  */
-export const CHAT_SYSTEM = [
-  "You are tsforge, an expert TypeScript coding assistant. You are launched inside a repository, but NOT every request is about that repository. The user talks to you; you help by answering, and by inspecting/changing code with your tools.",
-  "Tools: `read` (inspect a file), `run` (execute any shell command — `ls`, `rg`, tests, `tsc`), `edit` (replace an exact, unique snippet), `create` (a new file).",
-  "File paths are RELATIVE to the workspace root: use `tsconfig.json` or `src/app.ts` — never an absolute path, and never repeat the workspace folder in the path.",
-  "MATCH EFFORT TO THE REQUEST. A self-contained ask — 'write a `double` function', 'explain `satisfies`' — has nothing to do with the surrounding repo: just answer it directly (reply with the code; only `create` a file if asked). Do NOT read or scan the repository for these. Investigate the codebase ONLY when the request is actually about THIS project (a bug here, a change here, 'what would you change?').",
-  "ASK BEFORE GUESSING when the request is genuinely ambiguous — unclear scope, unclear which file to touch, or unclear whether it even relates to this repo (e.g. 'add a retry' with no target). Ask ONE short clarifying question and stop; the user will answer and you continue. But don't over-ask: when a sensible default is obvious, take it and state the assumption in one line.",
-  "Be decisive, not exhaustive. When you do investigate, a few targeted reads beat reading everything — as soon as you can answer or act, STOP calling tools and reply.",
-  "For a QUESTION about the repo, investigate briefly then give a concise, concrete answer (cite specific files/symbols; offer your top few recommendations, not a survey). For a CHANGE, make it with `edit`/`create`, verify by `run`ning the tests or `tsc`, then briefly state what you did.",
-  "When you write code, use strict TypeScript: `I`-prefixed interfaces; `===`; no `var`; never the non-null `!` (guard index access: `const x = arr[i]; if (x === undefined) {…}`); no `any`/`as` (type parameters); explicit boolean conditions.",
-].join("\n");
+export function buildChatSystem(conventions: IConventions): string {
+  const naming = interfaceNamingPhrase(conventions);
+  const namingPart = naming === null ? "" : `${naming}; `;
+
+  return [
+    "You are tsforge, an expert TypeScript coding assistant. You are launched inside a repository, but NOT every request is about that repository. The user talks to you; you help by answering, and by inspecting/changing code with your tools.",
+    "Tools: `read` (inspect a file), `run` (execute any shell command — `ls`, `rg`, tests, `tsc`), `edit` (replace an exact, unique snippet), `create` (a new file).",
+    "File paths are RELATIVE to the workspace root: use `tsconfig.json` or `src/app.ts` — never an absolute path, and never repeat the workspace folder in the path.",
+    "MATCH EFFORT TO THE REQUEST. A self-contained ask — 'write a `double` function', 'explain `satisfies`' — has nothing to do with the surrounding repo: just answer it directly (reply with the code; only `create` a file if asked). Do NOT read or scan the repository for these. Investigate the codebase ONLY when the request is actually about THIS project (a bug here, a change here, 'what would you change?').",
+    "ASK BEFORE GUESSING when the request is genuinely ambiguous — unclear scope, unclear which file to touch, or unclear whether it even relates to this repo (e.g. 'add a retry' with no target). Ask ONE short clarifying question and stop; the user will answer and you continue. But don't over-ask: when a sensible default is obvious, take it and state the assumption in one line.",
+    "Be decisive, not exhaustive. When you do investigate, a few targeted reads beat reading everything — as soon as you can answer or act, STOP calling tools and reply.",
+    "For a QUESTION about the repo, investigate briefly then give a concise, concrete answer (cite specific files/symbols; offer your top few recommendations, not a survey). For a CHANGE, make it with `edit`/`create`, verify by `run`ning the tests or `tsc`, then briefly state what you did.",
+    `When you write code, use strict TypeScript: ${namingPart}\`===\`; no \`var\`; never the non-null \`!\` (guard index access: \`const x = arr[i]; if (x === undefined) {…}\`); no \`any\`/\`as\` (type parameters); explicit boolean conditions.`,
+  ].join("\n");
+}
+
+/** Default-conventions interactive prompt (back-compat constant). */
+export const CHAT_SYSTEM = buildChatSystem(DEFAULT_CONVENTIONS);
 
 /** Prompt for `/compact`: condense a long conversation, keeping what matters for
  *  continuing the work — not a chatty recap. */

--- a/packages/core/src/loop/run.ts
+++ b/packages/core/src/loop/run.ts
@@ -18,6 +18,7 @@ import type {
 import { mineLessons, consolidate as consolidateMemory } from "./memory";
 import { flags } from "../config";
 import type { ITsforgeProjectConfig } from "../config";
+import type { IConventions } from "../infer-rules/conventions.types";
 import type { PolicyMode, IPolicyRules } from "../policy";
 import { buildSystemPrompt, seedPrompt } from "./prompt";
 import { buildScoutContext } from "./scout";
@@ -195,10 +196,12 @@ async function resolveStackForRun(
   stackProfile: Awaited<ReturnType<typeof detectStack>>;
   ruleOverrides: Readonly<Record<string, "error" | "warn" | "off">>;
   policy: ITsforgeProjectConfig["policy"];
+  conventions: IConventions;
 }> {
   const detectedProfile = await detectStack(cwd);
   const { loadTsforgeConfig, resolveActivePacks, normalizeRuleOverrides } =
     await import("../config/tsforge-config");
+  const { resolveConventions } = await import("../infer-rules/conventions");
   const { loadAndRegisterPlugins } = await import("../config/external-plugins");
   const cfg = await loadTsforgeConfig(cwd);
   const activePacks = resolveActivePacks(detectedProfile.packs, cfg);
@@ -215,6 +218,7 @@ async function resolveStackForRun(
     },
     ruleOverrides: normalizeRuleOverrides(cfg),
     policy: cfg.policy,
+    conventions: resolveConventions(cfg.conventions),
   };
 }
 
@@ -313,12 +317,10 @@ export async function runTask(
   });
 
   // Detect stack once per run, early; tsforge.config.json may adjust it
-  const { stackProfile, ruleOverrides, policy } = await resolveStackForRun(
-    cwd,
-    (message) => {
+  const { stackProfile, ruleOverrides, policy, conventions } =
+    await resolveStackForRun(cwd, (message) => {
       report({ kind: "tool", task: task.id, message });
-    }
-  );
+    });
 
   report({
     kind: "tool",
@@ -342,7 +344,7 @@ export async function runTask(
   const messages: IChatMessage[] = [
     {
       role: "system",
-      content: buildSystemPrompt(hasExistingCode, stackProfile),
+      content: buildSystemPrompt(hasExistingCode, stackProfile, conventions),
     },
     {
       role: "user",

--- a/packages/core/src/loop/session.ts
+++ b/packages/core/src/loop/session.ts
@@ -35,7 +35,9 @@ import type { Reporter, ILoopEvent } from "./loop.types";
 import type { TtsrManager } from "./ttsr";
 import { initTtsrManager, applyTtsrInterrupt } from "./ttsr-init";
 import { mineLessons, consolidate as consolidateMemory } from "./memory";
-import { CHAT_SYSTEM, COMPACT_SYSTEM, TDD_GUIDANCE } from "./prompt";
+import { buildChatSystem, buildTddGuidance, COMPACT_SYSTEM } from "./prompt";
+import { resolveConventions } from "../infer-rules/conventions";
+import type { IConventions } from "../infer-rules/conventions.types";
 import {
   buildTsService,
   BUILD_NUDGE,
@@ -408,7 +410,11 @@ const MALFORMED_CALL_NUDGE =
 /** CHAT_SYSTEM + the (optional) workspace map + a short orientation to the
  *  workspace and gate. The map block, when present, is injected right after
  *  CHAT_SYSTEM so the agent is oriented before the task-specific lines. */
-function systemPrompt(cfg: ISessionConfig, workspaceMap: string): string {
+function systemPrompt(
+  cfg: ISessionConfig,
+  workspaceMap: string,
+  conventions: IConventions
+): string {
   const lines = [`Workspace: ${cfg.cwd}`];
   const files = cfg.files ?? [];
   const wholeRepo = files.length === 0 || files.includes("**/*");
@@ -437,9 +443,9 @@ function systemPrompt(cfg: ISessionConfig, workspaceMap: string): string {
   // buildSystemPrompt, but the interactive path never did, so the CLI agent was
   // never TOLD to write tests first and leaned entirely on the late gate. Inject
   // it here too so test-first is the out-of-the-box default everywhere.
-  const tdd = flags.tdd() ? `${TDD_GUIDANCE}\n\n` : "";
+  const tdd = flags.tdd() ? `${buildTddGuidance(conventions)}\n\n` : "";
 
-  return `${CHAT_SYSTEM}\n\n${tdd}${prefix}${lines.join("\n")}`;
+  return `${buildChatSystem(conventions)}\n\n${tdd}${prefix}${lines.join("\n")}`;
 }
 
 export class Session {
@@ -646,7 +652,16 @@ export class Session {
       messages:
         cfg.history !== undefined && cfg.history.length > 0
           ? [...cfg.history]
-          : [{ role: "system", content: systemPrompt(cfg, workspaceMap) }],
+          : [
+              {
+                role: "system",
+                content: systemPrompt(
+                  cfg,
+                  workspaceMap,
+                  resolveConventions(projectConfig.conventions)
+                ),
+              },
+            ],
       // Stream the gate's output live (the interactive CLI), so a slow gate
       // (vite build + chromium) shows progress instead of running silently — but
       // filtered so the raw eslint JSON blob never floods the terminal.

--- a/packages/core/src/render/wizard.ts
+++ b/packages/core/src/render/wizard.ts
@@ -459,6 +459,11 @@ export function runWizard(
       stdin.removeListener("keypress", onKey);
       out(`${SHOW_CURSOR}${EXIT_ALT}`);
 
+      // Restore the saved keypress listeners. They come from `rawListeners` typed
+      // as `Function[]`, which isn't assignable to the listener signature, so we
+      // forward through a thin wrapper (House rules forbid `as`). This mirrors the
+      // reviewed `pickCommand` pattern; within a run `onKey` is detached first, so
+      // there's no duplication.
       for (const l of saved) {
         stdin.on("keypress", (...args: unknown[]) => {
           Reflect.apply(l, stdin, args);

--- a/packages/core/src/render/wizard.ts
+++ b/packages/core/src/render/wizard.ts
@@ -1,0 +1,480 @@
+import { emitKeypressEvents } from "node:readline";
+import { STYLE, paint } from "./style";
+import { clampIndex } from "./command-menu";
+import type {
+  IWizardAction,
+  IWizardOption,
+  IWizardState,
+  IWizardStep,
+} from "./wizard.types";
+
+const ESC = String.fromCharCode(27);
+const ENTER_ALT = `${ESC}[?1049h${ESC}[r`;
+const EXIT_ALT = `${ESC}[?1049l`;
+const HIDE_CURSOR = `${ESC}[?25l`;
+const SHOW_CURSOR = `${ESC}[?25h`;
+const CLEAR_HOME = `${ESC}[2J${ESC}[H`;
+const RULE = "─".repeat(52);
+
+// ─────────────────────────── pure state model ───────────────────────────
+
+/** Initial state: step 0, cursor on each step's recommendation, multi-checks
+ *  seeded from defaults. */
+export function initWizard(steps: readonly IWizardStep[]): IWizardState {
+  const multi: Record<string, readonly number[]> = {};
+
+  for (const s of steps) {
+    if (s.kind === "multi") {
+      multi[s.key] = [...(s.defaultChecked ?? [])];
+    }
+  }
+
+  return {
+    stepIndex: 0,
+    cursor: steps[0]?.defaultIndex ?? 0,
+    single: {},
+    multi,
+    status: "active",
+  };
+}
+
+/** Where the cursor should sit when (re)entering a step: the recorded answer if
+ *  any, else the step's recommended default. */
+function cursorForStep(step: IWizardStep, state: IWizardState): number {
+  if (step.kind === "single") {
+    const chosen = state.single[step.key];
+
+    if (chosen !== undefined) {
+      const idx = step.options.findIndex((o) => o.value === chosen);
+
+      if (idx >= 0) {
+        return idx;
+      }
+    }
+  }
+
+  return step.defaultIndex ?? 0;
+}
+
+function toggleCheck(state: IWizardState, step: IWizardStep): IWizardState {
+  const set = new Set(state.multi[step.key] ?? []);
+
+  if (set.has(state.cursor)) {
+    set.delete(state.cursor);
+  } else {
+    set.add(state.cursor);
+  }
+
+  return {
+    ...state,
+    multi: { ...state.multi, [step.key]: [...set].sort((a, b) => a - b) },
+  };
+}
+
+function confirmStep(
+  state: IWizardState,
+  step: IWizardStep,
+  steps: readonly IWizardStep[]
+): IWizardState {
+  const single =
+    step.kind === "single"
+      ? {
+          ...state.single,
+          [step.key]:
+            step.options[clampIndex(state.cursor, step.options.length)]
+              ?.value ?? "",
+        }
+      : state.single;
+  const nextIndex = state.stepIndex + 1;
+  const next = steps[nextIndex];
+
+  return {
+    ...state,
+    single,
+    stepIndex: nextIndex,
+    cursor: next === undefined ? 0 : cursorForStep(next, { ...state, single }),
+  };
+}
+
+function goBack(
+  state: IWizardState,
+  steps: readonly IWizardStep[]
+): IWizardState {
+  if (state.stepIndex === 0) {
+    return { ...state, status: "cancel" };
+  }
+
+  const idx = state.stepIndex - 1;
+  const step = steps[idx];
+
+  return {
+    ...state,
+    stepIndex: idx,
+    cursor: step === undefined ? 0 : cursorForStep(step, state),
+  };
+}
+
+function reduceStep(
+  state: IWizardState,
+  action: IWizardAction,
+  step: IWizardStep,
+  steps: readonly IWizardStep[]
+): IWizardState {
+  switch (action) {
+    case "up":
+      return {
+        ...state,
+        cursor: clampIndex(state.cursor - 1, step.options.length),
+      };
+    case "down":
+      return {
+        ...state,
+        cursor: clampIndex(state.cursor + 1, step.options.length),
+      };
+    case "toggle":
+      return step.kind === "multi" ? toggleCheck(state, step) : state;
+    case "confirm":
+      return confirmStep(state, step, steps);
+    case "back":
+      return goBack(state, steps);
+    default:
+      return state;
+  }
+}
+
+function reduceOverview(
+  state: IWizardState,
+  action: IWizardAction,
+  steps: readonly IWizardStep[]
+): IWizardState {
+  if (action === "confirm") {
+    return { ...state, status: "apply" };
+  }
+
+  if (action === "back") {
+    const idx = steps.length - 1;
+    const step = steps[idx];
+
+    return {
+      ...state,
+      stepIndex: idx,
+      cursor: step === undefined ? 0 : cursorForStep(step, state),
+    };
+  }
+
+  return state;
+}
+
+/** The reducer: pure (state, action) → state. The whole wizard is testable through
+ *  this without a terminal. */
+export function reduceWizard(
+  state: IWizardState,
+  action: IWizardAction,
+  steps: readonly IWizardStep[]
+): IWizardState {
+  if (state.status !== "active") {
+    return state;
+  }
+
+  if (action === "cancel") {
+    return { ...state, status: "cancel" };
+  }
+
+  if (state.stepIndex >= steps.length) {
+    return reduceOverview(state, action, steps);
+  }
+
+  const step = steps[state.stepIndex];
+
+  return step === undefined ? state : reduceStep(state, action, step, steps);
+}
+
+/** Fold a sequence of actions from the initial state — used by tests. */
+export function driveWizard(
+  steps: readonly IWizardStep[],
+  actions: readonly IWizardAction[]
+): IWizardState {
+  return actions.reduce(
+    (state, action) => reduceWizard(state, action, steps),
+    initWizard(steps)
+  );
+}
+
+/** The checked option VALUES for a multi-select step. */
+export function checkedValues(
+  state: IWizardState,
+  step: IWizardStep
+): string[] {
+  return (state.multi[step.key] ?? []).flatMap((i) => {
+    const o = step.options[i];
+
+    return o === undefined ? [] : [o.value];
+  });
+}
+
+// ──────────────────────────── pure rendering ────────────────────────────
+
+function evidenceBlock(step: IWizardStep, color: boolean): string[] {
+  if (step.evidence.length === 0) {
+    return [];
+  }
+
+  return [
+    paint("Evidence", STYLE.bold, color),
+    ...step.evidence.map((e) => `  ${paint(e, STYLE.dim, color)}`),
+    "",
+  ];
+}
+
+function optionRow(
+  opt: IWizardOption,
+  active: boolean,
+  marker: string,
+  color: boolean
+): string {
+  const gutter = active ? paint("›", STYLE.brand, color) : " ";
+  const label = paint(opt.label, active ? STYLE.brand : STYLE.bold, color);
+  const rec =
+    opt.recommended === true
+      ? `  ${paint("recommended", STYLE.dim, color)}`
+      : "";
+  const note =
+    opt.note === undefined ? "" : `  ${paint(opt.note, STYLE.dim, color)}`;
+
+  return `${gutter} ${marker}${label}${rec}${note}`;
+}
+
+function singleChoiceRows(
+  step: IWizardStep,
+  cursor: number,
+  color: boolean
+): string[] {
+  return step.options.map((opt, i) => optionRow(opt, i === cursor, "", color));
+}
+
+function multiChoiceRows(
+  step: IWizardStep,
+  cursor: number,
+  checkedIdx: readonly number[],
+  color: boolean
+): string[] {
+  const checked = new Set(checkedIdx);
+
+  return step.options.map((opt, i) =>
+    optionRow(opt, i === cursor, `${checked.has(i) ? "◉" : "◯"} `, color)
+  );
+}
+
+function hints(step: IWizardStep, color: boolean): string {
+  const parts =
+    step.kind === "multi"
+      ? ["space toggle", "enter continue", "b back", "q cancel"]
+      : ["↑/↓ move", "enter select", "b back", "q cancel"];
+
+  return paint(parts.join("   "), STYLE.dim, color);
+}
+
+function renderStep(
+  step: IWizardStep,
+  state: IWizardState,
+  color: boolean,
+  total: number
+): string {
+  const rows =
+    step.kind === "multi"
+      ? multiChoiceRows(step, state.cursor, state.multi[step.key] ?? [], color)
+      : singleChoiceRows(step, state.cursor, color);
+
+  const active = step.options[clampIndex(state.cursor, step.options.length)];
+  const outcome =
+    step.kind === "single" && active?.outcome !== undefined
+      ? ["", paint("Outcome", STYLE.bold, color), `  ${active.outcome}`]
+      : [];
+
+  return [
+    paint("tsforge setup", STYLE.brand, color),
+    `${paint(`Step ${state.stepIndex + 1} of ${total}`, STYLE.bold, color)} · ${step.title}`,
+    RULE,
+    step.explanation,
+    "",
+    ...evidenceBlock(step, color),
+    paint("Choices", STYLE.bold, color),
+    ...rows,
+    ...outcome,
+    "",
+    hints(step, color),
+  ].join("\n");
+}
+
+/** One readable summary line per step for the overview ("Title: chosen"). */
+function overviewLines(
+  steps: readonly IWizardStep[],
+  state: IWizardState,
+  color: boolean
+): string[] {
+  return steps.map((step) => {
+    const checked = checkedValues(state, step).join(", ");
+    const value =
+      step.kind === "single"
+        ? (step.options.find((o) => o.value === state.single[step.key])
+            ?.label ?? "(default)")
+        : checked.length > 0
+          ? checked
+          : "(none)";
+
+    return `  ${paint(step.title, STYLE.bold, color)}: ${value}`;
+  });
+}
+
+function renderOverview(
+  steps: readonly IWizardStep[],
+  state: IWizardState,
+  color: boolean,
+  extra: string
+): string {
+  return [
+    paint("tsforge setup", STYLE.brand, color),
+    `${paint("Review", STYLE.bold, color)} · nothing is written until you Apply`,
+    RULE,
+    ...overviewLines(steps, state, color),
+    ...(extra.length > 0 ? ["", extra] : []),
+    "",
+    paint("enter apply   b back   q cancel", STYLE.dim, color),
+  ].join("\n");
+}
+
+/** Render the current frame (a step, or the final overview). `extra` is appended
+ *  to the overview (the exact config preview + evidence path). Pure. */
+export function renderFrame(
+  state: IWizardState,
+  steps: readonly IWizardStep[],
+  color: boolean,
+  extra = ""
+): string {
+  if (state.stepIndex >= steps.length) {
+    return renderOverview(steps, state, color, extra);
+  }
+
+  const step = steps[state.stepIndex];
+
+  return step === undefined ? "" : renderStep(step, state, color, steps.length);
+}
+
+// ──────────────────────────── interactive driver ────────────────────────────
+
+interface IKeyInfo {
+  readonly name?: string;
+  readonly ctrl?: boolean;
+}
+
+/** Map a raw keypress to a wizard action, or null to ignore. Digits jump the
+ *  cursor and are handled by the driver (not here). */
+function actionFor(
+  str: string | undefined,
+  key: IKeyInfo
+): IWizardAction | null {
+  if ((key.ctrl === true && key.name === "c") || key.name === "escape") {
+    return "cancel";
+  }
+
+  switch (key.name) {
+    case "up":
+      return "up";
+    case "down":
+      return "down";
+    case "space":
+      return "toggle";
+    case "return":
+    case "enter":
+      return "confirm";
+    default:
+      break;
+  }
+
+  if (str === "b") {
+    return "back";
+  }
+
+  if (str === "q") {
+    return "cancel";
+  }
+
+  if (str === " ") {
+    return "toggle";
+  }
+
+  return null;
+}
+
+/**
+ * Run the wizard interactively on the alternate screen, returning the final state
+ * (status "apply" or "cancel"). Owns keypress for its lifetime (stash + restore the
+ * existing listeners, like pickCommand), never toggles raw mode. Off a TTY it
+ * resolves immediately to a cancelled state — the CLI handles non-TTY separately.
+ * `extra(state)` supplies the live config preview for the overview.
+ */
+export function runWizard(
+  steps: readonly IWizardStep[],
+  color: boolean,
+  extra: (state: IWizardState) => string = () => "",
+  out: (s: string) => void = (s) => process.stdout.write(s)
+): Promise<IWizardState> {
+  const stdin = process.stdin;
+  const cancelled: IWizardState = { ...initWizard(steps), status: "cancel" };
+
+  if (!stdin.isTTY) {
+    return Promise.resolve(cancelled);
+  }
+
+  return new Promise((resolve) => {
+    let state = initWizard(steps);
+
+    emitKeypressEvents(stdin);
+
+    const saved = stdin.rawListeners("keypress");
+
+    stdin.removeAllListeners("keypress");
+
+    const draw = (): void => {
+      out(`${CLEAR_HOME}${renderFrame(state, steps, color, extra(state))}`);
+    };
+
+    const finish = (): void => {
+      stdin.removeListener("keypress", onKey);
+      out(`${SHOW_CURSOR}${EXIT_ALT}`);
+
+      for (const l of saved) {
+        stdin.on("keypress", (...args: unknown[]) => {
+          Reflect.apply(l, stdin, args);
+        });
+      }
+
+      resolve(state);
+    };
+
+    const onKey = (str: string | undefined, key: IKeyInfo): void => {
+      try {
+        const action = actionFor(str, key);
+
+        if (action === null) {
+          return;
+        }
+
+        state = reduceWizard(state, action, steps);
+
+        if (state.status !== "active") {
+          finish();
+        } else {
+          draw();
+        }
+      } catch {
+        state = cancelled;
+        finish();
+      }
+    };
+
+    stdin.on("keypress", onKey);
+    out(`${ENTER_ALT}${HIDE_CURSOR}`);
+    draw();
+  });
+}

--- a/packages/core/src/render/wizard.ts
+++ b/packages/core/src/render/wizard.ts
@@ -25,7 +25,10 @@ export function initWizard(steps: readonly IWizardStep[]): IWizardState {
 
   for (const s of steps) {
     if (s.kind === "multi") {
-      multi[s.key] = [...(s.defaultChecked ?? [])];
+      // Drop any default-checked index that's out of range for the options.
+      multi[s.key] = (s.defaultChecked ?? []).filter(
+        (i) => i >= 0 && i < s.options.length
+      );
     }
   }
 
@@ -57,6 +60,11 @@ function cursorForStep(step: IWizardStep, state: IWizardState): number {
 }
 
 function toggleCheck(state: IWizardState, step: IWizardStep): IWizardState {
+  // No options ⇒ nothing to toggle (clampIndex would otherwise yield index 0).
+  if (step.options.length === 0) {
+    return state;
+  }
+
   const set = new Set(state.multi[step.key] ?? []);
 
   if (set.has(state.cursor)) {
@@ -186,7 +194,15 @@ export function reduceWizard(
 
   const step = steps[state.stepIndex];
 
-  return step === undefined ? state : reduceStep(state, action, step, steps);
+  // A hole in the steps (e.g. an empty steps array) must still ADVANCE on confirm
+  // so the flow can reach the overview rather than wedging on a missing step.
+  if (step === undefined) {
+    return action === "confirm"
+      ? { ...state, stepIndex: state.stepIndex + 1 }
+      : state;
+  }
+
+  return reduceStep(state, action, step, steps);
 }
 
 /** Fold a sequence of actions from the initial state — used by tests. */

--- a/packages/core/src/render/wizard.types.ts
+++ b/packages/core/src/render/wizard.types.ts
@@ -1,0 +1,43 @@
+/** One selectable option in a wizard step. `outcome` is shown under the choices
+ *  when this option is highlighted (single-select); `note` is a trailing tag
+ *  (e.g. "always on", "next dependency found"). */
+export interface IWizardOption {
+  readonly label: string;
+  readonly value: string;
+  readonly recommended?: boolean;
+  readonly outcome?: string;
+  readonly note?: string;
+}
+
+/** A single wizard step — either arrow-key single-select or checkbox multi-select. */
+export interface IWizardStep {
+  readonly key: string;
+  readonly kind: "single" | "multi";
+  readonly title: string;
+  readonly explanation: string;
+  readonly evidence: readonly string[];
+  readonly options: readonly IWizardOption[];
+  /** Single-select: the preselected option index (the recommendation). */
+  readonly defaultIndex?: number;
+  /** Multi-select: option indices checked on entry. */
+  readonly defaultChecked?: readonly number[];
+}
+
+/** Normalized input action (the driver maps raw keypresses to these). */
+export type IWizardAction =
+  | "up"
+  | "down"
+  | "toggle"
+  | "confirm"
+  | "back"
+  | "cancel";
+
+/** The wizard's full state. `stepIndex === steps.length` is the final overview
+ *  screen. `status` leaves "active" only on apply/cancel. */
+export interface IWizardState {
+  readonly stepIndex: number;
+  readonly cursor: number;
+  readonly single: Readonly<Record<string, string>>;
+  readonly multi: Readonly<Record<string, readonly number[]>>;
+  readonly status: "active" | "apply" | "cancel";
+}

--- a/packages/core/src/setup/run-setup.ts
+++ b/packages/core/src/setup/run-setup.ts
@@ -1,0 +1,121 @@
+import { scanRepo, recommendConventions } from "../infer-rules/scan";
+import type { IConventions } from "../infer-rules/conventions.types";
+import type { IScanReport } from "../infer-rules/scan.types";
+import { runWizard } from "../render/wizard";
+import {
+  buildSteps,
+  configPreview,
+  nonDefaultConventions,
+  selectionsToConventions,
+} from "./wizard-flow";
+import { writeSetupConfig } from "./write-config";
+import type { ISetupConfig } from "./setup.types";
+
+export interface IRunSetupOptions {
+  readonly cwd: string;
+  readonly yes: boolean;
+  readonly color: boolean;
+  /** Defaults to process.stdin/out TTY detection; injectable for tests. */
+  readonly interactive?: boolean;
+  readonly out?: (s: string) => void;
+}
+
+const SAFETY_NOTE =
+  "Safety rules (no `any`/`as`/`!`, complexity cap, `===`) are NEVER weakened by setup.";
+
+function setupFor(conventions: IConventions): ISetupConfig {
+  const diff = nonDefaultConventions(conventions);
+
+  return Object.keys(diff).length > 0 ? { conventions: diff } : {};
+}
+
+/** Write the chosen conventions + evidence and print a calm summary. Returns the
+ *  process exit code. */
+async function applyAndReport(
+  opts: IRunSetupOptions,
+  conventions: IConventions,
+  report: IScanReport,
+  write: (s: string) => void
+): Promise<number> {
+  const result = await writeSetupConfig(
+    opts.cwd,
+    setupFor(conventions),
+    report
+  );
+
+  if (!result.ok) {
+    if (result.reason === "invalid-existing-json") {
+      write(
+        `\nExisting tsforge.config.json is invalid JSON (${result.error}). Fix or remove it, then re-run.\n`
+      );
+    } else {
+      write(`\nCould not write config: ${result.error}\n`);
+    }
+
+    return 1;
+  }
+
+  write(
+    `\n✓ Wrote ${result.path}. ${SAFETY_NOTE}\n` +
+      `  Evidence: ${result.evidencePath ?? "(none)"}\n` +
+      `  Tip: run /map to prime tsforge on this repo.\n`
+  );
+
+  return 0;
+}
+
+/** Print the scan + proposed config without writing (non-TTY, no --yes). */
+function reportNonTty(
+  report: IScanReport,
+  recommended: IConventions,
+  write: (s: string) => void
+): number {
+  write(
+    `\ntsforge setup (non-interactive)\n` +
+      `  stack: ${report.stack.name} (${report.stack.confidence})\n` +
+      `  files scanned: ${report.filesScanned}\n\n` +
+      `Proposed conventions:\n${configPreview(recommended)}\n\n` +
+      `${SAFETY_NOTE}\n` +
+      `Re-run in a terminal to choose interactively, or pass --yes to write these.\n`
+  );
+
+  return 0;
+}
+
+/**
+ * Run `tsforge setup`. Interactive TTY ⇒ the wizard (nothing written until Apply);
+ * `--yes` ⇒ writes the scan's recommendations non-interactively; non-TTY without
+ * `--yes` ⇒ prints the scan + proposal and writes nothing. Returns an exit code.
+ */
+export async function runSetup(opts: IRunSetupOptions): Promise<number> {
+  const write = opts.out ?? ((s: string): void => void process.stdout.write(s));
+  const report = await scanRepo(opts.cwd);
+  const recommended = recommendConventions(report);
+
+  if (opts.yes) {
+    return applyAndReport(opts, recommended, report, write);
+  }
+
+  const interactive =
+    opts.interactive ?? (process.stdin.isTTY && process.stdout.isTTY);
+
+  if (!interactive) {
+    return reportNonTty(report, recommended, write);
+  }
+
+  const steps = buildSteps(report);
+  const final = await runWizard(
+    steps,
+    opts.color,
+    (state) =>
+      `${configPreview(selectionsToConventions(state))}\n\n${SAFETY_NOTE}`
+  );
+
+  if (final.status !== "apply") {
+    write("\nSetup cancelled — nothing written.\n");
+
+    return 0;
+  }
+
+  return applyAndReport(opts, selectionsToConventions(final), report, write);
+}

--- a/packages/core/src/setup/run-setup.ts
+++ b/packages/core/src/setup/run-setup.ts
@@ -24,9 +24,10 @@ const SAFETY_NOTE =
   "Safety rules (no `any`/`as`/`!`, complexity cap, `===`) are NEVER weakened by setup.";
 
 function setupFor(conventions: IConventions): ISetupConfig {
-  const diff = nonDefaultConventions(conventions);
-
-  return Object.keys(diff).length > 0 ? { conventions: diff } : {};
+  // ALWAYS carry a conventions block (possibly empty) so the writer replaces or
+  // removes any prior block — re-running setup re-decides all four keys, and the
+  // written file always matches the choices the overview showed.
+  return { conventions: nonDefaultConventions(conventions) };
 }
 
 /** Write the chosen conventions + evidence and print a calm summary. Returns the

--- a/packages/core/src/setup/setup.types.ts
+++ b/packages/core/src/setup/setup.types.ts
@@ -1,0 +1,37 @@
+import type { ProfileId } from "../config/profiles";
+import type { IConventions } from "../infer-rules/conventions.types";
+import type { IScanReport } from "../infer-rules/scan.types";
+
+/** The setup-managed fields the wizard writes into tsforge.config.json. Everything
+ *  NOT listed here (mcpServers, plugins, policy, rules, stack, unknown keys) is
+ *  preserved untouched by the writer. */
+export interface ISetupConfig {
+  readonly profile?: ProfileId;
+  readonly packs?: {
+    readonly include?: readonly string[];
+    readonly exclude?: readonly string[];
+  };
+  readonly conventions?: Readonly<Partial<IConventions>>;
+}
+
+/** Result of writing the config. `invalid-existing-json` means the on-disk config
+ *  could not be parsed and `overwriteInvalid` was not set — the caller decides
+ *  (interactive: ask; non-TTY: exit non-zero). */
+export type IWriteResult =
+  | { readonly ok: true; readonly path: string; readonly evidencePath?: string }
+  | {
+      readonly ok: false;
+      readonly reason: "invalid-existing-json";
+      readonly error: string;
+    }
+  | {
+      readonly ok: false;
+      readonly reason: "write-failed";
+      readonly error: string;
+    };
+
+/** What the wizard collects and hands to the writer + the final overview screen. */
+export interface ISetupResult {
+  readonly setup: ISetupConfig;
+  readonly report: IScanReport;
+}

--- a/packages/core/src/setup/wizard-flow.ts
+++ b/packages/core/src/setup/wizard-flow.ts
@@ -1,0 +1,253 @@
+import { isWebStack } from "../stack-detection";
+import {
+  DEFAULT_CONVENTIONS,
+  isComponentFoldersConvention,
+  isEnumConvention,
+  isInterfaceConvention,
+  isTestConvention,
+} from "../infer-rules/conventions";
+import type { IConventions } from "../infer-rules/conventions.types";
+import { recommendConventions } from "../infer-rules/scan";
+import type { IScanReport } from "../infer-rules/scan.types";
+import type {
+  IWizardOption,
+  IWizardState,
+  IWizardStep,
+} from "../render/wizard.types";
+
+/** Build a single-select step whose recommended option (by value) is preselected
+ *  and tagged. Keeps option ORDER stable; only the default/flag follow the rec. */
+function singleStep(
+  key: string,
+  title: string,
+  explanation: string,
+  evidence: readonly string[],
+  options: readonly Omit<IWizardOption, "recommended">[],
+  recommended: string
+): IWizardStep {
+  const decorated = options.map((o) => ({
+    ...o,
+    recommended: o.value === recommended,
+  }));
+  const defaultIndex = Math.max(
+    0,
+    decorated.findIndex((o) => o.value === recommended)
+  );
+
+  return {
+    key,
+    kind: "single",
+    title,
+    explanation,
+    evidence,
+    options: decorated,
+    defaultIndex,
+  };
+}
+
+function interfacesStep(report: IScanReport, rec: IConventions): IWizardStep {
+  const { iPrefixed, bare, total, iExamples, bareExamples } = report.interfaces;
+  const evidence =
+    total === 0
+      ? ["No interfaces found — using the tsforge default."]
+      : [
+          `${total} interfaces scanned`,
+          `${iPrefixed} I-prefixed   ${iExamples.join(", ")}`.trim(),
+          `${bare} bare PascalCase   ${bareExamples.join(", ")}`.trim(),
+        ];
+
+  return singleStep(
+    "interfaces",
+    "Naming conventions",
+    "What should tsforge expect when it writes or reviews interfaces?",
+    evidence,
+    [
+      {
+        label: "Match repo: bare PascalCase",
+        value: "bare-pascal-case",
+        outcome:
+          'conventions.interfaces = "bare-pascal-case"; drops I-prefix from gate + prompts.',
+      },
+      {
+        label: "Enforce house style: I-prefix",
+        value: "i-prefix",
+        outcome: 'conventions.interfaces = "i-prefix" (IUser, IOrder).',
+      },
+      {
+        label: "Don't enforce interface naming",
+        value: "off",
+        outcome: 'conventions.interfaces = "off"; naming rule removed.',
+      },
+    ],
+    rec.interfaces
+  );
+}
+
+function enumsStep(report: IScanReport, rec: IConventions): IWizardStep {
+  return singleStep(
+    "enums",
+    "Enums",
+    "TypeScript `enum` is banned by default (use `as const`). Allowing enums NEVER affects the separate `as`-cast ban.",
+    [`${report.enums.fileCount} files declare an enum`],
+    [
+      {
+        label: "Ban enums (use `as const`)",
+        value: "ban",
+        outcome: 'conventions.enums = "ban".',
+      },
+      {
+        label: "Allow enums",
+        value: "allow",
+        outcome: 'conventions.enums = "allow"; cast bans stay intact.',
+      },
+    ],
+    rec.enums
+  );
+}
+
+function testsStep(report: IScanReport, rec: IConventions): IWizardStep {
+  return singleStep(
+    "tests",
+    "Test layout",
+    "Where should a logic file's test live for the gate to accept it?",
+    [
+      `${report.tests.coLocated} co-located · ${report.tests.mirrored} in a tests/ mirror`,
+    ],
+    [
+      {
+        label: "Co-located (`foo.test.ts` beside `foo.ts`)",
+        value: "co-located",
+        outcome: 'conventions.tests = "co-located".',
+      },
+      {
+        label: "Mirrored (`tests/` directory)",
+        value: "mirrored",
+        outcome: 'conventions.tests = "mirrored".',
+      },
+      {
+        label: "Either layout is fine",
+        value: "either",
+        outcome: 'conventions.tests = "either".',
+      },
+    ],
+    rec.tests
+  );
+}
+
+function componentFoldersStep(
+  report: IScanReport,
+  rec: IConventions
+): IWizardStep {
+  const f = report.folders;
+  const present = [
+    f.views ? "src/views" : "",
+    f.features ? "src/features" : "",
+    f.flatComponents ? "src/components" : "",
+    f.routeFolders ? "route folders" : "",
+  ].filter((s) => s.length > 0);
+
+  return singleStep(
+    "componentFolders",
+    "Component folders",
+    "How should frontend components be organized when tsforge writes them?",
+    [
+      present.length > 0
+        ? `Detected: ${present.join(", ")}`
+        : "No component folders detected yet.",
+    ],
+    [
+      {
+        label: "tsforge views (`src/views/<Feature>/`)",
+        value: "tsforge-views",
+        outcome: 'conventions.componentFolders = "tsforge-views".',
+      },
+      {
+        label: "Match the repo's own layout",
+        value: "repo",
+        outcome: 'conventions.componentFolders = "repo".',
+      },
+      {
+        label: "Warn only",
+        value: "warn",
+        outcome: 'conventions.componentFolders = "warn".',
+      },
+    ],
+    rec.componentFolders
+  );
+}
+
+/** Build the wizard steps from a scan. The component-folders step only appears for
+ *  frontend stacks (it's meaningless for a backend repo). */
+export function buildSteps(report: IScanReport): IWizardStep[] {
+  const rec = recommendConventions(report);
+  const steps = [
+    interfacesStep(report, rec),
+    enumsStep(report, rec),
+    testsStep(report, rec),
+  ];
+
+  if (
+    isWebStack(report.stack) ||
+    report.folders.views ||
+    report.folders.features
+  ) {
+    steps.push(componentFoldersStep(report, rec));
+  }
+
+  return steps;
+}
+
+/** Map the wizard's recorded single-select answers back to a resolved convention
+ *  set (any unanswered step falls back to the house default). */
+export function selectionsToConventions(state: IWizardState): IConventions {
+  const s = state.single;
+
+  return {
+    interfaces: isInterfaceConvention(s.interfaces)
+      ? s.interfaces
+      : DEFAULT_CONVENTIONS.interfaces,
+    enums: isEnumConvention(s.enums) ? s.enums : DEFAULT_CONVENTIONS.enums,
+    tests: isTestConvention(s.tests) ? s.tests : DEFAULT_CONVENTIONS.tests,
+    componentFolders: isComponentFoldersConvention(s.componentFolders)
+      ? s.componentFolders
+      : DEFAULT_CONVENTIONS.componentFolders,
+  };
+}
+
+/** Only the fields that DIFFER from the house default — what we actually write,
+ *  so a config stays minimal and a default choice adds no noise. */
+export function nonDefaultConventions(
+  conventions: IConventions
+): Partial<IConventions> {
+  const out: { -readonly [K in keyof IConventions]?: IConventions[K] } = {};
+
+  if (conventions.interfaces !== DEFAULT_CONVENTIONS.interfaces) {
+    out.interfaces = conventions.interfaces;
+  }
+
+  if (conventions.enums !== DEFAULT_CONVENTIONS.enums) {
+    out.enums = conventions.enums;
+  }
+
+  if (conventions.tests !== DEFAULT_CONVENTIONS.tests) {
+    out.tests = conventions.tests;
+  }
+
+  if (conventions.componentFolders !== DEFAULT_CONVENTIONS.componentFolders) {
+    out.componentFolders = conventions.componentFolders;
+  }
+
+  return out;
+}
+
+/** The exact tsforge.config.json fragment that will be written (overview preview).
+ *  Empty conventions ⇒ a note that nothing changes from the defaults. */
+export function configPreview(conventions: IConventions): string {
+  const diff = nonDefaultConventions(conventions);
+
+  if (Object.keys(diff).length === 0) {
+    return "tsforge.config.json: all choices are tsforge defaults — no conventions written.";
+  }
+
+  return `tsforge.config.json:\n${JSON.stringify({ conventions: diff }, null, 2)}`;
+}

--- a/packages/core/src/setup/write-config.ts
+++ b/packages/core/src/setup/write-config.ts
@@ -1,0 +1,110 @@
+import { join } from "node:path";
+import { isRecord } from "../lib/guards";
+import { writeFilesOrRollback, type IWriteFile } from "../lib/fs/fs";
+import type { IScanReport } from "../infer-rules/scan.types";
+import type { ISetupConfig, IWriteResult } from "./setup.types";
+
+const CONFIG_FILE = "tsforge.config.json";
+const EVIDENCE_FILE = ".tsforge/setup-evidence.json";
+
+/** Merge the setup-managed fields onto an existing config object, PRESERVING every
+ *  other key (mcpServers, plugins, policy, rules, stack, and any unknown keys).
+ *  User-selected setup fields win. Pure — no IO. */
+export function mergeSetupConfig(
+  existing: Readonly<Record<string, unknown>>,
+  setup: ISetupConfig
+): Record<string, unknown> {
+  const out: Record<string, unknown> = { ...existing };
+
+  if (setup.profile !== undefined) {
+    out.profile = setup.profile;
+  }
+
+  if (setup.packs !== undefined) {
+    out.packs = setup.packs;
+  }
+
+  if (setup.conventions !== undefined) {
+    out.conventions = setup.conventions;
+  }
+
+  return out;
+}
+
+/** Parse the existing config text, or signal that it's unparseable. */
+function parseExisting(
+  text: string
+): { ok: true; value: Record<string, unknown> } | { ok: false; error: string } {
+  try {
+    const parsed: unknown = JSON.parse(text);
+
+    if (!isRecord(parsed)) {
+      return { ok: false, error: "config root is not an object" };
+    }
+
+    return { ok: true, value: parsed };
+  } catch (err) {
+    return {
+      ok: false,
+      error: err instanceof Error ? err.message : String(err),
+    };
+  }
+}
+
+function serialize(value: unknown): string {
+  return `${JSON.stringify(value, null, 2)}\n`;
+}
+
+/**
+ * Write the wizard's choices into tsforge.config.json (merged, preserving unrelated
+ * fields) and the scan evidence into .tsforge/setup-evidence.json — ATOMICALLY (both
+ * land or neither, via writeFilesOrRollback). If the existing config is invalid JSON,
+ * refuse unless `overwriteInvalid` is set, so the caller can ask the user first.
+ * Runtime reads the CONFIG, never the evidence (which is audit/debug only).
+ */
+export async function writeSetupConfig(
+  cwd: string,
+  setup: ISetupConfig,
+  report: IScanReport | undefined,
+  opts: { overwriteInvalid?: boolean } = {}
+): Promise<IWriteResult> {
+  const configHandle = Bun.file(join(cwd, CONFIG_FILE));
+  let existing: Record<string, unknown> = {};
+
+  if (await configHandle.exists()) {
+    const parsed = parseExisting(await configHandle.text());
+
+    if (!parsed.ok) {
+      if (opts.overwriteInvalid !== true) {
+        return {
+          ok: false,
+          reason: "invalid-existing-json",
+          error: parsed.error,
+        };
+      }
+    } else {
+      existing = parsed.value;
+    }
+  }
+
+  const merged = mergeSetupConfig(existing, setup);
+  const files: IWriteFile[] = [
+    { path: CONFIG_FILE, content: serialize(merged) },
+  ];
+
+  if (report !== undefined) {
+    files.push({ path: EVIDENCE_FILE, content: serialize(report) });
+  }
+
+  const result = await writeFilesOrRollback(cwd, files);
+
+  if (!result.ok) {
+    return { ok: false, reason: "write-failed", error: result.reason };
+  }
+
+  return {
+    ok: true,
+    path: CONFIG_FILE,
+    ...(report === undefined ? {} : { evidencePath: EVIDENCE_FILE }),
+  };
+}

--- a/packages/core/src/setup/write-config.ts
+++ b/packages/core/src/setup/write-config.ts
@@ -25,7 +25,15 @@ export function mergeSetupConfig(
   }
 
   if (setup.conventions !== undefined) {
-    out.conventions = setup.conventions;
+    // The conventions block is wholly setup-owned. A present block REPLACES the
+    // existing one so a re-run reflects the new decision exactly; an EMPTY block
+    // (all choices back to default) REMOVES it, so a re-run can't leave a stale
+    // non-default block the overview said it wouldn't write.
+    if (Object.keys(setup.conventions).length > 0) {
+      out.conventions = setup.conventions;
+    } else {
+      delete out.conventions;
+    }
   }
 
   return out;

--- a/packages/core/strict.eslint.config.mjs
+++ b/packages/core/strict.eslint.config.mjs
@@ -10,7 +10,10 @@
 // Stack-aware rule packs are loaded via TSFORGE_PACKS env var (comma-separated
 // pack IDs), allowing the gate to inject stack-specific rules dynamically.
 // Rule overrides are loaded via TSFORGE_RULE_OVERRIDES env var (JSON-encoded
-// map of bare rule names to "error" | "warn" | "off").
+// map of bare rule names to "error" | "warn" | "off"). Project CONVENTIONS
+// (interface naming, enum policy) are loaded via TSFORGE_CONVENTIONS (JSON) and
+// rebuild the naming-convention / no-restricted-syntax rule OPTIONS — the single
+// source shared with the gate command, the write-time linter, and the prompts.
 import tseslint from "typescript-eslint";
 import stylistic from "@stylistic/eslint-plugin";
 import sonarjs from "eslint-plugin-sonarjs";
@@ -33,9 +36,7 @@ if (process.env.TSFORGE_RULE_OVERRIDES !== undefined) {
 
 if (packIds.length > 0) {
   try {
-    const { buildPackEslintConfig } = await import(
-      "./src/rule-packs/index.ts"
-    );
+    const { buildPackEslintConfig } = await import("./src/rule-packs/index.ts");
     const { plugin, rules } = buildPackEslintConfig(packIds, ruleOverrides);
     packConfig = [
       {
@@ -49,6 +50,83 @@ if (packIds.length > 0) {
   }
 }
 
+// The convention-managed rules. Default to tsforge's house style (I-prefix +
+// enum ban) so a failed import NEVER silently drops the enum ban / naming rule;
+// the builder then rebuilds them from TSFORGE_CONVENTIONS, and the override pass
+// honors TSFORGE_RULE_OVERRIDES on the bundled rules (safety floor protected).
+let conventionRules = {
+  "@typescript-eslint/naming-convention": [
+    "error",
+    { selector: "interface", format: ["PascalCase"], prefix: ["I"] },
+  ],
+  "no-restricted-syntax": [
+    "error",
+    {
+      selector: "TSEnumDeclaration",
+      message: "Use 'as const' object literals instead of enums.",
+    },
+  ],
+};
+let applyBundledOverrides = (rules) => rules;
+
+try {
+  const conv = await import("./src/infer-rules/eslint-conventions.ts");
+  const conventions = conv.parseConventionsEnv(process.env.TSFORGE_CONVENTIONS);
+  conventionRules = conv.conventionRuleEntries(conventions, "core");
+  applyBundledOverrides = (rules) =>
+    conv.applyBundledOverrides(rules, ruleOverrides);
+} catch {
+  // Keep the hardcoded house-style defaults above.
+}
+
+// Bundled syntactic rules MINUS the two convention-managed ones (spliced below).
+const bundledRules = {
+  // Concern-mixing / copy-paste ceiling (syntactic — no type info needed).
+  // cc <= 20 is the house rule tsforge holds ITSELF to (eslint.config.js); it
+  // forces the model to decompose a sprawling function into named helpers
+  // instead of one un-reviewable block. Not auto-fixable, so it surfaces as a
+  // hand-fix error — the intended "split this up" signal. max-depth/max-params
+  // are zero-dep ESLint-core complements.
+  "sonarjs/cognitive-complexity": ["error", 20],
+  "sonarjs/no-identical-functions": "error",
+  "max-depth": ["error", 4],
+  "max-params": ["error", 4],
+  // The idioms the model habitually violates — all caught WITHOUT type info.
+  "@typescript-eslint/consistent-type-assertions": [
+    "error",
+    { assertionStyle: "never" },
+  ],
+  "@typescript-eslint/no-explicit-any": "error",
+  "@typescript-eslint/no-non-null-assertion": "error",
+  "@typescript-eslint/no-inferrable-types": "error",
+  "prefer-const": "error",
+  "prefer-template": "error",
+  "no-var": "error",
+  // Blank-line discipline — the model rarely gets spacing right, so
+  // eslint --fix + prettier make it free. Uses @stylistic (the rule's
+  // maintained home; the core rule is deprecated and spams usedDeprecatedRules
+  // into eslint's --format json gate output).
+  "@stylistic/padding-line-between-statements": [
+    "error",
+    { blankLine: "always", prev: "import", next: "*" },
+    { blankLine: "any", prev: "import", next: "import" },
+    { blankLine: "always", prev: "*", next: "return" },
+    { blankLine: "always", prev: "*", next: "throw" },
+    { blankLine: "always", prev: ["const", "let", "var"], next: "*" },
+    {
+      blankLine: "any",
+      prev: ["const", "let", "var"],
+      next: ["const", "let", "var"],
+    },
+    { blankLine: "always", prev: "block-like", next: "*" },
+    { blankLine: "always", prev: "*", next: "block-like" },
+  ],
+  eqeqeq: ["error", "always"],
+  curly: ["error", "all"],
+};
+
+const rules = applyBundledOverrides({ ...bundledRules, ...conventionRules });
+
 export default tseslint.config(
   { ignores: ["**/node_modules/**", "**/dist/**", "**/build/**"] },
   {
@@ -59,61 +137,7 @@ export default tseslint.config(
       "@stylistic": stylistic,
       sonarjs,
     },
-    rules: {
-      // Concern-mixing / copy-paste ceiling (syntactic — no type info needed).
-      // cc <= 20 is the house rule tsforge holds ITSELF to (eslint.config.js); it
-      // forces the model to decompose a sprawling function into named helpers
-      // instead of one un-reviewable block. Not auto-fixable, so it surfaces as a
-      // hand-fix error — the intended "split this up" signal. max-depth/max-params
-      // are zero-dep ESLint-core complements.
-      "sonarjs/cognitive-complexity": ["error", 20],
-      "sonarjs/no-identical-functions": "error",
-      "max-depth": ["error", 4],
-      "max-params": ["error", 4],
-      // The idioms the model habitually violates — all caught WITHOUT type info.
-      "@typescript-eslint/consistent-type-assertions": [
-        "error",
-        { assertionStyle: "never" },
-      ],
-      "@typescript-eslint/no-explicit-any": "error",
-      "@typescript-eslint/no-non-null-assertion": "error",
-      "@typescript-eslint/no-inferrable-types": "error",
-      "@typescript-eslint/naming-convention": [
-        "error",
-        { selector: "interface", format: ["PascalCase"], prefix: ["I"] },
-      ],
-      "prefer-const": "error",
-      "prefer-template": "error",
-      "no-var": "error",
-      // Blank-line discipline — the model rarely gets spacing right, so
-      // eslint --fix + prettier make it free. Uses @stylistic (the rule's
-      // maintained home; the core rule is deprecated and spams usedDeprecatedRules
-      // into eslint's --format json gate output).
-      "@stylistic/padding-line-between-statements": [
-        "error",
-        { blankLine: "always", prev: "import", next: "*" },
-        { blankLine: "any", prev: "import", next: "import" },
-        { blankLine: "always", prev: "*", next: "return" },
-        { blankLine: "always", prev: "*", next: "throw" },
-        { blankLine: "always", prev: ["const", "let", "var"], next: "*" },
-        {
-          blankLine: "any",
-          prev: ["const", "let", "var"],
-          next: ["const", "let", "var"],
-        },
-        { blankLine: "always", prev: "block-like", next: "*" },
-        { blankLine: "always", prev: "*", next: "block-like" },
-      ],
-      eqeqeq: ["error", "always"],
-      curly: ["error", "all"],
-      "no-restricted-syntax": [
-        "error",
-        {
-          selector: "TSEnumDeclaration",
-          message: "Use 'as const' object literals instead of enums.",
-        },
-      ],
-    },
+    rules,
   },
   ...packConfig
 );

--- a/packages/core/strict.web.eslint.config.mjs
+++ b/packages/core/strict.web.eslint.config.mjs
@@ -7,7 +7,10 @@
 // via AST selectors), since `as const` is idiomatic for typed literal registries.
 //
 // Stack-aware rule packs are loaded via TSFORGE_PACKS env var (comma-separated
-// pack IDs), allowing the gate to inject stack-specific rules dynamically.
+// pack IDs). Rule overrides via TSFORGE_RULE_OVERRIDES (JSON severity map), and
+// project CONVENTIONS via TSFORGE_CONVENTIONS (JSON) — the latter rebuilds the
+// naming-convention / no-restricted-syntax rule OPTIONS (the single source shared
+// with the gate command, the write-time linter, and the prompts).
 import tseslint from "typescript-eslint";
 import stylistic from "@stylistic/eslint-plugin";
 import pluginReact from "eslint-plugin-react";
@@ -19,12 +22,25 @@ import sonarjs from "eslint-plugin-sonarjs";
 let packConfig = [];
 const packIds = (process.env.TSFORGE_PACKS ?? "").split(",").filter(Boolean);
 const isWebStack = packIds.length > 0;
+let ruleOverrides = {};
+
+if (process.env.TSFORGE_RULE_OVERRIDES !== undefined) {
+  try {
+    ruleOverrides = JSON.parse(process.env.TSFORGE_RULE_OVERRIDES);
+    if (typeof ruleOverrides !== "object" || ruleOverrides === null) {
+      ruleOverrides = {};
+    }
+  } catch {
+    // If parsing fails, silently ignore overrides
+  }
+}
+
 if (packIds.length > 0) {
   try {
     const { buildPackEslintConfig } = await import(
       "./src/rule-packs/index.ts"
     );
-    const { plugin, rules } = buildPackEslintConfig(packIds);
+    const { plugin, rules } = buildPackEslintConfig(packIds, ruleOverrides);
     packConfig = [
       {
         files: ["**/*.ts", "**/*.tsx"],
@@ -35,6 +51,50 @@ if (packIds.length > 0) {
   } catch {
     // If pack loading fails, silently continue without them
   }
+}
+
+// Convention-managed rules — default to the web house style (I-prefix with the
+// TanStack `Register` exemption + enum ban + the value-changing cast bans) so a
+// failed import NEVER drops the cast/enum safety; the builder then rebuilds them
+// from TSFORGE_CONVENTIONS (enum ban split from the ALWAYS-on cast bans).
+let conventionRules = {
+  "@typescript-eslint/naming-convention": [
+    "error",
+    {
+      selector: "interface",
+      format: ["PascalCase"],
+      prefix: ["I"],
+      filter: { regex: "^(Register)$", match: false },
+    },
+  ],
+  "no-restricted-syntax": [
+    "error",
+    {
+      selector: "TSEnumDeclaration",
+      message: "Use 'as const' object literals instead of enums.",
+    },
+    {
+      selector: "TSAsExpression[typeAnnotation.typeName.name!='const']",
+      message:
+        "No `as` type casts — type it properly (annotate, narrow, or guard). `as const` is allowed.",
+    },
+    {
+      selector: "TSTypeAssertion",
+      message:
+        "No angle-bracket type assertions — type it properly. `as const` is allowed.",
+    },
+  ],
+};
+let applyBundledOverrides = (rules) => rules;
+
+try {
+  const conv = await import("./src/infer-rules/eslint-conventions.ts");
+  const conventions = conv.parseConventionsEnv(process.env.TSFORGE_CONVENTIONS);
+  conventionRules = conv.conventionRuleEntries(conventions, "web");
+  applyBundledOverrides = (rules) =>
+    conv.applyBundledOverrides(rules, ruleOverrides);
+} catch {
+  // Keep the hardcoded house-style defaults above.
 }
 
 // Custom rule: ONE React component per .tsx file (boringstack). The classic
@@ -103,6 +163,65 @@ const oneComponentPerFile = {
   },
 };
 
+// Bundled web rules MINUS the two convention-managed ones. NOTE: we do NOT use
+// `consistent-type-assertions: never` here — that also bans `as const`, which is
+// idiomatic for typed literal/tuple data. Value-changing casts (`x as Foo`,
+// `<Foo>x`) are banned via the AST selectors inside the convention-managed
+// `no-restricted-syntax` (ALWAYS on, independent of the enum choice).
+const webBundledRules = {
+  // Concern-mixing / copy-paste ceiling (syntactic — mirrors the core config).
+  // cc <= 20 forces decomposition into named helpers; max-depth/max-params are
+  // zero-dep ESLint-core complements.
+  "sonarjs/cognitive-complexity": ["error", 20],
+  "sonarjs/no-identical-functions": "error",
+  "max-depth": ["error", 4],
+  "max-params": ["error", 4],
+  "@typescript-eslint/no-explicit-any": "error",
+  "@typescript-eslint/no-non-null-assertion": "error",
+  "@typescript-eslint/no-inferrable-types": "error",
+  // ONE React component per .tsx file (boringstack). Enforced by the custom
+  // rule defined above — eslint-plugin-react/no-multi-comp crashes on ESLint 10
+  // and @eslint-react has no equivalent, so we ship our own.
+  "boringstack/one-component-per-file": "error",
+  "react/jsx-key": "error",
+  "react/no-array-index-key": "error",
+  "react/button-has-type": "error",
+  "react-hooks/rules-of-hooks": "error",
+  "react-hooks/exhaustive-deps": "warn",
+  "prefer-const": "error",
+  "prefer-template": "error",
+  "no-var": "error",
+  // Blank-line discipline (mirrors the core config) — the model rarely gets
+  // spacing right, so prettier --write + this rule's --fix make it free. Uses
+  // @stylistic (the rule's maintained home; the core rule is deprecated and
+  // spams `usedDeprecatedRules` into eslint's --format json gate output).
+  "@stylistic/padding-line-between-statements": [
+    "error",
+    { blankLine: "always", prev: "import", next: "*" },
+    { blankLine: "any", prev: "import", next: "import" },
+    { blankLine: "always", prev: "*", next: "return" },
+    { blankLine: "always", prev: "*", next: "throw" },
+    { blankLine: "always", prev: ["const", "let", "var"], next: "*" },
+    {
+      blankLine: "any",
+      prev: ["const", "let", "var"],
+      next: ["const", "let", "var"],
+    },
+    { blankLine: "always", prev: "block-like", next: "*" },
+    { blankLine: "always", prev: "*", next: "block-like" },
+  ],
+  eqeqeq: ["error", "always"],
+  curly: ["error", "all"],
+};
+
+// Pack rules win last (they already had TSFORGE_RULE_OVERRIDES applied via
+// buildPackEslintConfig), so apply the bundled-override pass only to the bundled +
+// convention rules, then layer pack rules on top — unchanged from before.
+const rules = {
+  ...applyBundledOverrides({ ...webBundledRules, ...conventionRules }),
+  ...packConfig.reduce((acc, cfg) => ({ ...acc, ...(cfg.rules ?? {}) }), {}),
+};
+
 export default tseslint.config(
   { ignores: ["**/node_modules/**", "**/dist/**", "**/build/**"] },
   {
@@ -121,85 +240,7 @@ export default tseslint.config(
         )
         .reduce((acc, cfg) => ({ ...acc, ...cfg.plugins }), {}),
     },
-    rules: {
-      // NOTE: we do NOT use `consistent-type-assertions: never` here — that also
-      // bans `as const`, which is idiomatic and the cleanest escape for typed
-      // literal/tuple data (and it makes a fixed array a tuple, so literal-index
-      // access is defined, not `T | undefined`). Instead we ban only the
-      // value-changing forms (`x as Foo`, `<Foo>x`) via AST selectors below.
-      // Concern-mixing / copy-paste ceiling (syntactic — mirrors the core config).
-      // cc <= 20 forces decomposition into named helpers; max-depth/max-params are
-      // zero-dep ESLint-core complements.
-      "sonarjs/cognitive-complexity": ["error", 20],
-      "sonarjs/no-identical-functions": "error",
-      "max-depth": ["error", 4],
-      "max-params": ["error", 4],
-      "@typescript-eslint/no-explicit-any": "error",
-      "@typescript-eslint/no-non-null-assertion": "error",
-      "@typescript-eslint/no-inferrable-types": "error",
-      // I-prefixed interfaces (house style), EXCEPT library-mandated augmentation
-      // names you cannot rename (TanStack Router's `interface Register`).
-      "@typescript-eslint/naming-convention": [
-        "error",
-        {
-          selector: "interface",
-          format: ["PascalCase"],
-          prefix: ["I"],
-          filter: { regex: "^(Register)$", match: false },
-        },
-      ],
-      // ONE React component per .tsx file (boringstack). Enforced by the custom
-      // rule defined above — eslint-plugin-react/no-multi-comp crashes on ESLint 10
-      // and @eslint-react has no equivalent, so we ship our own.
-      "boringstack/one-component-per-file": "error",
-      "react/jsx-key": "error",
-      "react/no-array-index-key": "error",
-      "react/button-has-type": "error",
-      "react-hooks/rules-of-hooks": "error",
-      "react-hooks/exhaustive-deps": "warn",
-      "prefer-const": "error",
-      "prefer-template": "error",
-      "no-var": "error",
-      // Blank-line discipline (mirrors the core config) — the model rarely gets
-      // spacing right, so prettier --write + this rule's --fix make it free. Uses
-      // @stylistic (the rule's maintained home; the core rule is deprecated and
-      // spams `usedDeprecatedRules` into eslint's --format json gate output).
-      "@stylistic/padding-line-between-statements": [
-        "error",
-        { blankLine: "always", prev: "import", next: "*" },
-        { blankLine: "any", prev: "import", next: "import" },
-        { blankLine: "always", prev: "*", next: "return" },
-        { blankLine: "always", prev: "*", next: "throw" },
-        { blankLine: "always", prev: ["const", "let", "var"], next: "*" },
-        {
-          blankLine: "any",
-          prev: ["const", "let", "var"],
-          next: ["const", "let", "var"],
-        },
-        { blankLine: "always", prev: "block-like", next: "*" },
-        { blankLine: "always", prev: "*", next: "block-like" },
-      ],
-      eqeqeq: ["error", "always"],
-      curly: ["error", "all"],
-      "no-restricted-syntax": [
-        "error",
-        {
-          selector: "TSEnumDeclaration",
-          message: "Use 'as const' object literals instead of enums.",
-        },
-        {
-          selector: "TSAsExpression[typeAnnotation.typeName.name!='const']",
-          message:
-            "No `as` type casts — type it properly (annotate, narrow, or guard). `as const` is allowed.",
-        },
-        {
-          selector: "TSTypeAssertion",
-          message:
-            "No angle-bracket type assertions — type it properly. `as const` is allowed.",
-        },
-      ],
-      ...packConfig.reduce((acc, cfg) => ({ ...acc, ...(cfg.rules ?? {}) }), {}),
-    },
+    rules,
     settings: {
       react: { version: "detect" },
     },

--- a/packages/core/tests/cli.test.ts
+++ b/packages/core/tests/cli.test.ts
@@ -56,6 +56,18 @@ test("`tsforge run` with no id flags the run subcommand (so main can error)", ()
   expect(a.recipe).toBe("");
 });
 
+test("`tsforge setup` flags the setup subcommand; --yes sets setupYes", () => {
+  const a = parseArgs(["setup"]);
+
+  expect(a.setup).toBe(true);
+  expect(a.setupYes).toBe(false);
+
+  const b = parseArgs(["setup", "--yes"]);
+
+  expect(b.setup).toBe(true);
+  expect(b.setupYes).toBe(true);
+});
+
 test("`tsforge recipes` and `--recipe <id>` are recognized", () => {
   expect(parseArgs(["recipes"]).recipes).toBe(true);
   expect(parseArgs(["--recipe", "web-build", "build it"]).recipe).toBe(

--- a/packages/core/tests/conventions.test.ts
+++ b/packages/core/tests/conventions.test.ts
@@ -1,0 +1,121 @@
+import { describe, test, expect } from "bun:test";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { loadTsforgeConfig } from "../src/config/tsforge-config";
+import {
+  DEFAULT_CONVENTIONS,
+  isComponentFoldersConvention,
+  isEnumConvention,
+  isInterfaceConvention,
+  isTestConvention,
+  resolveConventions,
+} from "../src/infer-rules/conventions";
+
+async function withConfig<T>(
+  body: unknown,
+  fn: (dir: string) => Promise<T>
+): Promise<T> {
+  const dir = mkdtempSync(join(tmpdir(), "tsforge-conv-"));
+
+  try {
+    writeFileSync(join(dir, "tsforge.config.json"), JSON.stringify(body));
+
+    return await fn(dir);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+}
+
+describe("conventions core", () => {
+  test("defaults reproduce the current house style", () => {
+    expect(DEFAULT_CONVENTIONS).toEqual({
+      interfaces: "i-prefix",
+      enums: "ban",
+      tests: "either",
+      componentFolders: "tsforge-views",
+    });
+  });
+
+  test("resolveConventions fills unset fields from defaults", () => {
+    expect(resolveConventions({ interfaces: "bare-pascal-case" })).toEqual({
+      interfaces: "bare-pascal-case",
+      enums: "ban",
+      tests: "either",
+      componentFolders: "tsforge-views",
+    });
+  });
+
+  test("resolveConventions(undefined) is the full default set", () => {
+    expect(resolveConventions(undefined)).toEqual(DEFAULT_CONVENTIONS);
+  });
+
+  test("guards accept valid values and reject junk", () => {
+    expect(isInterfaceConvention("bare-pascal-case")).toBe(true);
+    expect(isInterfaceConvention("nope")).toBe(false);
+    expect(isEnumConvention("allow")).toBe(true);
+    expect(isEnumConvention(42)).toBe(false);
+    expect(isTestConvention("mirrored")).toBe(true);
+    expect(isTestConvention("")).toBe(false);
+    expect(isComponentFoldersConvention("repo")).toBe(true);
+    expect(isComponentFoldersConvention(null)).toBe(false);
+  });
+});
+
+describe("config: conventions field", () => {
+  test("valid conventions block is loaded", async () => {
+    const config = await withConfig(
+      {
+        conventions: {
+          interfaces: "bare-pascal-case",
+          enums: "allow",
+          tests: "mirrored",
+          componentFolders: "repo",
+        },
+      },
+      (dir) => loadTsforgeConfig(dir)
+    );
+
+    expect(config.conventions).toEqual({
+      interfaces: "bare-pascal-case",
+      enums: "allow",
+      tests: "mirrored",
+      componentFolders: "repo",
+    });
+  });
+
+  test("invalid sub-values are dropped, valid ones kept", async () => {
+    const config = await withConfig(
+      { conventions: { interfaces: "klingon", enums: "allow" } },
+      (dir) => loadTsforgeConfig(dir)
+    );
+
+    expect(config.conventions).toEqual({ enums: "allow" });
+  });
+
+  test("a conventions block of only-invalid values becomes undefined", async () => {
+    const config = await withConfig(
+      { conventions: { interfaces: 7, tests: "weekly" } },
+      (dir) => loadTsforgeConfig(dir)
+    );
+
+    expect(config.conventions).toBeUndefined();
+  });
+
+  test("non-object conventions is dropped", async () => {
+    const config = await withConfig({ conventions: "i-prefix" }, (dir) =>
+      loadTsforgeConfig(dir)
+    );
+
+    expect(config.conventions).toBeUndefined();
+  });
+
+  test("conventions is absent when not configured", async () => {
+    const config = await withConfig({ stack: "react" }, (dir) =>
+      loadTsforgeConfig(dir)
+    );
+
+    expect(config.conventions).toBeUndefined();
+    expect(config.stack).toBe("react");
+  });
+});

--- a/packages/core/tests/eslint-conventions.test.ts
+++ b/packages/core/tests/eslint-conventions.test.ts
@@ -1,0 +1,199 @@
+import { describe, test, expect } from "bun:test";
+import {
+  applyBundledOverrides,
+  conventionRuleEntries,
+  parseConventionsEnv,
+  PROTECTED_BUNDLED_RULES,
+} from "../src/infer-rules/eslint-conventions";
+import { resolveConventions } from "../src/infer-rules/conventions";
+import type { RuleEntry } from "../src/infer-rules/eslint-conventions.types";
+import { isRecord } from "../src/lib/guards";
+
+/** Pull the selector strings out of a `no-restricted-syntax` entry. */
+function selectorsOf(entry: RuleEntry | undefined): string[] {
+  if (entry === undefined || typeof entry === "string") {
+    return [];
+  }
+
+  return entry
+    .slice(1)
+    .flatMap((s) =>
+      isRecord(s) && typeof s.selector === "string" ? [s.selector] : []
+    );
+}
+
+describe("naming-convention from conventions", () => {
+  test("i-prefix (core) requires the I prefix", () => {
+    const entry = conventionRuleEntries(
+      resolveConventions({ interfaces: "i-prefix" }),
+      "core"
+    )["@typescript-eslint/naming-convention"];
+
+    expect(entry).toEqual([
+      "error",
+      { selector: "interface", format: ["PascalCase"], prefix: ["I"] },
+    ]);
+  });
+
+  test("bare-pascal-case drops the prefix", () => {
+    const entry = conventionRuleEntries(
+      resolveConventions({ interfaces: "bare-pascal-case" }),
+      "core"
+    )["@typescript-eslint/naming-convention"];
+
+    expect(entry).toEqual([
+      "error",
+      { selector: "interface", format: ["PascalCase"] },
+    ]);
+  });
+
+  test("off omits the rule entirely", () => {
+    const entries = conventionRuleEntries(
+      resolveConventions({ interfaces: "off" }),
+      "core"
+    );
+
+    expect(entries["@typescript-eslint/naming-convention"]).toBeUndefined();
+  });
+
+  test("web surface keeps the Register exemption", () => {
+    const entry = conventionRuleEntries(
+      resolveConventions({ interfaces: "i-prefix" }),
+      "web"
+    )["@typescript-eslint/naming-convention"];
+
+    expect(entry).toEqual([
+      "error",
+      {
+        selector: "interface",
+        format: ["PascalCase"],
+        prefix: ["I"],
+        filter: { regex: "^(Register)$", match: false },
+      },
+    ]);
+  });
+});
+
+describe("no-restricted-syntax: enum ban is split from cast bans", () => {
+  test("core + enums ban → only the enum selector", () => {
+    const entry = conventionRuleEntries(
+      resolveConventions({ enums: "ban" }),
+      "core"
+    )["no-restricted-syntax"];
+
+    expect(selectorsOf(entry)).toEqual(["TSEnumDeclaration"]);
+  });
+
+  test("core + enums allow → rule omitted (casts handled elsewhere on core)", () => {
+    const entries = conventionRuleEntries(
+      resolveConventions({ enums: "allow" }),
+      "core"
+    );
+
+    expect(entries["no-restricted-syntax"]).toBeUndefined();
+  });
+
+  test("web + enums ban → enum AND both cast selectors", () => {
+    const entry = conventionRuleEntries(
+      resolveConventions({ enums: "ban" }),
+      "web"
+    )["no-restricted-syntax"];
+
+    expect(selectorsOf(entry)).toEqual([
+      "TSEnumDeclaration",
+      "TSAsExpression[typeAnnotation.typeName.name!='const']",
+      "TSTypeAssertion",
+    ]);
+  });
+
+  test("SAFETY: web + enums ALLOW still keeps the cast bans", () => {
+    const entry = conventionRuleEntries(
+      resolveConventions({ enums: "allow" }),
+      "web"
+    )["no-restricted-syntax"];
+
+    const selectors = selectorsOf(entry);
+
+    expect(selectors).not.toContain("TSEnumDeclaration");
+    expect(selectors).toEqual([
+      "TSAsExpression[typeAnnotation.typeName.name!='const']",
+      "TSTypeAssertion",
+    ]);
+  });
+});
+
+describe("parseConventionsEnv", () => {
+  test("undefined → full defaults", () => {
+    expect(parseConventionsEnv(undefined)).toEqual(
+      resolveConventions(undefined)
+    );
+  });
+
+  test("partial JSON merges over defaults", () => {
+    expect(parseConventionsEnv('{"interfaces":"bare-pascal-case"}')).toEqual(
+      resolveConventions({ interfaces: "bare-pascal-case" })
+    );
+  });
+
+  test("malformed JSON → defaults (never throws)", () => {
+    expect(parseConventionsEnv("{not json")).toEqual(
+      resolveConventions(undefined)
+    );
+  });
+});
+
+describe("applyBundledOverrides protected-rule guard", () => {
+  const bundled: Record<string, RuleEntry> = {
+    "@typescript-eslint/no-explicit-any": "error",
+    "@typescript-eslint/no-non-null-assertion": "error",
+    "no-restricted-syntax": ["error", { selector: "TSEnumDeclaration" }],
+    "prefer-template": "error",
+    "@stylistic/padding-line-between-statements": ["error", { foo: 1 }],
+  };
+
+  test("safety rules cannot be turned off", () => {
+    const out = applyBundledOverrides(bundled, {
+      "no-explicit-any": "off",
+      "no-non-null-assertion": "warn",
+      "no-restricted-syntax": "off",
+    });
+
+    expect(out["@typescript-eslint/no-explicit-any"]).toBe("error");
+    expect(out["@typescript-eslint/no-non-null-assertion"]).toBe("error");
+    expect(out["no-restricted-syntax"]).toEqual([
+      "error",
+      { selector: "TSEnumDeclaration" },
+    ]);
+  });
+
+  test("non-protected rules can be downgraded (options preserved)", () => {
+    const out = applyBundledOverrides(bundled, {
+      "prefer-template": "warn",
+      "@stylistic/padding-line-between-statements": "warn",
+    });
+
+    expect(out["prefer-template"]).toBe("warn");
+    expect(out["@stylistic/padding-line-between-statements"]).toEqual([
+      "warn",
+      { foo: 1 },
+    ]);
+  });
+
+  test("non-protected rules can be turned off", () => {
+    const out = applyBundledOverrides(bundled, { "prefer-template": "off" });
+
+    expect("prefer-template" in out).toBe(false);
+  });
+
+  test("no overrides → unchanged copy", () => {
+    expect(applyBundledOverrides(bundled, undefined)).toEqual(bundled);
+  });
+
+  test("every protected name is in the set", () => {
+    expect(
+      PROTECTED_BUNDLED_RULES.has("@typescript-eslint/no-explicit-any")
+    ).toBe(true);
+    expect(PROTECTED_BUNDLED_RULES.has("no-restricted-syntax")).toBe(true);
+    expect(PROTECTED_BUNDLED_RULES.has("prefer-template")).toBe(false);
+  });
+});

--- a/packages/core/tests/gate-conventions.test.ts
+++ b/packages/core/tests/gate-conventions.test.ts
@@ -1,0 +1,185 @@
+import { describe, test, expect, beforeAll, afterAll } from "bun:test";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { basename, join } from "node:path";
+import { makeFileLinter } from "../src/detect-gate";
+import { resolveConventions } from "../src/infer-rules/conventions";
+
+// Integration test for the REAL gate path: spawn the bundled eslint config the
+// way buildGate/buildWebGate do, with TSFORGE_CONVENTIONS in the env, and assert
+// which rules fire. This proves the env channel — not just the in-process builder.
+const ROOT = join(import.meta.dir, "..", "..", "..");
+const ESLINT_BIN = join(ROOT, "node_modules", ".bin", "eslint");
+const STRICT_CONFIG = join(import.meta.dir, "..", "strict.eslint.config.mjs");
+const STRICT_WEB_CONFIG = join(
+  import.meta.dir,
+  "..",
+  "strict.web.eslint.config.mjs"
+);
+
+const BARE_INTERFACE = "export interface User {\n  id: string;\n}\n";
+const ENUM_DECL = "export enum Color {\n  Red,\n  Blue,\n}\n";
+const AS_CAST =
+  "const n: number = 1;\nexport const s = n as unknown as string;\n";
+
+let dir: string;
+
+beforeAll(() => {
+  dir = mkdtempSync(join(tmpdir(), "tsforge-gate-conv-"));
+});
+
+afterAll(() => {
+  rmSync(dir, { recursive: true, force: true });
+});
+
+interface ILintMessage {
+  ruleId: string | null;
+  severity: number;
+}
+
+interface ILintResult {
+  messages: ILintMessage[];
+}
+
+function isLintResults(value: unknown): value is ILintResult[] {
+  return Array.isArray(value);
+}
+
+/** Run the bundled config on `content` with a TSFORGE_CONVENTIONS env, returning
+ *  the set of rule IDs that errored. */
+async function erroredRules(
+  config: string,
+  content: string,
+  conventions?: string
+): Promise<Set<string>> {
+  const file = join(
+    dir,
+    `case-${Math.abs(hashOf(content + (conventions ?? "")))}.ts`
+  );
+
+  writeFileSync(file, content);
+
+  const env: Record<string, string | undefined> = { ...process.env };
+
+  if (conventions !== undefined) {
+    env.TSFORGE_CONVENTIONS = conventions;
+  }
+
+  const proc = Bun.spawn(
+    [
+      "bun",
+      ESLINT_BIN,
+      "--no-config-lookup",
+      "-c",
+      config,
+      "--format",
+      "json",
+      basename(file),
+    ],
+    { cwd: dir, env, stdout: "pipe", stderr: "pipe" }
+  );
+
+  const out = await new Response(proc.stdout).text();
+
+  await proc.exited;
+
+  const parsed: unknown = JSON.parse(out);
+  const results = isLintResults(parsed) ? parsed : [];
+  const ruleIds = new Set<string>();
+
+  for (const r of results) {
+    for (const m of r.messages) {
+      if (m.severity === 2 && m.ruleId !== null) {
+        ruleIds.add(m.ruleId);
+      }
+    }
+  }
+
+  return ruleIds;
+}
+
+/** Deterministic small hash so concurrent cases write distinct files. */
+function hashOf(s: string): number {
+  let h = 0;
+
+  for (const ch of s) {
+    h = (h * 31 + ch.charCodeAt(0)) | 0;
+  }
+
+  return h;
+}
+
+const NAMING = "@typescript-eslint/naming-convention";
+const NRS = "no-restricted-syntax";
+
+describe("core gate honors TSFORGE_CONVENTIONS", () => {
+  test("default: bare interface fails naming, enum is banned", async () => {
+    expect(await erroredRules(STRICT_CONFIG, BARE_INTERFACE)).toContain(NAMING);
+    expect(await erroredRules(STRICT_CONFIG, ENUM_DECL)).toContain(NRS);
+  });
+
+  test("bare-pascal-case: bare interface passes", async () => {
+    const errs = await erroredRules(
+      STRICT_CONFIG,
+      BARE_INTERFACE,
+      '{"interfaces":"bare-pascal-case"}'
+    );
+
+    expect(errs).not.toContain(NAMING);
+  });
+
+  test("enums allow: enum passes on core", async () => {
+    const errs = await erroredRules(
+      STRICT_CONFIG,
+      ENUM_DECL,
+      '{"enums":"allow"}'
+    );
+
+    expect(errs).not.toContain(NRS);
+  });
+});
+
+describe("web gate: enum allowance never removes cast bans", () => {
+  test("default: enum banned, cast banned", async () => {
+    expect(await erroredRules(STRICT_WEB_CONFIG, ENUM_DECL)).toContain(NRS);
+    expect(await erroredRules(STRICT_WEB_CONFIG, AS_CAST)).toContain(NRS);
+  });
+
+  test("SAFETY: enums allow → enum ok BUT cast STILL banned", async () => {
+    const enumErrs = await erroredRules(
+      STRICT_WEB_CONFIG,
+      ENUM_DECL,
+      '{"enums":"allow"}'
+    );
+    const castErrs = await erroredRules(
+      STRICT_WEB_CONFIG,
+      AS_CAST,
+      '{"enums":"allow"}'
+    );
+
+    // Enum is now allowed...
+    expect(enumErrs).not.toContain(NRS);
+    // ...but the value-changing cast ban is still enforced.
+    expect(castErrs).toContain(NRS);
+  });
+});
+
+describe("write-time linter honors conventions (overrideConfig path)", () => {
+  test("default flags a bare interface; bare-pascal-case does not", async () => {
+    const f = join(dir, "wl.ts");
+
+    writeFileSync(f, BARE_INTERFACE);
+
+    const def = await makeFileLinter("core", f.replace(/[^/]+$/u, ""))(f);
+    const bare = await makeFileLinter(
+      "core",
+      f.replace(/[^/]+$/u, ""),
+      undefined,
+      undefined,
+      resolveConventions({ interfaces: "bare-pascal-case" })
+    )(f);
+
+    expect(def.some((m) => m.ruleId === NAMING)).toBe(true);
+    expect(bare.some((m) => m.ruleId === NAMING)).toBe(false);
+  });
+});

--- a/packages/core/tests/prompt-conventions.test.ts
+++ b/packages/core/tests/prompt-conventions.test.ts
@@ -1,0 +1,61 @@
+import { describe, test, expect } from "bun:test";
+import {
+  buildChatSystem,
+  buildSystemPrompt,
+  buildTddGuidance,
+} from "../src/loop/prompt";
+import { resolveConventions } from "../src/infer-rules/conventions";
+
+const bare = resolveConventions({ interfaces: "bare-pascal-case" });
+const iprefix = resolveConventions({ interfaces: "i-prefix" });
+const off = resolveConventions({ interfaces: "off" });
+
+describe("system prompt reflects interface convention", () => {
+  test("i-prefix tells the model to use the I prefix", () => {
+    const p = buildSystemPrompt(false, undefined, iprefix);
+
+    expect(p).toContain("`I`-prefixed");
+    expect(p).not.toContain("NO `I` prefix");
+  });
+
+  test("bare-pascal-case: no stale I-prefix instruction", () => {
+    const p = buildSystemPrompt(false, undefined, bare);
+
+    expect(p).toContain("PascalCase with NO `I` prefix");
+    expect(p).not.toContain("interfaces are `I`-prefixed");
+  });
+
+  test("off: prompt makes no interface-naming claim at all", () => {
+    const p = buildSystemPrompt(false, undefined, off);
+
+    expect(p).not.toContain("`I`-prefixed");
+    expect(p).not.toContain("NO `I` prefix");
+  });
+
+  test("safety rules are unconditional regardless of naming", () => {
+    for (const c of [iprefix, bare, off]) {
+      const p = buildSystemPrompt(false, undefined, c);
+
+      expect(p).toContain("no `any` and no `as`");
+      expect(p).toContain("complexity at 20");
+    }
+  });
+});
+
+describe("chat prompt reflects interface convention", () => {
+  test("bare-pascal-case removes I-prefix from the chat prompt", () => {
+    expect(buildChatSystem(bare)).toContain("PascalCase with NO `I` prefix");
+    expect(buildChatSystem(bare)).not.toContain("`I`-prefixed interfaces");
+  });
+});
+
+describe("TDD guidance reflects test layout", () => {
+  test("co-located vs mirrored phrasing", () => {
+    expect(
+      buildTddGuidance(resolveConventions({ tests: "co-located" }))
+    ).toContain("co-located `*.test.ts` sibling");
+    expect(
+      buildTddGuidance(resolveConventions({ tests: "mirrored" }))
+    ).toContain("mirrored `tests/` file");
+  });
+});

--- a/packages/core/tests/scan.test.ts
+++ b/packages/core/tests/scan.test.ts
@@ -1,0 +1,173 @@
+import { describe, test, expect } from "bun:test";
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { recommendConventions, scanRepo } from "../src/infer-rules/scan";
+
+interface IFixtureFile {
+  path: string;
+  content: string;
+}
+
+async function withRepo<T>(
+  files: IFixtureFile[],
+  fn: (cwd: string) => Promise<T>
+): Promise<T> {
+  const dir = mkdtempSync(join(tmpdir(), "tsforge-scan-"));
+
+  try {
+    writeFileSync(join(dir, "package.json"), JSON.stringify({ name: "fix" }));
+
+    for (const f of files) {
+      const abs = join(dir, f.path);
+
+      mkdirSync(join(abs, ".."), { recursive: true });
+      writeFileSync(abs, f.content);
+    }
+
+    return await fn(dir);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+}
+
+describe("interface naming scan + recommendation", () => {
+  test("a bare-PascalCase repo recommends bare-pascal-case", async () => {
+    const files: IFixtureFile[] = [
+      { path: "src/a.ts", content: "export interface User { id: string; }" },
+      { path: "src/b.ts", content: "export interface Order { n: number; }" },
+      { path: "src/c.ts", content: "export interface Invoice { n: number; }" },
+    ];
+
+    await withRepo(files, async (cwd) => {
+      const report = await scanRepo(cwd);
+
+      expect(report.interfaces.bare).toBe(3);
+      expect(report.interfaces.iPrefixed).toBe(0);
+      expect(recommendConventions(report).interfaces).toBe("bare-pascal-case");
+    });
+  });
+
+  test("an I-prefixed repo recommends i-prefix; Register is exempt", async () => {
+    const files: IFixtureFile[] = [
+      { path: "src/a.ts", content: "export interface IUser { id: string; }" },
+      { path: "src/b.ts", content: "export interface IOrder { n: number; }" },
+      { path: "src/reg.ts", content: "interface Register { x: number; }" },
+    ];
+
+    await withRepo(files, async (cwd) => {
+      const report = await scanRepo(cwd);
+
+      expect(report.interfaces.iPrefixed).toBe(2);
+      expect(report.interfaces.total).toBe(2); // Register excluded
+      expect(recommendConventions(report).interfaces).toBe("i-prefix");
+    });
+  });
+
+  test("a split repo recommends off (contested)", async () => {
+    const files: IFixtureFile[] = [
+      { path: "src/a.ts", content: "export interface IUser { id: string; }" },
+      { path: "src/b.ts", content: "export interface Order { n: number; }" },
+    ];
+
+    await withRepo(files, async (cwd) => {
+      const report = await scanRepo(cwd);
+
+      expect(recommendConventions(report).interfaces).toBe("off");
+    });
+  });
+
+  test("empty repo recommends the house default i-prefix", async () => {
+    await withRepo([], async (cwd) => {
+      const report = await scanRepo(cwd);
+
+      expect(report.interfaces.total).toBe(0);
+      expect(recommendConventions(report).interfaces).toBe("i-prefix");
+    });
+  });
+});
+
+describe("enum scan", () => {
+  test("enums present → recommend allow; absent → ban", async () => {
+    await withRepo(
+      [{ path: "src/e.ts", content: "export enum Color { Red, Blue }" }],
+      async (cwd) => {
+        const report = await scanRepo(cwd);
+
+        expect(report.enums.fileCount).toBe(1);
+        expect(recommendConventions(report).enums).toBe("allow");
+      }
+    );
+
+    await withRepo(
+      [{ path: "src/x.ts", content: "export const x = 1;" }],
+      async (cwd) => {
+        expect(recommendConventions(await scanRepo(cwd)).enums).toBe("ban");
+      }
+    );
+  });
+});
+
+describe("test layout scan", () => {
+  test("co-located dominant → co-located", async () => {
+    const files: IFixtureFile[] = [
+      { path: "src/a.ts", content: "export const a = 1;" },
+      { path: "src/a.test.ts", content: "test('a', () => {});" },
+      { path: "src/b.test.ts", content: "test('b', () => {});" },
+    ];
+
+    await withRepo(files, async (cwd) => {
+      const report = await scanRepo(cwd);
+
+      expect(report.tests.coLocated).toBe(2);
+      expect(recommendConventions(report).tests).toBe("co-located");
+    });
+  });
+
+  test("mirrored tests/ dir → mirrored", async () => {
+    const files: IFixtureFile[] = [
+      { path: "src/a.ts", content: "export const a = 1;" },
+      { path: "tests/a.test.ts", content: "test('a', () => {});" },
+      { path: "tests/b.test.ts", content: "test('b', () => {});" },
+    ];
+
+    await withRepo(files, async (cwd) => {
+      const report = await scanRepo(cwd);
+
+      expect(report.tests.mirrored).toBe(2);
+      expect(recommendConventions(report).tests).toBe("mirrored");
+    });
+  });
+});
+
+describe("folder + tooling scan", () => {
+  test("src/views → tsforge-views; tooling presence detected", async () => {
+    const files: IFixtureFile[] = [
+      { path: "src/views/Dashboard/index.tsx", content: "export const x = 1;" },
+      { path: "tsconfig.json", content: "{}" },
+    ];
+
+    await withRepo(files, async (cwd) => {
+      const report = await scanRepo(cwd);
+
+      expect(report.folders.views).toBe(true);
+      expect(report.tooling.tsconfig).toBe(true);
+      expect(recommendConventions(report).componentFolders).toBe(
+        "tsforge-views"
+      );
+    });
+  });
+
+  test("repo-own layout (src/features) → repo", async () => {
+    const files: IFixtureFile[] = [
+      { path: "src/features/auth/login.ts", content: "export const x = 1;" },
+    ];
+
+    await withRepo(files, async (cwd) => {
+      const report = await scanRepo(cwd);
+
+      expect(report.folders.features).toBe(true);
+      expect(recommendConventions(report).componentFolders).toBe("repo");
+    });
+  });
+});

--- a/packages/core/tests/scan.test.ts
+++ b/packages/core/tests/scan.test.ts
@@ -1,5 +1,11 @@
 import { describe, test, expect } from "bun:test";
-import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
+import {
+  mkdtempSync,
+  mkdirSync,
+  rmSync,
+  writeFileSync,
+  chmodSync,
+} from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { recommendConventions, scanRepo } from "../src/infer-rules/scan";
@@ -168,6 +174,32 @@ describe("folder + tooling scan", () => {
 
       expect(report.folders.features).toBe(true);
       expect(recommendConventions(report).componentFolders).toBe("repo");
+    });
+  });
+});
+
+describe("scan resilience", () => {
+  test("an unreadable file mid-scan does not crash the scan", async () => {
+    const files: IFixtureFile[] = [
+      { path: "src/ok.ts", content: "export interface User { id: string; }" },
+      {
+        path: "src/locked.ts",
+        content: "export interface Order { n: number; }",
+      },
+    ];
+
+    await withRepo(files, async (cwd) => {
+      chmodSync(join(cwd, "src/locked.ts"), 0o000);
+
+      try {
+        // Must resolve (not reject) even if a file errors on read; the readable
+        // file is still tallied.
+        const report = await scanRepo(cwd);
+
+        expect(report.interfaces.total).toBeGreaterThanOrEqual(1);
+      } finally {
+        chmodSync(join(cwd, "src/locked.ts"), 0o644);
+      }
     });
   });
 });

--- a/packages/core/tests/setup-flow.test.ts
+++ b/packages/core/tests/setup-flow.test.ts
@@ -1,0 +1,156 @@
+import { describe, test, expect } from "bun:test";
+import {
+  mkdtempSync,
+  mkdirSync,
+  rmSync,
+  writeFileSync,
+  existsSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  buildSteps,
+  configPreview,
+  nonDefaultConventions,
+  selectionsToConventions,
+} from "../src/setup/wizard-flow";
+import { driveWizard } from "../src/render/wizard";
+import type { IWizardAction } from "../src/render/wizard.types";
+import { runSetup } from "../src/setup/run-setup";
+import { scanRepo } from "../src/infer-rules/scan";
+import { resolveConventions } from "../src/infer-rules/conventions";
+
+function repo(files: { path: string; content: string }[]): string {
+  const dir = mkdtempSync(join(tmpdir(), "tsforge-setup-"));
+
+  writeFileSync(join(dir, "package.json"), JSON.stringify({ name: "fix" }));
+
+  for (const f of files) {
+    const abs = join(dir, f.path);
+
+    mkdirSync(join(abs, ".."), { recursive: true });
+    writeFileSync(abs, f.content);
+  }
+
+  return dir;
+}
+
+describe("wizard flow mapping", () => {
+  test("selectionsToConventions reads single answers; defaults fill gaps", () => {
+    const state = {
+      stepIndex: 0,
+      cursor: 0,
+      single: { interfaces: "bare-pascal-case", enums: "allow" },
+      multi: {},
+      status: "active" as const,
+    };
+
+    expect(selectionsToConventions(state)).toEqual(
+      resolveConventions({ interfaces: "bare-pascal-case", enums: "allow" })
+    );
+  });
+
+  test("nonDefaultConventions keeps only diffs from the house default", () => {
+    expect(
+      nonDefaultConventions(resolveConventions({ enums: "allow" }))
+    ).toEqual({ enums: "allow" });
+
+    expect(nonDefaultConventions(resolveConventions(undefined))).toEqual({});
+  });
+
+  test("configPreview shows the fragment, or a no-op note for all-defaults", () => {
+    expect(configPreview(resolveConventions({ enums: "allow" }))).toContain(
+      '"enums": "allow"'
+    );
+    expect(configPreview(resolveConventions(undefined))).toContain(
+      "no conventions written"
+    );
+  });
+
+  test("buildSteps drives end-to-end on a bare-PascalCase repo", async () => {
+    const dir = repo([
+      { path: "src/a.ts", content: "export interface User { id: string; }" },
+      { path: "src/b.ts", content: "export interface Order { n: number; }" },
+    ]);
+
+    try {
+      const report = await scanRepo(dir);
+      const steps = buildSteps(report);
+
+      // The interfaces step preselects the recommendation (bare-pascal-case).
+      const actions: IWizardAction[] = [
+        ...steps.map((): IWizardAction => "confirm"),
+        "confirm", // overview → apply
+      ];
+      const applied = driveWizard(steps, actions);
+
+      expect(selectionsToConventions(applied).interfaces).toBe(
+        "bare-pascal-case"
+      );
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});
+
+describe("runSetup orchestration", () => {
+  test("non-TTY without --yes prints a proposal and writes nothing", async () => {
+    const dir = repo([
+      { path: "src/e.ts", content: "export enum Color { Red }" },
+    ]);
+    let out = "";
+
+    try {
+      const code = await runSetup({
+        cwd: dir,
+        yes: false,
+        color: false,
+        interactive: false,
+        out: (s) => {
+          out += s;
+        },
+      });
+
+      expect(code).toBe(0);
+      expect(out).toContain("non-interactive");
+      expect(out).toContain("Re-run in a terminal");
+      expect(existsSync(join(dir, "tsforge.config.json"))).toBe(false);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test("--yes writes the recommended conventions", async () => {
+    const dir = repo([
+      { path: "src/a.ts", content: "export interface User { id: string; }" },
+      { path: "src/b.ts", content: "export interface Order { n: number; }" },
+      { path: "src/e.ts", content: "export enum Color { Red }" },
+    ]);
+    let out = "";
+
+    try {
+      const code = await runSetup({
+        cwd: dir,
+        yes: true,
+        color: false,
+        out: (s) => {
+          out += s;
+        },
+      });
+
+      expect(code).toBe(0);
+      expect(out).toContain("Wrote tsforge.config.json");
+
+      const written = JSON.parse(
+        await Bun.file(join(dir, "tsforge.config.json")).text()
+      );
+
+      // Bare interfaces + enums present → bare-pascal-case + allow.
+      expect(written.conventions.interfaces).toBe("bare-pascal-case");
+      expect(written.conventions.enums).toBe("allow");
+      expect(existsSync(join(dir, ".tsforge/setup-evidence.json"))).toBe(true);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});

--- a/packages/core/tests/wizard.test.ts
+++ b/packages/core/tests/wizard.test.ts
@@ -92,6 +92,41 @@ describe("wizard reducer", () => {
     expect(s.status).toBe("cancel");
   });
 
+  test("defensive: an empty steps array reaches a terminal state, never wedges", () => {
+    // stepIndex 0 >= length 0 ⇒ already the overview; confirm applies, cancel cancels.
+    expect(reduceWizard(initWizard([]), "confirm", []).status).toBe("apply");
+    expect(reduceWizard(initWizard([]), "cancel", []).status).toBe("cancel");
+  });
+
+  test("defensive: init drops out-of-range defaultChecked indices", () => {
+    const step: IWizardStep = {
+      key: "m",
+      kind: "multi",
+      title: "M",
+      explanation: "",
+      evidence: [],
+      options: [{ label: "a", value: "a" }],
+      defaultChecked: [0, 5, 10],
+    };
+
+    expect(initWizard([step]).multi.m).toEqual([0]);
+  });
+
+  test("defensive: toggle on a zero-option multi is a no-op", () => {
+    const step: IWizardStep = {
+      key: "empty",
+      kind: "multi",
+      title: "E",
+      explanation: "",
+      evidence: [],
+      options: [],
+    };
+
+    const s = reduceWizard(initWizard([step]), "toggle", [step]);
+
+    expect(s.multi.empty).toEqual([]);
+  });
+
   test("back from overview returns to the last step", () => {
     let s = driveWizard(STEPS, ["confirm", "confirm"]); // at overview
 

--- a/packages/core/tests/wizard.test.ts
+++ b/packages/core/tests/wizard.test.ts
@@ -1,0 +1,136 @@
+import { describe, test, expect } from "bun:test";
+import {
+  driveWizard,
+  initWizard,
+  reduceWizard,
+  renderFrame,
+} from "../src/render/wizard";
+import type { IWizardStep } from "../src/render/wizard.types";
+
+const STEPS: IWizardStep[] = [
+  {
+    key: "interfaces",
+    kind: "single",
+    title: "Naming",
+    explanation: "pick naming",
+    evidence: ["312 interfaces scanned", "300 bare PascalCase   User, Order"],
+    options: [
+      {
+        label: "bare PascalCase",
+        value: "bare-pascal-case",
+        recommended: true,
+      },
+      { label: "I-prefix", value: "i-prefix" },
+      { label: "off", value: "off" },
+    ],
+    defaultIndex: 0,
+  },
+  {
+    key: "packs",
+    kind: "multi",
+    title: "Packs",
+    explanation: "toggle packs",
+    evidence: [],
+    options: [
+      { label: "generic-ts", value: "generic-ts", note: "always on" },
+      { label: "nextjs", value: "nextjs" },
+    ],
+    defaultChecked: [0],
+  },
+];
+
+describe("wizard reducer", () => {
+  test("starts on the recommended option", () => {
+    const s = initWizard(STEPS);
+
+    expect(s.stepIndex).toBe(0);
+    expect(s.cursor).toBe(0);
+    expect(s.multi.packs).toEqual([0]);
+  });
+
+  test("down moves the cursor; confirm records + advances", () => {
+    let s = initWizard(STEPS);
+
+    s = reduceWizard(s, "down", STEPS); // cursor → i-prefix
+    s = reduceWizard(s, "confirm", STEPS);
+
+    expect(s.single.interfaces).toBe("i-prefix");
+    expect(s.stepIndex).toBe(1);
+  });
+
+  test("space toggles a checkbox", () => {
+    let s = initWizard(STEPS);
+
+    s = reduceWizard(s, "confirm", STEPS); // → packs step
+    s = reduceWizard(s, "down", STEPS); // cursor → nextjs
+    s = reduceWizard(s, "toggle", STEPS); // check nextjs
+
+    expect(s.multi.packs).toEqual([0, 1]);
+
+    s = reduceWizard(s, "toggle", STEPS); // uncheck nextjs
+
+    expect(s.multi.packs).toEqual([0]);
+  });
+
+  test("back from the first step cancels", () => {
+    const s = reduceWizard(initWizard(STEPS), "back", STEPS);
+
+    expect(s.status).toBe("cancel");
+  });
+
+  test("happy path: confirm through all steps → overview → apply", () => {
+    const s = driveWizard(STEPS, ["confirm", "confirm", "confirm"]);
+
+    // 2 steps + overview confirm = apply
+    expect(s.status).toBe("apply");
+    expect(s.single.interfaces).toBe("bare-pascal-case");
+  });
+
+  test("cancel anywhere stops with nothing applied", () => {
+    const s = driveWizard(STEPS, ["confirm", "cancel"]);
+
+    expect(s.status).toBe("cancel");
+  });
+
+  test("back from overview returns to the last step", () => {
+    let s = driveWizard(STEPS, ["confirm", "confirm"]); // at overview
+
+    expect(s.stepIndex).toBe(STEPS.length);
+
+    s = reduceWizard(s, "back", STEPS);
+    expect(s.stepIndex).toBe(STEPS.length - 1);
+    expect(s.status).toBe("active");
+  });
+});
+
+describe("wizard render (no color)", () => {
+  test("step frame shows progress, evidence, cursor, recommended", () => {
+    const frame = renderFrame(initWizard(STEPS), STEPS, false);
+
+    expect(frame).toContain("Step 1 of 2 · Naming");
+    expect(frame).toContain("312 interfaces scanned");
+    expect(frame).toContain("› bare PascalCase");
+    expect(frame).toContain("recommended");
+    expect(frame).toContain("enter select");
+  });
+
+  test("checkbox step shows checked/unchecked markers", () => {
+    const s = reduceWizard(initWizard(STEPS), "confirm", STEPS); // packs step
+    const frame = renderFrame(s, STEPS, false);
+
+    expect(frame).toContain("◉ generic-ts");
+    expect(frame).toContain("◯ nextjs");
+    expect(frame).toContain("always on");
+    expect(frame).toContain("space toggle");
+  });
+
+  test("overview lists choices and the extra preview; nothing-written language", () => {
+    const s = driveWizard(STEPS, ["confirm", "confirm"]);
+    const frame = renderFrame(s, STEPS, false, "PREVIEW-BLOCK");
+
+    expect(frame).toContain("nothing is written until you Apply");
+    expect(frame).toContain("Naming: bare PascalCase");
+    expect(frame).toContain("PREVIEW-BLOCK");
+    expect(frame).toContain("enter apply");
+  });
+});

--- a/packages/core/tests/write-config.test.ts
+++ b/packages/core/tests/write-config.test.ts
@@ -40,6 +40,25 @@ describe("mergeSetupConfig (pure)", () => {
 
     expect(merged.profile).toBe("security");
   });
+
+  test("an empty conventions decision REMOVES a stale block (re-run to defaults)", () => {
+    const merged = mergeSetupConfig(
+      { plugins: ["p"], conventions: { interfaces: "bare-pascal-case" } },
+      { conventions: {} }
+    );
+
+    expect("conventions" in merged).toBe(false);
+    expect(merged.plugins).toEqual(["p"]); // unrelated keys still preserved
+  });
+
+  test("a non-empty decision REPLACES the prior block wholesale", () => {
+    const merged = mergeSetupConfig(
+      { conventions: { interfaces: "bare-pascal-case", enums: "allow" } },
+      { conventions: { tests: "mirrored" } }
+    );
+
+    expect(merged.conventions).toEqual({ tests: "mirrored" });
+  });
 });
 
 describe("writeSetupConfig (IO)", () => {

--- a/packages/core/tests/write-config.test.ts
+++ b/packages/core/tests/write-config.test.ts
@@ -1,0 +1,159 @@
+import { describe, test, expect } from "bun:test";
+import { mkdtempSync, rmSync, writeFileSync, existsSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { mergeSetupConfig, writeSetupConfig } from "../src/setup/write-config";
+import type { IScanReport } from "../src/infer-rules/scan.types";
+
+function tmp(): string {
+  return mkdtempSync(join(tmpdir(), "tsforge-wc-"));
+}
+
+describe("mergeSetupConfig (pure)", () => {
+  test("preserves unrelated fields, overrides setup-managed ones", () => {
+    const existing = {
+      mcpServers: { x: { command: "y" } },
+      plugins: ["p"],
+      policy: { mode: "ci" },
+      stack: "react",
+      conventions: { interfaces: "i-prefix" },
+    };
+
+    const merged = mergeSetupConfig(existing, {
+      conventions: { interfaces: "bare-pascal-case", enums: "allow" },
+      profile: "strict",
+    });
+
+    expect(merged.mcpServers).toEqual({ x: { command: "y" } });
+    expect(merged.plugins).toEqual(["p"]);
+    expect(merged.policy).toEqual({ mode: "ci" });
+    expect(merged.stack).toBe("react");
+    expect(merged.profile).toBe("strict");
+    expect(merged.conventions).toEqual({
+      interfaces: "bare-pascal-case",
+      enums: "allow",
+    });
+  });
+
+  test("leaves setup-managed fields untouched when not provided", () => {
+    const merged = mergeSetupConfig({ profile: "security" }, {});
+
+    expect(merged.profile).toBe("security");
+  });
+});
+
+describe("writeSetupConfig (IO)", () => {
+  test("creates config + evidence atomically, preserving existing keys", async () => {
+    const dir = tmp();
+
+    try {
+      writeFileSync(
+        join(dir, "tsforge.config.json"),
+        JSON.stringify({ plugins: ["keep-me"] })
+      );
+
+      const result = await writeSetupConfig(
+        dir,
+        { conventions: { interfaces: "bare-pascal-case" } },
+        undefined
+      );
+
+      expect(result.ok).toBe(true);
+
+      const written = JSON.parse(
+        await Bun.file(join(dir, "tsforge.config.json")).text()
+      );
+
+      expect(written.plugins).toEqual(["keep-me"]);
+      expect(written.conventions).toEqual({ interfaces: "bare-pascal-case" });
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test("writes evidence file when a report is given", async () => {
+    const dir = tmp();
+
+    try {
+      const report: IScanReport = {
+        stack: { name: "x", packs: [], confidence: "guess", reason: "r" },
+        interfaces: {
+          iPrefixed: 0,
+          bare: 0,
+          total: 0,
+          iExamples: [],
+          bareExamples: [],
+        },
+        enums: { fileCount: 0 },
+        tests: { coLocated: 0, mirrored: 0 },
+        folders: {
+          views: false,
+          features: false,
+          flatComponents: false,
+          routeFolders: false,
+        },
+        tooling: { tsconfig: false, eslint: false, prettier: false },
+        filesScanned: 0,
+      };
+
+      const result = await writeSetupConfig(dir, { profile: "strict" }, report);
+
+      expect(result.ok).toBe(true);
+      expect(existsSync(join(dir, ".tsforge/setup-evidence.json"))).toBe(true);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test("refuses to clobber invalid existing JSON by default", async () => {
+    const dir = tmp();
+
+    try {
+      writeFileSync(join(dir, "tsforge.config.json"), "{ broken json ");
+
+      const result = await writeSetupConfig(
+        dir,
+        { conventions: { enums: "allow" } },
+        undefined
+      );
+
+      expect(result.ok).toBe(false);
+
+      if (!result.ok) {
+        expect(result.reason).toBe("invalid-existing-json");
+      }
+
+      // The broken file is untouched.
+      expect(await Bun.file(join(dir, "tsforge.config.json")).text()).toBe(
+        "{ broken json "
+      );
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test("overwriteInvalid replaces a broken config", async () => {
+    const dir = tmp();
+
+    try {
+      writeFileSync(join(dir, "tsforge.config.json"), "{ broken ");
+
+      const result = await writeSetupConfig(
+        dir,
+        { conventions: { enums: "allow" } },
+        undefined,
+        { overwriteInvalid: true }
+      );
+
+      expect(result.ok).toBe(true);
+
+      const written = JSON.parse(
+        await Bun.file(join(dir, "tsforge.config.json")).text()
+      );
+
+      expect(written.conventions).toEqual({ enums: "allow" });
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});


### PR DESCRIPTION
## What

`tsforge setup` — an interactive onboarding wizard that scans a repo, infers its conventions (interface naming, enums, test layout, component folders), and writes them to `tsforge.config.json` so the guardrails adapt to *your* style — **without ever weakening the safety floor**.

```bash
tsforge setup          # the wizard (nothing written until you Apply)
tsforge setup --yes    # write the scan's recommendations, no prompts
```
Also `/setup` in the REPL, and a one-line hint at startup when a repo has no config.

## The core idea: taste vs safety

Two kinds of rules, and setup only touches one:

- **Safety floor — never negotiable.** `no any` / `no as` / `no !` / complexity cap / `===` / `no-var` / `prefer-const`. The wizard physically cannot disable these, and neither can a hand-edited config or `TSFORGE_RULE_OVERRIDES`. A surface-aware protected-rule guard enforces it.
- **Conventions — adapted to your repo.** `interfaces` (`i-prefix`/`bare-pascal-case`/`off`), `enums` (`ban`/`allow`), `tests` (`co-located`/`mirrored`/`either`), `componentFolders`.

Enum allowance is split from the `as`-cast ban, so "allow enums" never removes cast safety.

## Single source of truth

One resolved `IConventions` object drives **both** halves so they can never disagree:

- **Gate** — both bundled `.mjs` configs rebuild `naming-convention`/`no-restricted-syntax` *options* from `TSFORGE_CONVENTIONS` (severity overrides can't express this); `makeFileLinter` applies the same at write-time.
- **Prompts** — `buildSystem`/`buildChatSystem`/TDD/simplicity phrase naming + test layout from the same conventions, so the model is never told "I-prefix" while the gate accepts bare names.

A default-conventions project is byte-identical to before this PR (no env emitted, hardcoded `.mjs` fallback).

## How it's built (9 slices)

config contract + validation → convention core + eslint builder + protected guard → gate channel → read-only AST scan + recommendations → flagship wizard UI (pure reducer/render + thin stdin driver) → atomic merge-preserving writer → prompt dynamism → CLI/REPL wiring → docs.

## Verification

- `bun run validate` green (1288 pass, 0 fail); docs build clean.
- Integration tests spawn the **real gate** to prove bare-PascalCase passes and enum-allow keeps cast bans; prompt tests prove no stale I-prefix; scan/writer/wizard each tested.
- **Adversarial harness review** (4 repro-driven slices) before merge: safety floor verified secure (no P1s), terminal never wedges, scanner never executes repo code. Findings fixed in-PR: writer re-run stale block (P2), wizard defensive guards (P3), manifest entry (P3).

## Deliberate scope (documented, not bugs)

- The `--web` **scaffold** path stays house-style (greenfield; gate + guidance consistent). Conventions govern the core/brownfield path.
- The eval-sweep `model-agent` prompt stays house-style (eval-only path).

Both noted in `docs/harness-subsystems.md` + a `cli.ts` comment.
