### PR TITLE
fix: harness-review sweep — 6 fixes across tools/browser/inference/mcp/oracles/gate

### DIFF
--- a/docs/harness-subsystems.md
+++ b/docs/harness-subsystems.md
@@ -94,7 +94,7 @@ degenerate stream; reasoning/content channels are kept distinct.
 **Risk areas** repetition penalty penalizing tool-call JSON (→ narration, no writes);
 reasoning-token capture for the active provider dialect.
 
-## rule-packs / meta-rules — `src/rules/*`, packs, `scripts/build-rule-docs.ts`
+## rule-packs / meta-rules — `src/meta-rules/*`, `src/rule-packs/*`, `src/infer-rules/*`, `scripts/build-rule-docs.ts`
 
 ESLint rule packs, structural meta-rules, profile gating.
 
@@ -178,8 +178,10 @@ The ONE shared command runner; path normalization; scope checks.
 
 **Invariants** ONE place runs shell commands (gate + `run` both route here) so
 cancellation + kill-timeout are uniform; a timeout/abort kills the whole process
-group (no leaked `&` child); argv (no-shell) form for any model/content-built command;
-a missing binary → exit 127, not a throw.
+group (no leaked `&` child); argv (no-shell) form for any content-built command (e.g.
+`add_dependency` → `bun add …`) — the model's own `run` tool is the one deliberate
+shell form, gated by `isReadOnlyCommand` in plan mode and the destructive-shell policy
+otherwise; a missing binary → exit 127, not a throw.
 
 **Risk areas** kill that leaves grandchildren (the fixed P2a); shell-injection via the
 shell form; an uncapped read.

--- a/packages/core/scripts/proptest-check.ts
+++ b/packages/core/scripts/proptest-check.ts
@@ -20,6 +20,17 @@ import {
   renderPropertyFile,
   propTestPath,
 } from "../src/proptest/discover";
+import { runArgvCommand } from "../src/lib/fs";
+
+/** Hard cap on the generated property suite. fast-check shrinking on a genuinely
+ *  non-terminating function could otherwise hang the gate indefinitely (observed:
+ *  a 15-minute wedge). Treat exceeding it as a failure, not a hang. Overridable
+ *  via TSFORGE_PROPTEST_TIMEOUT_MS (also the seam the regression test uses). */
+function proptestTimeoutMs(): number {
+  const env = Number(process.env.TSFORGE_PROPTEST_TIMEOUT_MS);
+
+  return Number.isFinite(env) && env > 0 ? env : 120_000;
+}
 
 /** Build a Program from the project's tsconfig (or a permissive default). */
 function buildProgram(cwd: string): ts.Program | null {
@@ -50,16 +61,26 @@ function fastCheckPath(): string | null {
   }
 }
 
