### PR TITLE
fix: harness-review quality pass — 9 fixes across policy/loop/inference/render/conventions/wizard/meta-rules (11 passes)

### DIFF
--- a/packages/core/src/agent/model-agent.ts
+++ b/packages/core/src/agent/model-agent.ts
@@ -124,15 +124,18 @@ async function applyAgentEdit(
   const result = await applyEdits(ctx.cwd, edit.file, edit.edits);
 
   if (result.ok) {
-    for (const r of edit.edits) {
-      ctx.report?.({
-        kind: "edit",
-        task: ctx.task.id,
-        file: edit.file,
-        message: `edit ${edit.file}`,
-        oldString: r.oldString,
-        newString: r.newString,
-      });
+    // Skip the mutation event for a no-op edit (same content) so it isn't counted.
+    if (result.changed) {
+      for (const r of edit.edits) {
+        ctx.report?.({
+          kind: "edit",
+          task: ctx.task.id,
+          file: edit.file,
+          message: `edit ${edit.file}`,
+          oldString: r.oldString,
+          newString: r.newString,
+        });
+      }
     }
 
     return null;

--- a/packages/core/src/files/edit.ts
+++ b/packages/core/src/files/edit.ts
@@ -41,9 +41,18 @@ export async function applyEdit(cwd: string, edit: IEdit): Promise<EditResult> {
   }
 
   // Unique match: split/join avoids `$`-pattern interpretation in newString.
-  await Bun.write(path, content.split(edit.oldString).join(edit.newString));
+  const next = content.split(edit.oldString).join(edit.newString);
 
-  return { ok: true, file: edit.file };
+  // A same-content replacement (oldString === newString, or it was already
+  // applied) leaves the file byte-identical. Skip the write and flag it so the
+  // caller doesn't count a no-op as a mutation or trigger a needless re-gate.
+  if (next === content) {
+    return { ok: true, file: edit.file, changed: false };
+  }
+
+  await Bun.write(path, next);
+
+  return { ok: true, file: edit.file, changed: true };
 }
 
 /**
@@ -70,7 +79,8 @@ export async function applyEdits(
     return { ok: false, file, index: 0, reason: EDIT_FAIL_REASON.notFound };
   }
 
-  let content = await f.text();
+  const original = await f.text();
+  let content = original;
 
   for (let i = 0; i < edits.length; i += 1) {
     const replacement = edits[i];
@@ -122,9 +132,16 @@ export async function applyEdits(
     content = content.split(replacement.oldString).join(replacement.newString);
   }
 
+  // A batch that resolves to byte-identical content (all replacements were no-ops
+  // or already applied) must not be counted as a mutation — skip the write and
+  // flag it so the caller neither re-gates nor tallies a phantom edit.
+  if (content === original) {
+    return { ok: true, file, count: edits.length, changed: false };
+  }
+
   await Bun.write(path, content);
 
-  return { ok: true, file, count: edits.length };
+  return { ok: true, file, count: edits.length, changed: true };
 }
 
 /**

--- a/packages/core/src/files/files.types.ts
+++ b/packages/core/src/files/files.types.ts
@@ -85,7 +85,14 @@ export type HashlineFailReason =
   | "invalid-op";
 
 export type HashlineResult =
-  | { ok: true; file: string; newHash: string }
+  | {
+      ok: true;
+      file: string;
+      newHash: string;
+      /** False when the ops resolved to identical content (a no-op write) — the
+       *  caller must NOT count it as a mutation or re-gate on it. */
+      changed: boolean;
+    }
   | {
       ok: false;
       file: string;

--- a/packages/core/src/files/files.types.ts
+++ b/packages/core/src/files/files.types.ts
@@ -14,7 +14,13 @@ export type EditFailReason =
   (typeof EDIT_FAIL_REASON)[keyof typeof EDIT_FAIL_REASON];
 
 export type EditResult =
-  | { ok: true; file: string }
+  | {
+      ok: true;
+      file: string;
+      /** False when the match resolved to identical content (a no-op write) — the
+       *  caller must NOT count it as a mutation or re-gate on it. */
+      changed: boolean;
+    }
   | {
       ok: false;
       file: string;
@@ -30,7 +36,14 @@ export interface IReplacement {
 }
 
 export type EditsResult =
-  | { ok: true; file: string; count: number }
+  | {
+      ok: true;
+      file: string;
+      count: number;
+      /** False when the batch resolved to identical content (a no-op write) — the
+       *  caller must NOT count it as a mutation or re-gate on it. */
+      changed: boolean;
+    }
   | {
       ok: false;
       file: string;

--- a/packages/core/src/files/hashline.ts
+++ b/packages/core/src/files/hashline.ts
@@ -160,6 +160,9 @@ export interface IHashlineResult {
   ok: boolean;
   file: string;
   newHash?: string;
+  /** On a successful edit: false when the ops resolved to identical content (a
+   *  no-op write). The caller must NOT count a no-op as a mutation or re-gate. */
+  changed?: boolean;
   reason?: string; // error reason
   suggestions?: string[]; // actionable feedback
 }
@@ -354,6 +357,26 @@ export function parseHashlineEdit(input: string): {
 /**
  * Apply hashline edits to file content. Handles stale-tag recovery via 3-way merge.
  */
+/** Write the resolved text and build the success result — but skip the write when
+ *  the ops resolved to identical content (a no-op), flagging `changed:false` so the
+ *  caller doesn't count a phantom mutation or trigger a needless re-gate. */
+async function commitHashline(
+  store: SessionSnapshotStore,
+  path: string,
+  file: string,
+  text: string,
+  liveContent: string
+): Promise<IHashlineResult> {
+  const changed = text !== liveContent;
+
+  if (changed) {
+    await Bun.write(path, text);
+    store.record(file, text);
+  }
+
+  return { ok: true, file, newHash: computeFileHash(text), changed };
+}
+
 export async function applyHashlineEdit(
   store: SessionSnapshotStore,
   cwd: string,
@@ -390,16 +413,7 @@ export async function applyHashlineEdit(
       return { ...result, file };
     }
 
-    const newHash = computeFileHash(result.text);
-
-    await Bun.write(path, result.text);
-    store.record(file, result.text);
-
-    return {
-      ok: true,
-      file,
-      newHash,
-    };
+    return commitHashline(store, path, file, result.text, liveContent);
   }
 
   // Case 2: Hash is stale, try recovery via snapshot
@@ -415,16 +429,13 @@ export async function applyHashlineEdit(
         mergedResult.cleanMerge &&
         mergedResult.text !== undefined
       ) {
-        const newHash = computeFileHash(mergedResult.text);
-
-        await Bun.write(path, mergedResult.text);
-        store.record(file, mergedResult.text);
-
-        return {
-          ok: true,
+        return commitHashline(
+          store,
+          path,
           file,
-          newHash,
-        };
+          mergedResult.text,
+          liveContent
+        );
       }
 
       if (!mergedResult.ok || !mergedResult.cleanMerge) {

--- a/packages/core/src/infer-rules/conventions.ts
+++ b/packages/core/src/infer-rules/conventions.ts
@@ -57,6 +57,37 @@ export function isComponentFoldersConvention(
   return typeof v === "string" && COMPONENT_FOLDER_SET.has(v);
 }
 
+/** Keep only the fields whose value is a VALID convention, dropping everything
+ *  else (null, wrong type, unknown enum). Untrusted channels — the
+ *  `TSFORGE_CONVENTIONS` env in particular — must pass through here before
+ *  {@link resolveConventions}, otherwise a `{"interfaces":null}` would overwrite
+ *  the house default with null and silently LOOSEN a convention (e.g. drop the
+ *  I-prefix requirement). Mirrors the field-by-field validation the config loader
+ *  applies, via the same guards. */
+export function pickValidConventions(
+  parsed: Readonly<Record<string, unknown>>
+): Partial<IConventions> {
+  const out: { -readonly [K in keyof IConventions]?: IConventions[K] } = {};
+
+  if (isInterfaceConvention(parsed.interfaces)) {
+    out.interfaces = parsed.interfaces;
+  }
+
+  if (isEnumConvention(parsed.enums)) {
+    out.enums = parsed.enums;
+  }
+
+  if (isTestConvention(parsed.tests)) {
+    out.tests = parsed.tests;
+  }
+
+  if (isComponentFoldersConvention(parsed.componentFolders)) {
+    out.componentFolders = parsed.componentFolders;
+  }
+
+  return out;
+}
+
 /** Fill any unset field from {@link DEFAULT_CONVENTIONS}, yielding a fully-decided
  *  set. This is THE function every consumer (gate, linter, prompts) calls so they
  *  all agree on the same resolved choices. */

--- a/packages/core/src/infer-rules/eslint-conventions.ts
+++ b/packages/core/src/infer-rules/eslint-conventions.ts
@@ -1,4 +1,8 @@
-import { isDefaultConventions, resolveConventions } from "./conventions";
+import {
+  isDefaultConventions,
+  pickValidConventions,
+  resolveConventions,
+} from "./conventions";
 import type { IConventions } from "./conventions.types";
 import type {
   EslintSurface,
@@ -156,7 +160,11 @@ export function parseConventionsEnv(raw: string | undefined): IConventions {
   try {
     const parsed: unknown = JSON.parse(raw);
 
-    return resolveConventions(isRecord(parsed) ? parsed : undefined);
+    // Validate field-by-field: a null/garbage value must FALL BACK to the house
+    // default, never overwrite it (which would silently loosen a convention).
+    return resolveConventions(
+      isRecord(parsed) ? pickValidConventions(parsed) : undefined
+    );
   } catch {
     return resolveConventions(undefined);
   }

--- a/packages/core/src/inference/request.ts
+++ b/packages/core/src/inference/request.ts
@@ -54,7 +54,8 @@ function reasoningFields(
         ...(opts.enableThinking === undefined
           ? {}
           : { chat_template_kwargs: { enable_thinking: opts.enableThinking } }),
-        ...(opts.thinkingTokenBudget === undefined
+        ...(opts.thinkingTokenBudget === undefined ||
+        !Number.isFinite(opts.thinkingTokenBudget)
           ? {}
           : { thinking_token_budget: opts.thinkingTokenBudget }),
       };
@@ -82,7 +83,14 @@ function reasoningFields(
 
 /** The output-token cap field — o-series renamed `max_tokens` → `max_completion_tokens`. */
 function tokenCapField(cfg: IOpenAICompatibleConfig): Record<string, number> {
-  const max = cfg.maxTokens ?? PROVIDER_LIMITS.maxTokens;
+  // A NaN/Infinity maxTokens (bad config/env) would JSON.stringify to `null`,
+  // which a server reads as an explicit choice, not "unset" — fall back to the
+  // provider default instead (matches the temperature/repetitionPenalty guard).
+  const configured = cfg.maxTokens;
+  const max =
+    configured !== undefined && Number.isFinite(configured)
+      ? configured
+      : PROVIDER_LIMITS.maxTokens;
 
   return style(cfg) === "openai"
     ? { max_completion_tokens: max }

--- a/packages/core/src/loop/tools/edit-hashline.ts
+++ b/packages/core/src/loop/tools/edit-hashline.ts
@@ -80,6 +80,12 @@ export async function doHashlineEdit(
   );
 
   if (result.ok) {
+    // A no-op edit (ops resolved to identical content) wrote nothing — report NO
+    // mutation event so it can't trigger a re-gate or count toward "done".
+    if (result.changed !== true) {
+      return `edit_lines ${edit.file}: no change — the ops resolved to identical content. Move on to the next fix or run the gate.`;
+    }
+
     ctx.report({
       kind: "edit",
       task: ctx.task,

--- a/packages/core/src/loop/tools/file-ops.ts
+++ b/packages/core/src/loop/tools/file-ops.ts
@@ -576,6 +576,13 @@ export async function doEdit(
   const result = await applyEdits(ctx.cwd, edit.file, edit.edits);
 
   if (result.ok) {
+    // A no-op edit (same content / already applied) wrote nothing — report NO
+    // mutation event so it can't trigger a re-gate or count toward "done", and
+    // tell the model plainly so it doesn't think it made progress.
+    if (!result.changed) {
+      return `edit ${edit.file}: no change — the file already matches (oldString and newString are identical, or this edit was already applied). Move on to the next fix or run the gate.`;
+    }
+
     for (const r of edit.edits) {
       ctx.report({
         kind: "edit",

--- a/packages/core/src/meta-rules/runner.ts
+++ b/packages/core/src/meta-rules/runner.ts
@@ -4,49 +4,84 @@ import type {
   IMetaRuleViolation,
 } from "./meta-rules.types";
 
+type SeverityOverride = "error" | "warn" | "off";
+
+/** Whether the rule should run at all for this context (not silenced "off", and
+ *  — if pack-scoped — at least one of its packs is active). */
+function ruleEnabled(
+  rule: IMetaRule,
+  ctx: IMetaRuleContext,
+  override: SeverityOverride | undefined
+): boolean {
+  if (override === "off") {
+    return false;
+  }
+
+  if (rule.appliesTo === undefined || rule.appliesTo.length === 0) {
+    return true;
+  }
+
+  return rule.appliesTo.some((pack) => ctx.activePacks.includes(pack));
+}
+
+/** Run ONE rule, isolated. A throwing rule (a harness bug — an unexpected AST
+ *  shape, a bad regex) must NOT abort the whole batch: without isolation one
+ *  broken rule makes runMetaRules throw, the gate's call-site catch swallows it
+ *  to an EMPTY list, and EVERY other meta-rule is silently skipped for the cycle
+ *  — a real violation (test-sibling, supply-chain, circular-imports) goes
+ *  unreported and the gate can go GREEN. The failure surfaces as a non-blocking
+ *  warning (a harness bug shouldn't hard-fail the user's gate). A present
+ *  override (not "off") rewrites each violation's severity. */
+function runOneRule(
+  rule: IMetaRule,
+  ctx: IMetaRuleContext,
+  override: SeverityOverride | undefined
+): IMetaRuleViolation[] {
+  let ruleViolations: IMetaRuleViolation[];
+
+  try {
+    ruleViolations = rule.run(ctx);
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+
+    return [
+      {
+        file: `(meta-rule ${rule.id})`,
+        ruleId: rule.id,
+        severity: "warn",
+        message: `meta-rule "${rule.id}" failed to run and was skipped: ${message}`,
+      },
+    ];
+  }
+
+  if (override !== undefined && override !== "off") {
+    return ruleViolations.map((v) => ({ ...v, severity: override }));
+  }
+
+  return ruleViolations;
+}
+
 /**
  * Run applicable meta-rules and return violations sorted deterministically
  * (by file, then rule ID). Severity overrides can silence rules ("off") or
- * change their severity (rule ID mapped to "error" | "warn" | "off").
+ * change their severity (rule ID mapped to "error" | "warn" | "off"). Each rule
+ * runs in isolation — a throwing rule can't disable the others (see runOneRule).
  */
 export function runMetaRules(
   rules: readonly IMetaRule[],
   ctx: IMetaRuleContext,
-  severityOverrides?: Readonly<Record<string, "error" | "warn" | "off">>
+  severityOverrides?: Readonly<Record<string, SeverityOverride>>
 ): IMetaRuleViolation[] {
   const violations: IMetaRuleViolation[] = [];
 
   for (const rule of rules) {
-    // Check if rule is silenced via overrides
-    if (severityOverrides?.[rule.id] === "off") {
+    const override = severityOverrides?.[rule.id];
+
+    if (!ruleEnabled(rule, ctx, override)) {
       continue;
     }
 
-    // Check if rule applies to this project's active packs
-    if (rule.appliesTo !== undefined && rule.appliesTo.length > 0) {
-      const applies = rule.appliesTo.some((pack) =>
-        ctx.activePacks.includes(pack)
-      );
-
-      if (!applies) {
-        continue;
-      }
-    }
-
-    const ruleViolations = rule.run(ctx);
-    const override = severityOverrides?.[rule.id];
-
-    // Apply severity override if present (and not "off")
-    if (override !== undefined && override !== "off") {
-      for (const v of ruleViolations) {
-        violations.push({
-          ...v,
-          severity: override,
-        });
-      }
-    } else {
-      violations.push(...ruleViolations);
-    }
+    violations.push(...runOneRule(rule, ctx, override));
   }
 
   // Deterministic ordering: file path, then rule ID

--- a/packages/core/src/policy/patterns.ts
+++ b/packages/core/src/policy/patterns.ts
@@ -191,7 +191,16 @@ export function isPrivateKeyPath(path: string): boolean {
  *  commands (`git commit`, `bun test`) stay allowed. Tokens are split on shell
  *  metacharacters and unquoted so `"~/.ssh/id_rsa"` is still seen. */
 export function commandReadsPrivateKey(command: string): boolean {
-  return command
-    .split(/[\s;&|<>()`'"]+/u)
-    .some((token) => token.length > 0 && isPrivateKeyPath(unquote(token)));
+  // Tokenize so a QUOTED string stays ONE token (then gets unquoted), rather than
+  // splitting on the spaces inside it — otherwise a key word inside a quoted
+  // commit message / grep pattern (`git commit -m "fix id_rsa"`) would be torn
+  // into a bare `id_rsa` token and falsely tripped. Only a token that, whole and
+  // unquoted, IS a key path trips the guard.
+  const tokens = command.match(/"[^"]*"|'[^']*'|[^\s;&|<>()`"']+/gu) ?? [];
+
+  return tokens.some((token) => {
+    const path = unquote(token);
+
+    return path.length > 0 && isPrivateKeyPath(path);
+  });
 }

--- a/packages/core/src/policy/patterns.ts
+++ b/packages/core/src/policy/patterns.ts
@@ -182,3 +182,16 @@ const PRIVATE_KEY_PATTERNS: readonly RegExp[] = [
 export function isPrivateKeyPath(path: string): boolean {
   return PRIVATE_KEY_PATTERNS.some((re) => re.test(path));
 }
+
+/** True when a shell command references private-key material as one of its tokens
+ *  (`cat ~/.ssh/id_rsa`, `cp deploy.pem /tmp`, `base64 server.key`). The `read`
+ *  tool denies these in EVERY mode; the `run` tool must not be a side door around
+ *  that same critical guard. Conservative: only a token that itself looks like key
+ *  material (the SAME patterns as {@link isPrivateKeyPath}) trips it, so ordinary
+ *  commands (`git commit`, `bun test`) stay allowed. Tokens are split on shell
+ *  metacharacters and unquoted so `"~/.ssh/id_rsa"` is still seen. */
+export function commandReadsPrivateKey(command: string): boolean {
+  return command
+    .split(/[\s;&|<>()`'"]+/u)
+    .some((token) => token.length > 0 && isPrivateKeyPath(unquote(token)));
+}

--- a/packages/core/src/policy/policy.ts
+++ b/packages/core/src/policy/policy.ts
@@ -1,4 +1,9 @@
-import { isDestructiveShell, isPrivateKeyPath, pipesToShell } from "./patterns";
+import {
+  commandReadsPrivateKey,
+  isDestructiveShell,
+  isPrivateKeyPath,
+  pipesToShell,
+} from "./patterns";
 import type {
   ActionKind,
   IPolicyContext,
@@ -212,6 +217,19 @@ function criticalDeny(
         rule: "critical:private-key-read",
       };
     }
+  }
+
+  // The `read` tool's private-key deny holds in every mode; a shell command that
+  // reads the same material (`cat ~/.ssh/id_rsa`) must not be a side door around it.
+  if (
+    action.kind === "shell" &&
+    action.command !== undefined &&
+    commandReadsPrivateKey(action.command)
+  ) {
+    return {
+      reason: `private-key file access blocked: ${preview(action.command)}`,
+      rule: "critical:private-key-read",
+    };
   }
 
   if (

--- a/packages/core/src/render/status-bar.ts
+++ b/packages/core/src/render/status-bar.ts
@@ -146,12 +146,16 @@ function buildBarBody(
   rows: number,
   color: boolean
 ): string {
-  const borderRow = rows - 1;
+  // Clamp to row 1 so a terminal shrunk below the reserved height can never emit
+  // an invalid `${ESC}[0;1H` / `${ESC}[-1;1H` (normal terminals are >= MIN_ROWS,
+  // where the clamp is a no-op).
+  const segRow = Math.max(1, rows);
+  const borderRow = Math.max(1, rows - 1);
   const segs = assemble(barSegments(info), columns, color);
 
   return (
     `${ESC}[${borderRow};1H${ESC}[2K${topBorder(columns, color)}` +
-    `${ESC}[${rows};1H${ESC}[2K${segs}`
+    `${ESC}[${segRow};1H${ESC}[2K${segs}`
   );
 }
 
@@ -210,7 +214,9 @@ export function buildInputFrame(
   rows: number,
   color: boolean
 ): string {
-  const inputRow = rows - 2;
+  // Clamp to row 1 so a shrunk terminal can't emit an invalid `${ESC}[0;1H`
+  // (normal terminals are >= MIN_ROWS, where this is a no-op).
+  const inputRow = Math.max(1, rows - 2);
   const avail = Math.max(0, columns - PROMPT_COLS);
   const { visible, cursorCol } = clipInput(line, cursor, avail);
 
@@ -355,12 +361,17 @@ export class StatusBar {
 
     const rows = this.out.rows ?? 0;
 
-    this.out.write(`${ESC}[1;${rows - this.reserved}r`);
+    // Clamp to row 1: a resize BELOW `reserved` (a terminal shrunk after install)
+    // would otherwise make `rows - reserved` non-positive and emit invalid
+    // `${ESC}[1;-1r` / `${ESC}[-1;1H` sequences. Mirrors teardown()'s clamp.
+    const regionEnd = Math.max(1, rows - this.reserved);
+
+    this.out.write(`${ESC}[1;${regionEnd}r`);
 
     // The saved stream cursor may now point off-screen — re-anchor it to the
     // bottom of the (resized) region so output continues there.
     if (this.withInput) {
-      this.out.write(`${ESC}[${rows - this.reserved};1H`);
+      this.out.write(`${ESC}[${regionEnd};1H`);
       this.out.write(`${ESC}7`);
     }
 

--- a/packages/core/src/render/wizard.ts
+++ b/packages/core/src/render/wizard.ts
@@ -457,7 +457,17 @@ export function runWizard(
 
     const finish = (): void => {
       stdin.removeListener("keypress", onKey);
-      out(`${SHOW_CURSOR}${EXIT_ALT}`);
+
+      // The terminal write is best-effort and must NEVER throw out of finish: a
+      // throwing `out` (e.g. EPIPE on a closed stdout) would otherwise skip the
+      // listener restore + resolve below AND re-enter finish via onKey's catch,
+      // wedging the terminal (dead keypress, hung Promise) on exit. The terminal
+      // is already gone in that case, so there's nothing to restore on it.
+      try {
+        out(`${SHOW_CURSOR}${EXIT_ALT}`);
+      } catch {
+        // swallow — the stream is closed; cleanup below still runs
+      }
 
       // Restore the saved keypress listeners. They come from `rawListeners` typed
       // as `Function[]`, which isn't assignable to the listener signature, so we

--- a/packages/core/tests/eslint-conventions.test.ts
+++ b/packages/core/tests/eslint-conventions.test.ts
@@ -140,6 +140,22 @@ describe("parseConventionsEnv", () => {
       resolveConventions(undefined)
     );
   });
+
+  test("a null/invalid field FALLS BACK to the default (never loosens it)", () => {
+    // `{"interfaces":null}` used to overwrite the house default with null, which
+    // dropped the I-prefix naming requirement — a silent loosening. It must now
+    // be ignored, leaving the full defaults intact.
+    expect(parseConventionsEnv('{"interfaces":null}')).toEqual(
+      resolveConventions(undefined)
+    );
+    expect(parseConventionsEnv('{"enums":"klingon","interfaces":7}')).toEqual(
+      resolveConventions(undefined)
+    );
+    // A valid field still applies even alongside a garbage one.
+    expect(
+      parseConventionsEnv('{"interfaces":"bare-pascal-case","tests":null}')
+    ).toEqual(resolveConventions({ interfaces: "bare-pascal-case" }));
+  });
 });
 
 describe("applyBundledOverrides protected-rule guard", () => {

--- a/packages/core/tests/files-edit.test.ts
+++ b/packages/core/tests/files-edit.test.ts
@@ -66,6 +66,55 @@ test("ambiguous when oldString matches more than once; file unchanged", async ()
   }
 });
 
+test("same-content edit is ok but flagged changed:false (no-op, not a mutation)", async () => {
+  const dir = await tmp({ "a.ts": "export const x = 1;\n" });
+
+  try {
+    const single = await applyEdit(dir, {
+      file: "a.ts",
+      oldString: "const x = 1;",
+      newString: "const x = 1;", // identical → no real change
+    });
+
+    expect(single).toMatchObject({ ok: true, changed: false });
+
+    const batch = await applyEdits(dir, "a.ts", [
+      { oldString: "const x = 1;", newString: "const x = 1;" },
+    ]);
+
+    expect(batch).toMatchObject({ ok: true, changed: false });
+
+    // The file is left byte-identical.
+    expect(await Bun.file(join(dir, "a.ts")).text()).toBe(
+      "export const x = 1;\n"
+    );
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test("a real edit reports changed:true", async () => {
+  const dir = await tmp({ "a.ts": "export const x = 1;\n" });
+
+  try {
+    const single = await applyEdit(dir, {
+      file: "a.ts",
+      oldString: "= 1",
+      newString: "= 2",
+    });
+
+    expect(single).toMatchObject({ ok: true, changed: true });
+
+    const batch = await applyEdits(dir, "a.ts", [
+      { oldString: "= 2", newString: "= 3" },
+    ]);
+
+    expect(batch).toMatchObject({ ok: true, count: 1, changed: true });
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
 test("fuzzy edit preserves CRLF line endings (no mixed endings) — issue #24", async () => {
   // CRLF file; oldString has wrong indentation so the exact match misses and the
   // fuzzy (trim-normalized) fallback fires. The result must stay all-CRLF.

--- a/packages/core/tests/hashline.test.ts
+++ b/packages/core/tests/hashline.test.ts
@@ -211,6 +211,67 @@ describe("SessionSnapshotStore", () => {
 });
 
 describe("applyHashlineEdit", () => {
+  test("a no-op edit (replace with identical content) reports changed:false and writes nothing", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "hashline-"));
+
+    try {
+      const filePath = "test.ts";
+      const content = "line 1\nline 2\nline 3\n";
+
+      await Bun.write(join(dir, filePath), content);
+
+      const store = new SessionSnapshotStore();
+      const hash = store.record(filePath, content);
+
+      // Replace line 2 with its EXACT current text → resolves to identical content.
+      const input = `¶${filePath}#${hash}\nreplace 2..2:\n+line 2`;
+      const parsed = parseHashlineEdit(input);
+
+      const result = await applyHashlineEdit(
+        store,
+        dir,
+        filePath,
+        hash,
+        parsed.ops
+      );
+
+      expect(result).toMatchObject({ ok: true, changed: false });
+      // The file is left byte-identical.
+      expect(await Bun.file(join(dir, filePath)).text()).toBe(content);
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  test("a real replace reports changed:true", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "hashline-"));
+
+    try {
+      const filePath = "test.ts";
+      const content = "line 1\nline 2\nline 3\n";
+
+      await Bun.write(join(dir, filePath), content);
+
+      const store = new SessionSnapshotStore();
+      const hash = store.record(filePath, content);
+
+      const input = `¶${filePath}#${hash}\nreplace 2..2:\n+changed line`;
+      const parsed = parseHashlineEdit(input);
+
+      const result = await applyHashlineEdit(
+        store,
+        dir,
+        filePath,
+        hash,
+        parsed.ops
+      );
+
+      expect(result).toMatchObject({ ok: true, changed: true });
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
   test("applies replace operation", async () => {
     const dir = await mkdtemp(join(tmpdir(), "hashline-"));
 

--- a/packages/core/tests/meta-rules.test.ts
+++ b/packages/core/tests/meta-rules.test.ts
@@ -15,6 +15,11 @@ import {
   buildMetaRuleContext,
   runMetaRules,
 } from "../src/meta-rules";
+import type {
+  IMetaRule,
+  IMetaRuleContext,
+  IMetaRuleViolation,
+} from "../src/meta-rules";
 
 let tempDir: string;
 
@@ -1223,6 +1228,85 @@ test("no-circular-imports: passes an acyclic graph", () => {
   const violations = runMetaRules(META_RULES, ctx).filter(
     (v) => v.ruleId === "no-circular-imports"
   );
+
+  expect(violations).toHaveLength(0);
+});
+
+// === Per-rule isolation (a throwing rule must not disable the others) ===
+
+function emptyMetaContext(): IMetaRuleContext {
+  return {
+    root: "/ws",
+    packageJson: null,
+    sourceFiles: [],
+    changedFiles: [],
+    configFiles: [],
+    workflowFiles: [],
+    dockerfiles: [],
+    activePacks: [],
+    readFile: () => null,
+  };
+}
+
+test("runMetaRules isolates a throwing rule — others still enforce, no silent disable", () => {
+  const boom: IMetaRule = {
+    id: "boom-rule",
+    category: "config",
+    description: "throws on purpose",
+    severity: "error",
+    run: () => {
+      throw new Error("kaboom");
+    },
+  };
+
+  const good: IMetaRule = {
+    id: "good-rule",
+    category: "config",
+    description: "reports a real violation",
+    severity: "error",
+    run: (): IMetaRuleViolation[] => [
+      {
+        file: "src/a.ts",
+        ruleId: "good-rule",
+        severity: "error",
+        message: "real violation",
+      },
+    ],
+  };
+
+  // boom runs FIRST: before the fix it threw out of runMetaRules and the good
+  // rule never ran (its real error went unreported — a false green).
+  const violations = runMetaRules([boom, good], emptyMetaContext());
+
+  // The good rule's real error still surfaces (enforcement preserved)...
+  const goodHit = violations.find((v) => v.ruleId === "good-rule");
+
+  expect(goodHit).toBeDefined();
+  expect(goodHit?.severity).toBe("error");
+
+  // ...and the throwing rule is surfaced as a NON-blocking warning, not a crash.
+  const boomHit = violations.find((v) => v.ruleId === "boom-rule");
+
+  expect(boomHit).toBeDefined();
+  expect(boomHit?.severity).toBe("warn");
+  expect(boomHit?.message).toContain("failed to run");
+  expect(boomHit?.message).toContain("kaboom");
+});
+
+test("runMetaRules: a throwing rule silenced via override does not run or report", () => {
+  const boom: IMetaRule = {
+    id: "boom-rule",
+    category: "config",
+    description: "throws on purpose",
+    severity: "error",
+    run: () => {
+      throw new Error("kaboom");
+    },
+  };
+
+  const violations = runMetaRules([boom], emptyMetaContext(), {
+    "boom-rule": "off",
+  });
 
   expect(violations).toHaveLength(0);
 });

--- a/packages/core/tests/policy-evaluation.test.ts
+++ b/packages/core/tests/policy-evaluation.test.ts
@@ -402,6 +402,38 @@ describe("evaluatePolicy — critical denies win in every mode", () => {
     expect(evaluatePolicy(a, ctx("bypassPermissions")).decision).toBe("deny");
   });
 
+  test("private-key read via the shell tool is also critically denied", () => {
+    // The `read` tool's private-key deny holds in every mode; the `run` tool must
+    // not be a side door (`cat ~/.ssh/id_rsa`). Denied even under bypassPermissions.
+    for (const command of [
+      "cat ~/.ssh/id_rsa",
+      'cat "/home/u/.ssh/id_rsa"',
+      "cp deploy.pem /tmp/x",
+      "base64 server.key",
+    ]) {
+      const v = evaluatePolicy(
+        action("shell", { command }),
+        ctx("bypassPermissions")
+      );
+
+      expect(v.decision).toBe("deny");
+      expect(v.matchedRules).toContain("critical:private-key-read");
+    }
+  });
+
+  test("benign shell commands are not tripped by the key-read guard", () => {
+    for (const command of [
+      "git commit -m wip",
+      "bun test packages",
+      "cat src/index.ts",
+      "ls -la src",
+    ]) {
+      expect(
+        evaluatePolicy(action("shell", { command }), ctx("default")).decision
+      ).toBe("allow");
+    }
+  });
+
   test("scope is deferred to the tool layer, not a policy critical", () => {
     // Out-of-scope writes are enforced unconditionally by the write tools
     // (writable/isVendored) in every mode, so policy intentionally does NOT

--- a/packages/core/tests/policy-evaluation.test.ts
+++ b/packages/core/tests/policy-evaluation.test.ts
@@ -424,6 +424,10 @@ describe("evaluatePolicy — critical denies win in every mode", () => {
   test("benign shell commands are not tripped by the key-read guard", () => {
     for (const command of [
       "git commit -m wip",
+      // a key word INSIDE a quoted multi-word string (commit message) must not
+      // be torn into a bare `id_rsa`/`.pem` token and falsely denied.
+      'git commit -m "fix id_rsa"',
+      'git commit -m "update deploy.pem handling"',
       "bun test packages",
       "cat src/index.ts",
       "ls -la src",

--- a/packages/core/tests/request-builder.test.ts
+++ b/packages/core/tests/request-builder.test.ts
@@ -100,6 +100,20 @@ describe("buildRequestBody: base body", () => {
     );
     // a finite value still passes through
     expect(body({ repetitionPenalty: 1.1 }, {}).repetition_penalty).toBe(1.1);
+
+    // maxTokens: a non-finite cap must fall back to the provider default, never
+    // serialize to `null` (which a server reads as "no limit" / an error).
+    expect(body({ maxTokens: NaN }, {}).max_tokens).toBe(16384);
+    expect(body({ maxTokens: Infinity }, {}).max_tokens).toBe(16384);
+    expect(body({ maxTokens: 2048 }, {}).max_tokens).toBe(2048);
+
+    // thinkingTokenBudget (qwen): a non-finite budget is dropped, not sent as null.
+    expect(
+      "thinking_token_budget" in body({}, { thinkingTokenBudget: NaN })
+    ).toBe(false);
+    expect(body({}, { thinkingTokenBudget: 512 }).thinking_token_budget).toBe(
+      512
+    );
   });
 
   test("extraBody is merged last and overrides built-ins", () => {

--- a/packages/core/tests/status-bar.test.ts
+++ b/packages/core/tests/status-bar.test.ts
@@ -251,6 +251,28 @@ describe("StatusBar with input row", () => {
     }
   });
 
+  test("resize after a shrink below the reserved height emits no row index < 1", () => {
+    const term = new FakeTerm(true, 24, 80);
+    const bar = withInput(term); // reserves 3 rows
+
+    bar.install(INFO);
+    term.rows = 1; // shrunk below `reserved` (3) after install
+    term.writes.length = 0;
+    bar.resize(INFO);
+
+    const out = term.text();
+
+    // The scroll-region end (`[1;Nr`) must stay >= 1 (never `[1;-2r`).
+    for (const match of out.matchAll(/\[1;(-?\d+)r/g)) {
+      expect(Number(match[1])).toBeGreaterThanOrEqual(1);
+    }
+
+    // Every cursor-position sequence must target a 1-indexed (>= 1) row.
+    for (const match of out.matchAll(/\[(-?\d+);1H/g)) {
+      expect(Number(match[1])).toBeGreaterThanOrEqual(1);
+    }
+  });
+
   test("teardown clears all THREE reserved rows", () => {
     const term = new FakeTerm(true, 24, 80);
     const bar = withInput(term);

--- a/packages/core/tests/tool-accounting.test.ts
+++ b/packages/core/tests/tool-accounting.test.ts
@@ -125,6 +125,39 @@ test("a successful in-scope create counts as one edit and re-gates", async () =>
   }
 });
 
+// P2: a same-content edit (oldString === newString, or already-applied) writes
+// nothing. The handler must NOT emit an edit event for it, so it neither counts
+// toward `state.edits` nor re-gates — otherwise a no-op edit lets a green gate
+// claim "done" though disk never changed (and can mask a spinning model).
+test("a no-op edit (same content) is NOT counted and does not re-gate", async () => {
+  const dir = await mkdtemp(join(tmpdir(), "tsforge-acct-noop-"));
+
+  try {
+    await Bun.write(join(dir, "x.ts"), "export const x = 1;\n");
+
+    const state = freshState();
+    const touched = await runToolCalls(
+      [
+        {
+          name: "edit",
+          arguments: {
+            file: "x.ts",
+            oldString: "const x = 1;",
+            newString: "const x = 1;", // identical → no real change
+          },
+        },
+      ],
+      ctxFor(dir, ["**/*"]),
+      state
+    );
+
+    expect(touched).toBe(false);
+    expect(state.edits).toBe(0);
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
 test("an out-of-scope edit is NOT counted and does not re-gate", async () => {
   const dir = await mkdtemp(join(tmpdir(), "tsforge-acct-"));
 

--- a/packages/core/tests/wizard.test.ts
+++ b/packages/core/tests/wizard.test.ts
@@ -1,9 +1,11 @@
 import { describe, test, expect } from "bun:test";
+import { EventEmitter } from "node:events";
 import {
   driveWizard,
   initWizard,
   reduceWizard,
   renderFrame,
+  runWizard,
 } from "../src/render/wizard";
 import type { IWizardStep } from "../src/render/wizard.types";
 
@@ -167,5 +169,80 @@ describe("wizard render (no color)", () => {
     expect(frame).toContain("Naming: bare PascalCase");
     expect(frame).toContain("PREVIEW-BLOCK");
     expect(frame).toContain("enter apply");
+  });
+});
+
+describe("runWizard interactive teardown", () => {
+  /** A minimal TTY-shaped stdin: an EventEmitter plus the stream methods the
+   *  driver / emitKeypressEvents touch. We drive it by emitting `keypress`. */
+  class FakeStdin extends EventEmitter {
+    isTTY = true;
+
+    setRawMode(): this {
+      return this;
+    }
+
+    resume(): this {
+      return this;
+    }
+
+    pause(): this {
+      return this;
+    }
+
+    setEncoding(): this {
+      return this;
+    }
+  }
+
+  test("finish() restores listeners and resolves even when the terminal write throws", async () => {
+    const fake = new FakeStdin();
+    // A pre-existing keypress listener that MUST survive (be restored) on exit.
+    let preexistingCalls = 0;
+
+    const preexisting = (): void => {
+      preexistingCalls += 1;
+    };
+
+    fake.on("keypress", preexisting);
+
+    const realStdin = process.stdin;
+
+    Object.defineProperty(process, "stdin", {
+      value: fake,
+      configurable: true,
+    });
+
+    try {
+      // `out` throws on the finish-specific write (SHOW_CURSOR = ESC[?25h),
+      // simulating an EPIPE on a closed stdout during teardown.
+      const out = (s: string): void => {
+        if (s.includes("[?25h")) {
+          throw new Error("EPIPE: terminal write failed");
+        }
+      };
+
+      const done = runWizard(STEPS, false, () => "", out);
+
+      // Drive a cancel keypress → terminal state → finish() (whose out throws).
+      fake.emit("keypress", undefined, { name: "escape" });
+
+      // The fix's guarantee: the promise still resolves (no hang)...
+      const state = await done;
+
+      expect(state.status).toBe("cancel");
+
+      // ...exactly one keypress listener remains (the restored one, not onKey)...
+      expect(fake.listeners("keypress").length).toBe(1);
+
+      // ...and it forwards to the original listener (restoration really happened).
+      fake.emit("keypress", undefined, { name: "down" });
+      expect(preexistingCalls).toBe(1);
+    } finally {
+      Object.defineProperty(process, "stdin", {
+        value: realStdin,
+        configurable: true,
+      });
+    }
   });
 });


### PR DESCRIPTION
## Summary

**11 independent adversarial harness-review passes** over the tsforge subsystems in `docs/harness-subsystems.md`. Each pass picked a high-risk subsystem/invariant *not already deeply covered*, read source + tests, and tried to break the contract with a concrete repro. Findings are deduped across passes and accumulated on this one branch.

**9 fixes landed**, each with a regression test. No rules were relaxed and no tests removed — this PR *tightens* the safety floor. Verified-clean subsystems and rejected/deferred candidates are documented below so "clean" is backed by evidence, not assertion.

**`bun run validate`: 1321 pass / 14 skip / 0 fail** (+12 regression tests vs. base). typecheck + eslint + prettier all green.

## The 11 passes

| # | Subsystem / angle | Result |
|---|---|---|
| 1 | broad sweep (all subsystems, one level) | **5 P2 fixes** (policy shell key-read, no-op edit accounting, inference NaN params, StatusBar resize, conventions null) |
| 2 | files/edit — hashline `edit_lines` no-op | **1 P2 fix** (no-op `edit_lines` counted as a mutation) |
| 3 | lib/fs process runner — races & edge cases (deep) | clean (group-kill, abort-during-spawn, FLUSH_GRACE, escape-timer, exit-127 ruled out) |
| 4 | web_fetch / web_search — SSRF (deep) | clean (IP-encoding evasions normalized by URL parser; DNS-resolution + per-hop redirect re-validation present; rebinding TOCTOU documented out-of-scope) |
| 5 | inference streaming + tool-call repair (deep) | no fix — 3 candidates verified as non-bug / unrealistic-threat (see Deferred) |
| 6 | gate / detect-gate — error parser, autofix, accept scripts (deep) | clean (combined parser unions both; autofix scope-bounded + model-notified; exit-code authority) |
| 7 | meta-rules — change-scoping & profile-gating (deep) | no fix — candidate "P1" verified as a non-bug (per-write context already scopes `sourceFiles`; an applied agent fix that would have *weakened* the gate was reverted) |
| 8 | mcp — transport concurrency & lifecycle (deep) | clean (id multiplexing, independent timeouts, dead-server fail-soft, unbounded-buffer cases) |
| 9 | setup/wizard + scaffold (deep) | **1 P3 fix** (wizard teardown could wedge the terminal on a throwing write) |
| 10 | cli input queue + browser oracle (deep) | clean (queue drain, signal teardown, path-traversal, SPA fallback, private-host guard) |
| 11 | session/loop orchestration — meta-rule isolation (deep) | **1 P2 fix** (one throwing meta-rule silently disabled the whole gate layer → false green) |

## Fixed findings (by severity)

### P2 — policy: private-key read deny bypassable via the `run` shell tool *(pass 1)*
`criticalDeny` denied private-key reads only for `read_file` (policy.ts:206). `run: cat ~/.ssh/id_rsa` is `shell` kind, checked only for destructive/pipe-to-shell — so a key read via the shell tool was **allowed in every mode, including `bypassPermissions`**, defeating the "holds in every mode" intent of `critical:private-key-read`.
Fix: `commandReadsPrivateKey()` (policy/patterns.ts) + a shell critical-deny (policy.ts). Tokenizes with quoted strings kept whole (so a key word inside a commit message isn't torn into a bare token — see Gemini fix below), unquotes, and trips only when a whole token *is* key material.
Tests: `policy-evaluation.test.ts` (deny set in every mode + benign allow-list incl. quoted commit messages).

### P2 — loop/turn: a no-op `edit` is counted as a mutation and re-gates *(pass 1)*
`applyEdit`/`applyEdits` wrote byte-identical content and returned `ok` for a same-content edit; `doEdit` fired an `edit` event unconditionally → `turn.ts` set `touchedEditable`, incremented `state.edits`, and re-gated. This is exactly the no-op the loop/turn invariant forbids ("a no-op op must not let a green gate claim done") and can mask a spinning model.
Fix: edit results carry `changed`; the write is skipped and `changed:false` returned on identical content; both handlers (`file-ops.ts`, eval `model-agent.ts`) emit the event only when `changed`.
Tests: `files-edit.test.ts` (unit), `tool-accounting.test.ts` (turn-level: no-op → `touched:false`, `edits:0`).

### P2 — files/edit: a no-op `edit_lines` (hashline) is counted as a mutation *(pass 2)*
The pass-1 fix missed the hashline path: `applyHashlineEdit` wrote identical bytes and returned `ok` for ops resolving to unchanged content (e.g. replacing a line with its current text), so `doHashlineEdit` fired a `kind:"edit"` event and the turn counted a phantom mutation + re-gated.
Fix: `applyHashlineEdit` reports `changed` via a shared `commitHashline` helper that skips the write when content is identical; the handler emits the event only when changed.
Tests: `hashline.test.ts` (no-op `changed:false` + file untouched; real `changed:true`).

### P2 — meta-rules: one throwing rule silently disables the whole gate layer (false green) *(pass 11)*
`runMetaRules` called `rule.run(ctx)` with no per-rule isolation (runner.ts:36). A single throwing rule (a harness bug — unexpected AST shape, bad regex) made the whole function throw; the gate's call-site catch in `settleGate` (turn.ts:643) swallows it to an **empty violation list**, so EVERY other meta-rule is silently skipped for that cycle — a real violation (test-sibling-required, supply-chain, circular-imports) goes unreported and the gate can go GREEN.
Fix: each rule now runs isolated (`runOneRule`) — a throw surfaces as a non-blocking warning (a harness bug shouldn't hard-fail the user's gate) and the remaining rules keep enforcing. Extracted `ruleEnabled`/`runOneRule` to stay under the complexity cap.
Tests: `meta-rules.test.ts` (a throwing rule alongside a good one still surfaces the good rule's error + warns on the broken rule; an `off` override still suppresses a throwing rule entirely).

### P2 — inference: NaN/Infinity reaches the wire for `maxTokens` / `thinkingTokenBudget` *(pass 1)*
The non-finite guard from #38 covered `temperature`/`repetitionPenalty` but not `maxTokens` (request.ts:85) or `thinkingTokenBudget` (request.ts:57). A non-finite value `JSON.stringify`s to `null`, which a server reads as an explicit choice — violating "a NaN tuning param never reaches the wire."
Fix: `tokenCapField` falls back to `PROVIDER_LIMITS.maxTokens`; `thinking_token_budget` is omitted when non-finite.
Test: extended `request-builder.test.ts` non-finite case.

### P2 — render: `StatusBar.resize` emits invalid ANSI on shrink below reserved height *(pass 1)*
`teardown()` was clamped (a prior fix) but `resize()` (status-bar.ts:358,363) and the `buildBarBody`/`buildInputFrame` builders were not — a terminal shrunk below the reserved height after `install()` produced `[1;-1r` / `[0;1H` / `[-1;1H`.
Fix: clamp the scroll-region end, re-anchor cursor row, and bar/input frame rows to `Math.max(1, …)`. No-op for normal terminals (≥ `MIN_ROWS`).
Test: `status-bar.test.ts` resize-after-shrink asserts every emitted row index ≥ 1.

### P2 — conventions: `parseConventionsEnv` lets a null/garbage field loosen a convention *(pass 1)*
`parseConventionsEnv` spread raw parsed JSON into `resolveConventions`, so `{"interfaces":null}` overwrote the `i-prefix` default with `null` and `namingRule` dropped the I-prefix requirement — contradicting the function's own "tolerating junk" docstring. The config-file loader validates field-by-field; the env channel didn't.
Fix: `pickValidConventions()` (conventions.ts, same `is*Convention` guards the config loader uses) filters invalid values before the merge.
Test: `eslint-conventions.test.ts` (`{"interfaces":null}` and garbage → full defaults; a valid field still applies alongside garbage).

### P3 — wizard: a throwing terminal write could wedge the wizard on exit *(pass 9)*
`runWizard`'s `finish()` wrote the cursor-restore/exit-alt sequence *before* restoring keypress listeners and resolving the promise. A throwing `out()` (EPIPE on a closed stdout) would skip listener restore + resolve and re-enter `finish()` via `onKey`'s catch — wedging the terminal (dead keypress, hung promise).
Fix: the terminal write is now best-effort (swallowed); listener restore + resolve always run.
Test: `wizard.test.ts` drives a cancel keypress with a throwing `out`, asserts the promise resolves and the saved listener is restored (fake-TTY stdin).

### (review) policy: `commandReadsPrivateKey` quoted-string false positive *(Gemini review of pass 1)*
Gemini caught that the initial space+quote split tore a key word inside a quoted multi-word string (`git commit -m "fix id_rsa"`) into a bare `id_rsa` token, denying the benign command. Fixed by tokenizing with quoted strings kept whole; benign commit-message cases added to the allow-list. Both review threads resolved.

## Tests added/updated
`files-edit.test.ts`, `tool-accounting.test.ts`, `hashline.test.ts`, `meta-rules.test.ts`, `policy-evaluation.test.ts`, `request-builder.test.ts`, `status-bar.test.ts`, `eslint-conventions.test.ts`, `wizard.test.ts`.

## Validation
`bun run validate` → **1321 pass / 14 skip / 0 fail**; typecheck, eslint, prettier clean. (The `proptest-check … killed` and `tsforge.config.json invalid …` lines in output are intentional test fixtures, not failures.)

## Deferred findings (verified-real-but-not-fixed, with rationale)
- **P3 — inference `[DONE]` not breaking the read loop** (stream.ts:228): data after `data: [DONE]` is processed until the stream closes. Only reachable by a non-compliant/malicious *provider* server (already the trust root for all generated content); compliant servers close right after `[DONE]`, so no hang and no injection in practice. Threading a `seenDone` flag through the hot streaming path adds churn/risk without a realistic benefit. Recommend: honor `[DONE]` as an early-cancel if a future provider needs it.
- **P3 — inference tool-call delta missing `index` defaults to 0** (stream.ts:320): two distinct calls both omitting `index` would merge. The OpenAI streaming protocol guarantees `index` on every `tool_call` delta, so this only manifests with a non-compliant server and can't produce a false-green. Speculative hardening; recommend tracking call identity by `id` when `index` is absent.
- **Not-a-bug — malformed tool-call args → `{}`** (wire.ts `parseArgs`): a truncated/malformed args JSON parses to `{}`, but the tool handler then rejects with actionable "malformed args" feedback (no mutation, no event, no false-green). The agent-proposed "drop the call" change would *regress* UX (model gets no tool result), so it was not applied.
- **Not-a-bug — meta-rule change-scoping** (pass 7): `no-eslint-disable-comments` / `no-ts-suppressions` scanning `sourceFiles` is correct — the per-write context already scopes `sourceFiles` to the single written file (`singleFileMetaContext`), while the full gate intentionally scans all files (a project-wide suppression ban is the floor; only `test-sibling-required` is change-scoped). An applied agent fix that made them change-scoped (weakening the gate) was reverted.
- **Out-of-scope — web_fetch DNS-rebinding TOCTOU** (web-fetch.ts, already documented in source): closing it requires pinning the resolved IP and connecting to it with a Host header (undici-level), a larger change than this PR. The wildcard-DNS / public-name-resolving-to-private class is already closed.
