### PR TITLE
fix(meta-rules): exclude .gen.tsx from source-text scan; close 3 test gaps

### DIFF
--- a/packages/core/src/meta-rules/rules/source-text/is-scannable.ts
+++ b/packages/core/src/meta-rules/rules/source-text/is-scannable.ts
@@ -1,6 +1,6 @@
 /**
  * A file the source-text meta-rules should scan: a TypeScript source file
- * (`.ts`/`.tsx`/`.mts`/`.cts`) that isn't generated. A generated `*.gen.{ts,mts,cts}`
+ * (`.ts`/`.tsx`/`.mts`/`.cts`) that isn't generated. A generated `*.gen.{ts,tsx,mts,cts}`
  * ships its own blanket eslint-disable banner and `@ts-nocheck` (e.g. TanStack's
  * route tree) and is vendored — the model can't author it — so the
  * disable/suppression bans must skip it to stay airtight where it matters.
@@ -10,5 +10,5 @@
  * file walk to pre-filter.
  */
 export function isScannableSource(path: string): boolean {
-  return /\.[cm]?tsx?$/u.test(path) && !/\.gen\.[cm]?ts$/u.test(path);
+  return /\.[cm]?tsx?$/u.test(path) && !/\.gen\.[cm]?tsx?$/u.test(path);
 }

--- a/packages/core/src/validate/index.ts
+++ b/packages/core/src/validate/index.ts
@@ -1,5 +1,5 @@
 export * from "./validate.types";
