### PR TITLE
docs: freshness pass + landing 'Capabilities' section (pre-0.18)

### DIFF
--- a/apps/docs/astro.config.mjs
+++ b/apps/docs/astro.config.mjs
@@ -194,8 +194,10 @@ export default defineConfig({
           items: [
             { label: "Models (any provider)", link: "/inference/models-json/" },
             { label: "tsforge.config.json", link: "/guardrails/config/" },
+            { label: "Permissions & policy", link: "/guardrails/policy/" },
             { label: "Environment variables", link: "/reference/flags/" },
             { label: "MCP servers", link: "/integrations/mcp/" },
+            { label: "Web access", link: "/integrations/web-tools/" },
           ],
         },
         {

--- a/apps/docs/src/components/Landing.astro
+++ b/apps/docs/src/components/Landing.astro
@@ -7,6 +7,7 @@ import Stats from "./landing/Stats.astro";
 import Bento from "./landing/Bento.astro";
 import RulesMarquee from "./landing/RulesMarquee.astro";
 import GateExplained from "./landing/GateExplained.astro";
+import Capabilities from "./landing/Capabilities.astro";
 import TerminalShowcase from "./landing/TerminalShowcase.astro";
 import CTA from "./landing/CTA.astro";
 ---
@@ -17,6 +18,7 @@ import CTA from "./landing/CTA.astro";
   <Bento />
   <RulesMarquee />
   <GateExplained />
+  <Capabilities />
   <TerminalShowcase />
   <CTA />
 </div>

--- a/apps/docs/src/components/landing/Bento.astro
+++ b/apps/docs/src/components/landing/Bento.astro
@@ -48,7 +48,7 @@ const composable: [string, string][] = [
             </div>
             <div class="mt-4 flex gap-2 items-center">
               <Icon name="shield-check" class="h-3.5 w-3.5 text-primary" />
-              <span class="font-mono text-[11px]">184 rules across 21 packs</span>
+              <span class="font-mono text-[11px]">122 rules across 21 packs · 31 project checks</span>
             </div>
           </div>
         </div>

--- a/apps/docs/src/components/landing/Capabilities.astro
+++ b/apps/docs/src/components/landing/Capabilities.astro
@@ -1,0 +1,115 @@
+---
+/* "More than a gate" — surfaces the agent capabilities the rest of the landing
+   only hints at, each linking to its doc. Icon-free by design (matches the
+   minimal, mono aesthetic) and dependency-free. */
+import Icon from "./Icon.astro";
+
+interface Capability {
+  title: string;
+  body: string;
+  href: string;
+}
+
+const capabilities: Capability[] = [
+  {
+    title: "Setup wizard",
+    body: "Scans a repo's conventions and adapts the gate to them — no safety lost.",
+    href: "/cli/setup/",
+  },
+  {
+    title: "Functional review",
+    body: "Senior-lens diff review, each finding adversarially re-checked against the code.",
+    href: "/cli/review/",
+  },
+  {
+    title: "Workspace map",
+    body: "Primes the agent on your repo's shape so it starts oriented, not guessing.",
+    href: "/cli/map/",
+  },
+  {
+    title: "Pre-edit scout",
+    body: "Seeds brownfield edits with a type-exact caller blast radius.",
+    href: "/loop/scout/",
+  },
+  {
+    title: "Recipes",
+    body: "Declarative, checked-in run setups — invoke with tsforge run <id>.",
+    href: "/cli/recipes/",
+  },
+  {
+    title: "Cross-session memory",
+    body: "Learns the fixes that worked and recalls the recurring ones later.",
+    href: "/uplift/memory/",
+  },
+  {
+    title: "MCP servers",
+    body: "Plug in external Model Context Protocol tools and live docs.",
+    href: "/integrations/mcp/",
+  },
+  {
+    title: "Plan mode",
+    body: "Read-only exploration — you approve the plan before anything is edited.",
+    href: "/cli/plan-mode/",
+  },
+  {
+    title: "Permissions & policy",
+    body: "Deny-first modes for writes, shell, and network; a ledger of every action.",
+    href: "/guardrails/policy/",
+  },
+  {
+    title: "Web scaffolding",
+    body: "Bootstraps a building Vite + React app for the model to fill in.",
+    href: "/scaffold/web/",
+  },
+  {
+    title: "Opt-in oracles",
+    body: "Boot smoke, coverage, property tests, a11y, real browser render.",
+    href: "/loop/gate-floor/",
+  },
+  {
+    title: "Free web access",
+    body: "Local web_fetch + web_search — no API key, fully on-machine.",
+    href: "/integrations/web-tools/",
+  },
+];
+---
+
+<section class="hairline-b">
+  <div class="mx-auto max-w-[1400px] px-6 py-16 md:py-24">
+    <div class="max-w-2xl mb-16">
+      <div class="flex items-center gap-3 mb-5">
+        <span class="h-px w-8 bg-primary"></span>
+        <span class="mono-caps">More than a gate</span>
+      </div>
+      <h2
+        class="font-mono text-[34px] md:text-[44px] leading-[1.05] tracking-[-0.02em]"
+      >
+        A full agent harness,<br />
+        <span class="text-muted-foreground">not a linter.</span>
+      </h2>
+    </div>
+
+    <div
+      class="grid sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-px bg-border border border-border"
+    >
+      {
+        capabilities.map((c) => (
+          <a href={c.href} class="bg-background p-6 group block">
+            <div class="flex items-center justify-between">
+              <h3 class="font-mono text-[15px] tracking-tight group-hover:text-primary transition-colors">
+                {c.title}
+              </h3>
+              <Icon
+                name="arrow-right"
+                class="h-3.5 w-3.5 text-muted-foreground/40 group-hover:text-primary group-hover:translate-x-0.5 transition-all"
+              />
+            </div>
+            <p class="mt-3 text-[13px] text-muted-foreground leading-relaxed">
+              {c.body}
+            </p>
+          </a>
+        ))
+      }
+    </div>
+  </div>
+</section>

--- a/apps/docs/src/components/landing/Hero.astro
+++ b/apps/docs/src/components/landing/Hero.astro
@@ -29,7 +29,7 @@ const INSTALL = "curl -fsSL https://tsforge.dev/install.sh | bash";
       </h1>
 
       <p class="mt-7 max-w-[52ch] text-[15px] leading-relaxed text-muted-foreground">
-        A harness with <span class="text-foreground">184 enforced rules</span> for full-stack
+        A harness with <span class="text-foreground">153 enforced rules</span> for full-stack
         TypeScript — React, Next, Node, Bun, Drizzle, Fastify, and more. The build doesn't
         finish until the gate passes.
       </p>

--- a/apps/docs/src/components/landing/RulesMarquee.astro
+++ b/apps/docs/src/components/landing/RulesMarquee.astro
@@ -27,7 +27,7 @@ const doubled = [...rules, ...rules];
       <span class="h-px w-8 bg-primary"></span>
       <span class="mono-caps">A sliver of the ruleset</span>
     </div>
-    <span class="mono-caps !text-[10px]">184 enforced · 0 optional</span>
+    <span class="mono-caps !text-[10px]">153 enforced · 0 optional</span>
   </div>
 
   <div class="flex gap-3 whitespace-nowrap animate-marquee w-max">

--- a/apps/docs/src/components/landing/Stats.astro
+++ b/apps/docs/src/components/landing/Stats.astro
@@ -1,6 +1,6 @@
 ---
 const stats = [
-  { value: "184", label: "Enforced rules", sub: "Hand-tuned, opinionated" },
+  { value: "153", label: "Enforced rules", sub: "Hand-tuned, opinionated" },
   { value: "0", label: "Escape hatches", sub: "No `any`. No `@ts-ignore`." },
   { value: "strict", label: "Type checking", sub: "tsc strict + type-aware ESLint" },
   { value: "gate", label: "Required to merge", sub: "Build stops until green" },

--- a/apps/docs/src/content/docs/guardrails/config.mdx
+++ b/apps/docs/src/content/docs/guardrails/config.mdx
@@ -19,6 +19,7 @@ Add **`tsforge.config.json`** at your repo root when you want to override what t
 | `conventions` | object | Project taste tsforge adapts to: `interfaces`, `enums`, `tests`, `componentFolders` — written by [`tsforge setup`](/cli/setup/) |
 | `plugins` | object[] | External modules providing extra rule packs (see below) |
 | `mcpServers` | object | External [MCP servers](/integrations/mcp/) whose tools the agent can call |
+| `policy` | object | Permission `mode` + deny/allow/ask `rules` for tool actions — see [Permissions & policy](/guardrails/policy/) |
 
 Resolution order: detect from the repo → apply **`profile`** (packs + default severities) → apply `stack` → apply `include` → apply `exclude` → add external plugin packs → dedupe → merge `rules` overrides (user wins).
 

--- a/apps/docs/src/content/docs/guardrails/policy.mdx
+++ b/apps/docs/src/content/docs/guardrails/policy.mdx
@@ -1,0 +1,54 @@
+---
+title: Permissions & policy
+description: "tsforge evaluates every tool action against a deny-first policy — a mode sets the baseline (plan, default, CI…), config rules refine it, and a few critical denies always win."
+---
+
+Every action the agent takes — read a file, write one, run a shell command, hit the network, call an MCP tool — is checked against a policy before it runs. The policy is **deny-first**: the order is critical denies → your config rules → the active mode's default. Nothing ambiguous is ever silently allowed.
+
+## Modes
+
+A mode sets the baseline posture. Pick one with `--policy-mode <mode>`, or `policy.mode` in `tsforge.config.json` (the flag wins). Plan mode (`--plan` / `/plan`) overrides to `plan` while it's on.
+
+| Mode | Writes | Shell | Network | Delete | Use it for |
+| --- | --- | --- | --- | --- | --- |
+| `default` | allow | allow | allow | deny | Interactive day-to-day (the default). |
+| `plan` | **deny** | read-only | allow | deny | Read-only exploration before you approve a plan. |
+| `acceptEdits` | allow | **ask** | deny | deny | Auto-accept edits, but still confirm shell. |
+| `ci` | allow | **deny** | **deny** | deny | Non-interactive pipelines — anything that would prompt is denied. |
+| `dontAsk` | allow | **deny** | **deny** | deny | A local "never prompt me" run (identical to `ci`). |
+| `bypassPermissions` | allow | allow | allow | allow | The escape hatch — allow everything (critical denies still apply). |
+
+In `plan` mode the `run` tool is allowed through but its own read-only guard restricts it to read-only commands, so exploration can't mutate. `delete` is denied in every mode except `bypassPermissions`. Anything that would otherwise **ask** collapses to **deny** when there's no interactive approval path (non-interactive runs).
+
+## Config rules
+
+Refine a mode with deny / allow / ask lists under `policy.rules`. They're evaluated **before** the mode default, in that order (deny wins over allow wins over ask):
+
+```json
+{
+  "policy": {
+    "mode": "default",
+    "rules": {
+      "deny": [{ "kind": "shell", "commandPrefix": "rm " }],
+      "allow": [{ "kind": "network" }],
+      "ask": [{ "kind": "delete_file", "pathPattern": "src/**" }]
+    }
+  }
+}
+```
+
+A rule matches when **every field it specifies** matches the action (an empty rule matches everything — a deliberate catch-all). Available fields: `kind`, `toolName`, `pathPattern` (glob), `commandPrefix`, `commandPattern` (regex), `mcpServer`. Action kinds are `read_file`, `write_file`, `edit_file`, `delete_file`, `shell`, `network`, `mcp_tool`, `plugin_tool`, `unknown`.
+
+## Critical denies (always win)
+
+These fire in **every** mode, including `bypassPermissions` — they have no safe override:
+
+- **Destructive shell** — commands like `rm -rf /` are blocked.
+- **Private-key reads** — reading an SSH/PEM private-key path is blocked.
+- **Unregistered MCP servers** — an `mcp__*` call to a server not in your config is blocked.
+
+## The run ledger
+
+With `--log`, tsforge records every tool call, its policy decision (allow / ask / deny, with the matched rule and a risk level), the model's reasoning, and each gate verdict as JSONL under `~/.tsforge/logs/`. [`tsforge trace`](/observability/trace/) turns that ledger into a one-screen summary — deterministically, with no model call — so you can audit exactly what ran and why.
+
+→ [tsforge.config.json](/guardrails/config/) · [Trace a run](/observability/trace/) · [Plan mode](/cli/plan-mode/)

--- a/apps/docs/src/content/docs/index.mdx
+++ b/apps/docs/src/content/docs/index.mdx
@@ -1,6 +1,6 @@
 ---
 title: tsforge
-description: "A full-stack TypeScript harness with 184 enforced rules. The build doesn't finish until the gate passes."
+description: "A full-stack TypeScript harness with 153 enforced rules. The build doesn't finish until the gate passes."
 template: splash
 hero:
   tagline: Ship TypeScript that can't cheat.

--- a/apps/docs/src/content/docs/integrations/web-tools.mdx
+++ b/apps/docs/src/content/docs/integrations/web-tools.mdx
@@ -1,0 +1,30 @@
+---
+title: Web access (free, local)
+description: "Opt-in web_fetch + web_search tools — no API key, no paid service. Fully local extraction, DuckDuckGo by default, SearXNG for full privacy."
+---
+
+Set `TSFORGE_WEB=1` to give the agent two read-only web tools. They're **free and fully local** — no API key, no paid search service, nothing leaves your machine except the fetch itself. Off by default, so a run without the flag has no network reach beyond your model endpoint.
+
+```bash
+TSFORGE_WEB=1 tsforge "update the deprecated API call — check the library's current docs"
+```
+
+## The tools
+
+- **`web_fetch`** — retrieve a URL and return readable markdown. The page is fetched and the content extracted **on-machine** (no third-party reader API), so you get clean text without shipping the URL to a service.
+- **`web_search`** — discover sources for a query. Defaults to DuckDuckGo's keyless HTML endpoint; point it at a self-hosted [SearXNG](https://docs.searxng.org/) instance for full privacy and control:
+
+```bash
+TSFORGE_WEB=1 TSFORGE_SEARXNG_URL=http://localhost:8888 tsforge
+```
+
+## Why opt-in
+
+The tools are read-only and offline-safe, but web access is still reach the agent doesn't have by default — so it's a deliberate flag, not an always-on capability. Under a policy mode that denies `network` (e.g. `ci`), the tools are unavailable even with the flag set. See [Permissions & policy](/guardrails/policy/).
+
+| Env var | Default | Effect |
+| --- | --- | --- |
+| `TSFORGE_WEB` | off | enable `web_fetch` + `web_search` (`=1`) |
+| `TSFORGE_SEARXNG_URL` | unset | route `web_search` to a self-hosted SearXNG instance |
+
+→ [Environment variables](/reference/flags/) · [MCP servers](/integrations/mcp/) · [Permissions & policy](/guardrails/policy/)

--- a/apps/docs/src/content/docs/integrations/web-tools.mdx
+++ b/apps/docs/src/content/docs/integrations/web-tools.mdx
@@ -20,7 +20,7 @@ TSFORGE_WEB=1 TSFORGE_SEARXNG_URL=http://localhost:8888 tsforge
 
 ## Why opt-in
 
-The tools are read-only and offline-safe, but web access is still reach the agent doesn't have by default — so it's a deliberate flag, not an always-on capability. Under a policy mode that denies `network` (e.g. `ci`), the tools are unavailable even with the flag set. See [Permissions & policy](/guardrails/policy/).
+The tools are read-only and offline-safe, but web access is still more reach than the agent has by default — so it's a deliberate flag, not an always-on capability. Under a policy mode that denies `network` (e.g. `ci`), the tools are unavailable even with the flag set. See [Permissions & policy](/guardrails/policy/).
 
 | Env var | Default | Effect |
 | --- | --- | --- |

--- a/apps/docs/src/content/docs/observability/trace.mdx
+++ b/apps/docs/src/content/docs/observability/trace.mdx
@@ -67,4 +67,4 @@ console.log(formatTrace(events));
 
 `parseEventLog` tolerates both the ledger shape and the older flat shape, and `analyzeEvents` feeds the [A/B sweep report](/eval/ab-testing/#why-runs-failed).
 
-→ [Token metrics](/observability/metrics/) · [tsforge.config.json](/guardrails/config/) · [A/B testing](/eval/ab-testing/)
+→ [Token metrics](/observability/metrics/) · [Permissions & policy](/guardrails/policy/) · [tsforge.config.json](/guardrails/config/) · [A/B testing](/eval/ab-testing/)

--- a/apps/docs/src/content/docs/reference/flags.mdx
+++ b/apps/docs/src/content/docs/reference/flags.mdx
@@ -32,7 +32,7 @@ Offered only when there is existing code to inspect (greenfield scratch builds h
 
 ## Web access
 
-Opt-in, free, and fully local — no API key, no paid service. `TSFORGE_WEB=1` adds two read-only tools: `web_fetch` (retrieve a URL → readable markdown, extracted on-machine) and `web_search` (discover sources). Search defaults to DuckDuckGo's keyless HTML endpoint; point at a self-hosted [SearXNG](https://docs.searxng.org/) instance for full privacy/control.
+Opt-in, free, and fully local — no API key, no paid service. `TSFORGE_WEB=1` adds two read-only tools: `web_fetch` (retrieve a URL → readable markdown, extracted on-machine) and `web_search` (discover sources). Search defaults to DuckDuckGo's keyless HTML endpoint; point at a self-hosted [SearXNG](https://docs.searxng.org/) instance for full privacy/control. Full guide: [Web access](/integrations/web-tools/).
 
 | Variable | Default | Toggles |
 | --- | --- | --- |
@@ -91,6 +91,7 @@ Extra gate steps (default off; each skips cleanly when nothing applies). See [Ho
 | --- | --- |
 | `TSFORGE_PACKS` | comma-separated pack IDs |
 | `TSFORGE_RULE_OVERRIDES` | JSON severity map |
+| `TSFORGE_CONVENTIONS` | JSON conventions block (interface naming / enums) — rebuilds the bundled rule options; written by [`tsforge setup`](/cli/setup/) |
 
 ## Eval scripts
 
@@ -109,4 +110,4 @@ Extra gate steps (default off; each skips cleanly when nothing applies). See [Ho
 | `TSFORGE_BROWSER_TESTS` | off (`=1` for Playwright integration) |
 | `TSFORGE_WEB_LIVE_TESTS` | off (`=1` for live `web_fetch`/`web_search` network tests) |
 
-→ [Commands](/reference/commands/)
+→ [Commands](/reference/commands/) · [Permissions & policy](/guardrails/policy/)

--- a/apps/docs/src/content/docs/reference/roadmap.mdx
+++ b/apps/docs/src/content/docs/reference/roadmap.mdx
@@ -1,33 +1,33 @@
 ---
 title: Roadmap
-description: What shipped in v0.1, the path to 1.0, and candidate work.
+description: What's shipped through 0.18, the path to 1.0, and candidate work.
 ---
 
 TypeScript coding harness for web projects — `packages/core` for the loop and gate, [tsforge.dev](https://tsforge.dev) for docs.
 
-## Shipped in v0.1.0
+## Shipped through 0.18
 
-- Stack detection + 13 ESLint rule packs (~50 rules)
-- Meta-rule engine (10 rules: config, CI, supply chain, testing)
-- `tsforge.config.json` overrides (force stack, exclude packs, severity tuning)
-- Tool-call repair ladder (L0–L3)
-- Hashline edit tool with snapshot recovery
-- TTSR stream-interrupting rules
-- Instant write diagnostics (LSP feedback on edit/create)
-- A/B eval support — [A/B testing](/eval/ab-testing/)
-- Next.js rule pack (App Router server/client boundaries, dead pages-router APIs)
-- `.tsforge/rules.json` custom TTSR rules wired into the loop
+**Strictness & the gate**
+- Stack detection → **21 ESLint rule packs (122 rules)** + a **31-rule meta-rule engine** (config, CI, supply chain, container, testing, structure). See [Rule packs](/guardrails/rule-packs/) · [Meta-rules](/guardrails/meta-rules/).
+- **6 profiles** (recommended → strict / security / frontend / backend / opinionated); a type-aware ESLint overlay; progress-based loop termination (no blunt turn cap). See [When the gate fails](/loop/validation/).
+- **Tests by default** — `test-sibling-required` is an error on changed logic files. **Opt-in gate oracles** (coverage, boot smoke, property tests). See [Tests by default](/quality/tests/) · [the gate](/loop/gate-floor/).
 
-## Shipped since v0.1 (0.1.x → 0.2.x)
+**Adapt to your repo**
+- **`tsforge setup`** — a conventions wizard that scans the repo and writes `tsforge.config.json` (interface naming, enums, test layout, component folders) without weakening the safety floor. See [Set up a repo](/cli/setup/).
+- `tsforge.config.json` overrides + **external plugin packs**. See [config](/guardrails/config/).
 
-- **Provider-agnostic models** — `~/.tsforge/models.json` for any OpenAI-compatible API; reasoning dialects (`qwen`/`deepseek`/`openai`), with the DeepSeek dialect **auto-detected** so DeepSeek thinking models work out of the box. See [models.json](/inference/models-json/).
-- **MCP servers** — connect stdio MCP servers as read-only context/tools. See [MCP servers](/integrations/mcp/).
-- **Web scaffolding** — greenfield Vite + React + shadcn + TanStack stacks; `scaffold_web`/`scaffold_ui`/`scaffold_routes`; a web gate ladder that ends in a real browser smoke test. See [Web scaffolding](/scaffold/web/).
-- **Views layout enforced** — scaffolded apps use `src/views/<Feature>/`; the new `component-file-purity` rule and a rewritten `component-folder-structure` keep types/constants/helpers out of component files, and the core `Table` is column-driven (no per-feature wrappers).
-- **Progress-based loop termination** — the blunt 40-turn cap is gone; tsforge stops on **lack of progress** (a single error surviving 5 fix cycles) with a blocker diagnosis, and interactive sessions ride a high runaway backstop. See [When the gate fails](/loop/validation/).
-- **Cross-session memory** — tsforge mines its own runs for failure→fix lessons and recalls the recurring ones as dormant triggers. See [Learning from past runs](/uplift/memory/).
-- **Observability** — live tok/s in the status bar, `/metrics`, and a `--log` JSONL analyzer with a failure-class taxonomy. See [Token metrics](/observability/metrics/).
-- **Also**: plan mode, external plugin packs, a type-aware ESLint overlay, and an auto-gate that runs the project's own tests.
+**The agent surface**
+- **Functional review** (`tsforge review`, gate-aware) · **workspace map** (`tsforge map`) · **pre-edit scout** · **declarative recipes** (`tsforge run`) · **plan mode** · **cross-session memory**.
+- **Permissions & policy** — 6 modes, deny-first config rules, and a run **ledger** summarized by `tsforge trace`. See [Permissions & policy](/guardrails/policy/) · [Trace a run](/observability/trace/).
+- **Free, local web access** — opt-in `web_fetch` + `web_search`, no API key. See [Web access](/integrations/web-tools/).
+- **Web scaffolding** — Vite + React + shadcn + TanStack, ending in a real browser smoke test. See [Web scaffolding](/scaffold/web/).
+
+**Models & observability**
+- **Provider-agnostic** `~/.tsforge/models.json` (any OpenAI-compatible API; `qwen`/`deepseek`/`openai` reasoning dialects, DeepSeek auto-detected). See [models.json](/inference/models-json/).
+- **MCP servers** as read-only context/tools. See [MCP servers](/integrations/mcp/).
+- Live tok/s + `/metrics` + a `--log` JSONL analyzer. See [Token metrics](/observability/metrics/).
+
+**Reliability internals**: tool-call repair ladder (L0–L3), hashline `edit_lines` with snapshot recovery, TTSR stream-interrupting rules, instant per-write type diagnostics, A/B eval support.
 
 **Sequencing rule:** Measured wins first. No feature defaults change and no 1.0 tag until A/B numbers against the reference model exist.
 


### PR DESCRIPTION
Ahead of the 0.18 release: bring the docs current and reveal the harness's breadth (lots of shipped features weren't surfaced).

## Freshness pass

- **Rule-count headline reconciled.** The catalog (`RULES.md`, where the "Read the rulebook" CTA points) lists **153** = 122 pack rules + 31 meta-rules, but the landing hardcoded **184** in 5 places. Updated Hero / Stats / RulesMarquee / `index.mdx` description → 153, and the Bento detail → "122 across 21 packs · 31 project checks". (Verified against `bun run rules:build`.)
- **New page — Permissions & policy** (`guardrails/policy.mdx`): the 6 modes, `--policy-mode`, deny/allow/ask config rules, the always-on critical denies, and the run ledger → `tsforge trace`. This whole capability had no page. Added the missing `policy` row to `config.mdx`; cross-linked from `flags.mdx` + `trace.mdx`.
- **New page — Web access** (`integrations/web-tools.mdx`): promotes the free, local `web_fetch`/`web_search` out of the env-var table into a discoverable page.
- **`flags.mdx`**: added `TSFORGE_CONVENTIONS`; linked the web-tools page.
- **`roadmap.mdx`**: refreshed to "Shipped through 0.18" — setup/conventions wizard, policy + ledger, gate-aware review, recipes, scout, trace, map, cross-session memory, free web tools; current pack/rule counts (was "13 packs / ~50 rules / 10 meta-rules").
- **Sidebar**: added *Permissions & policy* and *Web access* under Configure.

## Landing expansion

New on-brand **"More than a gate"** section (`Capabilities.astro`) — 12 cards surfacing the agent capabilities the rest of the page only hinted at (setup, review, map, scout, recipes, memory, MCP, plan mode, policy, web scaffolding, opt-in oracles, free web tools), each linking to its doc. Inserted between `GateExplained` and `TerminalShowcase`. Icon-free, dependency-free, matches the existing tiled card style.

## Verification

- `bunx astro build` green — **43 pages** (was 41; +2 new). All 12 capability links resolve; landing renders the new section; zero "184" left.
- `bun run validate` green (1289 pass) — no `packages/core` changes.

Docs-only; no code touched. After this merges I'll cut **0.18.0** (#32–#35 + this are unreleased since 0.17.0).
