### PR TITLE
fix(review,policy): untracked-file review, honest coverage reporting, hunk-scoped findings, policy catch-all guard

### DIFF
--- a/packages/core/src/config/tsforge-config.ts
+++ b/packages/core/src/config/tsforge-config.ts
@@ -351,6 +351,19 @@ function validatePolicyRule(parsed: unknown): IPolicyRule | undefined {
     rule.mcpServer = parsed.mcpServer;
   }
 
+  // A rule that PROVIDED fields but produced NO valid matcher (e.g. a typo like
+  // `{ kind: "shel" }`) would collapse to `{}` — which the policy treats as a
+  // match-EVERYTHING catch-all, turning a typo into a global allow/deny. Drop it
+  // with a warning. A literal `{}` (no fields provided) is preserved as an
+  // intentional catch-all.
+  if (Object.keys(rule).length === 0 && Object.keys(parsed).length > 0) {
+    warnConfig(
+      "tsforge.config.json: a policy rule had fields but no valid matcher (all unknown/wrong-typed) — dropped (an empty rule would match everything)"
+    );
+
+    return undefined;
+  }
+
   return rule;
 }
 

--- a/packages/core/src/loop/review/index.ts
+++ b/packages/core/src/loop/review/index.ts
@@ -1,6 +1,7 @@
 export {
   reviewChange,
   formatReport,
+  changedLineRanges,
   type IReviewOptions,
 } from "./review-change";
 export { LENSES } from "./lenses";

--- a/packages/core/src/loop/review/review-change.ts
+++ b/packages/core/src/loop/review/review-change.ts
@@ -73,37 +73,149 @@ async function detectBase(cwd: string, override?: string): Promise<string> {
   return "HEAD";
 }
 