-export { validate } from "./validate";
+export { validate, fallbackMessage } from "./validate";
 export {
   parseTsc,
   genericErrors,

--- a/packages/core/src/validate/validate.ts
+++ b/packages/core/src/validate/validate.ts
@@ -11,7 +11,7 @@ const FALLBACK_CAP = 1200;
  *  parseable errors (e.g. a render/build failure). Drops eslint's machine JSON
  *  line — it's never for human eyes — and caps the length so the terminal isn't
  *  flooded with raw build output. */
-function fallbackMessage(output: string): string {
+export function fallbackMessage(output: string): string {
   const cleaned = output
     .split("\n")
     .filter((line) => !isEslintJsonLine(line))

--- a/packages/core/tests/inference.test.ts
+++ b/packages/core/tests/inference.test.ts
@@ -1,5 +1,6 @@
 import { expect, test } from "bun:test";
 import { OpenAICompatibleProvider } from "../src/inference";
+import { parseResponse, toWire } from "../src/inference/wire";
 
 function okResponse(): Response {
   return new Response(
@@ -419,4 +420,67 @@ test("qwen keeps per-turn thinking control (no latch)", async () => {
 
   expect(bodies[0]?.chat_template_kwargs).toEqual({ enable_thinking: false });
   expect(bodies[1]?.chat_template_kwargs).toEqual({ enable_thinking: true });
+});
+
+// DeepSeek's thinking mode requires an assistant turn's reasoning_content to be
+// CAPTURED from the response and REPLAYED on the next request — drop it and the
+// next turn's history is malformed (the provider crashes). This pins the full
+// round-trip across the two pure wire helpers: capture (parseResponse) → replay
+// (toWire), with the channel kept distinct from content.
+test("captures reasoning_content from a response and replays it for DeepSeek only", () => {
+  const captured = parseResponse({
+    choices: [
+      {
+        message: {
+          content: "the answer is 42",
+          reasoning_content: "let me think step by step…",
+        },
+      },
+    ],
+  });
+
+  // capture: reasoning lands on its own channel, not mixed into content.
+  expect(captured.content).toBe("the answer is 42");
+  expect(captured.reasoning).toBe("let me think step by step…");
+
+  // replay: DeepSeek (includeReasoning=true) gets reasoning_content back…
+  expect(
+    toWire(
+      {
+        role: "assistant",
+        content: captured.content,
+        reasoningContent: captured.reasoning,
+      },
+      true
+    )
+  ).toMatchObject({
+    role: "assistant",
+    content: "the answer is 42",
+    reasoning_content: "let me think step by step…",
+  });
+
+  // …every other provider must NOT receive it.
+  expect(
+    toWire(
+      {
+        role: "assistant",
+        content: captured.content,
+        reasoningContent: captured.reasoning,
+      },
+      false
+    ).reasoning_content
+  ).toBeUndefined();
+});
+
+test("a response without reasoning_content carries no reasoning channel", () => {
+  const captured = parseResponse({
+    choices: [{ message: { content: "plain answer" } }],
+  });
+
+  expect(captured.reasoning).toBeUndefined();
+  // even on DeepSeek, an empty/absent reasoning field is never serialized.
+  expect(
+    toWire({ role: "assistant", content: "plain answer" }, true)
+      .reasoning_content
+  ).toBeUndefined();
 });

--- a/packages/core/tests/meta-rules.test.ts
+++ b/packages/core/tests/meta-rules.test.ts
@@ -278,9 +278,7 @@ test("isScannableSource: covers .ts/.tsx/.mts/.cts, skips generated variants", a
 
   for (const ext of ["ts", "tsx", "mts", "cts"]) {
     expect(isScannableSource(`src/app.${ext}`)).toBe(true);
-    expect(
-      isScannableSource(`src/routeTree.gen.${ext === "tsx" ? "ts" : ext}`)
-    ).toBe(false);
+    expect(isScannableSource(`src/routeTree.gen.${ext}`)).toBe(false);
   }
 
   expect(isScannableSource("src/data.json")).toBe(false);

--- a/packages/core/tests/parse.test.ts
+++ b/packages/core/tests/parse.test.ts
@@ -6,6 +6,7 @@ import {
   combinedParser,
   parserFor,
   isEslintJsonLine,
+  fallbackMessage,
 } from "../src/validate";
 
 test("parseTsc extracts file/line/rule per diagnostic", () => {
@@ -193,4 +194,29 @@ test("combinedParser structures eslint JSON output (the tsc-passes phase)", () =
     line: 58,
     rule: "@typescript-eslint/no-non-null-assertion",
   });
+});
+
+test("fallbackMessage drops eslint's machine JSON line", () => {
+  const eslintJson = `[{"filePath":"/r/a.ts","messages":[]}]`;
+  const msg = fallbackMessage(`vite build failed: bad import\n${eslintJson}`);
+
+  expect(msg).toBe("vite build failed: bad import");
+  expect(msg).not.toContain('"filePath"');
+});
+
+test("fallbackMessage caps a wall of build output and marks the truncation", () => {
+  const blob = "x".repeat(5000);
+  const msg = fallbackMessage(blob);
+
+  // capped to FALLBACK_CAP (1200) + the truncation marker, not the raw 5000.
+  expect(msg.length).toBeLessThan(1300);
+  expect(msg.startsWith("x".repeat(1200))).toBe(true);
+  expect(msg).toContain("… (output truncated)");
+});
+
+test("fallbackMessage degrades to a fixed string when nothing human-readable remains", () => {
+  const onlyJson = `[{"filePath":"/r/a.ts","messages":[]}]`;
+
+  expect(fallbackMessage(onlyJson)).toBe("command exited non-zero");
+  expect(fallbackMessage("   \n  ")).toBe("command exited non-zero");
 });

--- a/packages/core/tests/process.test.ts
+++ b/packages/core/tests/process.test.ts
@@ -2,7 +2,7 @@ import { test, expect } from "bun:test";
 import { mkdtemp, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { runShellCommand } from "../src/lib/fs/process";
+import { runShellCommand, runArgvCommand } from "../src/lib/fs/process";
 
 // P2 (review): a timed-out command killed only the `sh -c` wrapper, so a
 // `&`-backgrounded grandchild survived and could still mutate the workspace AFTER
@@ -53,6 +53,27 @@ test("returns promptly even when a leftover child holds the output pipe open", a
     expect(run.timedOut).toBe(false);
     expect(run.stdout).toContain("ready");
     expect(elapsedMs).toBeLessThan(2500);
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+// A missing binary must surface as exit 127 — NEVER a throw into the loop. If
+// `Bun.spawn` rejects (ENOENT), the catch must convert it to a tool-error result
+// so a model that runs a non-existent command gets feedback, not a crashed turn.
+test("a missing binary returns exit 127 without throwing", async () => {
+  const dir = await mkdtemp(join(tmpdir(), "tsforge-proc-127-"));
+
+  try {
+    const run = await runArgvCommand(
+      dir,
+      ["tsforge-nonexistent-binary-xyz", "--version"],
+      { timeoutMs: 5000 }
+    );
+
+    expect(run.exitCode).toBe(127);
+    expect(run.timedOut).toBe(false);
+    expect(run.stderr.length).toBeGreaterThan(0);
   } finally {
     await rm(dir, { recursive: true, force: true });
   }


### PR DESCRIPTION
## Harness review sweep (all 12 subsystems)

Full adversarial `/harness-review all` after v0.18.4. **11 subsystems clean, 0 P1s.** This PR lands the one ship-worthy code finding plus three missing-regression-test gaps.

### P2 (real, with masking test) — `isScannableSource` excludes `.gen.tsx`
`src/meta-rules/rules/source-text/is-scannable.ts` matched `.tsx` (`/\.[cm]?tsx?$/u`) but its generated-file exclusion (`!/\.gen\.[cm]?ts$/u`) had **no `x?`** — so a generated `*.gen.tsx` was scanned by `no-eslint-disable-comments` / `no-ts-suppressions` and flagged for its own vendored eslint-disable/`@ts-nocheck` banner.

Latent (no `.gen.tsx` producer in-tree today), but the existing regression test **rigged itself around the gap**: `isScannableSource(\`src/routeTree.gen.${ext === "tsx" ? "ts" : ext}\`)` quietly substituted `.gen.ts` for the `tsx` case. De-rigged — reverting the source fix now fails the test (verified).

- Fix: `!/\.gen\.[cm]?tsx?$/u` + doc comment `*.gen.{ts,tsx,mts,cts}`.

### P2 (missing regression tests for verified-but-unguarded contracts)
- **gate** `fallbackMessage()` (`src/validate/validate.ts`) — 1200-char cap + eslint-JSON drop + truncation marker had zero coverage (the prior "vacuous cap test" suspicion). Now exported + unit-tested with >1200-char input.
- **lib/fs** `runArgvCommand()` — missing binary → exit 127, never a throw (the `Bun.spawn` catch path).
- **inference** wire — DeepSeek `reasoning_content` capture→replay round-trip, and omission for non-DeepSeek providers.

### Verification
`bun run validate`: **1337 pass, 0 fail**. Each new test confirmed to fail against the un-fixed code where applicable.

### Subsystems verified clean
loop/turn, tools, gate, oracles, browser, inference, render/CLI, mcp, web-scaffold, setup/conventions, lib/fs — all invariants checked against source + tests with repros.