### PR TITLE
feat(cli): @ file selector for the interactive REPL

### DIFF
--- a/packages/core/src/cli.ts
+++ b/packages/core/src/cli.ts
@@ -7,8 +7,13 @@ import { createInterface } from "node:readline/promises";
 import { emitKeypressEvents } from "node:readline";
 import { formatHelp, takesArg } from "./cli/commands";
 import { pickCommand } from "./render/command-menu";
-import { pickFile, shouldOpenAtPicker } from "./render/file-menu";
-import { resolveScopeFiles } from "./lib/fs";
+import {
+  pickFileInline,
+  formatCompletionRows,
+  shouldOpenAtPicker,
+  type IPickerView,
+} from "./render/file-menu";
+import { listWorkspaceFiles } from "./lib/fs";
 import { composeMessage } from "./loop/prompt";
 import {
   runTask,
@@ -1546,16 +1551,37 @@ async function repl(args: ICliArgs): Promise<number> {
       }
     };
 
-    // Open the interactive `@` file picker: pick a workspace file from a navigable
-    // list, then insert its path after the typed `@` (the surrounding message is
-    // kept — unlike the `/` palette we do NOT clear the line). At send time the
-    // `@path` is expanded to the file's contents (see composeMessage / runSend).
+    // Open the interactive `@` file picker: a compact dropdown rendered INLINE just
+    // above the input row (the conversation stays visible — no alternate screen),
+    // recency-ordered, type to fuzzy-filter. The buffer keeps its `@`; the live
+    // query is echoed onto the input row for feedback (it isn't in readline's
+    // buffer — the picker owns input). On select, the full path is appended after
+    // the `@`; at send time `@path` expands to the file's contents (see runSend).
     const openFilePicker = async (): Promise<void> => {
       paletteOpen = true;
 
+      const base = rl.line; // text up to and including the just-typed `@`
+
+      const view: IPickerView = {
+        render: (query, items, selected): void => {
+          const rows = formatCompletionRows(
+            items,
+            selected,
+            process.stdout.columns,
+            process.stdout.isTTY
+          );
+
+          statusBar.setInput(`${base}${query}`, base.length + query.length);
+          statusBar.setOverlay(rows, statusInfo());
+        },
+        close: (): void => {
+          statusBar.clearOverlay(statusInfo());
+        },
+      };
+
       try {
-        const files = await resolveScopeFiles(args.dir, ["**/*"]);
-        const picked = await pickFile(files, process.stdout.isTTY);
+        const files = await listWorkspaceFiles(args.dir);
+        const picked = await pickFileInline(files, view);
 
         if (picked !== null) {
           rl.write(`${picked} `); // append after the already-typed `@`
@@ -1589,7 +1615,10 @@ async function repl(args: ICliArgs): Promise<number> {
               void openPalette();
             }
           });
-        } else if (str === "@") {
+        } else if (str === "@" && useInputRow) {
+          // The inline dropdown renders above the input row, so it needs that row
+          // (a tall-enough TTY). Without it we skip the picker — `@path` typed by
+          // hand still expands at send time (composeMessage), just no live popup.
           setImmediate(() => {
             if (
               !busy &&

--- a/packages/core/src/cli.ts
+++ b/packages/core/src/cli.ts
@@ -7,6 +7,9 @@ import { createInterface } from "node:readline/promises";
 import { emitKeypressEvents } from "node:readline";
 import { formatHelp, takesArg } from "./cli/commands";
 import { pickCommand } from "./render/command-menu";
+import { pickFile, shouldOpenAtPicker } from "./render/file-menu";
+import { resolveScopeFiles } from "./lib/fs";
+import { composeMessage } from "./loop/prompt";
 import {
   runTask,
   RUN_STATUS,
@@ -1016,8 +1019,14 @@ async function repl(args: ICliArgs): Promise<number> {
     await persist();
   };
 
+  // Free-text user sends route through here: resolve `@file` mentions to inlined
+  // contents (composeMessage) before handing the message to the session. The
+  // plan-approval / staged-build sends call session.send directly and are not
+  // touched, so only ordinary messages get mention expansion.
   const runSend = (line: string): Promise<void> =>
-    drive((opts) => session.send(line, opts));
+    drive(async (opts) =>
+      session.send(await composeMessage(args.dir, line), opts)
+    );
 
   // A from-scratch web build: stage it (plan + types, then implement) so the
   // model designs the type contract before writing UI — far less API invention.
@@ -1537,23 +1546,60 @@ async function repl(args: ICliArgs): Promise<number> {
       }
     };
 
-    // Press `/` on an empty line ⇒ open the palette. setImmediate lets readline
-    // finish inserting the slash first, so `rl.line === "/"` confirms it's a fresh
-    // command start (not a slash mid-text). No-op while busy or already open.
+    // Open the interactive `@` file picker: pick a workspace file from a navigable
+    // list, then insert its path after the typed `@` (the surrounding message is
+    // kept — unlike the `/` palette we do NOT clear the line). At send time the
+    // `@path` is expanded to the file's contents (see composeMessage / runSend).
+    const openFilePicker = async (): Promise<void> => {
+      paletteOpen = true;
+
+      try {
+        const files = await resolveScopeFiles(args.dir, ["**/*"]);
+        const picked = await pickFile(files, process.stdout.isTTY);
+
+        if (picked !== null) {
+          rl.write(`${picked} `); // append after the already-typed `@`
+        }
+      } finally {
+        paletteOpen = false;
+
+        if (useInputRow) {
+          statusBar.update(statusInfo());
+          syncInput();
+        }
+      }
+    };
+
+    // `/` on an empty line opens the palette; `@` at a word boundary opens the file
+    // picker. setImmediate lets readline insert the key first, so we can inspect the
+    // settled buffer (`rl.line === "/"` / shouldOpenAtPicker). The shared paletteOpen
+    // guard keeps the two overlays mutually exclusive. No-op while busy.
     if (process.stdin.isTTY) {
       emitKeypressEvents(process.stdin);
       process.stdin.on("keypress", (str: string | undefined) => {
         syncInput(); // keep the pinned input row in sync as the user types
 
-        if (busy || paletteOpen || str !== "/") {
+        if (busy || paletteOpen) {
           return;
         }
 
-        setImmediate(() => {
-          if (!busy && !paletteOpen && rl.line === "/") {
-            void openPalette();
-          }
-        });
+        if (str === "/") {
+          setImmediate(() => {
+            if (!busy && !paletteOpen && rl.line === "/") {
+              void openPalette();
+            }
+          });
+        } else if (str === "@") {
+          setImmediate(() => {
+            if (
+              !busy &&
+              !paletteOpen &&
+              shouldOpenAtPicker(rl.line, rl.cursor)
+            ) {
+              void openFilePicker();
+            }
+          });
+        }
       });
     }
 

--- a/packages/core/src/lib/fs/fs.ts
+++ b/packages/core/src/lib/fs/fs.ts
@@ -1,5 +1,5 @@
 import { join } from "node:path";
-import { rm } from "node:fs/promises";
+import { rm, stat } from "node:fs/promises";
 import { Glob } from "bun";
 import type { IFileView } from "./fs.types";
 
@@ -196,4 +196,26 @@ export async function resolveScopeFiles(
   }
 
   return [...out];
+}
+
+/**
+ * All readable workspace files (same scope as the glob expansion above), ordered
+ * MOST-RECENTLY-MODIFIED first. This is the source for the `@` file picker: a
+ * recency order means the files you're actually working on surface at the top
+ * instead of an alphabetical dump of the whole tree. Unstattable files sort last.
+ */
+export async function listWorkspaceFiles(cwd: string): Promise<string[]> {
+  const files = await resolveScopeFiles(cwd, ["**/*"]);
+
+  const stamped = await Promise.all(
+    files.map(async (path) => {
+      try {
+        return { path, mtimeMs: (await stat(join(cwd, path))).mtimeMs };
+      } catch {
+        return { path, mtimeMs: 0 };
+      }
+    })
+  );
+
+  return stamped.sort((a, b) => b.mtimeMs - a.mtimeMs).map((f) => f.path);
 }

--- a/packages/core/src/loop/prompt/at-mention.ts
+++ b/packages/core/src/loop/prompt/at-mention.ts
@@ -1,0 +1,70 @@
+import { readFiles } from "../../lib/fs";
+import { renderFileSection } from "./project-map";
+import type { IFileView } from "../../lib/fs";
+
+// An `@`-mention: `@` at the line start or after whitespace, then a run of
+// non-space, non-`@` characters (the path). The leading boundary is captured so
+// it can be preserved when the `@` is stripped. Anchoring on the boundary is what
+// stops it matching inside an email (`ag@host`) or a mid-word `@`.
+const AT_MENTION = /(^|\s)@([^\s@]+)/gu;
+
+/** The unique candidate paths `@`-mentioned in a line, in first-seen order. */
+export function parseAtPaths(line: string): string[] {
+  const seen = new Set<string>();
+
+  for (const m of line.matchAll(AT_MENTION)) {
+    const path = m[2];
+
+    if (path !== undefined) {
+      seen.add(path);
+    }
+  }
+
+  return [...seen];
+}
+
+/**
+ * Resolve the `@`-mentions in a user line to file views. Each `@path` that names a
+ * readable workspace file is read; the `@` is stripped from those (recognized)
+ * tokens in the returned text so the model reads a clean path, while unrecognized
+ * `@`-tokens (typos, decorators, non-files) are left untouched. Returns the cleaned
+ * text plus the resolved views (empty when nothing matched).
+ */
+export async function resolveAtMentions(
+  cwd: string,
+  line: string
+): Promise<{ text: string; views: IFileView[] }> {
+  const paths = parseAtPaths(line);
+
+  if (paths.length === 0) {
+    return { text: line, views: [] };
+  }
+
+  const views = await readFiles(cwd, paths);
+  const found = new Set(views.map((v) => v.path));
+
+  const text = line.replace(AT_MENTION, (whole, pre: string, path: string) =>
+    found.has(path) ? `${pre}${path}` : whole
+  );
+
+  return { text, views };
+}
+
+/**
+ * Build the message actually sent for a user line: when it `@`-mentions readable
+ * files, their contents (or a MAP when large — see renderFileSection) are prepended
+ * so the model sees them immediately, with the `@` stripped from the inline text.
+ * With no resolved mentions the line passes through unchanged.
+ */
+export async function composeMessage(
+  cwd: string,
+  line: string
+): Promise<string> {
+  const { text, views } = await resolveAtMentions(cwd, line);
+
+  if (views.length === 0) {
+    return text;
+  }
+
+  return `${renderFileSection(views).text}\n\n${text}`;
+}

--- a/packages/core/src/loop/prompt/index.ts
+++ b/packages/core/src/loop/prompt/index.ts
@@ -10,3 +10,4 @@ export {
   seedPrompt,
 } from "./prompt";
 export { renderFileSection, exportedSymbols } from "./project-map";
+export { parseAtPaths, resolveAtMentions, composeMessage } from "./at-mention";

--- a/packages/core/src/render/file-menu.ts
+++ b/packages/core/src/render/file-menu.ts
@@ -2,18 +2,9 @@ import { emitKeypressEvents } from "node:readline";
 import { STYLE, paint } from "./style";
 import { clampIndex } from "./command-menu";
 
-const ESC = String.fromCharCode(27);
-// Same alternate-screen approach as the `/` command palette (see command-menu.ts):
-// render on the ALT buffer so frames redraw cleanly instead of fighting the status
-// bar's scroll region, and exit restores the previous screen verbatim.
-const ENTER_ALT = `${ESC}[?1049h${ESC}[r`;
-const EXIT_ALT = `${ESC}[?1049l`;
-const HIDE_CURSOR = `${ESC}[?25l`;
-const SHOW_CURSOR = `${ESC}[?25h`;
-const CLEAR_HOME = `${ESC}[2J${ESC}[H`;
-
-/** Most files shown at once — keeps the menu a screenful, not a 400-line dump. */
-const MAX_VISIBLE = 50;
+/** Rows shown in the popup at once — a tight dropdown above the prompt, never a
+ *  whole-tree dump. On an empty query these are the most-recently-modified files. */
+const MAX_VISIBLE = 8;
 
 /** Basename of a workspace-relative path (the part after the last `/`). */
 function baseName(path: string): string {
@@ -21,7 +12,8 @@ function baseName(path: string): string {
 }
 
 /** Lower rank = better match: basename-prefix beats path-prefix beats basename
- *  substring beats anywhere. Stable within a rank by path (see filterFiles). */
+ *  substring beats anywhere. Ties keep the caller's order (recency) — sort is
+ *  stable — so the most-recently-touched match within a rank surfaces first. */
 function rank(path: string, q: string): number {
   const base = baseName(path).toLowerCase();
   const full = path.toLowerCase();
@@ -42,7 +34,8 @@ function rank(path: string, q: string): number {
 }
 
 /** Filter files by a query (the text typed after `@`), case-insensitive substring
- *  over the whole path, best matches first. Empty query ⇒ the first MAX_VISIBLE. */
+ *  over the whole path, best matches first (ties keep caller/recency order — sort
+ *  is stable). Empty query ⇒ the first MAX_VISIBLE of the caller's order. */
 export function filterFiles(files: readonly string[], query: string): string[] {
   const q = query.toLowerCase();
 
@@ -52,43 +45,47 @@ export function filterFiles(files: readonly string[], query: string): string[] {
 
   return files
     .filter((f) => f.toLowerCase().includes(q))
-    .sort((a, b) => {
-      const byRank = rank(a, q) - rank(b, q);
-
-      return byRank === 0 ? a.localeCompare(b) : byRank;
-    })
+    .sort((a, b) => rank(a, q) - rank(b, q))
     .slice(0, MAX_VISIBLE);
 }
 
-/** Render the file picker as a block of lines (no trailing newline). The header
- *  echoes the current `@`-query + key hints; the selected row is highlighted. */
-export function renderFileMenu(
-  items: readonly string[],
-  selected: number,
-  query: string,
-  color: boolean
-): string {
-  const header =
-    paint(`@${query}`, STYLE.brand, color) +
-    paint(
-      "  ↑/↓ select · type to filter · enter link · esc cancel",
-      STYLE.dim,
-      color
-    );
-
-  if (items.length === 0) {
-    return `${header}\n  ${paint("no matching file", STYLE.dim, color)}`;
+/** Truncate a path to `max` columns keeping its TAIL (the filename matters most),
+ *  prefixing `…` when clipped. `max <= 0` ⇒ empty. */
+export function truncatePath(path: string, max: number): string {
+  if (max <= 0) {
+    return "";
   }
 
-  const rows = items.map((path, i) => {
+  if (path.length <= max) {
+    return path;
+  }
+
+  return `…${path.slice(-(max - 1))}`;
+}
+
+/**
+ * The popup rows for the inline file dropdown — one painted line per visible file,
+ * each truncated to `columns` (no wrapping), the selected row gutter-highlighted.
+ * Pure/width-aware so it can be asserted without a terminal. Empty list ⇒ a single
+ * "no matching file" row so the dropdown never silently vanishes mid-type.
+ */
+export function formatCompletionRows(
+  items: readonly string[],
+  selected: number,
+  columns: number,
+  color: boolean
+): string[] {
+  if (items.length === 0) {
+    return [`  ${paint("no matching file", STYLE.dim, color)}`];
+  }
+
+  return items.map((path, i) => {
     const active = i === selected;
     const gutter = active ? paint("›", STYLE.brand, color) : " ";
-    const label = paint(path, active ? STYLE.brand : STYLE.bold, color);
+    const text = truncatePath(path, Math.max(0, columns - 2));
 
-    return `${gutter} ${label}`;
+    return `${gutter} ${paint(text, active ? STYLE.brand : STYLE.dim, color)}`;
   });
-
-  return [header, ...rows].join("\n");
 }
 
 /** True when an `@` just typed at `cursor` starts a fresh mention — i.e. the `@`
@@ -112,19 +109,29 @@ interface IKeyInfo {
 }
 
 /**
- * The interactive `@` file picker. A direct sibling of `pickCommand` — it owns
- * `keypress` input for its lifetime (stash + detach the existing listeners so only
- * `onKey` reacts), renders a navigable file list on the alternate screen, and
- * resolves to the chosen path or null (Esc / Ctrl-C / backspace-past-empty).
- * `finish()` ALWAYS restores the saved listeners. No-ops to null off a TTY.
- *
- * Like pickCommand, stdin stays in readline's raw, flowing mode — we only swap WHO
+ * The terminal-facing side of the inline picker, supplied by the CLI. `render` is
+ * called on every change with the current query + filtered items so the host can
+ * paint the dropdown above the input row and echo the live `@query`; `close` tears
+ * the dropdown down. Keeping these as callbacks lets pickFileInline own only the
+ * keypress state machine, with no knowledge of the status bar.
+ */
+export interface IPickerView {
+  render(query: string, items: readonly string[], selected: number): void;
+  close(): void;
+}
+
+/**
+ * The interactive `@` file picker, rendered INLINE (no alternate screen): it owns
+ * `keypress` for its lifetime — stash + detach the existing listeners so only
+ * `onKey` reacts — drives a tight dropdown via `view`, and resolves to the chosen
+ * path or null (Esc / Ctrl-C / backspace-past-empty). Enter or Tab accept the
+ * highlighted row. `view.close()` + listener restore ALWAYS run. No-ops to null
+ * off a TTY. stdin stays in readline's raw, flowing mode — we only swap WHO
  * listens, never toggle raw mode, so the terminal can't be left wedged.
  */
-export function pickFile(
+export function pickFileInline(
   files: readonly string[],
-  color: boolean,
-  out: (s: string) => void = (s) => process.stdout.write(s)
+  view: IPickerView
 ): Promise<string | null> {
   const stdin = process.stdin;
 
@@ -146,13 +153,12 @@ export function pickFile(
       const items = filterFiles(files, query);
 
       selected = clampIndex(selected, items.length);
-
-      out(`${CLEAR_HOME}${renderFileMenu(items, selected, query, color)}`);
+      view.render(query, items, selected);
     };
 
     const finish = (result: string | null): void => {
       stdin.removeListener("keypress", onKey);
-      out(`${SHOW_CURSOR}${EXIT_ALT}`);
+      view.close();
 
       for (const l of saved) {
         stdin.on("keypress", (...args: unknown[]) => {
@@ -163,18 +169,20 @@ export function pickFile(
       resolve(result);
     };
 
+    const accept = (): void => {
+      const items = filterFiles(files, query);
+
+      finish(items[clampIndex(selected, items.length)] ?? null);
+    };
+
     const onKey = (str: string | undefined, key: IKeyInfo): void => {
       try {
         if ((key.ctrl === true && key.name === "c") || key.name === "escape") {
           finish(null);
-
-          return;
-        }
-
-        const items = filterFiles(files, query);
-
-        if (key.name === "return" || key.name === "enter") {
-          finish(items[clampIndex(selected, items.length)] ?? null);
+        } else if (key.name === "return" || key.name === "enter") {
+          accept();
+        } else if (key.name === "tab") {
+          accept();
         } else if (key.name === "up") {
           selected -= 1;
           draw();
@@ -200,7 +208,6 @@ export function pickFile(
     };
 
     stdin.on("keypress", onKey);
-    out(`${ENTER_ALT}${HIDE_CURSOR}`);
     draw();
   });
 }

--- a/packages/core/src/render/file-menu.ts
+++ b/packages/core/src/render/file-menu.ts
@@ -1,0 +1,206 @@
+import { emitKeypressEvents } from "node:readline";
+import { STYLE, paint } from "./style";
+import { clampIndex } from "./command-menu";
+
+const ESC = String.fromCharCode(27);
+// Same alternate-screen approach as the `/` command palette (see command-menu.ts):
+// render on the ALT buffer so frames redraw cleanly instead of fighting the status
+// bar's scroll region, and exit restores the previous screen verbatim.
+const ENTER_ALT = `${ESC}[?1049h${ESC}[r`;
+const EXIT_ALT = `${ESC}[?1049l`;
+const HIDE_CURSOR = `${ESC}[?25l`;
+const SHOW_CURSOR = `${ESC}[?25h`;
+const CLEAR_HOME = `${ESC}[2J${ESC}[H`;
+
+/** Most files shown at once — keeps the menu a screenful, not a 400-line dump. */
+const MAX_VISIBLE = 50;
+
+/** Basename of a workspace-relative path (the part after the last `/`). */
+function baseName(path: string): string {
+  return path.slice(path.lastIndexOf("/") + 1);
+}
+
+/** Lower rank = better match: basename-prefix beats path-prefix beats basename
+ *  substring beats anywhere. Stable within a rank by path (see filterFiles). */
+function rank(path: string, q: string): number {
+  const base = baseName(path).toLowerCase();
+  const full = path.toLowerCase();
+
+  if (base.startsWith(q)) {
+    return 0;
+  }
+
+  if (full.startsWith(q)) {
+    return 1;
+  }
+
+  if (base.includes(q)) {
+    return 2;
+  }
+
+  return 3;
+}
+
+/** Filter files by a query (the text typed after `@`), case-insensitive substring
+ *  over the whole path, best matches first. Empty query ⇒ the first MAX_VISIBLE. */
+export function filterFiles(files: readonly string[], query: string): string[] {
+  const q = query.toLowerCase();
+
+  if (q.length === 0) {
+    return files.slice(0, MAX_VISIBLE);
+  }
+
+  return files
+    .filter((f) => f.toLowerCase().includes(q))
+    .sort((a, b) => {
+      const byRank = rank(a, q) - rank(b, q);
+
+      return byRank === 0 ? a.localeCompare(b) : byRank;
+    })
+    .slice(0, MAX_VISIBLE);
+}
+
+/** Render the file picker as a block of lines (no trailing newline). The header
+ *  echoes the current `@`-query + key hints; the selected row is highlighted. */
+export function renderFileMenu(
+  items: readonly string[],
+  selected: number,
+  query: string,
+  color: boolean
+): string {
+  const header =
+    paint(`@${query}`, STYLE.brand, color) +
+    paint(
+      "  ↑/↓ select · type to filter · enter link · esc cancel",
+      STYLE.dim,
+      color
+    );
+
+  if (items.length === 0) {
+    return `${header}\n  ${paint("no matching file", STYLE.dim, color)}`;
+  }
+
+  const rows = items.map((path, i) => {
+    const active = i === selected;
+    const gutter = active ? paint("›", STYLE.brand, color) : " ";
+    const label = paint(path, active ? STYLE.brand : STYLE.bold, color);
+
+    return `${gutter} ${label}`;
+  });
+
+  return [header, ...rows].join("\n");
+}
+
+/** True when an `@` just typed at `cursor` starts a fresh mention — i.e. the `@`
+ *  is at the line start or follows whitespace. Guards against firing inside an
+ *  email (`ag@host`) or a decorator typed mid-word. `cursor` is readline's index
+ *  AFTER the `@` was inserted, so the `@` sits at `cursor - 1`. */
+export function shouldOpenAtPicker(line: string, cursor: number): boolean {
+  if (line[cursor - 1] !== "@") {
+    return false;
+  }
+
+  const before = line[cursor - 2];
+
+  return before === undefined || /\s/u.test(before);
+}
+
+/** One keypress, as decoded by readline's `emitKeypressEvents`. */
+interface IKeyInfo {
+  readonly name?: string;
+  readonly ctrl?: boolean;
+}
+
+/**
+ * The interactive `@` file picker. A direct sibling of `pickCommand` — it owns
+ * `keypress` input for its lifetime (stash + detach the existing listeners so only
+ * `onKey` reacts), renders a navigable file list on the alternate screen, and
+ * resolves to the chosen path or null (Esc / Ctrl-C / backspace-past-empty).
+ * `finish()` ALWAYS restores the saved listeners. No-ops to null off a TTY.
+ *
+ * Like pickCommand, stdin stays in readline's raw, flowing mode — we only swap WHO
+ * listens, never toggle raw mode, so the terminal can't be left wedged.
+ */
+export function pickFile(
+  files: readonly string[],
+  color: boolean,
+  out: (s: string) => void = (s) => process.stdout.write(s)
+): Promise<string | null> {
+  const stdin = process.stdin;
+
+  if (!stdin.isTTY) {
+    return Promise.resolve(null);
+  }
+
+  return new Promise((resolve) => {
+    let query = "";
+    let selected = 0;
+
+    emitKeypressEvents(stdin);
+
+    const saved = stdin.rawListeners("keypress");
+
+    stdin.removeAllListeners("keypress");
+
+    const draw = (): void => {
+      const items = filterFiles(files, query);
+
+      selected = clampIndex(selected, items.length);
+
+      out(`${CLEAR_HOME}${renderFileMenu(items, selected, query, color)}`);
+    };
+
+    const finish = (result: string | null): void => {
+      stdin.removeListener("keypress", onKey);
+      out(`${SHOW_CURSOR}${EXIT_ALT}`);
+
+      for (const l of saved) {
+        stdin.on("keypress", (...args: unknown[]) => {
+          Reflect.apply(l, stdin, args);
+        });
+      }
+
+      resolve(result);
+    };
+
+    const onKey = (str: string | undefined, key: IKeyInfo): void => {
+      try {
+        if ((key.ctrl === true && key.name === "c") || key.name === "escape") {
+          finish(null);
+
+          return;
+        }
+
+        const items = filterFiles(files, query);
+
+        if (key.name === "return" || key.name === "enter") {
+          finish(items[clampIndex(selected, items.length)] ?? null);
+        } else if (key.name === "up") {
+          selected -= 1;
+          draw();
+        } else if (key.name === "down") {
+          selected += 1;
+          draw();
+        } else if (key.name === "backspace") {
+          if (query.length === 0) {
+            finish(null); // backspace past the `@` closes the picker
+          } else {
+            query = query.slice(0, -1);
+            selected = 0;
+            draw();
+          }
+        } else if (key.ctrl !== true && str?.length === 1 && str >= " ") {
+          query += str;
+          selected = 0;
+          draw();
+        }
+      } catch {
+        finish(null); // never let a render error wedge input
+      }
+    };
+
+    stdin.on("keypress", onKey);
+    out(`${ENTER_ALT}${HIDE_CURSOR}`);
+    draw();
+  });
+}

--- a/packages/core/src/render/index.ts
+++ b/packages/core/src/render/index.ts
@@ -9,6 +9,7 @@ export {
   StatusBar,
   buildBarFrame,
   buildInputFrame,
+  buildOverlayFrame,
   MIN_ROWS,
   type IStatusBarTerminal,
 } from "./status-bar";

--- a/packages/core/src/render/status-bar.ts
+++ b/packages/core/src/render/status-bar.ts
@@ -229,6 +229,36 @@ export function buildInputFrame(
 }
 
 /**
+ * Paint a transient popup of `lines` directly ABOVE the input row (an `@`-file
+ * dropdown), bottom-aligned against the prompt. `clearRows` is the height of the
+ * previous popup so a shrinking list erases its old top rows. Pure/width-aware:
+ * positions absolutely, clears each row first, and writes nothing into the bar or
+ * input row (the caller repaints those). Clamped so it never addresses above row 1.
+ */
+export function buildOverlayFrame(
+  lines: readonly string[],
+  clearRows: number,
+  rows: number
+): string {
+  const inputRow = Math.max(1, rows - 2);
+  const count = Math.min(
+    Math.max(lines.length, clearRows),
+    Math.max(0, inputRow - 1)
+  );
+  const blank = count - lines.length; // cleared (old) rows sit above the new list
+  let out = "";
+
+  for (let i = 0; i < count; i += 1) {
+    const row = Math.max(1, inputRow - count + i);
+    const line = i - blank >= 0 ? (lines[i - blank] ?? "") : "";
+
+    out += `${ESC}[${row};1H${ESC}[2K${line}`;
+  }
+
+  return out;
+}
+
+/**
  * An always-visible status bar pinned to the terminal's bottom via an ANSI scroll
  * region (DECSTBM). Streaming output and readline input scroll in the region
  * above it; the bar is repainted on state changes and resize. Inactive (no-op)
@@ -241,6 +271,9 @@ export class StatusBar {
    *  stream chunk can re-paint the input row and re-park the cursor. */
   private line = "";
   private cursorPos = 0;
+  /** Height of the `@`-picker popup currently painted above the input row (0 = none),
+   *  so the next paint knows how many old rows to erase. */
+  private overlayRows = 0;
 
   constructor(
     private readonly out: IStatusBarTerminal,
@@ -338,6 +371,39 @@ export class StatusBar {
     this.out.write(text); // scrolls within the region
     this.out.write(`${ESC}7`); // save the advanced stream cursor
     this.out.write(RESET_SGR); // don't bleed mid-stream color into the input row
+    this.paintInput();
+  }
+
+  /** Paint the `@`-picker dropdown of `lines` just above the input row, then
+   *  repaint the bar + input row and re-park the cursor. Safe to call repeatedly as
+   *  the list filters — a shrinking list erases its old rows. Input-row mode only;
+   *  a no-op otherwise (the caller then has no inline surface and skips the picker). */
+  setOverlay(lines: readonly string[], info: IStatusInfo): void {
+    if (!this.installed || !this.withInput) {
+      return;
+    }
+
+    const columns = this.out.columns ?? 80;
+    const rows = this.out.rows ?? 0;
+
+    this.out.write(buildOverlayFrame(lines, this.overlayRows, rows));
+    this.overlayRows = lines.length;
+    this.out.write(buildBarBody(info, columns, rows, this.color));
+    this.paintInput();
+  }
+
+  /** Erase the `@`-picker dropdown and repaint the bar + input row. Idempotent. */
+  clearOverlay(info: IStatusInfo): void {
+    if (!this.installed || !this.withInput || this.overlayRows === 0) {
+      return;
+    }
+
+    const columns = this.out.columns ?? 80;
+    const rows = this.out.rows ?? 0;
+
+    this.out.write(buildOverlayFrame([], this.overlayRows, rows));
+    this.overlayRows = 0;
+    this.out.write(buildBarBody(info, columns, rows, this.color));
     this.paintInput();
   }
 

--- a/packages/core/tests/at-mention.test.ts
+++ b/packages/core/tests/at-mention.test.ts
@@ -1,0 +1,66 @@
+import { test, expect, beforeAll, afterAll } from "bun:test";
+import { mkdtemp, rm, writeFile, mkdir } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  parseAtPaths,
+  resolveAtMentions,
+  composeMessage,
+} from "../src/loop/prompt/at-mention";
+
+let dir = "";
+
+beforeAll(async () => {
+  dir = await mkdtemp(join(tmpdir(), "tsforge-at-"));
+  await mkdir(join(dir, "src"), { recursive: true });
+  await writeFile(join(dir, "src", "foo.ts"), "export const foo = 1;\n");
+  await writeFile(join(dir, "big.ts"), "x".repeat(13_000)); // > mapThresholdChars
+});
+
+afterAll(async () => {
+  await rm(dir, { recursive: true, force: true });
+});
+
+test("parseAtPaths: only matches @ at a word boundary, de-duped", () => {
+  expect(parseAtPaths("fix @src/foo.ts please")).toEqual(["src/foo.ts"]);
+  expect(parseAtPaths("@a.ts and @a.ts again")).toEqual(["a.ts"]);
+  expect(parseAtPaths("mail ag@dreamdata.io now")).toEqual([]); // email: no boundary
+  expect(parseAtPaths("no mentions here")).toEqual([]);
+});
+
+test("resolveAtMentions: strips @ from resolved files, reads their views", async () => {
+  const { text, views } = await resolveAtMentions(dir, "explain @src/foo.ts");
+
+  expect(views.map((v) => v.path)).toEqual(["src/foo.ts"]);
+  expect(text).toBe("explain src/foo.ts"); // @ stripped from the recognized token
+});
+
+test("resolveAtMentions: leaves unresolved @-tokens untouched", async () => {
+  const { text, views } = await resolveAtMentions(
+    dir,
+    "see @nope.ts and @Component"
+  );
+
+  expect(views).toEqual([]);
+  expect(text).toBe("see @nope.ts and @Component");
+});
+
+test("composeMessage: inlines small file contents above the cleaned line", async () => {
+  const msg = await composeMessage(dir, "explain @src/foo.ts");
+
+  expect(msg).toContain("export const foo = 1;"); // full contents inlined
+  expect(msg.endsWith("explain src/foo.ts")).toBe(true);
+});
+
+test("composeMessage: large file is rendered as a MAP, not inlined verbatim", async () => {
+  const msg = await composeMessage(dir, "look at @big.ts");
+
+  expect(msg).toContain("big.ts ("); // MAP marker: "  big.ts (N lines)"
+  expect(msg).toContain("lines)");
+  expect(msg).not.toContain("File big.ts:"); // not the inline-contents branch
+  expect(msg).not.toContain("x".repeat(13_000)); // raw blob not dumped
+});
+
+test("composeMessage: a line with no mentions passes through unchanged", async () => {
+  expect(await composeMessage(dir, "just a question")).toBe("just a question");
+});

--- a/packages/core/tests/file-menu.test.ts
+++ b/packages/core/tests/file-menu.test.ts
@@ -1,0 +1,62 @@
+import { test, expect } from "bun:test";
+import {
+  filterFiles,
+  renderFileMenu,
+  shouldOpenAtPicker,
+} from "../src/render/file-menu";
+
+const FILES = [
+  "src/cli.ts",
+  "src/render/status-bar.ts",
+  "components/navbar.tsx",
+  "bar.ts",
+  "README.md",
+];
+
+test("filterFiles: empty query returns all (capped to a screenful)", () => {
+  expect(filterFiles(FILES, "")).toEqual(FILES.slice(0, 50));
+
+  const many = Array.from({ length: 60 }, (_, i) => `f${String(i)}.ts`);
+
+  expect(filterFiles(many, "")).toHaveLength(50);
+});
+
+test("filterFiles: substring match is case-insensitive over the whole path", () => {
+  expect(filterFiles(FILES, "STATUS")).toEqual(["src/render/status-bar.ts"]);
+  expect(filterFiles(FILES, "render")).toEqual(["src/render/status-bar.ts"]);
+});
+
+test("filterFiles: basename-prefix matches rank ahead of mid-path matches", () => {
+  // "bar.ts" basename starts with "ba" (rank 0); "navbar.tsx" only contains it (rank 2)
+  expect(filterFiles(FILES, "ba")[0]).toBe("bar.ts");
+});
+
+test("renderFileMenu: marks the selected row; header echoes the @query", () => {
+  const items = filterFiles(FILES, "");
+  const out = renderFileMenu(items, 2, "", false);
+  const lines = out.split("\n");
+
+  expect(lines).toHaveLength(items.length + 1); // header + one row per file
+  expect(lines[0]?.startsWith("@")).toBe(true);
+  expect(lines[3]?.startsWith("›")).toBe(true); // selected index 2 → row line 3
+  expect(out).toContain("src/cli.ts");
+  expect(out).not.toContain(String.fromCharCode(27)); // color=false ⇒ no ANSI
+});
+
+test("renderFileMenu: empty result shows a 'no matching file' line", () => {
+  expect(renderFileMenu([], 0, "zzz", false)).toContain("no matching file");
+});
+
+test("shouldOpenAtPicker: fires at line start and after whitespace", () => {
+  expect(shouldOpenAtPicker("@", 1)).toBe(true);
+  expect(shouldOpenAtPicker("fix @", 5)).toBe(true);
+});
+
+test("shouldOpenAtPicker: does NOT fire inside a word (email / mid-token)", () => {
+  expect(shouldOpenAtPicker("ag@", 3)).toBe(false); // email-like, no boundary
+  expect(shouldOpenAtPicker("foo@", 4)).toBe(false);
+});
+
+test("shouldOpenAtPicker: false when the char before the cursor is not @", () => {
+  expect(shouldOpenAtPicker("@x", 2)).toBe(false); // cursor sits after a typed char
+});

--- a/packages/core/tests/file-menu.test.ts
+++ b/packages/core/tests/file-menu.test.ts
@@ -1,7 +1,8 @@
 import { test, expect } from "bun:test";
 import {
   filterFiles,
-  renderFileMenu,
+  formatCompletionRows,
+  truncatePath,
   shouldOpenAtPicker,
 } from "../src/render/file-menu";
 
@@ -13,12 +14,13 @@ const FILES = [
   "README.md",
 ];
 
-test("filterFiles: empty query returns all (capped to a screenful)", () => {
-  expect(filterFiles(FILES, "")).toEqual(FILES.slice(0, 50));
+test("filterFiles: empty query returns the caller's order, capped tight (8)", () => {
+  expect(filterFiles(FILES, "")).toEqual(FILES); // fewer than the cap ⇒ all, in order
 
-  const many = Array.from({ length: 60 }, (_, i) => `f${String(i)}.ts`);
+  const many = Array.from({ length: 30 }, (_, i) => `f${String(i)}.ts`);
 
-  expect(filterFiles(many, "")).toHaveLength(50);
+  expect(filterFiles(many, "")).toHaveLength(8); // a dropdown, not a whole-tree dump
+  expect(filterFiles(many, "")).toEqual(many.slice(0, 8)); // preserves input order
 });
 
 test("filterFiles: substring match is case-insensitive over the whole path", () => {
@@ -31,20 +33,39 @@ test("filterFiles: basename-prefix matches rank ahead of mid-path matches", () =
   expect(filterFiles(FILES, "ba")[0]).toBe("bar.ts");
 });
 
-test("renderFileMenu: marks the selected row; header echoes the @query", () => {
-  const items = filterFiles(FILES, "");
-  const out = renderFileMenu(items, 2, "", false);
-  const lines = out.split("\n");
-
-  expect(lines).toHaveLength(items.length + 1); // header + one row per file
-  expect(lines[0]?.startsWith("@")).toBe(true);
-  expect(lines[3]?.startsWith("›")).toBe(true); // selected index 2 → row line 3
-  expect(out).toContain("src/cli.ts");
-  expect(out).not.toContain(String.fromCharCode(27)); // color=false ⇒ no ANSI
+test("filterFiles: ties preserve caller order (recency), no alphabetical reshuffle", () => {
+  expect(filterFiles(["z/app.ts", "a/api.ts"], "a")).toEqual([
+    "z/app.ts",
+    "a/api.ts",
+  ]);
 });
 
-test("renderFileMenu: empty result shows a 'no matching file' line", () => {
-  expect(renderFileMenu([], 0, "zzz", false)).toContain("no matching file");
+test("truncatePath: keeps the tail (filename) with a leading ellipsis when clipped", () => {
+  expect(truncatePath("src/cli.ts", 40)).toBe("src/cli.ts"); // fits ⇒ unchanged
+  expect(truncatePath("packages/core/src/render/status-bar.ts", 12)).toBe(
+    "…atus-bar.ts" // exactly 12 cols: ellipsis + last 11 chars
+  );
+  expect(truncatePath("anything", 0)).toBe("");
+});
+
+test("formatCompletionRows: one truncated row per file; selected gutter; no wrap", () => {
+  const rows = formatCompletionRows(FILES, 1, 40, false);
+
+  expect(rows).toHaveLength(FILES.length);
+  expect(rows[1]?.startsWith("›")).toBe(true); // selected row marked
+
+  for (const r of rows) {
+    expect(r.length).toBeLessThanOrEqual(40); // never wider than the terminal
+  }
+
+  expect(rows.join("\n")).not.toContain(String.fromCharCode(27)); // color off ⇒ no ANSI
+});
+
+test("formatCompletionRows: empty list still shows a 'no matching file' row", () => {
+  const rows = formatCompletionRows([], 0, 40, false);
+
+  expect(rows).toHaveLength(1);
+  expect(rows[0]).toContain("no matching file");
 });
 
 test("shouldOpenAtPicker: fires at line start and after whitespace", () => {
@@ -53,10 +74,10 @@ test("shouldOpenAtPicker: fires at line start and after whitespace", () => {
 });
 
 test("shouldOpenAtPicker: does NOT fire inside a word (email / mid-token)", () => {
-  expect(shouldOpenAtPicker("ag@", 3)).toBe(false); // email-like, no boundary
+  expect(shouldOpenAtPicker("ag@", 3)).toBe(false);
   expect(shouldOpenAtPicker("foo@", 4)).toBe(false);
 });
 
 test("shouldOpenAtPicker: false when the char before the cursor is not @", () => {
-  expect(shouldOpenAtPicker("@x", 2)).toBe(false); // cursor sits after a typed char
+  expect(shouldOpenAtPicker("@x", 2)).toBe(false);
 });

--- a/packages/core/tests/list-workspace-files.test.ts
+++ b/packages/core/tests/list-workspace-files.test.ts
@@ -1,0 +1,28 @@
+import { test, expect, beforeAll, afterAll } from "bun:test";
+import { mkdtemp, rm, writeFile, utimes } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { listWorkspaceFiles } from "../src/lib/fs";
+
+let dir = "";
+
+beforeAll(async () => {
+  dir = await mkdtemp(join(tmpdir(), "tsforge-lwf-"));
+
+  // Write three files, then stamp distinct mtimes (oldest → newest).
+  for (const name of ["old.ts", "mid.ts", "new.ts"]) {
+    await writeFile(join(dir, name), "export const x = 1;\n");
+  }
+
+  await utimes(join(dir, "old.ts"), new Date(1_000), new Date(1_000));
+  await utimes(join(dir, "mid.ts"), new Date(2_000), new Date(2_000));
+  await utimes(join(dir, "new.ts"), new Date(3_000), new Date(3_000));
+});
+
+afterAll(async () => {
+  await rm(dir, { recursive: true, force: true });
+});
+
+test("listWorkspaceFiles: orders most-recently-modified first", async () => {
+  expect(await listWorkspaceFiles(dir)).toEqual(["new.ts", "mid.ts", "old.ts"]);
+});

--- a/packages/core/tests/status-bar.test.ts
+++ b/packages/core/tests/status-bar.test.ts
@@ -3,6 +3,7 @@ import {
   StatusBar,
   buildBarFrame,
   buildInputFrame,
+  buildOverlayFrame,
   type IStatusInfo,
   type IStatusBarTerminal,
 } from "../src/render";
@@ -288,5 +289,64 @@ describe("StatusBar with input row", () => {
     expect(out).toContain("\x1b[23;1H"); // border row cleared
     expect(out).toContain("\x1b[24;1H"); // segments row cleared
     expect(out).toContain("\x1b[?25h"); // show cursor
+  });
+});
+
+describe("buildOverlayFrame (@-picker dropdown)", () => {
+  test("paints rows bottom-aligned directly above the input row", () => {
+    // rows=24 ⇒ input row is 22; a 2-line popup sits on rows 20 and 21.
+    const frame = buildOverlayFrame(["a.ts", "b.ts"], 0, 24);
+
+    expect(frame).toContain("\x1b[20;1H\x1b[2Ka.ts");
+    expect(frame).toContain("\x1b[21;1H\x1b[2Kb.ts");
+    expect(frame).not.toContain("\x1b[22;1H"); // never touches the input row
+  });
+
+  test("a shrunk list clears the old top rows above the new ones", () => {
+    // Was 3 rows tall, now 1 ⇒ still operate over 3 rows; top 2 are cleared blank.
+    const frame = buildOverlayFrame(["only.ts"], 3, 24);
+
+    expect(frame).toContain("\x1b[19;1H\x1b[2K"); // cleared (old) row, no content
+    expect(frame).toContain("\x1b[20;1H\x1b[2K");
+    expect(frame).toContain("\x1b[21;1H\x1b[2Konly.ts"); // new row, bottom-aligned
+  });
+
+  test("clamps so it never addresses above row 1 on a short terminal", () => {
+    const frame = buildOverlayFrame(["x", "y", "z"], 0, 5); // input row = 3
+
+    expect(frame).not.toContain("\x1b[0;1H"); // never row 0 / negative
+    expect(frame).not.toContain("\x1b[-1;1H");
+    expect(frame).toContain("\x1b[1;1H"); // clamped to row 1
+  });
+});
+
+describe("StatusBar @-picker overlay", () => {
+  test("setOverlay paints the popup, then clearOverlay erases it", () => {
+    const term = new FakeTerm(true, 24, 80);
+    const bar = new StatusBar(term, true, false, true); // withInput
+
+    bar.install(INFO);
+    bar.setInput("explain @", 9);
+    term.writes.length = 0;
+
+    bar.setOverlay(["src/a.ts", "src/b.ts"], INFO);
+    expect(term.text()).toContain("src/a.ts");
+    expect(term.text()).toContain("\x1b[21;1H"); // popup row above the input row (22)
+
+    term.writes.length = 0;
+    bar.clearOverlay(INFO);
+    expect(term.text()).toContain("\x1b[20;1H\x1b[2K"); // old popup rows erased
+    expect(term.text()).toContain("\x1b[21;1H\x1b[2K");
+  });
+
+  test("setOverlay is a no-op without an input row (no inline surface)", () => {
+    const term = new FakeTerm(true, 24, 80);
+    const bar = new StatusBar(term, true, false, false); // no input row
+
+    bar.install(INFO);
+    term.writes.length = 0;
+    bar.setOverlay(["a.ts"], INFO);
+
+    expect(term.writes).toHaveLength(0);
   });
 });


### PR DESCRIPTION
Press `@` at a word boundary to open a compact **inline dropdown** above the input row (conversation stays visible, like the Claude Code `@` menu): recency-ordered workspace files, type to fuzzy-filter, Enter/Tab to select. The picked path is inserted after the `@`; at send time `@path` mentions expand to the file's contents (or a MAP when large) prepended to the message — no extra round-trip.

## Implementation
- `lib/fs`: `listWorkspaceFiles` (mtime-desc recency order)
- `render/file-menu`: `filterFiles` (cap 8, stable sort keeps recency on ties), `truncatePath`, `formatCompletionRows`, `pickFileInline` (inline, via `IPickerView` — no alternate screen), `shouldOpenAtPicker` boundary guard
- `render/status-bar`: `setOverlay`/`clearOverlay` + pure `buildOverlayFrame` paint a transient popup above the input row
- `loop/prompt/at-mention`: `parseAtPaths`/`resolveAtMentions`/`composeMessage`; boundary-anchored so `ag@host` / mid-word `@` don't match
- `cli`: `@` trigger beside `/` (gated on the input row); `runSend` expands mentions

History: the first cut was a full-screen alternate-screen dump and was reworked to this inline dropdown.

## Verification
Full `bun run validate` green: 1359 pass / 14 skip / 0 fail. Pure-builder + FakeTerm tests for the picker/overlay; flip-and-confirm-fail on overlay alignment, recency, `@`-strip, and boundary guard. Live-tested in a real terminal.