-/** Changed source files in the working tree vs `base` (or staged-only). */
-async function changedFiles(
-  cwd: string,
-  base: string,
-  staged: boolean
-): Promise<string[]> {
-  // --diff-filter=d drops deleted files — no point reviewing a file that's gone.
-  const argv = staged
-    ? ["diff", "--name-only", "--diff-filter=d", "--staged"]
-    : ["diff", "--name-only", "--diff-filter=d", base];
-  const out = await gitText(cwd, argv);
+const SOURCE_RE = /\.(ts|tsx|js|jsx|mts|cts)$/;
 
+function splitFiles(out: string): string[] {
   return out
     .split("\n")
     .map((f) => f.trim())
-    .filter((f) => /\.(ts|tsx|js|jsx|mts|cts)$/.test(f))
-    .slice(0, MAX_FILES);
+    .filter((f) => SOURCE_RE.test(f));
+}
+
+/** The set of changed source files to review, with coverage bookkeeping so a
+ *  capped run never reports as if it were complete. */
+interface IChangeSet {
+  /** Files to review (deduped, capped at MAX_FILES). */
+  files: string[];
+  /** Total candidate files BEFORE the cap (files.length when nothing was dropped). */
+  totalCandidates: number;
+  /** Which of `files` are untracked (need a synthesized added-file diff). */
+  untracked: ReadonlySet<string>;
+}
+
+/** Changed source files in the working tree vs `base` (or staged-only), INCLUDING
+ *  brand-new untracked files. `git diff` against a ref only sees TRACKED files, so
+ *  without unioning `ls-files --others` a newly created (never `git add`ed) source
+ *  file is silently skipped — the review would report "nothing to review" for a
+ *  whole new module. Staged mode reviews the index only, where a new file is
+ *  already tracked, so untracked files are excluded there. */
+async function collectChangedFiles(
+  cwd: string,
+  base: string,
+  staged: boolean
+): Promise<IChangeSet> {
+  // --diff-filter=d drops deleted files — no point reviewing a file that's gone.
+  const trackedArgv = staged
+    ? ["diff", "--name-only", "--diff-filter=d", "--staged"]
+    : ["diff", "--name-only", "--diff-filter=d", base];
+  const tracked = splitFiles(await gitText(cwd, trackedArgv));
+
+  const untrackedList = staged
+    ? []
+    : splitFiles(
+        await gitText(cwd, ["ls-files", "--others", "--exclude-standard"])
+      );
+  const untracked = new Set(untrackedList);
+
+  const all: string[] = [];
+
+  for (const file of [...tracked, ...untrackedList]) {
+    if (!all.includes(file)) {
+      all.push(file);
+    }
+  }
+
+  return {
+    files: all.slice(0, MAX_FILES),
+    totalCandidates: all.length,
+    untracked,
+  };
+}
+
+/** A file's diff plus coverage flags. `ranges` is the new-side line spans the
+ *  change actually touched (parsed from the FULL diff, before truncation) — used
+ *  to keep findings on changed lines rather than pre-existing code. */
+interface IFileDiff {
+  diff: string;
+  truncated: boolean;
+  ranges: readonly (readonly [number, number])[];
+}
+
+/** Synthesize an all-added unified diff for an untracked file (it has no `base`
+ *  side to diff against), so the find pass sees it as a fully new addition and the
+ *  hunk parser marks every line as changed. */
+async function syntheticAddedDiff(cwd: string, file: string): Promise<string> {
+  const abs = isAbsolute(file) ? file : join(cwd, file);
+  const text = await Bun.file(abs)
+    .text()
+    .catch(() => "");
+
+  if (text.length === 0) {
+    return "";
+  }
+
+  const lines = text.split("\n");
+
+  // A trailing newline leaves a final empty element — drop it so the @@ count
+  // matches the real line count.
+  if (lines.length > 0 && lines[lines.length - 1] === "") {
+    lines.pop();
+  }
+
+  const body = lines.map((l) => `+${l}`).join("\n");
+
+  return `--- /dev/null\n+++ b/${file}\n@@ -0,0 +1,${String(lines.length)} @@\n${body}`;
+}
+
+/** New-side line ranges a unified diff touches, from its `@@ -a,b +c,d @@` heads.
+ *  A finding outside every range sits on code the change didn't touch. */
+function changedLineRanges(diff: string): [number, number][] {
+  const ranges: [number, number][] = [];
+  const re = /^@@ -\d+(?:,\d+)? \+(\d+)(?:,(\d+))? @@/gmu;
+
+  for (let m = re.exec(diff); m !== null; m = re.exec(diff)) {
+    const start = Number.parseInt(m[1] ?? "", 10);
+    const count = m[2] === undefined ? 1 : Number.parseInt(m[2], 10);
+
+    if (
+      Number.isFinite(start) &&
+      start > 0 &&
+      Number.isFinite(count) &&
+      count > 0
+    ) {
+      ranges.push([start, start + count - 1]);
+    }
+  }
+
+  return ranges;
+}
+
+function lineInRanges(
+  line: number,
+  ranges: readonly (readonly [number, number])[]
+): boolean {
+  return ranges.some(([from, to]) => line >= from && line <= to);
 }
 
 async function fileDiff(
   cwd: string,
   base: string,
   file: string,
-  staged: boolean
-): Promise<string> {
-  const argv = staged
-    ? ["diff", "--staged", "--", file]
-    : ["diff", base, "--", file];
-  const out = await gitText(cwd, argv);
+  staged: boolean,
+  untracked: boolean
+): Promise<IFileDiff> {
+  const raw = untracked
+    ? await syntheticAddedDiff(cwd, file)
+    : await gitText(
+        cwd,
+        staged ? ["diff", "--staged", "--", file] : ["diff", base, "--", file]
+      );
 
-  return out.slice(0, DIFF_CHARS);
+  return {
+    diff: raw.slice(0, DIFF_CHARS),
+    truncated: raw.length > DIFF_CHARS,
+    ranges: changedLineRanges(raw),
+  };
 }
 
 const FIND_SYSTEM_BASE = [
@@ -359,9 +471,19 @@ export async function reviewChange(
   const gateFailingRules = [...(opts.gateFailingRules ?? [])];
   const system = buildFindSystem(gateFailingRules);
   const base = await detectBase(cwd, opts.base);
-  const files = await changedFiles(cwd, base, staged);
+  const { files, totalCandidates, untracked } = await collectChangedFiles(
+    cwd,
+    base,
+    staged
+  );
 
   log(`reviewing ${files.length} changed file(s) vs ${base}`);
+
+  if (totalCandidates > files.length) {
+    log(
+      `⚠ coverage: ${totalCandidates} changed files, reviewing the first ${files.length} (MAX_FILES=${MAX_FILES})`
+    );
+  }
 
   if (gateFailingRules.length > 0) {
     log(`gate-aware: skipping ${gateFailingRules.length} failing gate rule(s)`);
@@ -371,16 +493,45 @@ export async function reviewChange(
   // caller blast-radius signal. Built once; falls back gracefully when absent.
   const svc: TsService | null = await buildTsService(cwd);
   const raw: IRepoFinding[] = [];
+  const truncatedFiles: string[] = [];
+  let preexisting = 0;
 
   // Sequential on purpose: this harness targets a single local-model server, so
   // we don't fan out concurrent requests that would swamp it. Each file is
   // isolated in try/catch so one bad file can't abort the whole review.
   for (const file of files) {
-    const diff = await fileDiff(cwd, base, file, staged);
+    const { diff, truncated, ranges } = await fileDiff(
+      cwd,
+      base,
+      file,
+      staged,
+      untracked.has(file)
+    );
+
+    if (truncated) {
+      truncatedFiles.push(file);
+    }
+
     const found = await safeFind(provider, system, svc, cwd, file, diff, log);
 
-    log(`  ${file}: ${found.length} candidate finding(s)`);
-    raw.push(...found);
+    // Keep only findings ON a changed line — a finding on pre-existing code the
+    // change didn't touch is not a regression in THIS change. Skip the filter
+    // when no hunks parsed (can't tell), so we never silently drop everything.
+    const onChange =
+      ranges.length === 0
+        ? found
+        : found.filter((f) => lineInRanges(f.line, ranges));
+
+    preexisting += found.length - onChange.length;
+
+    log(
+      `  ${file}: ${onChange.length} candidate finding(s)${
+        found.length !== onChange.length
+          ? ` (${found.length - onChange.length} on pre-existing lines, skipped)`
+          : ""
+      }`
+    );
+    raw.push(...onChange);
   }
 
   const doVerify = opts.verify ?? true;
@@ -407,6 +558,9 @@ export async function reviewChange(
     findings: verified,
     rejected,
     gateFailingRules,
+    totalChangedFiles: totalCandidates,
+    truncatedFiles,
+    preexisting,
   };
 }
 
@@ -432,9 +586,29 @@ export function formatReport(report: IReviewReport): string {
         ]
       : [];
 
+  // Coverage warnings: a capped/truncated run must NOT read as if it reviewed
+  // everything. Shown in BOTH the clean and the findings branch.
+  const reviewed = report.changedFiles.length;
+  const total = report.totalChangedFiles ?? reviewed;
+  const truncated = report.truncatedFiles ?? [];
+  const coverageNotes: string[] = [];
+
+  if (total > reviewed) {
+    coverageNotes.push(
+      `⚠ coverage: reviewed ${reviewed} of ${total} changed file(s); ${total - reviewed} not reviewed (cap ${MAX_FILES}) — re-run scoped to cover them.`
+    );
+  }
+
+  if (truncated.length > 0) {
+    coverageNotes.push(
+      `⚠ ${truncated.length} file(s) had diffs truncated at ${DIFF_CHARS} chars — review saw only a prefix: ${truncated.join(", ")}`
+    );
+  }
+
   if (report.findings.length === 0) {
     return [
-      `No functional issues found across ${report.changedFiles.length} changed file(s) (${report.rejected} candidate(s) rejected on verification).`,
+      `No functional issues found across ${reviewed} reviewed file(s) (${report.rejected} candidate(s) rejected on verification).`,
+      ...coverageNotes,
       ...gateNote,
     ].join("\n");
   }
@@ -448,8 +622,9 @@ export function formatReport(report: IReviewReport): string {
   );
 
   return [
-    `Review of ${report.changedFiles.length} changed file(s) vs ${report.base}:`,
+    `Review of ${reviewed} changed file(s) vs ${report.base}:`,
     `${report.findings.length} verified finding(s), ${report.rejected} rejected.`,
+    ...coverageNotes,
     ...gateNote,
     "",
     ...lines,

--- a/packages/core/src/loop/review/review-change.ts
+++ b/packages/core/src/loop/review/review-change.ts
@@ -118,9 +118,11 @@ async function collectChangedFiles(
   const untracked = new Set(untrackedList);
 
   const all: string[] = [];
+  const seen = new Set<string>();
 
   for (const file of [...tracked, ...untrackedList]) {
-    if (!all.includes(file)) {
+    if (!seen.has(file)) {
+      seen.add(file);
       all.push(file);
     }
   }
@@ -168,8 +170,9 @@ async function syntheticAddedDiff(cwd: string, file: string): Promise<string> {
 }
 
 /** New-side line ranges a unified diff touches, from its `@@ -a,b +c,d @@` heads.
- *  A finding outside every range sits on code the change didn't touch. */
-function changedLineRanges(diff: string): [number, number][] {
+ *  A finding outside every range sits on code the change didn't touch. Exported
+ *  for direct unit tests (incl. the delete-only `+c,0` edge). */
+export function changedLineRanges(diff: string): [number, number][] {
   const ranges: [number, number][] = [];
   const re = /^@@ -\d+(?:,\d+)? \+(\d+)(?:,(\d+))? @@/gmu;
 
@@ -177,14 +180,23 @@ function changedLineRanges(diff: string): [number, number][] {
     const start = Number.parseInt(m[1] ?? "", 10);
     const count = m[2] === undefined ? 1 : Number.parseInt(m[2], 10);
 
-    if (
-      Number.isFinite(start) &&
-      start > 0 &&
-      Number.isFinite(count) &&
-      count > 0
-    ) {
-      ranges.push([start, start + count - 1]);
+    if (!Number.isFinite(start) || !Number.isFinite(count) || count < 0) {
+      continue;
     }
+
+    if (count > 0) {
+      ranges.push([start, start + count - 1]);
+      continue;
+    }
+
+    // A pure DELETION hunk has new-side count 0 (`@@ -10,5 +9,0 @@`): no new lines
+    // exist, but the change touches the boundary at `start` (the surviving line
+    // the deleted block sat next to). Cover that line and the one after it —
+    // clamped to >= 1 since `+0,0` (delete at file start) yields start 0 — so a
+    // finding adjacent to a deletion still counts as on-change.
+    const at = Math.max(1, start);
+
+    ranges.push([at, at + 1]);
   }
 
   return ranges;

--- a/packages/core/src/loop/review/review.types.ts
+++ b/packages/core/src/loop/review/review.types.ts
@@ -50,4 +50,14 @@ export interface IReviewReport {
    *  empty/omitted when review ran without a gate signal. Optional so a report from
    *  an older/external caller (without the field) stays valid. */
   gateFailingRules?: string[];
+  /** Total changed source files detected BEFORE the MAX_FILES cap. When greater
+   *  than `changedFiles.length`, coverage was partial (the rest were not reviewed)
+   *  and the report must say so rather than read as complete. */
+  totalChangedFiles?: number;
+  /** Files whose diff was truncated at the per-file char cap — the review saw only
+   *  a prefix of the change, so a problem past the cut is invisible. */
+  truncatedFiles?: string[];
+  /** Raw candidate findings dropped because they landed on pre-existing (unchanged)
+   *  lines rather than a line the change actually touched. */
+  preexisting?: number;
 }

--- a/packages/core/tests/policy-config.test.ts
+++ b/packages/core/tests/policy-config.test.ts
@@ -94,6 +94,29 @@ describe("policy config parsing (warn-and-drop)", () => {
       }
     );
   });
+
+  test("a rule whose ONLY fields are invalid is dropped, not turned into a catch-all", async () => {
+    // `{ kind: "shel" }` is a typo: the invalid field is dropped, leaving `{}` —
+    // which the policy treats as match-EVERYTHING. That would silently turn a
+    // typo'd deny into a GLOBAL deny (or allow). It must be dropped instead.
+    await withConfig(
+      { policy: { rules: { deny: [{ kind: "shel" }] } } },
+      async (dir) => {
+        const deny = (await loadTsforgeConfig(dir)).policy?.rules?.deny ?? [];
+
+        expect(deny).toHaveLength(0);
+      }
+    );
+  });
+
+  test("a literal empty rule {} is preserved as an intentional catch-all", async () => {
+    await withConfig({ policy: { rules: { deny: [{}] } } }, async (dir) => {
+      const deny = (await loadTsforgeConfig(dir)).policy?.rules?.deny ?? [];
+
+      expect(deny).toHaveLength(1);
+      expect(Object.keys(deny[0] ?? {})).toHaveLength(0);
+    });
+  });
 });
 
 describe("policy config → session enforcement", () => {

--- a/packages/core/tests/review-change.test.ts
+++ b/packages/core/tests/review-change.test.ts
@@ -4,7 +4,12 @@ import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import type { IProvider } from "../src/inference";
-import { reviewChange, formatReport, LENSES } from "../src/loop/review";
+import {
+  reviewChange,
+  formatReport,
+  changedLineRanges,
+  LENSES,
+} from "../src/loop/review";
 
 /** A provider that answers the find pass and the verify pass differently,
  *  keyed on the system prompt (so call order doesn't matter). */
@@ -309,6 +314,21 @@ test("formatReport warns loudly when coverage is capped or truncated", () => {
   // truncated: a prefix-only file is named
   expect(text).toContain("truncated");
   expect(text).toContain("b.ts");
+});
+
+test("changedLineRanges parses add/modify hunks and delete-only (+c,0) hunks", () => {
+  // a normal modify hunk: new-side lines 17..23
+  expect(changedLineRanges("@@ -17,7 +17,7 @@ ctx\n more")).toEqual([[17, 23]]);
+
+  // a single-line hunk with implicit count (no ",d")
+  expect(changedLineRanges("@@ -5 +5 @@")).toEqual([[5, 5]]);
+
+  // a PURE DELETION hunk (+9,0): no new lines, but the boundary at line 9 is
+  // touched — must yield a range (9..10), not be silently dropped.
+  expect(changedLineRanges("@@ -10,5 +9,0 @@")).toEqual([[9, 10]]);
+
+  // delete at file start (+0,0) clamps to line 1, never 0.
+  expect(changedLineRanges("@@ -1,3 +0,0 @@")).toEqual([[1, 2]]);
 });
 
 test("the senior-review rubric ships with the expected lenses", () => {

--- a/packages/core/tests/review-change.test.ts
+++ b/packages/core/tests/review-change.test.ts
@@ -223,6 +223,94 @@ test("formatReport shows the gate-aware note even when 0 findings", () => {
   expect(text).toContain("gate-aware: skipped 2");
 });
 
+test("reviews a brand-new UNTRACKED source file (not just tracked diffs)", async () => {
+  // A newly created, never-`git add`ed file is invisible to `git diff <base>`;
+  // without unioning `ls-files --others` it would be silently skipped.
+  writeFileSync(
+    join(repo, "newmod.ts"),
+    "export function f(): number {\n  return 1 - 2;\n}\n"
+  );
+
+  const report = await reviewChange(stub(FINDINGS, true), repo);
+
+  expect(report.changedFiles).toContain("newmod.ts");
+  // FINDINGS cites line 2, inside the synthesized added range → kept.
+  expect(report.findings.some((f) => f.file === "newmod.ts")).toBe(true);
+});
+
+test("drops a finding on a pre-existing line outside the changed hunk", async () => {
+  const big = mkdtempSync(join(tmpdir(), "tsforge-review-big-"));
+  const bgit = (...a: string[]): void =>
+    void execFileSync("git", a, { cwd: big, stdio: "ignore" });
+
+  try {
+    bgit("init", "-q");
+    bgit("config", "user.email", "t@t.t");
+    bgit("config", "user.name", "t");
+    bgit("config", "commit.gpgsign", "false");
+
+    const orig = Array.from(
+      { length: 30 },
+      (_, i) => `const v${String(i)} = ${String(i)};`
+    ).join("\n");
+
+    writeFileSync(join(big, "big.ts"), `${orig}\n`);
+    bgit("add", "-A");
+    bgit("commit", "-q", "-m", "init");
+
+    // Change ONLY line 20 → its hunk (3 lines of context) is far from line 2.
+    const lines = orig.split("\n");
+
+    lines[19] = "const v19 = 999;";
+    writeFileSync(join(big, "big.ts"), `${lines.join("\n")}\n`);
+
+    const twoFindings = JSON.stringify({
+      findings: [
+        {
+          line: 20,
+          severity: "error",
+          lens: "correctness",
+          claim: "on the changed line",
+          reason: "x",
+        },
+        {
+          line: 2,
+          severity: "error",
+          lens: "correctness",
+          claim: "pre-existing, untouched line",
+          reason: "y",
+        },
+      ],
+    });
+
+    const report = await reviewChange(stub(twoFindings, true), big);
+
+    expect(report.findings).toHaveLength(1);
+    expect(report.findings[0]?.line).toBe(20);
+    expect(report.preexisting).toBe(1);
+  } finally {
+    rmSync(big, { recursive: true, force: true });
+  }
+});
+
+test("formatReport warns loudly when coverage is capped or truncated", () => {
+  const text = formatReport({
+    base: "HEAD",
+    changedFiles: ["a.ts"],
+    findings: [],
+    rejected: 0,
+    totalChangedFiles: 30,
+    truncatedFiles: ["b.ts"],
+  });
+
+  // capped: reviewed 1 of 30 — must NOT read as complete
+  expect(text).toContain("reviewed 1 of 30");
+  expect(text).toContain("not reviewed");
+  // truncated: a prefix-only file is named
+  expect(text).toContain("truncated");
+  expect(text).toContain("b.ts");
+});
+
 test("the senior-review rubric ships with the expected lenses", () => {
   const ids = LENSES.map((l) => l.id);
 


### PR DESCRIPTION
## Summary

Closes 4 findings on the `tsforge review` flow (`loop/review/review-change.ts`) and the policy config loader (`config/tsforge-config.ts`). Each is verified against the real code and ships with a regression test.

**`bun run validate`: 1326 pass / 14 skip / 0 fail** (+5 tests). typecheck + eslint + prettier green.

## Fixed findings

### P1 — `tsforge review` missed untracked new source files
`changedFiles` derived the file list only from `git diff --name-only <base>` (and the per-file diff likewise from `git diff`). `git diff` against a ref only sees **tracked** files, so a newly created, never-`git add`ed `.ts` file made review report *"No changed source files to review"* — a whole new module silently unreviewed.
**Fix:** `collectChangedFiles` unions `git ls-files --others --exclude-standard` (non-staged mode; staged mode reviews the index where new files are already tracked) and `syntheticAddedDiff` builds an all-added unified diff (`@@ -0,0 +1,N @@`) for untracked files so they're reviewed as full additions and the hunk parser marks every line changed.
**Test:** a brand-new untracked file appears in `changedFiles` and gets a finding.

### P1 — review coverage was silently capped, then reported as complete
`MAX_FILES = 25` (`.slice`) drops files and `DIFF_CHARS = 6000` (`.slice`) truncates diffs, but the report read *"No functional issues found across N changed file(s)"* with no indication coverage was partial.
**Fix:** the report now carries `totalChangedFiles`, `truncatedFiles`, and `preexisting`; `formatReport` prints a loud `⚠ coverage` warning (`reviewed N of M … not reviewed`; truncated files named) in **both** the clean and the findings branch, and the run logs the cap.
**Test:** `formatReport` with a capped + truncated report surfaces both warnings and never reads as complete.

### P2 — review verification didn't prove a finding was on a changed line
`parseFindings` accepted any positive line and `verifyFinding` judged a window of the *current file* around the cited line — not the diff hunk. A finding on **pre-existing** code in a changed file could be reported as a review failure.
**Fix:** `changedLineRanges` parses the `@@ … +c,d @@` new-side spans from the **full** diff (before truncation); findings outside every changed range are dropped and counted as `preexisting`. When no hunks parse (defensive), the filter is skipped so we never drop everything.
**Test:** a 30-line file with one changed line keeps a finding on the changed line and drops a finding cited on an untouched line (`preexisting === 1`).

### P2 — a malformed policy rule could become a catch-all (global allow/deny)
`validatePolicyRule` dropped invalid/unknown fields and returned the leftover object — so a typo like `{ "kind": "shel" }` collapsed to `{}`, which `ruleMatches` treats as **match-everything**. A typo'd `deny`/`allow` rule silently became global.
**Fix:** a rule that **provided** fields but produced **no valid matcher** is warned-and-dropped; a **literal `{}`** (no fields provided) is preserved as an intentional catch-all.
**Test:** `{ kind: "shel" }` → the deny list is empty (rule dropped); `{}` → preserved as a single empty (catch-all) rule.

## Tests added/updated
`packages/core/tests/review-change.test.ts` (untracked file, pre-existing-line drop, coverage warnings), `packages/core/tests/policy-config.test.ts` (typo'd rule dropped, literal `{}` preserved).

## Validation
`bun run validate` → **1326 pass / 14 skip / 0 fail**; typecheck, eslint, prettier clean.

## Suggestions considered (deferred — out of scope for this focused PR)
- **Review non-source behavioral changes** (package.json, lockfiles, CI, config, generated rule docs): the find/verify lenses are tuned for source logic; reviewing config/CONFIG diffs well needs prompt work — track separately.
- **Align web scaffold deps with the exact-deps meta-rule** (React template uses caret ranges): a scaffold-template change with version-resolution implications — separate change.
- **Use the active gate's strict config for formatter fixes** (`formatFile` uses the core config even under the web gate): plausible, needs care around which config is "active" per run.
- **Exclude `dist`/`build`/`.tsforge` from the core test-file probe** (the web probe already does): small hygiene fix in the gate probe — separate change.