-async function runGeneratedSuite(testFile: string): Promise<number> {
-  const proc = Bun.spawn(["bun", "test", testFile], {
-    cwd: process.cwd(),
-    stdout: "inherit",
-    stderr: "inherit",
+export async function runGeneratedSuite(testFile: string): Promise<number> {
+  // Route through the shared runner so a non-terminating property can't wedge the
+  // gate: it enforces a kill-timeout AND a whole-process-group kill (raw Bun.spawn
+  // did neither). Stream output live so fuzz failures stay visible.
+  const timeoutMs = proptestTimeoutMs();
+  const run = await runArgvCommand(process.cwd(), ["bun", "test", testFile], {
+    timeoutMs,
+    onChunk: (text) => process.stdout.write(text),
   });
 
-  await proc.exited;
+  if (run.timedOut) {
+    process.stdout.write(
+      `\nproptest-check: generated suite exceeded ${String(timeoutMs)}ms ` +
+        "and was killed — a property under test may not terminate. Treating as a failure.\n"
+    );
 
-  return proc.exitCode ?? -1;
+    return 1;
+  }
+
+  return run.exitCode;
 }
 
 async function main(): Promise<number> {

--- a/packages/core/src/browser/oracle.ts
+++ b/packages/core/src/browser/oracle.ts
@@ -374,7 +374,14 @@ export function startStaticServer(
       // the served root. Reject anything that resolves outside `base`.
       const within = relative(base, full);
 
-      if (within.startsWith("..") || isAbsolute(within)) {
+      // Match a real escape only — `..`, `../…`, `..\…`, or an absolute path — so
+      // a legitimately-named file like `..foo` inside the root isn't false-404'd.
+      if (
+        within === ".." ||
+        within.startsWith("../") ||
+        within.startsWith("..\\") ||
+        isAbsolute(within)
+      ) {
         return new Response("not found", { status: 404 });
       }
 

--- a/packages/core/src/browser/oracle.ts
+++ b/packages/core/src/browser/oracle.ts
@@ -1,4 +1,11 @@
-import { resolve, dirname, basename, join } from "node:path";
+import {
+  resolve,
+  dirname,
+  basename,
+  join,
+  relative,
+  isAbsolute,
+} from "node:path";
 import { isRecord } from "../lib/guards";
 import { serveEphemeral } from "../lib/serve";
 // `playwright` is an OPTIONAL peer: bundling it (+ a browser binary) into every
@@ -349,8 +356,9 @@ async function capturePage(
 /** Serve a directory on an ephemeral localhost port. SPA FALLBACK: an
  *  extension-less path that isn't a real file → index.html (so the client router
  *  renders that route). Missing ASSETS (paths with a `.`) still 404, so a broken
- *  bundle/import surfaces as a real error. */
-function startStaticServer(
+ *  bundle/import surfaces as a real error. Exported for the traversal/404
+ *  regression test. */
+export function startStaticServer(
   root: string
 ): Promise<ReturnType<typeof Bun.serve>> {
   return serveEphemeral({
@@ -358,7 +366,19 @@ function startStaticServer(
       const path = new URL(req.url).pathname;
       const rel =
         path === "/" ? "index.html" : decodeURIComponent(path.slice(1));
-      const handle = Bun.file(join(root, rel));
+      const base = resolve(root);
+      const full = resolve(base, rel);
+
+      // Path-traversal guard: `decodeURIComponent` turns `%2e%2e%2f` back into
+      // `../`, so a request like `/..%2F..%2Fetc%2Fpasswd` would otherwise escape
+      // the served root. Reject anything that resolves outside `base`.
+      const within = relative(base, full);
+
+      if (within.startsWith("..") || isAbsolute(within)) {
+        return new Response("not found", { status: 404 });
+      }
+
+      const handle = Bun.file(full);
 
       if (await handle.exists()) {
         return new Response(handle);

--- a/packages/core/src/inference/request.ts
+++ b/packages/core/src/inference/request.ts
@@ -116,9 +116,13 @@ export function buildRequestBody(
   opts: ICompleteOptions,
   streaming: boolean
 ): Record<string, unknown> {
-  // o-series rejects `temperature` entirely; everywhere else send it only when set.
+  // o-series rejects `temperature` entirely; everywhere else send it only when set
+  // AND finite — a NaN/Infinity (bad config/env) would JSON.stringify to `null`,
+  // which a server reads as an explicit choice, not "unset". Drop it instead.
   const omitTemperature =
-    style(cfg) === "openai" || opts.temperature === undefined;
+    style(cfg) === "openai" ||
+    opts.temperature === undefined ||
+    !Number.isFinite(opts.temperature);
 
   // DeepSeek's thinking mode requires each prior assistant turn's
   // `reasoning_content` replayed; other providers don't want it.
@@ -129,7 +133,8 @@ export function buildRequestBody(
     messages: messages.map((m) => toWire(m, includeReasoning)),
     ...tokenCapField(cfg),
     ...(omitTemperature ? {} : { temperature: opts.temperature }),
-    ...(cfg.repetitionPenalty === undefined
+    ...(cfg.repetitionPenalty === undefined ||
+    !Number.isFinite(cfg.repetitionPenalty)
       ? {}
       : { repetition_penalty: cfg.repetitionPenalty }),
     ...toolsBlock(cfg, opts),

--- a/packages/core/src/loop/tools/web-fetch.ts
+++ b/packages/core/src/loop/tools/web-fetch.ts
@@ -132,7 +132,18 @@ export async function doWebFetch(
     return `web_fetch: failed to fetch ${url.href} — ${msg}`;
   }
 
-  const content = await deps.extract(body, url.href);
+  let content: string;
+
+  try {
+    content = await deps.extract(body, url.href);
+  } catch (err) {
+    // Self-contained: an extractor throw must become a tool-error STRING, not
+    // propagate into the loop (the outer dispatch boundary would catch it, but a
+    // handler owning its own failure gives the model a precise, actionable message).
+    const msg = err instanceof Error ? err.message : "unknown error";
+
+    return `web_fetch: fetched ${url.href} but failed to extract readable content — ${msg}`;
+  }
 
   return truncate(content, maxChars(args));
 }

--- a/packages/core/src/mcp/jsonrpc.ts
+++ b/packages/core/src/mcp/jsonrpc.ts
@@ -58,7 +58,11 @@ export function isResponseFor(
   return isRecord(value) && value.jsonrpc === "2.0" && value.id === id;
 }
 
-/** Extract a human-readable error string from a JSON-RPC error member. */
+/** Extract a human-readable error string from a JSON-RPC error member. Returns
+ *  null ONLY when there is no error member at all (a real success). A present-but-
+ *  malformed error (e.g. `{error:{code:-32600}}` with no `message`) still returns a
+ *  string, so the caller rejects rather than resolving `message.result` to
+ *  `undefined` — which the model would otherwise read as a successful empty result. */
 export function errorText(value: unknown): string | null {
   if (!isRecord(value)) {
     return null;
@@ -66,9 +70,13 @@ export function errorText(value: unknown): string | null {
 
   const error = value.error;
 
+  if (error === undefined || error === null) {
+    return null;
+  }
+
   if (isRecord(error) && typeof error.message === "string") {
     return error.message;
   }
 
-  return null;
+  return "MCP error response with no message field";
 }

--- a/packages/core/src/mcp/jsonrpc.ts
+++ b/packages/core/src/mcp/jsonrpc.ts
@@ -74,6 +74,11 @@ export function errorText(value: unknown): string | null {
     return null;
   }
 
+  // Some non-standard servers send a bare string error — surface it verbatim.
+  if (typeof error === "string") {
+    return error;
+  }
+
   if (isRecord(error) && typeof error.message === "string") {
     return error.message;
   }

--- a/packages/core/tests/browser-oracle.test.ts
+++ b/packages/core/tests/browser-oracle.test.ts
@@ -1,8 +1,9 @@
 import { test, expect } from "bun:test";
-import { mkdtemp, writeFile, rm } from "node:fs/promises";
+import { mkdtemp, writeFile, rm, mkdir } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { renderCheck } from "../src/browser";
+import { startStaticServer } from "../src/browser/oracle";
 
 /** Write a tiny SPA fixture: one index.html whose inline script renders per
  *  location.pathname — throws on "/bad", leaves the root blank on "/blank". With
@@ -50,6 +51,44 @@ const enabled = process.env.TSFORGE_BROWSER_TESTS === "1";
 const hasChromium = enabled && (await chromiumAvailable());
 // skipped unless TSFORGE_BROWSER_TESTS=1 and Playwright chromium is installed
 const browserTest = hasChromium ? test : test.skip;
+
+// Static-server logic needs NO browser, so it runs in the default suite. Covers
+// the 404/SPA-fallback contract AND the path-traversal guard (decodeURIComponent
+// must not let `/..%2F…` escape the served root).
+test("static server: 404s missing assets, SPA-falls-back, blocks ../ traversal", async () => {
+  const dir = await mkdtemp(join(tmpdir(), "tsforge-static-"));
+  const root = join(dir, "site");
+
+  await mkdir(root, { recursive: true });
+  await writeFile(join(root, "index.html"), "<h1>home</h1>");
+  await writeFile(join(root, "app.js"), "console.log(1)");
+  // a secret OUTSIDE the served root — traversal must never reach it
+  await writeFile(join(dir, "secret.txt"), "TOPSECRET");
+
+  const server = await startStaticServer(root);
+  const base = `http://localhost:${String(server.port)}`;
+
+  try {
+    expect((await fetch(`${base}/app.js`)).status).toBe(200); // real asset
+
+    const miss = await fetch(`${base}/missing.js`); // has a dot → 404, not index
+
+    expect(miss.status).toBe(404);
+
+    const route = await fetch(`${base}/some/route`); // extensionless → SPA fallback
+
+    expect(route.status).toBe(200);
+    expect(await route.text()).toContain("home");
+
+    const trav = await fetch(`${base}/..%2Fsecret.txt`); // encoded ../ escape
+
+    expect(trav.status).toBe(404);
+    expect(await trav.text()).not.toContain("TOPSECRET");
+  } finally {
+    await server.stop(true);
+    await rm(dir, { recursive: true, force: true });
+  }
+});
 
 browserTest("renders clean HTML and confirms expected content", async () => {
   const result = await renderCheck({

--- a/packages/core/tests/browser-oracle.test.ts
+++ b/packages/core/tests/browser-oracle.test.ts
@@ -62,6 +62,8 @@ test("static server: 404s missing assets, SPA-falls-back, blocks ../ traversal",
   await mkdir(root, { recursive: true });
   await writeFile(join(root, "index.html"), "<h1>home</h1>");
   await writeFile(join(root, "app.js"), "console.log(1)");
+  // a legitimately-named dotfile inside the root — the guard must NOT 404 it
+  await writeFile(join(root, "..foo.js"), "ok-inside");
   // a secret OUTSIDE the served root — traversal must never reach it
   await writeFile(join(dir, "secret.txt"), "TOPSECRET");
 
@@ -84,6 +86,12 @@ test("static server: 404s missing assets, SPA-falls-back, blocks ../ traversal",
 
     expect(trav.status).toBe(404);
     expect(await trav.text()).not.toContain("TOPSECRET");
+
+    // a file NAMED `..foo.js` inside the root is served (not a false-positive 404)
+    const dotfile = await fetch(`${base}/..foo.js`);
+
+    expect(dotfile.status).toBe(200);
+    expect(await dotfile.text()).toBe("ok-inside");
   } finally {
     await server.stop(true);
     await rm(dir, { recursive: true, force: true });

--- a/packages/core/tests/detect-gate.test.ts
+++ b/packages/core/tests/detect-gate.test.ts
@@ -434,6 +434,58 @@ test("buildGate includeTests: appends tests only when the project has them", asy
   }
 });
 
+test("opt-in oracles join the gate ONLY when their env var is set", async () => {
+  const dir = await tempDir();
+  const keys = [
+    "TSFORGE_COVERAGE",
+    "TSFORGE_BOOT",
+    "TSFORGE_PROPTEST",
+  ] as const;
+  const saved = new Map(keys.map((k) => [k, process.env[k]]));
+
+  for (const k of keys) {
+    Reflect.deleteProperty(process.env, k);
+  }
+
+  try {
+    await writeFile(join(dir, "package.json"), JSON.stringify({ name: "x" }));
+
+    // Default: none of the oracles are present.
+    const off = await buildGate(dir);
+
+    expect(off.label).not.toContain("test coverage");
+    expect(off.label).not.toContain("boot smoke");
+    expect(off.label).not.toContain("property tests");
+
+    // Each env var pulls in exactly its oracle.
+    process.env.TSFORGE_COVERAGE = "80";
+    expect((await buildGate(dir)).label).toContain("test coverage");
+    delete process.env.TSFORGE_COVERAGE;
+
+    process.env.TSFORGE_BOOT = "bun run start";
+    expect((await buildGate(dir)).label).toContain("boot smoke");
+    delete process.env.TSFORGE_BOOT;
+
+    process.env.TSFORGE_PROPTEST = "1";
+    expect((await buildGate(dir)).label).toContain("property tests");
+    delete process.env.TSFORGE_PROPTEST;
+
+    // An empty value does NOT count as set (guards against `export X=`).
+    process.env.TSFORGE_COVERAGE = "";
+    expect((await buildGate(dir)).label).not.toContain("test coverage");
+  } finally {
+    for (const [k, v] of saved) {
+      if (v === undefined) {
+        Reflect.deleteProperty(process.env, k);
+      } else {
+        process.env[k] = v;
+      }
+    }
+
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
 test("scaffoldWeb never overwrites an existing file", async () => {
   const dir = await tempDir();
 

--- a/packages/core/tests/mcp-unit.test.ts
+++ b/packages/core/tests/mcp-unit.test.ts
@@ -95,7 +95,8 @@ describe("mcp: jsonrpc framing", () => {
     expect(
       errorText({ jsonrpc: "2.0", id: 1, error: { code: -32600 } })
     ).not.toBe(null);
-    expect(errorText({ jsonrpc: "2.0", id: 1, error: "boom" })).not.toBe(null);
+    // a bare string error is surfaced verbatim (more actionable than the generic)
+    expect(errorText({ jsonrpc: "2.0", id: 1, error: "boom" })).toBe("boom");
 
     // No error member ⇒ a real success ⇒ null (so the caller resolves the result).
     expect(errorText({ jsonrpc: "2.0", id: 1, result: { ok: true } })).toBe(

--- a/packages/core/tests/mcp-unit.test.ts
+++ b/packages/core/tests/mcp-unit.test.ts
@@ -10,6 +10,7 @@ import {
   type IMcpToolInfo,
   type IMcpTransport,
 } from "../src/mcp";
+import { errorText } from "../src/mcp/jsonrpc";
 
 class FakeTransport implements IMcpTransport {
   connected = false;
@@ -76,6 +77,31 @@ describe("mcp: jsonrpc framing", () => {
     const d = new LineDecoder();
 
     expect(d.push('not json\n\n{"ok":true}\n')).toEqual([{ ok: true }]);
+  });
+
+  test("errorText: a present error member is never null (no message ⇒ generic)", () => {
+    // A well-formed error message passes through verbatim.
+    expect(
+      errorText({
+        jsonrpc: "2.0",
+        id: 1,
+        error: { code: -32600, message: "bad" },
+      })
+    ).toBe("bad");
+
+    // A malformed error (error member present, no string message) must STILL be
+    // an error — else the transport resolves message.result to `undefined`, which
+    // the model reads as a successful empty result (lost error signal).
+    expect(
+      errorText({ jsonrpc: "2.0", id: 1, error: { code: -32600 } })
+    ).not.toBe(null);
+    expect(errorText({ jsonrpc: "2.0", id: 1, error: "boom" })).not.toBe(null);
+
+    // No error member ⇒ a real success ⇒ null (so the caller resolves the result).
+    expect(errorText({ jsonrpc: "2.0", id: 1, result: { ok: true } })).toBe(
+      null
+    );
+    expect(errorText("not an object")).toBe(null);
   });
 });
 

--- a/packages/core/tests/proptest-oracle.test.ts
+++ b/packages/core/tests/proptest-oracle.test.ts
@@ -10,6 +10,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import ts from "typescript";
 import { propertyTargets, renderPropertyFile } from "../src/proptest/discover";
+import { runGeneratedSuite } from "../scripts/proptest-check";
 
 const PROPTEST_SCRIPT = join(
   import.meta.dir,
@@ -116,6 +117,41 @@ test("oracle PASSES a total function", async () => {
   try {
     expect(await runOracle(dir)).toBe(0);
   } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("runGeneratedSuite kills a non-terminating suite at the timeout (no infinite hang)", async () => {
+  // A property whose function never returns would otherwise wedge the gate
+  // indefinitely (observed: a 15-minute hang). The shared runner's kill-timeout
+  // must cap it and report a failure instead.
+  const dir = realpathSync(mkdtempSync(join(tmpdir(), "tsforge-pt-hang-")));
+  const testFile = join(dir, "hang.test.ts");
+
+  writeFileSync(
+    testFile,
+    `import { test } from "bun:test";\n` +
+      `test("never resolves", async () => { await new Promise(() => undefined); });\n`
+  );
+
+  const prev = process.env.TSFORGE_PROPTEST_TIMEOUT_MS;
+
+  process.env.TSFORGE_PROPTEST_TIMEOUT_MS = "500";
+
+  const started = Date.now();
+
+  try {
+    const code = await runGeneratedSuite(testFile);
+
+    expect(code).toBe(1); // timed out ⇒ treated as a failure, not a hang
+    expect(Date.now() - started).toBeLessThan(20_000); // killed promptly
+  } finally {
+    if (prev === undefined) {
+      Reflect.deleteProperty(process.env, "TSFORGE_PROPTEST_TIMEOUT_MS");
+    } else {
+      process.env.TSFORGE_PROPTEST_TIMEOUT_MS = prev;
+    }
+
     rmSync(dir, { recursive: true, force: true });
   }
 });

--- a/packages/core/tests/request-builder.test.ts
+++ b/packages/core/tests/request-builder.test.ts
@@ -90,6 +90,18 @@ describe("buildRequestBody: base body", () => {
     expect(body({}, { temperature: 0.5 }).temperature).toBe(0.5);
   });
 
+  test("a non-finite tuning param never reaches the wire (NaN/Infinity dropped)", () => {
+    // JSON.stringify(NaN) is `null` — a server reads that as an explicit choice,
+    // not "unset". The builder must omit the field entirely instead.
+    expect("temperature" in body({}, { temperature: NaN })).toBe(false);
+    expect("temperature" in body({}, { temperature: Infinity })).toBe(false);
+    expect("repetition_penalty" in body({ repetitionPenalty: NaN }, {})).toBe(
+      false
+    );
+    // a finite value still passes through
+    expect(body({ repetitionPenalty: 1.1 }, {}).repetition_penalty).toBe(1.1);
+  });
+
   test("extraBody is merged last and overrides built-ins", () => {
     const b = body(
       { extraBody: { temperature: 0.9, custom_flag: true } },

--- a/packages/core/tests/web-fetch.test.ts
+++ b/packages/core/tests/web-fetch.test.ts
@@ -225,3 +225,21 @@ test("doWebFetch handles a network error gracefully", async () => {
 
   expect(r.toLowerCase()).toContain("failed");
 });
+
+test("doWebFetch returns a string when the extractor throws (never propagates)", async () => {
+  // The handler must own its failure: an extractor throw becomes a tool-error
+  // string, not an exception into the loop.
+  const r = await doWebFetch(
+    { url: "https://example.com" },
+    ctx(),
+    deps({
+      extract: async () => {
+        throw new Error("readability blew up");
+      },
+    })
+  );
+
+  expect(typeof r).toBe("string");
+  expect(r).toContain("web_fetch");
+  expect(r).toContain("failed to extract");
+});


### PR DESCRIPTION
A multi-round adversarial sweep with `/harness-review`, covering **all 12 harness
subsystems** in `docs/harness-subsystems.md`. Each finding was reproduced (or
traced to a concrete `file:line`) before fixing, and every fix ships with a
regression test. One commit per find-fix cycle; full `bun run validate` green
(**1309 pass / 0 fail**).

## Fixes (7 cycles)

1. **tools — `web_fetch` not self-contained (P1).** `doWebFetch` ran `extract()`
   outside its try/catch; an extractor throw relied on the outer dispatch
   boundary. Now returns a precise tool-error string.
2. **gate — opt-in oracle env-gating had no test (P2).** Locks that
   COVERAGE/BOOT/PROPTEST join the gate only when their env var is set.
3. **browser — path traversal (P1).** The render-oracle static server decoded the
   request path before `join(root, …)`, so `/..%2F..%2Fetc%2Fpasswd` escaped the
   root. Added a `relative()` containment guard; 404/SPA-fallback also covered.
4. **inference — non-finite tuning param hit the wire (P2).** `NaN`/`Infinity`
   `temperature`/`repetition_penalty` `JSON.stringify`'d to `null`. Now dropped.
5. **mcp — lost error signal (P2).** `errorText()` returned null for a
   present-but-malformed JSON-RPC error, so the transport resolved `undefined` as
   success. A present error member now always yields a string ⇒ caller rejects.
6. **oracles — proptest could wedge the gate (P2).** `runGeneratedSuite` used raw
   `Bun.spawn` with no timeout; a non-terminating property hung the gate (~15 min
   observed). Routed through the shared `runArgvCommand` (kill-timeout +
   process-group kill); timeout ⇒ failure. Overridable via
   `TSFORGE_PROPTEST_TIMEOUT_MS`.
7. **manifest — stale (P3).** Corrected the rule-packs glob and the lib/fs
   argv-vs-shell wording.

## Verified clean (no fix needed)
loop/turn (mutation re-gate/accounting), lib/fs (group-kill, exit-127, scope
traversal), rules/meta-rules (pack-gating + doc parity), web-scaffold
(non-destructive + conditional `mutated`), setup safety-floor
(`PROTECTED_BUNDLED_RULES`), render/cli, oracles' `serveEphemeral` usage. Each
traced to the upholding `file:line`.

## Test plan
- `bun run validate` — 1309 pass / 0 fail.
- Repros now closed: `/..%2F..` traversal → 404; `temperature: NaN` omitted;
  malformed JSON-RPC error → reject; a non-terminating proptest suite → killed at
  the timeout (not a 15-min hang); `web_fetch` extractor throw → tool-error string.
