### PR TITLE
feat: loop evolution — accept-rate metrics, post-green review-repair, greenfield multi-role harness

### DIFF
--- a/apps/docs/astro.config.mjs
+++ b/apps/docs/astro.config.mjs
@@ -171,6 +171,7 @@ export default defineConfig({
             { label: "Set up a repo", link: "/cli/setup/" },
             { label: "Chat with your repo", link: "/cli/interactive/" },
             { label: "Drive a change to green", link: "/workflows/fix-to-green/" },
+            { label: "Build a whole app", link: "/loop/greenfield/" },
             { label: "Review your changes", link: "/cli/review/" },
             { label: "Recipes", link: "/cli/recipes/" },
             { label: "Pre-edit scout", link: "/loop/scout/" },

--- a/apps/docs/src/content/docs/cli/recipes.mdx
+++ b/apps/docs/src/content/docs/cli/recipes.mdx
@@ -51,6 +51,9 @@ A project recipe **overrides** a global one with the same id. `tsforge recipes` 
 | `policyMode` | `--policy-mode` | `plan` / `default` / `acceptEdits` / `ci` / `dontAsk` / `bypassPermissions` |
 | `base`, `staged` | `--base` / `--staged` | for review-style runs |
 | `scout` | `--scout` | seed a [pre-edit blast-radius scout](/loop/scout/) |
+| `withReview` | `--with-review` | after green, run the review and feed verified findings into one repair cycle |
+| `mode` | `--greenfield` | `"greenfield"` selects the [feature-checklist build loop](/loop/greenfield/) |
+| `plannerModel`, `workModel`, `evaluatorModel` | greenfield roles | per-role model names; each falls back to `model`/active |
 | `web`, `plan`, `log`, `strictFloorOnly` | the matching flags | booleans |
 
 A recipe is, in effect, a saved set of CLI options: `tsforge run <id>` applies them, and you can also combine `--recipe <id>` with other commands (e.g. `tsforge review --recipe …`). **An explicit CLI flag always wins** over the recipe, so `tsforge run api-endpoint --files lib/**` overrides just the scope.

--- a/apps/docs/src/content/docs/loop/greenfield.mdx
+++ b/apps/docs/src/content/docs/loop/greenfield.mdx
@@ -1,0 +1,71 @@
+---
+title: Greenfield builds
+description: Build a whole app feature-by-feature with a filesystem-tracked checklist, a planner/generator/evaluator split, and the same gate + browser + judge verification used everywhere else.
+---
+
+Most of tsforge drives **one change to green**. Greenfield mode drives a **whole build to green**, one feature at a time, keeping its state on disk so a long run can be interrupted and resumed without losing the plot.
+
+```bash
+tsforge --greenfield "build a kanban board" --accept "bun run build"
+```
+
+## How it works
+
+1. **Plan** — a planner model turns your one-line goal into a high-level spec and a flat feature checklist (sprints, not file-level steps). Written to `.tsforge/greenfield/`.
+2. **Loop** — for the first unfinished feature: the work model implements it, then the **layered evaluator** verifies it. On success the feature is ticked; the loop moves on.
+3. **Stop** — when every feature is verified (`done`), or a single feature exhausts its attempts (`stuck`) so a non-converging feature can't wedge the whole build.
+
+The state lives in the repo, not the model's context:
+
+| File | Purpose |
+| --- | --- |
+| `.tsforge/greenfield/spec.md` | The planner's high-level spec |
+| `.tsforge/greenfield/features.json` | The checklist (`{id, desc, passes, attempts}`) — the source of truth |
+| `.tsforge/greenfield/progress.md` | Human-readable status |
+
+Because `features.json` is the source of truth, re-running the same command **resumes** from the last verified feature.
+
+## The layered evaluator
+
+Each feature passes only if all three layers agree, checked cheapest-first and short-circuiting on the first failure:
+
+1. **Gate** — the deterministic build gate (`--accept`: tsc / eslint / tests, and the browser smoke that the web gate already runs). The authority for "done".
+2. **Browser** — optional per-feature interaction steps via the Playwright oracle (skipped gracefully when Playwright isn't installed, so it never blocks).
+3. **Judge** — a harsh, reject-by-default quality review that sees **only the built code**, never how it was produced.
+
+That last point is a deliberate rule: the evaluator never sees the generator's reasoning or tool trace, so it judges the result, not the persuasion behind it.
+
+## Role-based model routing
+
+Each role can run on its own model (names from your [models.json](/inference/models-json/)); any role left unset falls back to the active model, so a single-endpoint setup still works:
+
+```json
+{
+  "id": "kanban",
+  "mode": "greenfield",
+  "gate": "bun run build",
+  "plannerModel": "big-thinker",
+  "workModel": "fast-coder",
+  "evaluatorModel": "harsh-judge"
+}
+```
+
+```bash
+tsforge run kanban "build a kanban board"
+```
+
+## Contract negotiation (experimental)
+
+Set `TSFORGE_CONTRACT=1` to make the generator and evaluator agree a **build contract** for each feature *before* building — the generator proposes "I'll build X, verified by Y" and the evaluator pushes back until it's concrete. The agreed contract then anchors the implementation, and the negotiation is saved to `.tsforge/greenfield/contracts/<feature>.md`. Off by default — it's unproven and adds model calls.
+
+## Unattended runs & scheduling
+
+Greenfield runs are long and headless-friendly. There's no built-in scheduler — wire one with your OS:
+
+```bash
+# nightly build attempt, pinging you when it finishes or gets stuck
+0 2 * * *  tsforge run kanban "build a kanban board" \
+             --log --notify 'curl -s "$WEBHOOK?status=$TSFORGE_STATUS"'
+```
+
+`--notify <cmd>` runs a shell command on completion with the outcome in `$TSFORGE_STATUS` (e.g. `greenfield done 7/7` or `greenfield stuck 3/7`). It's best-effort: a failing notifier never changes the run's exit code. Pair it with `--log` and [`tsforge trace`](/observability/trace/) to inspect what happened.

--- a/apps/docs/src/content/docs/observability/trace.mdx
+++ b/apps/docs/src/content/docs/observability/trace.mdx
@@ -27,6 +27,8 @@ model calls        1
 tokens out         380
 peak context       4200 (13% of 32000)
 edits/creates      1 (0 created)
+accept rate        100% (0 reverted)
+cost/accepted      380 tok
 gate runs          1
 policy denials     1 (1 high)
 policy asks        0
@@ -39,6 +41,7 @@ wall clock         0s
 | `turns` / `turns to green` | repair iterations, and how many it took to first pass the gate (lower is better) |
 | `model calls` / `tokens out` / `peak context` | call count, completion tokens, and the context high-water mark |
 | `edits/creates` / `gate runs` | file mutations and how many times the gate ran |
+| `accept rate` / `cost/accepted` | share of edits that stuck (vs were reverted), and completion tokens per durable change — tokens mean little if most edits get reverted |
 | `policy denials` / `policy asks` | [action-policy](/guardrails/config/) verdicts that blocked or paused an action, denials bucketed by risk |
 
 ## The `--log` ledger

--- a/apps/docs/src/content/docs/reference/commands.mdx
+++ b/apps/docs/src/content/docs/reference/commands.mdx
@@ -55,6 +55,23 @@ tsforge run api-endpoint --files lib/**  # ...with a CLI override (CLI wins)
 
 A recipe is declarative JSON in `.tsforge/recipes/<id>.json` (project) or `~/.tsforge/recipes/<id>.json` (global) that composes a run's options — model, gate, scope, limits, policy mode. See [Recipes](/cli/recipes/).
 
+## Build a whole app (greenfield)
+
+```bash
+tsforge --greenfield "build a kanban board" --accept "bun run build"
+tsforge --greenfield "..." --notify 'curl -s "$WEBHOOK?s=$TSFORGE_STATUS"'
+```
+
+`--greenfield` (or a recipe with `mode: "greenfield"`) plans a feature checklist and drives it to all-green one feature at a time, persisting state under `.tsforge/greenfield/` so a long run resumes. Each feature is verified by the gate, the browser oracle, and a reject-by-default judge. `--notify <cmd>` runs a shell command on completion with the outcome in `$TSFORGE_STATUS`. See [Greenfield builds](/loop/greenfield/).
+
+## Drive one change, then review it
+
+```bash
+tsforge "fix the off-by-one in paginate" --accept "bun test" --with-review
+```
+
+`--with-review` runs the functional review **after** the gate goes green and feeds any verified findings into a single repair pass, reverting it if it breaks the gate. Also a recipe field (`withReview`).
+
 ## Map the repo to prime the agent
 
 ```bash
@@ -72,7 +89,7 @@ tsforge trace            # summarize the newest --log run
 tsforge trace run.jsonl  # a specific log file
 ```
 
-`tsforge trace` (or `/trace` in a session) reads a `--log` ledger and prints a one-screen summary — model/tool calls, **policy decisions** (allow/ask/deny by risk), gate verdicts, and turns-to-green — deterministically, with no model call. See [Trace a run](/observability/trace/).
+`tsforge trace` (or `/trace` in a session) reads a `--log` ledger and prints a one-screen summary — model/tool calls, **policy decisions** (allow/ask/deny by risk), gate verdicts, turns-to-green, and the **accept rate / cost-per-accepted-change** (how many edits stuck vs were reverted) — deterministically, with no model call. See [Trace a run](/observability/trace/).
 
 ## Merge gate (repo root)
 

--- a/apps/docs/src/content/docs/reference/flags.mdx
+++ b/apps/docs/src/content/docs/reference/flags.mdx
@@ -17,6 +17,7 @@ description: Canonical list of every TSFORGE_* environment variable.
 | `TSFORGE_SIMPLICITY` | off | shortest-solution guidance, scratch non-web (`=1`) |
 | `TSFORGE_TDD` | ON (`≠ "0"`) | test-first guidance + `test-sibling-required` is an error on changed logic files (`=0` to opt out) |
 | `TSFORGE_WEB` | off | free, local web access — the `web_fetch` + `web_search` tools (`=1`) |
+| `TSFORGE_CONTRACT` | off | experimental per-feature [contract negotiation](/loop/greenfield/) in greenfield builds (`=1`) |
 | `TSFORGE_NO_UPDATE_CHECK` | off | silence the startup "update available" check (`=1`) |
 | `TSFORGE_NO_GIT_TOOL` | off | withhold the `git_context` tool (`=1`) |
 

--- a/packages/core/src/cli.ts
+++ b/packages/core/src/cli.ts
@@ -31,6 +31,9 @@ import {
   evaluateFeature,
   planFeatures,
   judgeFeature,
+  negotiateContract,
+  writeContract,
+  contractEnabled,
   type IFeature,
   type IGreenfieldDeps,
   type Reporter,
@@ -2011,9 +2014,37 @@ function greenfieldDeps(
     context: [],
   });
 
+  // Optional pre-build contract negotiation (EXPERIMENTAL, gated by
+  // TSFORGE_CONTRACT). When on, the generator + evaluator agree a contract first
+  // and it anchors the implement prompt.
+  const contractPrefix = async (feature: IFeature): Promise<string> => {
+    if (!contractEnabled()) {
+      return "";
+    }
+
+    const result = await negotiateContract(work, evaluator, feature);
+
+    await writeContract(args.dir, feature, result);
+    report({
+      kind: "fix",
+      task: "greenfield",
+      message: `contract '${feature.id}': ${result.agreed ? "agreed" : "no agreement"} after ${result.rounds} round(s)`,
+    });
+
+    return `Agreed build contract:\n${result.contract}\n\n`;
+  };
+
   return {
     implement: async (feature) => {
-      await runTask(featureTask(feature), args.dir, work, { onEvent: report });
+      const prefix = await contractPrefix(feature);
+      const base = featureTask(feature);
+
+      await runTask(
+        { ...base, intent: `${prefix}${base.intent ?? ""}` },
+        args.dir,
+        work,
+        { onEvent: report }
+      );
     },
     evaluate: (feature) =>
       evaluateFeature(feature, {
@@ -2042,6 +2073,27 @@ function greenfieldDeps(
           }),
       }),
   };
+}
+
+/** Run the `--notify` shell command (if any) with the run outcome in
+ *  $TSFORGE_STATUS — a ping for unattended/cron runs. Best-effort: a failing or
+ *  missing notifier never changes the run's exit code. */
+async function runNotify(cmd: string, status: string): Promise<void> {
+  if (cmd.length === 0) {
+    return;
+  }
+
+  try {
+    const proc = Bun.spawn(["sh", "-c", cmd], {
+      env: { ...process.env, TSFORGE_STATUS: status },
+      stdout: "inherit",
+      stderr: "inherit",
+    });
+
+    await proc.exited;
+  } catch {
+    // A broken notifier must not break the run.
+  }
 }
 
 /** `tsforge --greenfield "<goal>"` / a recipe with `mode: "greenfield"`: plan a
@@ -2101,6 +2153,11 @@ async function greenfieldMode(args: ICliArgs): Promise<number> {
 
   process.stdout.write(
     `\n${result.status === "done" ? "✓ all features verified" : `✗ stuck on '${result.stuckFeature ?? "?"}'`} (${done}/${result.features.length})\n`
+  );
+
+  await runNotify(
+    args.notify,
+    `greenfield ${result.status} ${done}/${result.features.length}`
   );
 
   return result.status === "done" ? 0 : 1;

--- a/packages/core/src/cli.ts
+++ b/packages/core/src/cli.ts
@@ -2031,8 +2031,20 @@ function greenfieldDeps(
       message: `contract '${feature.id}': ${result.agreed ? "agreed" : "no agreement"} after ${result.rounds} round(s)`,
     });
 
-    return `Agreed build contract:\n${result.contract}\n\n`;
+    // Don't claim agreement the negotiation didn't reach — an unagreed contract
+    // is the generator's best proposal, labelled honestly so the build prompt
+    // doesn't assert a safety guarantee that isn't there.
+    const heading = result.agreed
+      ? "Agreed build contract"
+      : "Proposed build contract (negotiation did not converge)";
+
+    return `${heading}:\n${result.contract}\n\n`;
   };
+
+  const thinkingTokenBudget =
+    args.thinkingBudget > 0
+      ? args.thinkingBudget
+      : envNumber("TSFORGE_THINKING_BUDGET");
 
   return {
     implement: async (feature) => {
@@ -2043,7 +2055,14 @@ function greenfieldDeps(
         { ...base, intent: `${prefix}${base.intent ?? ""}` },
         args.dir,
         work,
-        { onEvent: report }
+        {
+          onEvent: report,
+          // The global gate is often already green between features, so don't
+          // bail RED-first — the model must still build this feature.
+          requireRed: false,
+          ...(thinkingTokenBudget === undefined ? {} : { thinkingTokenBudget }),
+          ...(args.maxTurns > 0 ? { maxTurns: args.maxTurns } : {}),
+        }
       );
     },
     evaluate: (feature) =>
@@ -2118,13 +2137,19 @@ async function greenfieldMode(args: ICliArgs): Promise<number> {
     return 1;
   }
 
-  const workName = args.workModel.length > 0 ? args.workModel : args.model;
+  // Each role falls back to the recipe's `model` (then the active model), per the
+  // recipe contract — a recipe that sets only `model` must route ALL roles there,
+  // not just the work role.
+  const roleName = (specific: string): string =>
+    specific.length > 0 ? specific : args.model;
   const planner = makeProvider(
-    (await resolveModelByName(args.plannerModel)).entry
+    (await resolveModelByName(roleName(args.plannerModel))).entry
   );
-  const work = makeProvider((await resolveModelByName(workName)).entry);
+  const work = makeProvider(
+    (await resolveModelByName(roleName(args.workModel))).entry
+  );
   const evaluator = makeProvider(
-    (await resolveModelByName(args.evaluatorModel)).entry
+    (await resolveModelByName(roleName(args.evaluatorModel))).entry
   );
 
   const state = await prepareState(args.dir, args.task, (goal) =>

--- a/packages/core/src/cli.ts
+++ b/packages/core/src/cli.ts
@@ -13,7 +13,8 @@ import {
   shouldOpenAtPicker,
   type IPickerView,
 } from "./render/file-menu";
-import { listWorkspaceFiles } from "./lib/fs";
+import { listWorkspaceFiles, readFiles } from "./lib/fs";
+import { renderCheck } from "./browser";
 import { composeMessage } from "./loop/prompt";
 import {
   runTask,
@@ -25,6 +26,15 @@ import {
   reviewChange,
   reviewRepair,
   formatReport,
+  runGreenfield,
+  prepareState,
+  evaluateFeature,
+  planFeatures,
+  judgeFeature,
+  type IFeature,
+  type IGreenfieldDeps,
+  type Reporter,
+  type SetupWebFn,
 } from "./loop";
 import { modelAgent } from "./agent";
 import { buildAndPersistMap, mapStatus, forgetMap } from "./codebase";
@@ -49,6 +59,7 @@ import {
 } from "./inference";
 import {
   resolveActiveModel,
+  resolveModelByName,
   setActiveModel,
   loadModelsConfig,
   resolveApiKey,
@@ -66,7 +77,6 @@ import {
   type IStatusInfo,
 } from "./render";
 import type { ITask } from "./spec";
-import type { Reporter, SetupWebFn } from "./loop";
 import { loadLedger, activeRules, forgetMemory } from "./loop/memory";
 import {
   buildGate,
@@ -1972,6 +1982,130 @@ async function traceMode(args: ICliArgs): Promise<number> {
   return runTraceCommand(args.task);
 }
 
+/** Concatenate the editable scope into a single, size-capped code window for the
+ *  feature judge — the BUILT ARTIFACT only (design-rule #2: no tool trace). */
+async function scopeCode(dir: string, files: string[]): Promise<string> {
+  const views = await readFiles(dir, files);
+  const joined = views.map((v) => `// ${v.path}\n${v.content}`).join("\n\n");
+  const CAP = 16000;
+
+  return joined.length > CAP ? `${joined.slice(0, CAP)}\n…[truncated]` : joined;
+}
+
+/** Build the greenfield deps: implement one feature with the work model (reusing
+ *  the headless runTask driver against the build gate), then evaluate it through
+ *  the layered stack — deterministic gate, optional browser steps, reject-by-
+ *  default judge on the EVALUATOR model (which only ever sees the built code). */
+function greenfieldDeps(
+  args: ICliArgs,
+  work: OpenAICompatibleProvider,
+  evaluator: OpenAICompatibleProvider,
+  scope: string[],
+  report: Reporter
+): IGreenfieldDeps {
+  const featureTask = (feature: IFeature): ITask => ({
+    id: feature.id,
+    intent: `${args.task}\n\nImplement this feature: ${feature.desc}`,
+    accept: args.accept,
+    files: scope,
+    context: [],
+  });
+
+  return {
+    implement: async (feature) => {
+      await runTask(featureTask(feature), args.dir, work, { onEvent: report });
+    },
+    evaluate: (feature) =>
+      evaluateFeature(feature, {
+        gate: async () => {
+          const v = await validate(featureTask(feature), args.dir);
+
+          return { passed: v.passed, output: v.output };
+        },
+        // The browser layer runs the feature's steps only when a render target
+        // (`--browser <html>`) is configured; otherwise it's a no-op skip (the
+        // build gate already browser-smokes web apps).
+        browser: async () =>
+          args.browser.length > 0
+            ? renderCheck({
+                file: args.browser,
+                smoke: true,
+                ...(feature.steps === undefined
+                  ? {}
+                  : { steps: feature.steps }),
+              })
+            : { ok: true, errors: [], skipped: true },
+        judge: async () =>
+          judgeFeature(evaluator, {
+            feature: feature.desc,
+            code: await scopeCode(args.dir, scope),
+          }),
+      }),
+  };
+}
+
+/** `tsforge --greenfield "<goal>"` / a recipe with `mode: "greenfield"`: plan a
+ *  feature checklist (planner model), then drive it to all-green one feature at a
+ *  time on the existing gate + browser + judge stack, persisting state so a long
+ *  run resumes. Roles route to separate models when configured, else all share
+ *  the active model. */
+async function greenfieldMode(args: ICliArgs): Promise<number> {
+  if (args.task.length === 0) {
+    process.stdout.write(
+      'missing build goal — usage: tsforge --greenfield "build a kanban app"\n'
+    );
+
+    return 1;
+  }
+
+  if (args.accept.length === 0) {
+    process.stdout.write(
+      "greenfield needs a build gate — pass --accept '<cmd>' or set `gate` in the recipe\n"
+    );
+
+    return 1;
+  }
+
+  const workName = args.workModel.length > 0 ? args.workModel : args.model;
+  const planner = makeProvider(
+    (await resolveModelByName(args.plannerModel)).entry
+  );
+  const work = makeProvider((await resolveModelByName(workName)).entry);
+  const evaluator = makeProvider(
+    (await resolveModelByName(args.evaluatorModel)).entry
+  );
+
+  const state = await prepareState(args.dir, args.task, (goal) =>
+    planFeatures(planner, goal)
+  );
+
+  if (state === null) {
+    process.stdout.write("planner produced no features — nothing to build\n");
+
+    return 1;
+  }
+
+  const report = makeReporter(
+    resolveLogPath("greenfield", args.log),
+    "greenfield"
+  );
+  const scope = scopeOf(args);
+  const result = await runGreenfield(
+    args.dir,
+    state,
+    greenfieldDeps(args, work, evaluator, scope, report),
+    { onEvent: report }
+  );
+
+  const done = result.features.filter((f) => f.passes).length;
+
+  process.stdout.write(
+    `\n${result.status === "done" ? "✓ all features verified" : `✗ stuck on '${result.stuckFeature ?? "?"}'`} (${done}/${result.features.length})\n`
+  );
+
+  return result.status === "done" ? 0 : 1;
+}
+
 export async function main(): Promise<number> {
   const args = parseArgs(process.argv.slice(2));
 
@@ -2009,6 +2143,10 @@ export async function main(): Promise<number> {
 
   if (args.setup) {
     return setupMode(args);
+  }
+
+  if (args.greenfield) {
+    return greenfieldMode(args);
   }
 
   // A positional task with a scope + gate ⇒ one-shot; otherwise interactive.

--- a/packages/core/src/cli.ts
+++ b/packages/core/src/cli.ts
@@ -23,8 +23,10 @@ import {
   ledgerTypeFor,
   PLAN_APPROVED_NOTE,
   reviewChange,
+  reviewRepair,
   formatReport,
 } from "./loop";
+import { modelAgent } from "./agent";
 import { buildAndPersistMap, mapStatus, forgetMap } from "./codebase";
 import { parseEventLog, formatTrace } from "./eval";
 import { loadRecipes, findRecipe } from "./config/recipes";
@@ -519,8 +521,10 @@ async function runOnce(args: ICliArgs): Promise<number> {
       ? args.thinkingBudget
       : envNumber("TSFORGE_THINKING_BUDGET");
   const { entry } = await modelForRun(args);
-  const result = await runTask(task, args.dir, makeProvider(entry), {
-    onEvent: makeReporter(logFile, "cli"),
+  const provider = makeProvider(entry);
+  const report = makeReporter(logFile, "cli");
+  const result = await runTask(task, args.dir, provider, {
+    onEvent: report,
     ...(thinkingTokenBudget === undefined ? {} : { thinkingTokenBudget }),
     ...(args.maxTurns > 0 ? { maxTurns: args.maxTurns } : {}),
     ...(args.scout ? { scout: true } : {}),
@@ -530,6 +534,15 @@ async function runOnce(args: ICliArgs): Promise<number> {
   process.stdout.write(
     `\n${ok ? "✓ done" : `✗ ${result.status}`} in ${String(result.cycles)} turn(s)\n`
   );
+
+  // Optional post-green adversarial review + one repair cycle (reverts if it
+  // breaks the gate). Only meaningful once the task is actually green.
+  if (ok && args.withReview) {
+    await reviewRepair(provider, args.dir, task, modelAgent(provider), {
+      ...(args.base.length > 0 ? { base: args.base } : {}),
+      onEvent: report,
+    });
+  }
 
   return ok ? 0 : 1;
 }

--- a/packages/core/src/cli/args.ts
+++ b/packages/core/src/cli/args.ts
@@ -46,6 +46,9 @@ export interface ICliArgs {
   /** Seed a brownfield run with a deterministic caller blast-radius scout
    *  (`--scout`). */
   scout: boolean;
+  /** Run the greenfield feature-checklist outer loop (`--greenfield`, or a recipe
+   *  with `mode: "greenfield"`). `task` carries the one-line build goal. */
+  greenfield: boolean;
   /** Explicit base ref to diff against for review (`--base <ref>`). */
   base: string;
   /** Build a structural workspace map (`tsforge map`). */
@@ -61,6 +64,10 @@ export interface ICliArgs {
   run: boolean;
   /** Model name override (from a recipe); "" = the active model. */
   model: string;
+  /** Greenfield role models (from a recipe); "" = fall back to `model`/active. */
+  plannerModel: string;
+  workModel: string;
+  evaluatorModel: string;
   /** Hard turn cap (from a recipe); 0 = the loop default. */
   maxTurns: number;
   /** Reasoning-token cap (from a recipe); 0 = the env/default. */
@@ -88,6 +95,7 @@ const BOOL_FLAGS: Record<
   | "withGate"
   | "withReview"
   | "scout"
+  | "greenfield"
   | "setupYes"
 > = {
   "--continue": "continue",
@@ -101,6 +109,7 @@ const BOOL_FLAGS: Record<
   "--with-gate": "withGate",
   "--with-review": "withReview",
   "--scout": "scout",
+  "--greenfield": "greenfield",
   "--yes": "setupYes",
 };
 
@@ -137,6 +146,7 @@ export function parseArgs(argv: readonly string[]): ICliArgs {
     withGate: false,
     withReview: false,
     scout: false,
+    greenfield: false,
     base: "",
     map: false,
     trace: false,
@@ -144,6 +154,9 @@ export function parseArgs(argv: readonly string[]): ICliArgs {
     recipes: false,
     run: false,
     model: "",
+    plannerModel: "",
+    workModel: "",
+    evaluatorModel: "",
     maxTurns: 0,
     thinkingBudget: 0,
     policyMode: "",
@@ -243,6 +256,8 @@ export function applyRecipe(args: ICliArgs, recipe: ITaskRecipe): void {
     args.model = recipe.model;
   }
 
+  applyRecipeModels(args, recipe);
+
   if (args.base.length === 0 && recipe.base !== undefined) {
     args.base = recipe.base;
   }
@@ -262,6 +277,22 @@ export function applyRecipe(args: ICliArgs, recipe: ITaskRecipe): void {
   applyRecipeFlags(args, recipe);
 }
 
+/** Recipe greenfield role models (split out to keep applyRecipe's complexity in
+ *  check). A recipe only fills a role still at its default. */
+function applyRecipeModels(args: ICliArgs, recipe: ITaskRecipe): void {
+  if (args.plannerModel.length === 0 && recipe.plannerModel !== undefined) {
+    args.plannerModel = recipe.plannerModel;
+  }
+
+  if (args.workModel.length === 0 && recipe.workModel !== undefined) {
+    args.workModel = recipe.workModel;
+  }
+
+  if (args.evaluatorModel.length === 0 && recipe.evaluatorModel !== undefined) {
+    args.evaluatorModel = recipe.evaluatorModel;
+  }
+}
+
 /** Recipe booleans (split out to keep applyRecipe's complexity in check). */
 function applyRecipeFlags(args: ICliArgs, recipe: ITaskRecipe): void {
   args.staged = args.staged || recipe.staged === true;
@@ -273,6 +304,7 @@ function applyRecipeFlags(args: ICliArgs, recipe: ITaskRecipe): void {
   args.withGate = args.withGate || recipe.withGate === true;
   args.withReview = args.withReview || recipe.withReview === true;
   args.scout = args.scout || recipe.scout === true;
+  args.greenfield = args.greenfield || recipe.mode === "greenfield";
 }
 
 // Default editable scope: the whole workspace — like any agentic CLI, the agent

--- a/packages/core/src/cli/args.ts
+++ b/packages/core/src/cli/args.ts
@@ -49,6 +49,9 @@ export interface ICliArgs {
   /** Run the greenfield feature-checklist outer loop (`--greenfield`, or a recipe
    *  with `mode: "greenfield"`). `task` carries the one-line build goal. */
   greenfield: boolean;
+  /** Shell command to run on completion of an unattended run (`--notify <cmd>`),
+   *  with the outcome in $TSFORGE_STATUS. "" = no notification. */
+  notify: string;
   /** Explicit base ref to diff against for review (`--base <ref>`). */
   base: string;
   /** Build a structural workspace map (`tsforge map`). */
@@ -123,6 +126,7 @@ const VALUE_FLAGS = new Set([
   "--base",
   "--policy-mode",
   "--recipe",
+  "--notify",
 ]);
 
 /** Parse argv (without the tsforge binary name). Always succeeds — mode is decided in main. */
@@ -147,6 +151,7 @@ export function parseArgs(argv: readonly string[]): ICliArgs {
     withReview: false,
     scout: false,
     greenfield: false,
+    notify: "",
     base: "",
     map: false,
     trace: false,
@@ -230,6 +235,8 @@ function applyValueFlag(flag: string, value: string, out: ICliArgs): void {
     out.policyMode = value;
   } else if (flag === "--recipe") {
     out.recipe = value;
+  } else if (flag === "--notify") {
+    out.notify = value;
   } else {
     out.accept = value; // --accept / --gate
   }

--- a/packages/core/src/cli/args.ts
+++ b/packages/core/src/cli/args.ts
@@ -39,6 +39,10 @@ export interface ICliArgs {
   /** Run the gate first and tell the reviewer to skip what it already covers
    *  (`tsforge review --with-gate`). */
   withGate: boolean;
+  /** After a one-shot run goes green, run the adversarial review and feed verified
+   *  findings into ONE repair cycle, reverting it if it breaks the gate
+   *  (`--with-review`). */
+  withReview: boolean;
   /** Seed a brownfield run with a deterministic caller blast-radius scout
    *  (`--scout`). */
   scout: boolean;
@@ -82,6 +86,7 @@ const BOOL_FLAGS: Record<
   | "strictFloorOnly"
   | "staged"
   | "withGate"
+  | "withReview"
   | "scout"
   | "setupYes"
 > = {
@@ -94,6 +99,7 @@ const BOOL_FLAGS: Record<
   "--strict-floor-only": "strictFloorOnly",
   "--staged": "staged",
   "--with-gate": "withGate",
+  "--with-review": "withReview",
   "--scout": "scout",
   "--yes": "setupYes",
 };
@@ -129,6 +135,7 @@ export function parseArgs(argv: readonly string[]): ICliArgs {
     review: false,
     staged: false,
     withGate: false,
+    withReview: false,
     scout: false,
     base: "",
     map: false,
@@ -264,6 +271,7 @@ function applyRecipeFlags(args: ICliArgs, recipe: ITaskRecipe): void {
   args.plan = args.plan || recipe.plan === true;
   args.log = args.log || recipe.log === true;
   args.withGate = args.withGate || recipe.withGate === true;
+  args.withReview = args.withReview || recipe.withReview === true;
   args.scout = args.scout || recipe.scout === true;
 }
 

--- a/packages/core/src/config/recipes.ts
+++ b/packages/core/src/config/recipes.ts
@@ -46,6 +46,9 @@ export interface ITaskRecipe {
   readonly log?: boolean;
   /** Run a gate-aware functional review after green (→ `review --with-gate`). */
   readonly withGate?: boolean;
+  /** After green, run the adversarial review and feed verified findings into ONE
+   *  repair cycle (revert if it breaks the gate) (→ `--with-review`). */
+  readonly withReview?: boolean;
   /** Seed a deterministic pre-edit caller blast-radius scout (→ `--scout`). */
   readonly scout?: boolean;
 }
@@ -107,6 +110,7 @@ function assignFlags(recipe: Mutable, raw: Record<string, unknown>): void {
   recipe.plan = optBool(raw.plan);
   recipe.log = optBool(raw.log);
   recipe.withGate = optBool(raw.withGate);
+  recipe.withReview = optBool(raw.withReview);
   recipe.scout = optBool(raw.scout);
 }
 
@@ -132,6 +136,7 @@ const KNOWN_KEYS = new Set<string>([
   "plan",
   "log",
   "withGate",
+  "withReview",
   "scout",
 ]);
 

--- a/packages/core/src/config/recipes.ts
+++ b/packages/core/src/config/recipes.ts
@@ -51,6 +51,10 @@ export interface ITaskRecipe {
   readonly withReview?: boolean;
   /** Seed a deterministic pre-edit caller blast-radius scout (→ `--scout`). */
   readonly scout?: boolean;
+  /** Run mode. `"greenfield"` selects the feature-checklist outer loop
+   *  (`runGreenfield`) instead of the default single-task loop. Omitted ⇒ the
+   *  normal brownfield/one-shot run. */
+  readonly mode?: "greenfield";
 }
 
 function optString(value: unknown): string | undefined {
@@ -100,6 +104,10 @@ function assignScalars(recipe: Mutable, raw: Record<string, unknown>): void {
   if (isPolicyMode(raw.policyMode)) {
     recipe.policyMode = raw.policyMode;
   }
+
+  if (raw.mode === "greenfield") {
+    recipe.mode = raw.mode;
+  }
 }
 
 /** Assign the optional boolean flags onto a recipe under construction. */
@@ -138,6 +146,7 @@ const KNOWN_KEYS = new Set<string>([
   "withGate",
   "withReview",
   "scout",
+  "mode",
 ]);
 
 /** Keys present in the raw recipe that this version doesn't recognize. */

--- a/packages/core/src/config/recipes.ts
+++ b/packages/core/src/config/recipes.ts
@@ -26,6 +26,13 @@ export interface ITaskRecipe {
   readonly gate?: string;
   /** A configured model name from `~/.tsforge/models.json` (→ the run's model). */
   readonly model?: string;
+  /** Greenfield role models (names from `~/.tsforge/models.json`). Each defaults
+   *  to `model`/the active model when unset, so single-endpoint setups still work
+   *  (same model, different role prompts). The evaluator stays trace-blind
+   *  regardless of which model backs it. */
+  readonly plannerModel?: string;
+  readonly workModel?: string;
+  readonly evaluatorModel?: string;
   /** Hard cap on model turns (→ run option `maxTurns`). */
   readonly maxTurns?: number;
   /** Reasoning-token cap per call (→ run option `thinkingTokenBudget`). */
@@ -96,6 +103,9 @@ function assignScalars(recipe: Mutable, raw: Record<string, unknown>): void {
   recipe.task = optString(raw.task);
   recipe.gate = optString(raw.gate);
   recipe.model = optString(raw.model);
+  recipe.plannerModel = optString(raw.plannerModel);
+  recipe.workModel = optString(raw.workModel);
+  recipe.evaluatorModel = optString(raw.evaluatorModel);
   recipe.base = optString(raw.base);
   recipe.files = stringArray(raw.files);
   recipe.maxTurns = optPositive(raw.maxTurns);
@@ -134,6 +144,9 @@ const KNOWN_KEYS = new Set<string>([
   "files",
   "gate",
   "model",
+  "plannerModel",
+  "workModel",
+  "evaluatorModel",
   "maxTurns",
   "thinkingBudget",
   "policyMode",

--- a/packages/core/src/eval/index.ts
+++ b/packages/core/src/eval/index.ts
@@ -1,5 +1,5 @@
 export * from "./eval.types";
-export { judge } from "./judge";
+export { judge, JUDGE_INPUT_SHAPE } from "./judge";
 export { summarize } from "./score";
 export { countLoc, countTaskLoc, type ITaskLoc } from "./loc";
 export { analyzeEvents, type IRunMetrics } from "./metrics";

--- a/packages/core/src/eval/judge.ts
+++ b/packages/core/src/eval/judge.ts
@@ -8,6 +8,24 @@ import { extractJson } from "../lib/json";
  * judge. Provider-agnostic: point it at a flagship model to measure the local
  * model's gap to flagship quality.
  */
+/**
+ * Every field the quality judge is allowed to see — built from the BUILT ARTIFACT
+ * only (goal, acceptance criteria, code), never the generator's tool trace,
+ * reasoning, or message history. This is design-rule #2 from the long-running-agent
+ * workshop: the evaluator must not see HOW the code was produced, only WHAT was
+ * produced, or it can be talked into approving by a persuasive trace.
+ *
+ * Typed `Record<keyof IJudgeInput, true>` so the list is FORCED to track the
+ * interface: adding a field to IJudgeInput is a compile error until it's listed
+ * here, where the trace-blindness test (judge.test.ts) rejects any trace-ish name.
+ * That makes the rule a ratchet, not a comment.
+ */
+export const JUDGE_INPUT_SHAPE: Record<keyof IJudgeInput, true> = {
+  goal: true,
+  criteria: true,
+  code: true,
+};
+
 const SYSTEM =
   "You are a senior TypeScript reviewer. Score the solution 1–5 on each of: " +
   "correctness/robustness (beyond the given tests), design, and readability/idiomatic TS. " +

--- a/packages/core/src/eval/metrics.ts
+++ b/packages/core/src/eval/metrics.ts
@@ -21,6 +21,16 @@ export interface IRunMetrics {
   peakContext: number;
   /** File mutations (`edit` + `create`). */
   edits: number;
+  /** Edit batches rolled back (`reverted` events) — gate-break or no quality gain.
+   *  Spent but never accepted; the numerator of wasted edit effort. */
+  editsReverted: number;
+  /** Share of mutations that stuck: (edits − editsReverted) / edits, in [0,1];
+   *  0 when there were no edits. The article's hidden trap — tokens mean nothing
+   *  if most edits get reverted. */
+  acceptRate: number;
+  /** Total completion tokens per edit that STAYED (tokensOut / net-accepted);
+   *  0 when nothing was accepted. Cost of one durable change, not one attempt. */
+  costPerAcceptedChange: number;
   /** Distinct files created. */
   filesCreated: number;
   /** Gate runs (`validated` events). */
@@ -50,6 +60,9 @@ function emptyMetrics(): IRunMetrics {
     tokensOut: 0,
     peakContext: 0,
     edits: 0,
+    editsReverted: 0,
+    acceptRate: 0,
+    costPerAcceptedChange: 0,
     filesCreated: 0,
     gateRuns: 0,
     turnsToGreen: null,
@@ -75,54 +88,94 @@ function countPolicy(m: IRunMetrics, event: ILoopEvent): void {
   }
 }
 
+/** Running sums that don't live on IRunMetrics until the end (averages and a
+ *  once-rounded wall clock), threaded through the per-event tally. */
+interface IAccum {
+  tpsSum: number;
+  tpsCount: number;
+  wallMs: number;
+  created: Set<string>;
+}
+
+/** Fold one `usage` event in (split out so the per-event tally stays flat). */
+function tallyUsage(m: IRunMetrics, event: ILoopEvent, acc: IAccum): void {
+  m.modelCalls += 1;
+  m.tokensOut += event.completionTokens ?? 0;
+  m.peakContext = Math.max(m.peakContext, event.promptTokens ?? 0);
+
+  if (event.tokensPerSecond !== undefined && event.tokensPerSecond > 0) {
+    acc.tpsSum += event.tokensPerSecond;
+    acc.tpsCount += 1;
+  }
+}
+
+/** Fold one event into the running metrics. A switch (not an else-if chain) so
+ *  adding a kind doesn't compound the function's cognitive complexity. */
+function tallyEvent(m: IRunMetrics, event: ILoopEvent, acc: IAccum): void {
+  switch (event.kind) {
+    case "cycle":
+      m.turns += 1;
+      break;
+    case "usage":
+      tallyUsage(m, event, acc);
+      break;
+    case "create":
+      m.edits += 1;
+
+      if (event.file !== undefined && event.file.length > 0) {
+        acc.created.add(event.file);
+      }
+
+      break;
+    case "edit":
+      m.edits += 1;
+      break;
+    case "reverted":
+      m.editsReverted += 1;
+      break;
+    case "timing":
+      acc.wallMs += event.ms ?? 0;
+      break;
+    case "validated":
+      m.gateRuns += 1;
+      break;
+    case "done":
+      m.finalStatus = "done";
+      m.turnsToGreen ??= m.turns;
+      break;
+    case "stuck":
+      m.finalStatus = "stuck";
+      break;
+    case "policy":
+      countPolicy(m, event);
+      break;
+    default:
+      break;
+  }
+}
+
 /** Reduce a run's event stream to its behavioral metrics. Pure — feed it the
  *  events from a `--log` JSONL or a captured `onEvent` stream. */
 export function analyzeEvents(events: readonly ILoopEvent[]): IRunMetrics {
   const m = emptyMetrics();
-  const created = new Set<string>();
-  let tpsSum = 0;
-  let tpsCount = 0;
   // Accumulate raw ms and round ONCE at the end: rounding each timing event
   // would floor sub-second turns to 0s (400+400+400ms → 0s instead of 1s).
-  let wallMs = 0;
+  const acc: IAccum = { tpsSum: 0, tpsCount: 0, wallMs: 0, created: new Set() };
 
   for (const event of events) {
-    if (event.kind === "cycle") {
-      m.turns += 1;
-    } else if (event.kind === "usage") {
-      m.modelCalls += 1;
-      m.tokensOut += event.completionTokens ?? 0;
-      m.peakContext = Math.max(m.peakContext, event.promptTokens ?? 0);
-
-      if (event.tokensPerSecond !== undefined && event.tokensPerSecond > 0) {
-        tpsSum += event.tokensPerSecond;
-        tpsCount += 1;
-      }
-    } else if (event.kind === "create") {
-      m.edits += 1;
-
-      if (event.file !== undefined && event.file.length > 0) {
-        created.add(event.file);
-      }
-    } else if (event.kind === "edit") {
-      m.edits += 1;
-    } else if (event.kind === "timing") {
-      wallMs += event.ms ?? 0;
-    } else if (event.kind === "validated") {
-      m.gateRuns += 1;
-    } else if (event.kind === "done") {
-      m.finalStatus = "done";
-      m.turnsToGreen ??= m.turns;
-    } else if (event.kind === "stuck") {
-      m.finalStatus = "stuck";
-    } else if (event.kind === "policy") {
-      countPolicy(m, event);
-    }
+    tallyEvent(m, event, acc);
   }
 
-  m.filesCreated = created.size;
-  m.avgTokensPerSecond = tpsCount > 0 ? Math.round(tpsSum / tpsCount) : 0;
-  m.wallClockSeconds = Math.round(wallMs / 1000);
+  m.filesCreated = acc.created.size;
+
+  const netAccepted = Math.max(0, m.edits - m.editsReverted);
+
+  m.acceptRate = m.edits > 0 ? netAccepted / m.edits : 0;
+  m.costPerAcceptedChange =
+    netAccepted > 0 ? Math.round(m.tokensOut / netAccepted) : 0;
+  m.avgTokensPerSecond =
+    acc.tpsCount > 0 ? Math.round(acc.tpsSum / acc.tpsCount) : 0;
+  m.wallClockSeconds = Math.round(acc.wallMs / 1000);
   m.failureClass = classifyRun(events).failureClass;
 
   return m;

--- a/packages/core/src/eval/parse-log.ts
+++ b/packages/core/src/eval/parse-log.ts
@@ -21,6 +21,7 @@ const KNOWN_KINDS = new Set<string>([
   "timing",
   "usage",
   "ttsr",
+  "reverted",
   "policy",
 ]);
 

--- a/packages/core/src/eval/trace.ts
+++ b/packages/core/src/eval/trace.ts
@@ -48,6 +48,16 @@ export function formatTrace(events: readonly ILoopEvent[]): string {
         : String(m.peakContext),
     ],
     ["edits/creates", `${m.edits} (${m.filesCreated} created)`],
+    [
+      "accept rate",
+      m.edits > 0
+        ? `${Math.round(m.acceptRate * 100)}% (${m.editsReverted} reverted)`
+        : "—",
+    ],
+    [
+      "cost/accepted",
+      m.costPerAcceptedChange > 0 ? `${m.costPerAcceptedChange} tok` : "—",
+    ],
     ["gate runs", String(m.gateRuns)],
     [
       "policy denials",

--- a/packages/core/src/lib/fs/fs.ts
+++ b/packages/core/src/lib/fs/fs.ts
@@ -41,8 +41,14 @@ function ignored(rel: string): boolean {
 }
 
 /** Expand a glob scope to the concrete, readable files under `cwd` (sorted),
- *  skipping ignored dirs and binary files, capped at MAX_GLOB_FILES. */
-async function expandGlob(cwd: string, pattern: string): Promise<string[]> {
+ *  skipping ignored dirs and binary files, capped at `limit` (default
+ *  MAX_GLOB_FILES — the prompt-safety bound). Pass `Infinity` when completeness
+ *  matters more than prompt size (e.g. a rollback snapshot must see every file). */
+async function expandGlob(
+  cwd: string,
+  pattern: string,
+  limit = MAX_GLOB_FILES
+): Promise<string[]> {
   const found: string[] = [];
 
   for await (const rel of new Glob(pattern).scan({ cwd, onlyFiles: true })) {
@@ -50,7 +56,7 @@ async function expandGlob(cwd: string, pattern: string): Promise<string[]> {
       found.push(rel);
     }
 
-    if (found.length >= MAX_GLOB_FILES) {
+    if (found.length >= limit) {
       break;
     }
   }
@@ -181,13 +187,14 @@ export async function writeFilesOrRollback(
  */
 export async function resolveScopeFiles(
   cwd: string,
-  paths: readonly string[]
+  paths: readonly string[],
+  limit = MAX_GLOB_FILES
 ): Promise<string[]> {
   const out = new Set<string>();
 
   for (const path of paths) {
     if (isGlobPattern(path)) {
-      for (const match of await expandGlob(cwd, path)) {
+      for (const match of await expandGlob(cwd, path, limit)) {
         out.add(match);
       }
     } else {

--- a/packages/core/src/loop/file-snapshot.ts
+++ b/packages/core/src/loop/file-snapshot.ts
@@ -1,44 +1,81 @@
 import { join } from "node:path";
+import { rm } from "node:fs/promises";
 import { resolveScopeFiles } from "../lib/fs";
 
-/** A snapshot of file contents keyed by workspace-relative path. */
-export type FileSnapshot = Map<string, string>;
+/** Per-file size cap on snapshot CONTENT (matches readFiles' MAX_FILE_BYTES): a
+ *  source file we'd ever edit is well under this. Oversize files are still
+ *  recorded as pre-existing (so they aren't tombstoned), just not content-backed. */
+const MAX_SNAPSHOT_BYTES = 131_072;
 
 /**
- * Capture the current contents of `files` (skipping ones that don't exist), so a
- * later `restoreFiles` can roll an edit batch back verbatim. The shared substrate
- * for every "try an edit, keep only if it helps" loop (quality repair, review
- * repair) — one definition so the revert semantics can't drift between them.
- *
- * `files` is the editable SCOPE, so it may contain globs (e.g. the whole-repo
- * default `**\/*`). Those are expanded to concrete paths first — a literal
- * `Bun.file("**\/*")` never exists, which would silently snapshot nothing and
- * make `restoreFiles` a no-op (a broken revert by default).
+ * A rollback point for an "try an edit, keep only if it helps" loop: the contents
+ * of every pre-existing file in scope, PLUS the full set of paths that existed at
+ * snapshot time (so `restoreFiles` can delete files the attempt newly created —
+ * tombstones — not just rewrite edited ones). Carries `cwd`/`scope` so restore
+ * needs no extra arguments and can re-list the same scope it captured.
+ */
+export interface IFileSnapshot {
+  cwd: string;
+  scope: readonly string[];
+  /** Every path that existed in scope at snapshot time (content-backed or not). */
+  existed: Set<string>;
+  /** Pre-edit contents of the files small enough to back (keyed by rel path). */
+  contents: Map<string, string>;
+}
+
+/** Resolve a scope to concrete files WITHOUT the prompt-safety cap — a rollback
+ *  must see every file, or a large repo would snapshot/tombstone incompletely. */
+function resolveAll(cwd: string, scope: readonly string[]): Promise<string[]> {
+  return resolveScopeFiles(cwd, scope, Number.POSITIVE_INFINITY);
+}
+
+/**
+ * Capture a rollback point for `scope` (which may contain globs — e.g. the
+ * whole-repo `**\/*`). Records pre-existing contents AND the pre-existing path
+ * set so a later `restoreFiles` can both rewrite edits and remove files the
+ * attempt created. The shared substrate for quality- and review-repair, so the
+ * revert semantics can't drift between them.
  */
 export async function snapshotFiles(
   cwd: string,
-  files: readonly string[]
-): Promise<FileSnapshot> {
-  const snapshot: FileSnapshot = new Map();
-  const resolved = await resolveScopeFiles(cwd, files);
+  scope: readonly string[]
+): Promise<IFileSnapshot> {
+  const existed = new Set<string>();
+  const contents = new Map<string, string>();
 
-  for (const file of resolved) {
+  for (const file of await resolveAll(cwd, scope)) {
     const handle = Bun.file(join(cwd, file));
 
-    if (await handle.exists()) {
-      snapshot.set(file, await handle.text());
+    if (!(await handle.exists())) {
+      continue;
+    }
+
+    existed.add(file);
+
+    if (handle.size <= MAX_SNAPSHOT_BYTES) {
+      contents.set(file, await handle.text());
     }
   }
 
-  return snapshot;
+  return { cwd, scope, existed, contents };
 }
 
-/** Write every captured file back to disk — the rollback half of a snapshot. */
-export async function restoreFiles(
-  cwd: string,
-  snapshot: FileSnapshot
-): Promise<void> {
-  for (const [file, content] of snapshot) {
+/**
+ * Roll the workspace back to a snapshot: rewrite every captured file, then delete
+ * any file now present in scope that did NOT exist at snapshot time (a tombstone
+ * for a helper/test the failed attempt created). Without the tombstone pass a
+ * reverted repair would leave new files behind.
+ */
+export async function restoreFiles(snapshot: IFileSnapshot): Promise<void> {
+  const { cwd, scope, existed, contents } = snapshot;
+
+  for (const [file, content] of contents) {
     await Bun.write(join(cwd, file), content);
+  }
+
+  for (const file of await resolveAll(cwd, scope)) {
+    if (!existed.has(file)) {
+      await rm(join(cwd, file), { force: true });
+    }
   }
 }

--- a/packages/core/src/loop/file-snapshot.ts
+++ b/packages/core/src/loop/file-snapshot.ts
@@ -1,4 +1,5 @@
 import { join } from "node:path";
+import { resolveScopeFiles } from "../lib/fs";
 
 /** A snapshot of file contents keyed by workspace-relative path. */
 export type FileSnapshot = Map<string, string>;
@@ -8,14 +9,20 @@ export type FileSnapshot = Map<string, string>;
  * later `restoreFiles` can roll an edit batch back verbatim. The shared substrate
  * for every "try an edit, keep only if it helps" loop (quality repair, review
  * repair) — one definition so the revert semantics can't drift between them.
+ *
+ * `files` is the editable SCOPE, so it may contain globs (e.g. the whole-repo
+ * default `**\/*`). Those are expanded to concrete paths first — a literal
+ * `Bun.file("**\/*")` never exists, which would silently snapshot nothing and
+ * make `restoreFiles` a no-op (a broken revert by default).
  */
 export async function snapshotFiles(
   cwd: string,
   files: readonly string[]
 ): Promise<FileSnapshot> {
   const snapshot: FileSnapshot = new Map();
+  const resolved = await resolveScopeFiles(cwd, files);
 
-  for (const file of files) {
+  for (const file of resolved) {
     const handle = Bun.file(join(cwd, file));
 
     if (await handle.exists()) {

--- a/packages/core/src/loop/file-snapshot.ts
+++ b/packages/core/src/loop/file-snapshot.ts
@@ -1,0 +1,37 @@
+import { join } from "node:path";
+
+/** A snapshot of file contents keyed by workspace-relative path. */
+export type FileSnapshot = Map<string, string>;
+
+/**
+ * Capture the current contents of `files` (skipping ones that don't exist), so a
+ * later `restoreFiles` can roll an edit batch back verbatim. The shared substrate
+ * for every "try an edit, keep only if it helps" loop (quality repair, review
+ * repair) — one definition so the revert semantics can't drift between them.
+ */
+export async function snapshotFiles(
+  cwd: string,
+  files: readonly string[]
+): Promise<FileSnapshot> {
+  const snapshot: FileSnapshot = new Map();
+
+  for (const file of files) {
+    const handle = Bun.file(join(cwd, file));
+
+    if (await handle.exists()) {
+      snapshot.set(file, await handle.text());
+    }
+  }
+
+  return snapshot;
+}
+
+/** Write every captured file back to disk — the rollback half of a snapshot. */
+export async function restoreFiles(
+  cwd: string,
+  snapshot: FileSnapshot
+): Promise<void> {
+  for (const [file, content] of snapshot) {
+    await Bun.write(join(cwd, file), content);
+  }
+}

--- a/packages/core/src/loop/greenfield/contract.ts
+++ b/packages/core/src/loop/greenfield/contract.ts
@@ -1,0 +1,181 @@
+import { mkdir, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+import type { IProvider } from "../../inference";
+import { isRecord } from "../../lib/guards";
+import { extractJson } from "../../lib/json";
+import { greenfieldDir } from "./state";
+import type { IFeature } from "./greenfield.types";
+
+/**
+ * Pre-build contract negotiation (EXPERIMENTAL — gated by TSFORGE_CONTRACT, OFF by
+ * default; the workshop itself flagged this as unproven). Before building a
+ * feature, the generator proposes "I'll build X, verified by Y" and the evaluator
+ * pushes back until they agree. The agreed contract then anchors the build, so the
+ * generator implements against a checked plan rather than raw prose.
+ *
+ * The evaluator sees ONLY the proposal text and the feature description — never the
+ * generator's reasoning or tool trace (design-rule #2), so it judges the plan, not
+ * the persuasion behind it.
+ */
+
+/** Whether contract negotiation is enabled (opt-in env flag). */
+export function contractEnabled(): boolean {
+  const flag = process.env.TSFORGE_CONTRACT;
+
+  return flag !== undefined && flag !== "" && flag !== "0" && flag !== "false";
+}
+
+export interface IContractTurn {
+  role: "generator" | "evaluator";
+  content: string;
+}
+
+export interface IContractResult {
+  /** The evaluator accepted the latest proposal. */
+  agreed: boolean;
+  /** Negotiation rounds consumed. */
+  rounds: number;
+  /** The final proposed contract text (agreed or not). */
+  contract: string;
+  transcript: IContractTurn[];
+}
+
+/** The evaluator's verdict on one proposal. */
+export interface IObjection {
+  agreed: boolean;
+  notes: string;
+}
+
+const GENERATOR_SYSTEM =
+  "You are the implementer. Propose a SHORT build contract for the ONE feature " +
+  "given: what you will build and exactly how it will be verified (gate command " +
+  "and/or browser steps). If given objections, revise the contract to address " +
+  "them. Respond with ONLY the contract text (no preamble).";
+
+const EVALUATOR_SYSTEM =
+  "You are a skeptical reviewer judging a build CONTRACT (a plan), not code. You " +
+  "see only the feature and the proposed contract — never how it will be built. " +
+  "Accept ONLY if the contract is concrete and its verification actually proves " +
+  "the feature. Default to objecting when it's vague or under-verified. Respond " +
+  'with ONLY JSON: {"agreed":true|false,"objections":"<one sentence>"}.';
+
+/** Parse the evaluator's verdict; an unparseable response is "not agreed" (fail
+ *  closed — a contract isn't agreed unless the evaluator clearly says so). */
+export function parseObjection(raw: string): IObjection {
+  let data: unknown;
+
+  try {
+    data = JSON.parse(extractJson(raw));
+  } catch {
+    return { agreed: false, notes: "unparseable evaluator response" };
+  }
+
+  if (!isRecord(data)) {
+    return { agreed: false, notes: "unparseable evaluator response" };
+  }
+
+  return {
+    agreed: data.agreed === true,
+    notes: typeof data.objections === "string" ? data.objections : "",
+  };
+}
+
+async function propose(
+  generator: IProvider,
+  feature: IFeature,
+  objections: string
+): Promise<string> {
+  const ask =
+    objections.length > 0
+      ? `Feature: ${feature.desc}\n\nThe reviewer objected: ${objections}\nRevise the contract.`
+      : `Feature: ${feature.desc}\n\nPropose the build contract.`;
+  const res = await generator.complete(
+    [
+      { role: "system", content: GENERATOR_SYSTEM },
+      { role: "user", content: ask },
+    ],
+    { temperature: 0 }
+  );
+
+  return res.content.trim();
+}
+
+async function review(
+  evaluator: IProvider,
+  feature: IFeature,
+  contract: string
+): Promise<IObjection> {
+  const res = await evaluator.complete(
+    [
+      { role: "system", content: EVALUATOR_SYSTEM },
+      {
+        role: "user",
+        content: `Feature: ${feature.desc}\n\nProposed contract:\n${contract}`,
+      },
+    ],
+    { temperature: 0 }
+  );
+
+  return parseObjection(res.content);
+}
+
+/**
+ * Run the propose↔object loop until the evaluator agrees or `maxRounds` is hit.
+ * Returns the final contract and whether it was agreed. Both models are injected;
+ * the evaluator only ever sees proposal text (rule #2).
+ */
+export async function negotiateContract(
+  generator: IProvider,
+  evaluator: IProvider,
+  feature: IFeature,
+  maxRounds = 3
+): Promise<IContractResult> {
+  const transcript: IContractTurn[] = [];
+  let objections = "";
+  let contract = "";
+
+  for (let round = 1; round <= maxRounds; round += 1) {
+    contract = await propose(generator, feature, objections);
+    transcript.push({ role: "generator", content: contract });
+
+    const verdict = await review(evaluator, feature, contract);
+
+    transcript.push({
+      role: "evaluator",
+      content: verdict.agreed ? "agreed" : verdict.notes,
+    });
+
+    if (verdict.agreed) {
+      return { agreed: true, rounds: round, contract, transcript };
+    }
+
+    objections = verdict.notes;
+  }
+
+  return { agreed: false, rounds: maxRounds, contract, transcript };
+}
+
+/** Persist a negotiation to `.tsforge/greenfield/contracts/<feature-id>.md` for
+ *  later inspection (the workshop's "leave the negotiation on disk"). */
+export async function writeContract(
+  cwd: string,
+  feature: IFeature,
+  result: IContractResult
+): Promise<void> {
+  const dir = join(greenfieldDir(cwd), "contracts");
+
+  await mkdir(dir, { recursive: true });
+
+  const body = [
+    `# Contract: ${feature.id}`,
+    "",
+    `Feature: ${feature.desc}`,
+    `Status: ${result.agreed ? "agreed" : "not agreed"} (after ${result.rounds} round(s))`,
+    "",
+    "## Transcript",
+    "",
+    ...result.transcript.map((t) => `### ${t.role}\n\n${t.content}\n`),
+  ].join("\n");
+
+  await writeFile(join(dir, `${feature.id}.md`), `${body}\n`);
+}

--- a/packages/core/src/loop/greenfield/contract.ts
+++ b/packages/core/src/loop/greenfield/contract.ts
@@ -83,11 +83,15 @@ export function parseObjection(raw: string): IObjection {
 async function propose(
   generator: IProvider,
   feature: IFeature,
-  objections: string
+  objections: string,
+  previousContract: string
 ): Promise<string> {
+  // The provider call is stateless, so a revision must be shown its OWN prior
+  // proposal (plus the objection) — otherwise it "revises" from scratch and the
+  // negotiation can't converge.
   const ask =
     objections.length > 0
-      ? `Feature: ${feature.desc}\n\nThe reviewer objected: ${objections}\nRevise the contract.`
+      ? `Feature: ${feature.desc}\n\nYour previous contract:\n${previousContract}\n\nThe reviewer objected: ${objections}\nRevise the contract to address the objection.`
       : `Feature: ${feature.desc}\n\nPropose the build contract.`;
   const res = await generator.complete(
     [
@@ -135,7 +139,7 @@ export async function negotiateContract(
   let contract = "";
 
   for (let round = 1; round <= maxRounds; round += 1) {
-    contract = await propose(generator, feature, objections);
+    contract = await propose(generator, feature, objections, contract);
     transcript.push({ role: "generator", content: contract });
 
     const verdict = await review(evaluator, feature, contract);

--- a/packages/core/src/loop/greenfield/evaluate.ts
+++ b/packages/core/src/loop/greenfield/evaluate.ts
@@ -1,0 +1,77 @@
+import type { IRenderResult } from "../../browser";
+import type { IFeature, IFeatureVerdict } from "./greenfield.types";
+
+/** Result of the deterministic gate for one feature. */
+export interface IGateOutcome {
+  passed: boolean;
+  /** Gate output (first line is surfaced as the verdict note on failure). */
+  output: string;
+}
+
+/** Result of the LLM quality judge for one feature. */
+export interface IJudgeOutcome {
+  ok: boolean;
+  notes: string;
+}
+
+/**
+ * The three evaluator layers, injected so `evaluateFeature` is pure and testable
+ * and the real wiring (validate / renderCheck / judge) lives at the call site.
+ * Order is deliberate: cheapest + most authoritative first.
+ */
+export interface IEvaluateDeps {
+  /** Deterministic gate (tsc/eslint/tests) — the authority for "done". */
+  gate(feature: IFeature): Promise<IGateOutcome>;
+  /** Browser oracle (renderCheck) — proves the built UI actually runs. */
+  browser(feature: IFeature): Promise<IRenderResult>;
+  /** LLM rubric — judges quality the gate can't see (reject-by-default). */
+  judge(feature: IFeature): Promise<IJudgeOutcome>;
+}
+
+function firstLine(text: string): string {
+  return (
+    text
+      .split("\n")
+      .find((l) => l.trim().length > 0)
+      ?.trim() ?? ""
+  );
+}
+
+/**
+ * Evaluate one feature through the layered stack and short-circuit on the first
+ * failure: deterministic gate → browser oracle → LLM judge. The gate stays the
+ * authority — a feature is never "passed" on the judge's say-so alone, and the
+ * browser layer is skip-tolerant (no playwright ⇒ it doesn't block). Mirrors the
+ * workshop's "hard checks before soft checks" and design-rule #2 (the judge sees
+ * the built artifact, never the generator's trace).
+ */
+export async function evaluateFeature(
+  feature: IFeature,
+  deps: IEvaluateDeps
+): Promise<IFeatureVerdict> {
+  const gate = await deps.gate(feature);
+
+  if (!gate.passed) {
+    return { passed: false, stage: "gate", notes: firstLine(gate.output) };
+  }
+
+  const browser = await deps.browser(feature);
+
+  // A skipped render-check (playwright absent) must not block — it's an
+  // enhancement, exactly as the gate's own web ladder treats it.
+  if (!browser.ok && browser.skipped !== true) {
+    return {
+      passed: false,
+      stage: "browser",
+      notes: browser.errors.join("; "),
+    };
+  }
+
+  const judged = await deps.judge(feature);
+
+  if (!judged.ok) {
+    return { passed: false, stage: "judge", notes: judged.notes };
+  }
+
+  return { passed: true, notes: "gate + browser + judge all green" };
+}

--- a/packages/core/src/loop/greenfield/greenfield.types.ts
+++ b/packages/core/src/loop/greenfield/greenfield.types.ts
@@ -1,0 +1,65 @@
+import type { IStep } from "../../browser";
+import type { Reporter } from "../loop.types";
+
+/**
+ * One feature in a greenfield build's checklist. The unit the outer loop drives:
+ * pick the first one not yet `passes`, implement it, verify it, tick it. Persisted
+ * to `.tsforge/greenfield/features.json` — filesystem state the model can't
+ * silently lose across a multi-hour run (the workshop's "JSON resists overwrite").
+ */
+export interface IFeature {
+  /** Stable id (kebab-case), used in progress.md and logs. */
+  id: string;
+  /** One-line description of the behaviour to build. */
+  desc: string;
+  /** Verified working (gate + browser + judge all green). */
+  passes: boolean;
+  /** How many implement→evaluate cycles this feature has consumed (the per-feature
+   *  stop guard — a feature that won't converge can't wedge the whole run). */
+  attempts: number;
+  /** Browser interaction steps that PROVE the feature works (clicked through the
+   *  rendered app), proposed alongside the feature. Empty ⇒ a render smoke only. */
+  steps?: IStep[];
+}
+
+/** A greenfield build's whole state: the one-line goal + the feature checklist. */
+export interface IGreenfieldState {
+  /** The one-line build goal (what the planner was asked to build). */
+  goal: string;
+  features: IFeature[];
+}
+
+/** The verdict for one feature after the layered evaluator runs. */
+export interface IFeatureVerdict {
+  passed: boolean;
+  /** One-line reason (the failing layer's message, or a success note). */
+  notes: string;
+  /** Which layer decided it (for progress.md). Omitted on a pass. */
+  stage?: "gate" | "browser" | "judge";
+}
+
+export interface IGreenfieldResult {
+  status: "done" | "stuck";
+  features: IFeature[];
+  /** When stuck: the feature that exhausted its attempts. */
+  stuckFeature?: string;
+}
+
+/**
+ * The two model-/tool-driven steps the outer loop delegates, injected so the loop
+ * itself is pure and testable. `implement` makes the model build one feature;
+ * `evaluate` runs the layered evaluator (gate → browser → judge) for it.
+ */
+export interface IGreenfieldDeps {
+  implement(feature: IFeature, state: IGreenfieldState): Promise<void>;
+  evaluate(
+    feature: IFeature,
+    state: IGreenfieldState
+  ): Promise<IFeatureVerdict>;
+}
+
+export interface IGreenfieldOptions {
+  /** Give up on a feature after this many implement→evaluate cycles (default 3). */
+  maxAttemptsPerFeature?: number;
+  onEvent?: Reporter;
+}

--- a/packages/core/src/loop/greenfield/index.ts
+++ b/packages/core/src/loop/greenfield/index.ts
@@ -13,6 +13,13 @@ export { planFeatures, parsePlan } from "./plan";
 export type { IPlan } from "./plan";
 export { judgeFeature, parseFeatureVerdict } from "./judge";
 export type { IFeatureJudgeInput } from "./judge";
+export {
+  negotiateContract,
+  parseObjection,
+  writeContract,
+  contractEnabled,
+} from "./contract";
+export type { IContractResult, IContractTurn, IObjection } from "./contract";
 export type {
   IFeature,
   IFeatureVerdict,

--- a/packages/core/src/loop/greenfield/index.ts
+++ b/packages/core/src/loop/greenfield/index.ts
@@ -1,4 +1,4 @@
-export { runGreenfield } from "./run";
+export { runGreenfield, prepareState } from "./run";
 export {
   loadState,
   saveState,
@@ -9,6 +9,10 @@ export {
 } from "./state";
 export { evaluateFeature } from "./evaluate";
 export type { IEvaluateDeps, IGateOutcome, IJudgeOutcome } from "./evaluate";
+export { planFeatures, parsePlan } from "./plan";
+export type { IPlan } from "./plan";
+export { judgeFeature, parseFeatureVerdict } from "./judge";
+export type { IFeatureJudgeInput } from "./judge";
 export type {
   IFeature,
   IFeatureVerdict,

--- a/packages/core/src/loop/greenfield/index.ts
+++ b/packages/core/src/loop/greenfield/index.ts
@@ -1,0 +1,19 @@
+export { runGreenfield } from "./run";
+export {
+  loadState,
+  saveState,
+  writeSpec,
+  writeProgress,
+  renderProgress,
+  greenfieldDir,
+} from "./state";
+export { evaluateFeature } from "./evaluate";
+export type { IEvaluateDeps, IGateOutcome, IJudgeOutcome } from "./evaluate";
+export type {
+  IFeature,
+  IFeatureVerdict,
+  IGreenfieldState,
+  IGreenfieldResult,
+  IGreenfieldDeps,
+  IGreenfieldOptions,
+} from "./greenfield.types";

--- a/packages/core/src/loop/greenfield/judge.ts
+++ b/packages/core/src/loop/greenfield/judge.ts
@@ -1,0 +1,68 @@
+import type { IProvider } from "../../inference";
+import { isRecord } from "../../lib/guards";
+import { extractJson } from "../../lib/json";
+import type { IJudgeOutcome } from "./evaluate";
+
+/** What the feature judge is shown — the built artifact only, never the
+ *  generator's trace (design-rule #2, mirrors eval's IJudgeInput). */
+export interface IFeatureJudgeInput {
+  /** The feature being judged. */
+  feature: string;
+  /** The relevant built code. */
+  code: string;
+}
+
+/**
+ * A HARSH, reject-by-default judge for a greenfield feature — the soft-quality
+ * layer that runs only AFTER the deterministic gate and browser oracle are green.
+ * Mirrors review-change's VERIFY_SYSTEM: the default answer is "not done", and a
+ * feature passes only if the code clearly and fully implements it. This stops a
+ * model from declaring victory on a stub that merely compiles and renders.
+ */
+const SYSTEM =
+  "You are a harsh senior reviewer judging whether ONE feature is fully and " +
+  "correctly implemented in the code shown. Be skeptical and default to REJECT: " +
+  "pass ONLY if the code clearly and completely implements the feature with no " +
+  "stubs, TODOs, or obviously missing cases. If the evidence is partial, " +
+  "ambiguous, or absent, reject. You see only the built code, never how it was " +
+  'produced. Respond with ONLY JSON: {"pass":true|false,"notes":"<one sentence>"}.';
+
+/** Parse the judge's raw JSON; an unparseable response is a REJECT (fail closed,
+ *  consistent with the reject-by-default rubric). Pure — unit-testable. */
+export function parseFeatureVerdict(raw: string): IJudgeOutcome {
+  let data: unknown;
+
+  try {
+    data = JSON.parse(extractJson(raw));
+  } catch {
+    return { ok: false, notes: "unparseable judge response" };
+  }
+
+  if (!isRecord(data)) {
+    return { ok: false, notes: "unparseable judge response" };
+  }
+
+  return {
+    ok: data.pass === true,
+    notes: typeof data.notes === "string" ? data.notes : "",
+  };
+}
+
+/** Run the reject-by-default feature judge. */
+export async function judgeFeature(
+  provider: IProvider,
+  input: IFeatureJudgeInput
+): Promise<IJudgeOutcome> {
+  const res = await provider.complete(
+    [
+      { role: "system", content: SYSTEM },
+      {
+        role: "user",
+        content: `Feature: ${input.feature}\n\nCode:\n${input.code}`,
+      },
+    ],
+    { temperature: 0 }
+  );
+
+  return parseFeatureVerdict(res.content);
+}

--- a/packages/core/src/loop/greenfield/plan.ts
+++ b/packages/core/src/loop/greenfield/plan.ts
@@ -1,0 +1,93 @@
+import type { IProvider } from "../../inference";
+import { isRecord } from "../../lib/guards";
+import { extractJson } from "../../lib/json";
+import type { IStep } from "../../browser";
+import type { IFeature } from "./greenfield.types";
+
+/** The planner's output: a human-readable spec + a fresh feature checklist. */
+export interface IPlan {
+  /** Markdown spec (high-level sprints) → `.tsforge/greenfield/spec.md`. */
+  spec: string;
+  /** The initial checklist (all `passes:false`, `attempts:0`). */
+  features: IFeature[];
+}
+
+/**
+ * The planner role: turn a one-line build goal into a HIGH-LEVEL spec and a flat
+ * feature checklist. Deliberately coarse — sprints/features, not file-level steps
+ * — so granular technical errors don't cascade across the whole build (design
+ * rule #4: the planner stays high-level). The generator and evaluator work one
+ * feature at a time against this; the planner is consulted once, up front.
+ */
+const SYSTEM =
+  "You are a software planner. Given a one-line build goal, produce a HIGH-LEVEL " +
+  "plan: a short markdown spec (think sprints/milestones, NOT file-level steps) " +
+  "and a flat checklist of user-visible features, each independently verifiable. " +
+  "Keep features coarse (5–12 total). Respond with ONLY a JSON object: " +
+  '{"spec":"<markdown>","features":[{"id":"<kebab-case>","desc":"<one line>"}]}.';
+
+function toFeature(value: unknown): IFeature | null {
+  if (!isRecord(value)) {
+    return null;
+  }
+
+  const { id, desc, steps } = value;
+
+  if (typeof id !== "string" || typeof desc !== "string") {
+    return null;
+  }
+
+  const feature: IFeature = { id, desc, passes: false, attempts: 0 };
+
+  if (Array.isArray(steps)) {
+    feature.steps = steps.filter((s): s is IStep => isRecord(s));
+  }
+
+  return feature;
+}
+
+/** Parse the planner's raw JSON into a plan, or null when it isn't usable (no
+ *  valid features). Pure — split out so it can be unit-tested without a provider. */
+export function parsePlan(raw: string): IPlan | null {
+  let data: unknown;
+
+  try {
+    data = JSON.parse(extractJson(raw));
+  } catch {
+    return null;
+  }
+
+  if (!isRecord(data) || !Array.isArray(data.features)) {
+    return null;
+  }
+
+  const features = data.features
+    .map(toFeature)
+    .filter((f): f is IFeature => f !== null);
+
+  if (features.length === 0) {
+    return null;
+  }
+
+  const spec = typeof data.spec === "string" ? data.spec : "";
+
+  return { spec, features };
+}
+
+/** Ask the model to plan a build from a one-line goal. Returns null when the
+ *  model's response can't be parsed into a usable checklist (caller decides how
+ *  to surface that — there's nothing to build without features). */
+export async function planFeatures(
+  provider: IProvider,
+  goal: string
+): Promise<IPlan | null> {
+  const res = await provider.complete(
+    [
+      { role: "system", content: SYSTEM },
+      { role: "user", content: `Build goal: ${goal}` },
+    ],
+    { temperature: 0 }
+  );
+
+  return parsePlan(res.content);
+}

--- a/packages/core/src/loop/greenfield/run.ts
+++ b/packages/core/src/loop/greenfield/run.ts
@@ -1,0 +1,98 @@
+import type { Reporter } from "../loop.types";
+import { saveState, writeProgress } from "./state";
+import type {
+  IGreenfieldState,
+  IGreenfieldDeps,
+  IGreenfieldOptions,
+  IGreenfieldResult,
+  IFeature,
+} from "./greenfield.types";
+
+const DEFAULT_MAX_ATTEMPTS = 3;
+
+/**
+ * The greenfield outer loop: drive a feature checklist to all-green, one feature
+ * at a time, persisting state to disk after every step so a long run survives
+ * being interrupted and resumed. Picks the first unfinished feature, asks the
+ * model to implement it, runs the layered evaluator, ticks it on success — and
+ * gives up on a single feature (status `stuck`) once it exhausts its attempts,
+ * so a non-converging feature can't wedge the whole build. Filesystem state, not
+ * context, is the source of truth (the workshop's long-run pattern).
+ */
+export async function runGreenfield(
+  cwd: string,
+  state: IGreenfieldState,
+  deps: IGreenfieldDeps,
+  opts: IGreenfieldOptions = {}
+): Promise<IGreenfieldResult> {
+  const maxAttempts = opts.maxAttemptsPerFeature ?? DEFAULT_MAX_ATTEMPTS;
+  const report: Reporter = opts.onEvent ?? ((): void => undefined);
+
+  const say = (message: string): void => {
+    report({ kind: "fix", task: "greenfield", message });
+  };
+
+  await saveState(cwd, state);
+  await writeProgress(cwd, state);
+
+  for (;;) {
+    const feature = state.features.find((f) => !f.passes);
+
+    if (feature === undefined) {
+      report({
+        kind: "done",
+        task: "greenfield",
+        message: `all ${state.features.length} feature(s) verified`,
+      });
+
+      return { status: "done", features: state.features };
+    }
+
+    if (feature.attempts >= maxAttempts) {
+      report({
+        kind: "stuck",
+        task: "greenfield",
+        message: `feature '${feature.id}' stuck after ${feature.attempts} attempt(s)`,
+        detail: feature.desc,
+      });
+
+      return {
+        status: "stuck",
+        features: state.features,
+        stuckFeature: feature.id,
+      };
+    }
+
+    await attemptFeature(cwd, state, feature, deps, say);
+  }
+}
+
+/** One implement→evaluate→persist cycle for a single feature (mutates it). */
+async function attemptFeature(
+  cwd: string,
+  state: IGreenfieldState,
+  feature: IFeature,
+  deps: IGreenfieldDeps,
+  say: (message: string) => void
+): Promise<void> {
+  feature.attempts += 1;
+  say(`feature '${feature.id}': attempt ${feature.attempts} — ${feature.desc}`);
+
+  await deps.implement(feature, state);
+
+  const verdict = await deps.evaluate(feature, state);
+
+  if (verdict.passed) {
+    feature.passes = true;
+    say(`feature '${feature.id}': verified ✓`);
+  } else {
+    say(
+      `feature '${feature.id}': failed at ${verdict.stage ?? "?"} — ${verdict.notes}`
+    );
+  }
+
+  // Persist after every attempt so an interrupted run resumes from the last
+  // verified feature, not from scratch.
+  await saveState(cwd, state);
+  await writeProgress(cwd, state);
+}

--- a/packages/core/src/loop/greenfield/run.ts
+++ b/packages/core/src/loop/greenfield/run.ts
@@ -1,5 +1,6 @@
 import type { Reporter } from "../loop.types";
-import { saveState, writeProgress } from "./state";
+import { saveState, writeProgress, loadState, writeSpec } from "./state";
+import type { IPlan } from "./plan";
 import type {
   IGreenfieldState,
   IGreenfieldDeps,
@@ -7,6 +8,39 @@ import type {
   IGreenfieldResult,
   IFeature,
 } from "./greenfield.types";
+
+/**
+ * Resolve the state to run: resume the persisted checklist if one exists, else
+ * plan a fresh one from the goal (writing spec.md + features.json). Returns null
+ * when there's no prior state AND planning yields nothing to build. The planner
+ * is injected so this is testable without a model. Resume-first is the long-run
+ * contract: an interrupted build picks up from the last verified feature.
+ */
+export async function prepareState(
+  cwd: string,
+  goal: string,
+  plan: (goal: string) => Promise<IPlan | null>
+): Promise<IGreenfieldState | null> {
+  const existing = await loadState(cwd);
+
+  if (existing !== null && existing.features.length > 0) {
+    return existing;
+  }
+
+  const planned = await plan(goal);
+
+  if (planned === null) {
+    return null;
+  }
+
+  await writeSpec(cwd, planned.spec);
+
+  const state: IGreenfieldState = { goal, features: planned.features };
+
+  await saveState(cwd, state);
+
+  return state;
+}
 
 const DEFAULT_MAX_ATTEMPTS = 3;
 

--- a/packages/core/src/loop/greenfield/state.ts
+++ b/packages/core/src/loop/greenfield/state.ts
@@ -1,0 +1,116 @@
+import { mkdir, readFile, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+import { isRecord } from "../../lib/guards";
+import type { IStep } from "../../browser";
+import type { IFeature, IGreenfieldState } from "./greenfield.types";
+
+/** The greenfield state directory under the project's `.tsforge/`. */
+export function greenfieldDir(cwd: string): string {
+  return join(cwd, ".tsforge", "greenfield");
+}
+
+function featuresPath(cwd: string): string {
+  return join(greenfieldDir(cwd), "features.json");
+}
+
+function specPath(cwd: string): string {
+  return join(greenfieldDir(cwd), "spec.md");
+}
+
+function progressPath(cwd: string): string {
+  return join(greenfieldDir(cwd), "progress.md");
+}
+
+/** Coerce one parsed JSON value into an IFeature, dropping it (→ null) when it
+ *  isn't shaped like one. No `as` — every field is checked. `steps` rides through
+ *  opaquely (it's only ever produced by us and consumed by the browser oracle). */
+function toFeature(value: unknown): IFeature | null {
+  if (!isRecord(value)) {
+    return null;
+  }
+
+  const { id, desc, passes, attempts, steps } = value;
+
+  if (typeof id !== "string" || typeof desc !== "string") {
+    return null;
+  }
+
+  const feature: IFeature = {
+    id,
+    desc,
+    passes: passes === true,
+    attempts: typeof attempts === "number" && attempts >= 0 ? attempts : 0,
+  };
+
+  if (Array.isArray(steps)) {
+    feature.steps = steps.filter((s): s is IStep => isRecord(s));
+  }
+
+  return feature;
+}
+
+/** Read the persisted greenfield state, or null when none exists yet / it's
+ *  unreadable (a corrupt file degrades to "start fresh", never a crash). */
+export async function loadState(cwd: string): Promise<IGreenfieldState | null> {
+  let parsed: unknown;
+
+  try {
+    parsed = JSON.parse(await readFile(featuresPath(cwd), "utf8"));
+  } catch {
+    return null;
+  }
+
+  if (!isRecord(parsed) || typeof parsed.goal !== "string") {
+    return null;
+  }
+
+  const features = Array.isArray(parsed.features)
+    ? parsed.features.map(toFeature).filter((f): f is IFeature => f !== null)
+    : [];
+
+  return { goal: parsed.goal, features };
+}
+
+/** Persist the feature checklist as pretty JSON (diff-friendly, model-resistant). */
+export async function saveState(
+  cwd: string,
+  state: IGreenfieldState
+): Promise<void> {
+  await mkdir(greenfieldDir(cwd), { recursive: true });
+  await writeFile(featuresPath(cwd), `${JSON.stringify(state, null, 2)}\n`);
+}
+
+/** Write the human-readable spec (the planner's high-level sprints). */
+export async function writeSpec(cwd: string, spec: string): Promise<void> {
+  await mkdir(greenfieldDir(cwd), { recursive: true });
+  await writeFile(specPath(cwd), spec.endsWith("\n") ? spec : `${spec}\n`);
+}
+
+/** Render the checklist as a human-readable progress report. Pure (testable). */
+export function renderProgress(state: IGreenfieldState): string {
+  const done = state.features.filter((f) => f.passes).length;
+  const lines = state.features.map((f) => {
+    const box = f.passes ? "[x]" : "[ ]";
+    const attempts = f.attempts > 0 ? ` (attempts: ${f.attempts})` : "";
+
+    return `- ${box} ${f.id} — ${f.desc}${attempts}`;
+  });
+
+  return [
+    `# ${state.goal}`,
+    "",
+    `Progress: ${done}/${state.features.length} features verified`,
+    "",
+    ...lines,
+    "",
+  ].join("\n");
+}
+
+/** Write progress.md from the current state. */
+export async function writeProgress(
+  cwd: string,
+  state: IGreenfieldState
+): Promise<void> {
+  await mkdir(greenfieldDir(cwd), { recursive: true });
+  await writeFile(progressPath(cwd), renderProgress(state));
+}

--- a/packages/core/src/loop/index.ts
+++ b/packages/core/src/loop/index.ts
@@ -21,6 +21,10 @@ export {
   parsePlan,
   judgeFeature,
   parseFeatureVerdict,
+  negotiateContract,
+  parseObjection,
+  writeContract,
+  contractEnabled,
   loadState,
   saveState,
   writeSpec,
@@ -40,6 +44,9 @@ export type {
   IJudgeOutcome,
   IPlan,
   IFeatureJudgeInput,
+  IContractResult,
+  IContractTurn,
+  IObjection,
 } from "./greenfield";
 export {
   toolsFor,

--- a/packages/core/src/loop/index.ts
+++ b/packages/core/src/loop/index.ts
@@ -15,7 +15,12 @@ export { snapshotFiles, restoreFiles } from "./file-snapshot";
 export type { FileSnapshot } from "./file-snapshot";
 export {
   runGreenfield,
+  prepareState,
   evaluateFeature,
+  planFeatures,
+  parsePlan,
+  judgeFeature,
+  parseFeatureVerdict,
   loadState,
   saveState,
   writeSpec,
@@ -33,6 +38,8 @@ export type {
   IEvaluateDeps,
   IGateOutcome,
   IJudgeOutcome,
+  IPlan,
+  IFeatureJudgeInput,
 } from "./greenfield";
 export {
   toolsFor,

--- a/packages/core/src/loop/index.ts
+++ b/packages/core/src/loop/index.ts
@@ -12,7 +12,7 @@ export type {
   IReviewRepairOptions,
 } from "./review-repair";
 export { snapshotFiles, restoreFiles } from "./file-snapshot";
-export type { FileSnapshot } from "./file-snapshot";
+export type { IFileSnapshot } from "./file-snapshot";
 export {
   runGreenfield,
   prepareState,

--- a/packages/core/src/loop/index.ts
+++ b/packages/core/src/loop/index.ts
@@ -6,6 +6,13 @@ export type { SetupWebFn } from "./tools";
 export { runTask } from "./run";
 export { runSpec } from "./run-spec";
 export { qualityRepair } from "./quality";
+export { reviewRepair } from "./review-repair";
+export type {
+  IReviewRepairResult,
+  IReviewRepairOptions,
+} from "./review-repair";
+export { snapshotFiles, restoreFiles } from "./file-snapshot";
+export type { FileSnapshot } from "./file-snapshot";
 export {
   toolsFor,
   buildTsService,

--- a/packages/core/src/loop/index.ts
+++ b/packages/core/src/loop/index.ts
@@ -14,6 +14,27 @@ export type {
 export { snapshotFiles, restoreFiles } from "./file-snapshot";
 export type { FileSnapshot } from "./file-snapshot";
 export {
+  runGreenfield,
+  evaluateFeature,
+  loadState,
+  saveState,
+  writeSpec,
+  writeProgress,
+  renderProgress,
+  greenfieldDir,
+} from "./greenfield";
+export type {
+  IFeature,
+  IFeatureVerdict,
+  IGreenfieldState,
+  IGreenfieldResult,
+  IGreenfieldDeps,
+  IGreenfieldOptions,
+  IEvaluateDeps,
+  IGateOutcome,
+  IJudgeOutcome,
+} from "./greenfield";
+export {
   toolsFor,
   buildTsService,
   runToolCalls,

--- a/packages/core/src/loop/ledger-writer.ts
+++ b/packages/core/src/loop/ledger-writer.ts
@@ -26,6 +26,8 @@ export function ledgerTypeFor(event: ILoopEvent): LedgerEventType {
     case "create":
     case "run":
       return "tool_call_finished";
+    case "reverted":
+      return "edit_reverted";
     case "policy":
       return "policy_decision";
     case "tool":

--- a/packages/core/src/loop/ledger.types.ts
+++ b/packages/core/src/loop/ledger.types.ts
@@ -14,6 +14,8 @@ export type LedgerEventType =
   | "tool_call_started"
   | "tool_call_finished"
   | "tool_call_failed"
+  /** An applied edit batch was rolled back (gate-break or no quality gain). */
+  | "edit_reverted"
   | "policy_decision"
   | "gate_started"
   | "gate_finished"

--- a/packages/core/src/loop/loop.types.ts
+++ b/packages/core/src/loop/loop.types.ts
@@ -125,6 +125,13 @@ export interface IRunOptions {
   /** Seed the run with a deterministic pre-edit scout bundle (caller blast-radius
    *  of the editable files). Opt-in; only fires on brownfield (existing-code) runs. */
   scout?: boolean;
+  /** Require the gate to be RED before building (default true). The normal
+   *  contract: a task must fail first, so a no-op can't be mistaken for success.
+   *  Set false for greenfield feature builds, where the global gate is a guardrail
+   *  (often already green from prior features) rather than the per-feature signal —
+   *  the model must still implement the feature, and the per-feature browser/judge
+   *  layers decide whether it's done. */
+  requireRed?: boolean;
 }
 
 export interface ISpecResult {

--- a/packages/core/src/loop/loop.types.ts
+++ b/packages/core/src/loop/loop.types.ts
@@ -25,6 +25,11 @@ export interface ILoopEvent {
     | "timing"
     | "usage"
     | "ttsr"
+    // An edit batch was rolled back because it broke the gate or failed to raise
+    // quality (accounting-only; renders to nothing — the human-facing message
+    // rides a `fix` event). Feeds the accept-rate / cost-per-accepted-change
+    // metrics: a reverted edit was spent but never accepted.
+    | "reverted"
     // A unified-policy verdict for one proposed action (ledger-only; renders to
     // nothing on the terminal — a deny is already surfaced via its `tool` event).
     | "policy";

--- a/packages/core/src/loop/quality.ts
+++ b/packages/core/src/loop/quality.ts
@@ -6,6 +6,7 @@ import { validate, type ErrorParser } from "../validate";
 import { runAccept } from "../validate";
 import { judge } from "../eval";
 import { qualityHints } from "./feedback";
+import { snapshotFiles, restoreFiles } from "./file-snapshot";
 import type { Reporter } from "./loop.types";
 
 export interface IQualityResult {
@@ -59,7 +60,7 @@ export async function qualityRepair(
   while (best.quality < target && attempts < maxAttempts) {
     attempts += 1;
 
-    const snapshot = await snapshotFiles(task, cwd);
+    const snapshot = await snapshotFiles(cwd, task.files);
 
     // Turn the reviewer's prose into concrete bad→good guidance where we have a
     // card for the issue it named (the quality channel — these are idiomatic
@@ -90,7 +91,8 @@ export async function qualityRepair(
     const gate = await validate(task, cwd, opts.parse);
 
     if (!gate.passed) {
-      await restoreFiles(snapshot, cwd);
+      await restoreFiles(cwd, snapshot);
+      report({ kind: "reverted", task: task.id, message: "gate broken" });
       report({
         kind: "fix",
         task: task.id,
@@ -109,7 +111,8 @@ export async function qualityRepair(
         message: `quality ↑ ${best.quality}/5`,
       });
     } else {
-      await restoreFiles(snapshot, cwd);
+      await restoreFiles(cwd, snapshot);
+      report({ kind: "reverted", task: task.id, message: "no quality gain" });
       report({
         kind: "fix",
         task: task.id,
@@ -145,30 +148,4 @@ async function score(
   });
 
   return { quality: result.overall, notes: result.notes };
-}
-
-async function snapshotFiles(
-  task: ITask,
-  cwd: string
-): Promise<Map<string, string>> {
-  const snapshot = new Map<string, string>();
-
-  for (const file of task.files) {
-    const handle = Bun.file(join(cwd, file));
-
-    if (await handle.exists()) {
-      snapshot.set(file, await handle.text());
-    }
-  }
-
-  return snapshot;
-}
-
-async function restoreFiles(
-  snapshot: Map<string, string>,
-  cwd: string
-): Promise<void> {
-  for (const [file, content] of snapshot) {
-    await Bun.write(join(cwd, file), content);
-  }
 }

--- a/packages/core/src/loop/quality.ts
+++ b/packages/core/src/loop/quality.ts
@@ -91,7 +91,7 @@ export async function qualityRepair(
     const gate = await validate(task, cwd, opts.parse);
 
     if (!gate.passed) {
-      await restoreFiles(cwd, snapshot);
+      await restoreFiles(snapshot);
       report({ kind: "reverted", task: task.id, message: "gate broken" });
       report({
         kind: "fix",
@@ -111,7 +111,7 @@ export async function qualityRepair(
         message: `quality ↑ ${best.quality}/5`,
       });
     } else {
-      await restoreFiles(cwd, snapshot);
+      await restoreFiles(snapshot);
       report({ kind: "reverted", task: task.id, message: "no quality gain" });
       report({
         kind: "fix",

--- a/packages/core/src/loop/review-repair.ts
+++ b/packages/core/src/loop/review-repair.ts
@@ -88,41 +88,50 @@ export async function reviewRepair(
   // must restore.
   const snapshot = await snapshotFiles(cwd, task.files);
 
-  await agent.implement({
-    cwd,
-    task,
-    errors: findingsToErrors(findings),
-    cycle: 1,
-    report,
-  });
+  // A throw mid-repair (agent error, fix-command crash, gate runner failure)
+  // must still roll the workspace back — otherwise a half-applied edit batch is
+  // left on disk. Restore, then rethrow so the caller still sees the failure.
+  try {
+    await agent.implement({
+      cwd,
+      task,
+      errors: findingsToErrors(findings),
+      cycle: 1,
+      report,
+    });
 
-  if (task.fix !== undefined && task.fix.length > 0) {
-    await runAccept({ ...task, accept: task.fix }, cwd);
-  }
+    if (task.fix !== undefined && task.fix.length > 0) {
+      await runAccept({ ...task, accept: task.fix }, cwd);
+    }
 
-  const gate = await validate(task, cwd, opts.parse);
+    const gate = await validate(task, cwd, opts.parse);
 
-  if (!gate.passed) {
+    if (gate.passed) {
+      report({
+        kind: "fix",
+        task: task.id,
+        message: "post-green review repair kept (gate green)",
+      });
+
+      return { findings: findings.length, repaired: true, reverted: false };
+    }
+  } catch (error) {
     await restoreFiles(cwd, snapshot);
-    report({
-      kind: "reverted",
-      task: task.id,
-      message: "review repair broke the gate",
-    });
-    report({
-      kind: "fix",
-      task: task.id,
-      message: "post-green review repair broke the gate — reverted",
-    });
 
-    return { findings: findings.length, repaired: false, reverted: true };
+    throw error;
   }
 
+  await restoreFiles(cwd, snapshot);
+  report({
+    kind: "reverted",
+    task: task.id,
+    message: "review repair broke the gate",
+  });
   report({
     kind: "fix",
     task: task.id,
-    message: "post-green review repair kept (gate green)",
+    message: "post-green review repair broke the gate — reverted",
   });
 
-  return { findings: findings.length, repaired: true, reverted: false };
+  return { findings: findings.length, repaired: false, reverted: true };
 }

--- a/packages/core/src/loop/review-repair.ts
+++ b/packages/core/src/loop/review-repair.ts
@@ -116,12 +116,12 @@ export async function reviewRepair(
       return { findings: findings.length, repaired: true, reverted: false };
     }
   } catch (error) {
-    await restoreFiles(cwd, snapshot);
+    await restoreFiles(snapshot);
 
     throw error;
   }
 
-  await restoreFiles(cwd, snapshot);
+  await restoreFiles(snapshot);
   report({
     kind: "reverted",
     task: task.id,

--- a/packages/core/src/loop/review-repair.ts
+++ b/packages/core/src/loop/review-repair.ts
@@ -1,0 +1,128 @@
+import type { ITask } from "../spec";
+import type { IAgent } from "../agent";
+import type { IProvider } from "../inference";
+import { validate, runAccept } from "../validate";
+import type { ErrorParser, ErrorSet } from "../validate";
+import { reviewChange } from "./review/review-change";
+import type { IVerifiedFinding } from "./review/review.types";
+import { snapshotFiles, restoreFiles } from "./file-snapshot";
+import type { Reporter } from "./loop.types";
+
+/** Outcome of one post-green review-and-repair pass. */
+export interface IReviewRepairResult {
+  /** Verified findings the review surfaced (after the adversarial-verify pass). */
+  findings: number;
+  /** A repair was applied AND kept (the gate stayed green). */
+  repaired: boolean;
+  /** A repair was attempted but rolled back because it broke the gate. */
+  reverted: boolean;
+}
+
+export interface IReviewRepairOptions {
+  base?: string;
+  staged?: boolean;
+  parse?: ErrorParser;
+  onEvent?: Reporter;
+}
+
+/** Turn verified findings into the gate-style error set the implement agent
+ *  already knows how to consume (so the repair pass reuses the normal feedback
+ *  channel — no second prompt format). */
+function findingsToErrors(findings: readonly IVerifiedFinding[]): ErrorSet {
+  return findings.map((f) => ({
+    key: `review:${f.lens}:${f.file}:${f.line}`,
+    file: f.file,
+    line: f.line,
+    rule: f.lens,
+    message: `${f.claim} — ${f.reason}`,
+  }));
+}
+
+/**
+ * After a task is green, run the adversarial functional review (`reviewChange`)
+ * and feed any VERIFIED findings into exactly ONE repair cycle: snapshot →
+ * implement against the findings → re-gate → keep only if still green, else roll
+ * back. The deterministic gate stays the authority for "done": a fix that breaks
+ * it is reverted, never shipped. Distinct from `withGate` (which only makes the
+ * review gate-aware) — this closes the loop by acting on what the review found.
+ */
+export async function reviewRepair(
+  provider: IProvider,
+  cwd: string,
+  task: ITask,
+  agent: IAgent,
+  opts: IReviewRepairOptions = {}
+): Promise<IReviewRepairResult> {
+  const report: Reporter = opts.onEvent ?? ((): void => undefined);
+
+  const log = (m: string): void => {
+    report({ kind: "tool", task: task.id, message: m });
+  };
+
+  const review = await reviewChange(provider, cwd, {
+    ...(opts.base === undefined ? {} : { base: opts.base }),
+    staged: opts.staged ?? false,
+    verify: true,
+    log,
+  });
+
+  const { findings } = review;
+
+  if (findings.length === 0) {
+    report({
+      kind: "fix",
+      task: task.id,
+      message: "post-green review: no verified findings",
+    });
+
+    return { findings: 0, repaired: false, reverted: false };
+  }
+
+  report({
+    kind: "fix",
+    task: task.id,
+    message: `post-green review: ${findings.length} verified finding(s) — one repair pass`,
+  });
+
+  // The agent can only edit the task's declared scope, so that's all a revert
+  // must restore.
+  const snapshot = await snapshotFiles(cwd, task.files);
+
+  await agent.implement({
+    cwd,
+    task,
+    errors: findingsToErrors(findings),
+    cycle: 1,
+    report,
+  });
+
+  if (task.fix !== undefined && task.fix.length > 0) {
+    await runAccept({ ...task, accept: task.fix }, cwd);
+  }
+
+  const gate = await validate(task, cwd, opts.parse);
+
+  if (!gate.passed) {
+    await restoreFiles(cwd, snapshot);
+    report({
+      kind: "reverted",
+      task: task.id,
+      message: "review repair broke the gate",
+    });
+    report({
+      kind: "fix",
+      task: task.id,
+      message: "post-green review repair broke the gate — reverted",
+    });
+
+    return { findings: findings.length, repaired: false, reverted: true };
+  }
+
+  report({
+    kind: "fix",
+    task: task.id,
+    message: "post-green review repair kept (gate green)",
+  });
+
+  return { findings: findings.length, repaired: true, reverted: false };
+}

--- a/packages/core/src/loop/run.ts
+++ b/packages/core/src/loop/run.ts
@@ -1,6 +1,6 @@
 import type { ITask } from "../spec";
 import type { IChatMessage, IModelResponse, IProvider } from "../inference";
-import { validate, type ErrorParser } from "../validate";
+import { validate, type ErrorParser, type IValidateResult } from "../validate";
 import { parseEslintJson } from "../validate";
 import { readFiles, type IFileView } from "../lib/fs";
 import {
@@ -249,6 +249,56 @@ function scoutSeed(
   return buildScoutContext(tsService, cwd, editable);
 }
 
+/**
+ * Validate the goalpost up front. RED-first: the gate must fail before we build,
+ * so a no-op can't pass for success — UNLESS `requireRed` is false (greenfield,
+ * where the global gate is a guardrail, not the per-feature signal). Returns the
+ * gate result plus an `early` run result to stop on (already green + RED required),
+ * or `early: null` to proceed (after reporting the RED event).
+ */
+async function redPrecheck(
+  task: ITask,
+  cwd: string,
+  parse: ErrorParser | undefined,
+  requireRed: boolean,
+  report: Reporter
+): Promise<{ red: IValidateResult; early: IRunResult | null }> {
+  const red = await validate(task, cwd, parse);
+
+  if (red.passed && requireRed) {
+    report({
+      kind: "done",
+      task: task.id,
+      cycles: 0,
+      message: `task ${task.id}: already green`,
+    });
+
+    return {
+      red,
+      early: {
+        task: task.id,
+        redConfirmed: false,
+        status: RUN_STATUS.redNotConfirmed,
+        cycles: 0,
+        edits: 0,
+        regressions: 0,
+      },
+    };
+  }
+
+  report({
+    kind: "red",
+    task: task.id,
+    errors: red.errors.length,
+    // Carry the failing rule codes so the memory miner can seed the baseline
+    // failure set — a one-turn red→green fix has no prior `validated` event.
+    rules: red.errors.flatMap((e) => (e.rule === undefined ? [] : [e.rule])),
+    message: `task ${task.id}: RED (${red.errors.length} error(s))`,
+  });
+
+  return { red, early: null };
+}
+
 export async function runTask(
   task: ITask,
   cwd: string,
@@ -285,36 +335,18 @@ export async function runTask(
     message: `task ${task.id}: checking current state`,
   });
 
-  // RED: the goalpost must fail before we build.
-  const red = await validate(task, cwd, effectiveParse);
+  const requireRed = opts.requireRed ?? true;
+  const { red, early } = await redPrecheck(
+    task,
+    cwd,
+    effectiveParse,
+    requireRed,
+    report
+  );
 
-  if (red.passed) {
-    report({
-      kind: "done",
-      task: task.id,
-      cycles: 0,
-      message: `task ${task.id}: already green`,
-    });
-
-    return {
-      task: task.id,
-      redConfirmed: false,
-      status: RUN_STATUS.redNotConfirmed,
-      cycles: 0,
-      edits: 0,
-      regressions: 0,
-    };
+  if (early !== null) {
+    return early;
   }
-
-  report({
-    kind: "red",
-    task: task.id,
-    errors: red.errors.length,
-    // Carry the failing rule codes so the memory miner can seed the baseline
-    // failure set — a one-turn red→green fix has no prior `validated` event.
-    rules: red.errors.flatMap((e) => (e.rule === undefined ? [] : [e.rule])),
-    message: `task ${task.id}: RED (${red.errors.length} error(s))`,
-  });
 
   // Detect stack once per run, early; tsforge.config.json may adjust it
   const { stackProfile, ruleOverrides, policy, conventions } =

--- a/packages/core/src/models-config.ts
+++ b/packages/core/src/models-config.ts
@@ -234,3 +234,29 @@ export async function resolveActiveModel(): Promise<{
 
   return { name: cfg.active, entry: cfg.models[cfg.active] ?? QWEN_LOCAL };
 }
+
+/** Resolve a model by its registry name, falling back to the active model when
+ *  the name is unset or not in the registry. The seam for greenfield role routing
+ *  (planner / work / evaluator): an unconfigured role transparently reuses the
+ *  active model, so a single-endpoint setup still runs. Explicit TSFORGE_* env
+ *  still wins (it overrides the whole registry), matching resolveActiveModel. */
+export async function resolveModelByName(
+  name: string | undefined
+): Promise<{ name: string; entry: IModelEntry }> {
+  const env = envModelEntry();
+
+  if (env !== undefined) {
+    return { name: name ?? "env", entry: env };
+  }
+
+  if (name === undefined || name.length === 0) {
+    return resolveActiveModel();
+  }
+
+  const cfg = await loadModelsConfig();
+  const entry = cfg.models[name];
+
+  return entry === undefined
+    ? { name: cfg.active, entry: cfg.models[cfg.active] ?? QWEN_LOCAL }
+    : { name, entry };
+}

--- a/packages/core/src/render/ansi.ts
+++ b/packages/core/src/render/ansi.ts
@@ -293,6 +293,11 @@ function renderEventBody(event: ILoopEvent, color: boolean): string {
     case "tool":
       return `  ${paint(event.message, STYLE.dim, color)}\n`;
 
+    case "reverted":
+      // Accounting-only (feeds accept-rate); the human-facing "reverted" message
+      // rides the paired `fix` event, so this would only double-print.
+      return "";
+
     case "policy":
       // Ledger-only signal; a denial is already shown via its `tool` event.
       return "";

--- a/packages/core/src/render/wizard.ts
+++ b/packages/core/src/render/wizard.ts
@@ -451,12 +451,33 @@ export function runWizard(
 
     stdin.removeAllListeners("keypress");
 
+    // Raw mode is what turns an arrow key into a decoded `up`/`down` keypress
+    // instead of a raw `^[[A` the terminal echoes. When there were already
+    // keypress listeners (the REPL's readline, for `/setup`), a consumer owns raw
+    // mode — leave it. With none (standalone `tsforge setup`, cooked stdin) the
+    // wizard must enable it itself and restore on exit, or arrows do nothing.
+    const ownsRawMode =
+      stdin.isTTY &&
+      typeof stdin.setRawMode === "function" &&
+      saved.length === 0;
+
+    if (ownsRawMode) {
+      stdin.setRawMode(true);
+      stdin.resume();
+    }
+
     const draw = (): void => {
       out(`${CLEAR_HOME}${renderFrame(state, steps, color, extra(state))}`);
     };
 
     const finish = (): void => {
       stdin.removeListener("keypress", onKey);
+
+      // Undo the raw mode WE enabled (never touch it when a consumer owned it).
+      if (ownsRawMode) {
+        stdin.setRawMode(false);
+        stdin.pause();
+      }
 
       // The terminal write is best-effort and must NEVER throw out of finish: a
       // throwing `out` (e.g. EPIPE on a closed stdout) would otherwise skip the

--- a/packages/core/tests/cli.test.ts
+++ b/packages/core/tests/cli.test.ts
@@ -85,6 +85,28 @@ test("--scout parses, and a recipe can turn scout on", () => {
   expect(args.scout).toBe(true);
 });
 
+test("--greenfield parses, and a recipe with mode:greenfield turns it on + routes role models", () => {
+  expect(parseArgs(["build an app", "--greenfield"]).greenfield).toBe(true);
+  expect(parseArgs(["build an app"]).greenfield).toBe(false);
+
+  const args = parseArgs(["build a kanban app"]);
+
+  applyRecipe(args, {
+    id: "kanban",
+    mode: "greenfield",
+    gate: "bun run build",
+    plannerModel: "planner",
+    workModel: "coder",
+    evaluatorModel: "judge",
+  });
+
+  expect(args.greenfield).toBe(true);
+  expect(args.accept).toBe("bun run build");
+  expect(args.plannerModel).toBe("planner");
+  expect(args.workModel).toBe("coder");
+  expect(args.evaluatorModel).toBe("judge");
+});
+
 test("applyRecipe fills defaults but an explicit CLI value always wins", () => {
   const recipe: ITaskRecipe = {
     id: "api-endpoint",

--- a/packages/core/tests/file-snapshot.test.ts
+++ b/packages/core/tests/file-snapshot.test.ts
@@ -5,6 +5,7 @@ import {
   writeFileSync,
   readFileSync,
   mkdirSync,
+  existsSync,
 } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
@@ -29,24 +30,48 @@ afterEach(() => {
 test("snapshotFiles expands a glob scope (not a literal path)", async () => {
   const snap = await snapshotFiles(dir, ["**/*"]);
 
-  expect(snap.has("src/a.ts")).toBe(true);
-  expect(snap.has("src/b.ts")).toBe(true);
-  expect(snap.get("src/a.ts")).toContain("export const a = 1;");
+  expect(snap.existed.has("src/a.ts")).toBe(true);
+  expect(snap.existed.has("src/b.ts")).toBe(true);
+  expect(snap.contents.get("src/a.ts")).toContain("export const a = 1;");
 });
 
 test("restoreFiles rolls a glob-scoped edit batch back verbatim", async () => {
   const snap = await snapshotFiles(dir, ["**/*"]);
 
   writeFileSync(join(dir, "src", "a.ts"), "// CLOBBERED\n");
-  await restoreFiles(dir, snap);
+  await restoreFiles(snap);
 
   expect(readFileSync(join(dir, "src", "a.ts"), "utf8")).toBe(
     "export const a = 1;\n"
   );
 });
 
+// Regression: a failed repair that CREATED a helper/test file used to leave it
+// behind, because restore only rewrote pre-existing files. Restore now tombstones
+// files that appeared in scope after the snapshot.
+test("restoreFiles tombstones files created after the snapshot", async () => {
+  const snap = await snapshotFiles(dir, ["**/*"]);
+
+  writeFileSync(join(dir, "src", "a.ts"), "// edited\n");
+  writeFileSync(join(dir, "src", "helper.ts"), "// newly created\n");
+  mkdirSync(join(dir, "src", "sub"));
+  writeFileSync(join(dir, "src", "sub", "deep.ts"), "// nested new\n");
+
+  await restoreFiles(snap);
+
+  // edited file rolled back
+  expect(readFileSync(join(dir, "src", "a.ts"), "utf8")).toBe(
+    "export const a = 1;\n"
+  );
+  // created files removed (flat and nested)
+  expect(existsSync(join(dir, "src", "helper.ts"))).toBe(false);
+  expect(existsSync(join(dir, "src", "sub", "deep.ts"))).toBe(false);
+  // pre-existing untouched file survives
+  expect(existsSync(join(dir, "src", "b.ts"))).toBe(true);
+});
+
 test("a literal scope still snapshots exactly those files", async () => {
   const snap = await snapshotFiles(dir, ["src/a.ts"]);
 
-  expect([...snap.keys()]).toEqual(["src/a.ts"]);
+  expect([...snap.contents.keys()]).toEqual(["src/a.ts"]);
 });

--- a/packages/core/tests/file-snapshot.test.ts
+++ b/packages/core/tests/file-snapshot.test.ts
@@ -1,0 +1,52 @@
+import { test, expect, beforeEach, afterEach } from "bun:test";
+import {
+  mkdtempSync,
+  rmSync,
+  writeFileSync,
+  readFileSync,
+  mkdirSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { snapshotFiles, restoreFiles } from "../src/loop";
+
+let dir: string;
+
+beforeEach(() => {
+  dir = mkdtempSync(join(tmpdir(), "tsforge-snap-"));
+  mkdirSync(join(dir, "src"));
+  writeFileSync(join(dir, "src", "a.ts"), "export const a = 1;\n");
+  writeFileSync(join(dir, "src", "b.ts"), "export const b = 2;\n");
+});
+
+afterEach(() => {
+  rmSync(dir, { recursive: true, force: true });
+});
+
+// Regression: review-repair's default scope is the whole-repo glob `**/*`. A
+// literal `Bun.file("**/*")` never exists, so without glob expansion the snapshot
+// was empty and restore was a silent no-op — a broken revert by default.
+test("snapshotFiles expands a glob scope (not a literal path)", async () => {
+  const snap = await snapshotFiles(dir, ["**/*"]);
+
+  expect(snap.has("src/a.ts")).toBe(true);
+  expect(snap.has("src/b.ts")).toBe(true);
+  expect(snap.get("src/a.ts")).toContain("export const a = 1;");
+});
+
+test("restoreFiles rolls a glob-scoped edit batch back verbatim", async () => {
+  const snap = await snapshotFiles(dir, ["**/*"]);
+
+  writeFileSync(join(dir, "src", "a.ts"), "// CLOBBERED\n");
+  await restoreFiles(dir, snap);
+
+  expect(readFileSync(join(dir, "src", "a.ts"), "utf8")).toBe(
+    "export const a = 1;\n"
+  );
+});
+
+test("a literal scope still snapshots exactly those files", async () => {
+  const snap = await snapshotFiles(dir, ["src/a.ts"]);
+
+  expect([...snap.keys()]).toEqual(["src/a.ts"]);
+});

--- a/packages/core/tests/greenfield-contract.test.ts
+++ b/packages/core/tests/greenfield-contract.test.ts
@@ -1,0 +1,176 @@
+import { test, expect, describe, afterEach } from "bun:test";
+import { mkdtemp, rm, readFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { IProvider, IChatMessage } from "../src/inference";
+import {
+  negotiateContract,
+  parseObjection,
+  writeContract,
+  contractEnabled,
+  greenfieldDir,
+} from "../src/loop/greenfield";
+import type { IFeature } from "../src/loop/greenfield";
+
+const feature: IFeature = {
+  id: "add-todo",
+  desc: "add a todo via the input",
+  passes: false,
+  attempts: 0,
+};
+
+/** A generator that emits a fixed proposal, and an evaluator scripted to object
+ *  for the first `objectFor` reviews then agree. */
+function generator(text: string): IProvider {
+  return {
+    async complete() {
+      return { content: text, toolCalls: [] };
+    },
+  };
+}
+
+function evaluator(objectFor: number): IProvider {
+  let calls = 0;
+
+  return {
+    async complete() {
+      calls += 1;
+      const agreed = calls > objectFor;
+
+      return {
+        content: JSON.stringify({
+          agreed,
+          objections: agreed ? "" : `round ${calls}: too vague`,
+        }),
+        toolCalls: [],
+      };
+    },
+  };
+}
+
+describe("contractEnabled (env-gated, off by default)", () => {
+  const saved = process.env.TSFORGE_CONTRACT;
+
+  afterEach(() => {
+    if (saved === undefined) {
+      Reflect.deleteProperty(process.env, "TSFORGE_CONTRACT");
+    } else {
+      process.env.TSFORGE_CONTRACT = saved;
+    }
+  });
+
+  test("off unless the flag is a real truthy value", () => {
+    Reflect.deleteProperty(process.env, "TSFORGE_CONTRACT");
+    expect(contractEnabled()).toBe(false);
+
+    for (const off of ["", "0", "false"]) {
+      process.env.TSFORGE_CONTRACT = off;
+      expect(contractEnabled()).toBe(false);
+    }
+
+    process.env.TSFORGE_CONTRACT = "1";
+    expect(contractEnabled()).toBe(true);
+  });
+});
+
+describe("parseObjection (fail closed)", () => {
+  test("agreed only when explicitly true; junk → not agreed", () => {
+    expect(parseObjection('{"agreed":true}').agreed).toBe(true);
+    expect(parseObjection('{"agreed":false,"objections":"x"}').agreed).toBe(
+      false
+    );
+    expect(parseObjection("not json").agreed).toBe(false);
+    expect(parseObjection("not json").notes).toContain("unparseable");
+  });
+});
+
+describe("negotiateContract", () => {
+  test("agrees on the first round when the evaluator accepts", async () => {
+    const res = await negotiateContract(
+      generator("build an input + handler"),
+      evaluator(0),
+      feature
+    );
+
+    expect(res.agreed).toBe(true);
+    expect(res.rounds).toBe(1);
+    expect(res.transcript).toHaveLength(2); // one propose + one verdict
+  });
+
+  test("loops through objections, then agrees", async () => {
+    const res = await negotiateContract(
+      generator("build it"),
+      evaluator(2),
+      feature,
+      5
+    );
+
+    expect(res.agreed).toBe(true);
+    expect(res.rounds).toBe(3); // objected twice, agreed on the third
+  });
+
+  test("gives up (not agreed) after maxRounds of objections", async () => {
+    const res = await negotiateContract(
+      generator("vague"),
+      evaluator(99),
+      feature,
+      3
+    );
+
+    expect(res.agreed).toBe(false);
+    expect(res.rounds).toBe(3);
+  });
+
+  test("the evaluator is shown the proposal + feature but never a trace", async () => {
+    const seen: IChatMessage[] = [];
+    const spyEvaluator: IProvider = {
+      async complete(messages) {
+        seen.push(...messages);
+
+        return { content: '{"agreed":true}', toolCalls: [] };
+      },
+    };
+
+    await negotiateContract(
+      generator("PROPOSAL_SENTINEL"),
+      spyEvaluator,
+      feature
+    );
+
+    const text = seen.map((m) => m.content).join("\n");
+
+    expect(text).toContain("PROPOSAL_SENTINEL");
+    expect(text).toContain(feature.desc);
+    // design-rule #2: no trace/reasoning leaks into the evaluator's view
+    expect(text.toLowerCase()).not.toContain("reasoning");
+    expect(text.toLowerCase()).not.toContain("tool call");
+  });
+});
+
+describe("writeContract", () => {
+  let dir: string;
+
+  afterEach(async () => {
+    await rm(dir, { recursive: true, force: true });
+  });
+
+  test("persists a transcript under .tsforge/greenfield/contracts", async () => {
+    dir = await mkdtemp(join(tmpdir(), "tsforge-contract-"));
+    const res = await negotiateContract(
+      generator("the plan"),
+      evaluator(0),
+      feature
+    );
+
+    await writeContract(dir, feature, res);
+
+    const md = await readFile(
+      join(greenfieldDir(dir), "contracts", "add-todo.md"),
+      "utf8"
+    );
+
+    expect(md).toContain("# Contract: add-todo");
+    expect(md).toContain("agreed");
+    expect(md).toContain("the plan");
+  });
+});

--- a/packages/core/tests/greenfield-contract.test.ts
+++ b/packages/core/tests/greenfield-contract.test.ts
@@ -121,6 +121,26 @@ describe("negotiateContract", () => {
     expect(res.rounds).toBe(3);
   });
 
+  test("a revision shows the generator its OWN previous proposal", async () => {
+    // The generator returns a round-numbered proposal and records every prompt.
+    const prompts: string[] = [];
+    let round = 0;
+    const recordingGen: IProvider = {
+      async complete(messages) {
+        round += 1;
+        prompts.push(messages.find((m) => m.role === "user")?.content ?? "");
+
+        return { content: `PROPOSAL_ROUND_${round}`, toolCalls: [] };
+      },
+    };
+
+    await negotiateContract(recordingGen, evaluator(1), feature, 3);
+
+    // Round 2's prompt must echo round 1's proposal so it can revise, not restart.
+    expect(prompts[1]).toContain("PROPOSAL_ROUND_1");
+    expect(prompts[1]).toContain("objected");
+  });
+
   test("the evaluator is shown the proposal + feature but never a trace", async () => {
     const seen: IChatMessage[] = [];
     const spyEvaluator: IProvider = {

--- a/packages/core/tests/greenfield-planner.test.ts
+++ b/packages/core/tests/greenfield-planner.test.ts
@@ -1,0 +1,141 @@
+import { test, expect, describe, beforeEach, afterEach } from "bun:test";
+import { mkdtemp, rm, readFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { IProvider } from "../src/inference";
+import {
+  parsePlan,
+  planFeatures,
+  parseFeatureVerdict,
+  judgeFeature,
+  prepareState,
+  loadState,
+  greenfieldDir,
+  saveState,
+} from "../src/loop/greenfield";
+import type { IPlan } from "../src/loop/greenfield";
+
+function providerSaying(content: string): IProvider {
+  return {
+    async complete() {
+      return { content, toolCalls: [] };
+    },
+  };
+}
+
+describe("planner: parsePlan / planFeatures", () => {
+  const GOOD = JSON.stringify({
+    spec: "# Build it\n- sprint 1",
+    features: [
+      { id: "list-todos", desc: "show the todo list" },
+      { id: "add-todo", desc: "add a todo", steps: [{ click: "#add" }] },
+      { desc: "no id — dropped" },
+    ],
+  });
+
+  test("parses spec + features and drops malformed entries", () => {
+    const plan = parsePlan(GOOD);
+
+    expect(plan?.spec).toContain("Build it");
+    expect(plan?.features.map((f) => f.id)).toEqual(["list-todos", "add-todo"]);
+    expect(plan?.features.every((f) => !f.passes && f.attempts === 0)).toBe(true);
+    expect(plan?.features[1]?.steps).toHaveLength(1);
+  });
+
+  test("returns null when there are no usable features", () => {
+    expect(parsePlan("not json")).toBeNull();
+    expect(parsePlan(JSON.stringify({ spec: "x", features: [] }))).toBeNull();
+    expect(parsePlan(JSON.stringify({ spec: "x" }))).toBeNull();
+  });
+
+  test("planFeatures tolerates a fenced JSON block", async () => {
+    const plan = await planFeatures(
+      providerSaying("```json\n" + GOOD + "\n```"),
+      "build a todo app"
+    );
+
+    expect(plan?.features[0]?.id).toBe("list-todos");
+  });
+});
+
+describe("feature judge: reject-by-default", () => {
+  test("pass:true → ok", () => {
+    const v = parseFeatureVerdict('{"pass":true,"notes":"complete"}');
+
+    expect(v.ok).toBe(true);
+    expect(v.notes).toBe("complete");
+  });
+
+  test("pass:false, missing, and unparseable all → reject (fail closed)", () => {
+    expect(parseFeatureVerdict('{"pass":false,"notes":"stub"}').ok).toBe(false);
+    expect(parseFeatureVerdict('{"notes":"no verdict"}').ok).toBe(false);
+    expect(parseFeatureVerdict("garbage").ok).toBe(false);
+    expect(parseFeatureVerdict("garbage").notes.toLowerCase()).toContain(
+      "unparseable"
+    );
+  });
+
+  test("judgeFeature drives through the provider", async () => {
+    const v = await judgeFeature(providerSaying('{"pass":true,"notes":"ok"}'), {
+      feature: "add a todo",
+      code: "export const add = () => {};",
+    });
+
+    expect(v.ok).toBe(true);
+  });
+});
+
+describe("prepareState: resume-first, else plan", () => {
+  let dir: string;
+
+  beforeEach(async () => {
+    dir = await mkdtemp(join(tmpdir(), "tsforge-prep-"));
+  });
+
+  afterEach(async () => {
+    await rm(dir, { recursive: true, force: true });
+  });
+
+  const stubPlan =
+    (plan: IPlan | null) =>
+    async (): Promise<IPlan | null> =>
+      plan;
+
+  test("plans fresh when no state exists (writes spec.md + features.json)", async () => {
+    let planCalls = 0;
+    const state = await prepareState(dir, "build x", async (g) => {
+      planCalls += 1;
+      expect(g).toBe("build x");
+
+      return { spec: "# spec", features: [{ id: "a", desc: "do a", passes: false, attempts: 0 }] };
+    });
+
+    expect(planCalls).toBe(1);
+    expect(state?.features.map((f) => f.id)).toEqual(["a"]);
+    expect(await readFile(join(greenfieldDir(dir), "spec.md"), "utf8")).toContain(
+      "spec"
+    );
+    expect((await loadState(dir))?.goal).toBe("build x");
+  });
+
+  test("resumes existing state WITHOUT calling the planner", async () => {
+    await saveState(dir, {
+      goal: "old goal",
+      features: [{ id: "done", desc: "d", passes: true, attempts: 1 }],
+    });
+
+    let planCalls = 0;
+    const state = await prepareState(dir, "new goal", async () => {
+      planCalls += 1;
+
+      return null;
+    });
+
+    expect(planCalls).toBe(0); // resume-first: planner not consulted
+    expect(state?.goal).toBe("old goal");
+  });
+
+  test("returns null when nothing exists and planning yields nothing", async () => {
+    expect(await prepareState(dir, "x", stubPlan(null))).toBeNull();
+  });
+});

--- a/packages/core/tests/greenfield-planner.test.ts
+++ b/packages/core/tests/greenfield-planner.test.ts
@@ -38,7 +38,9 @@ describe("planner: parsePlan / planFeatures", () => {
 
     expect(plan?.spec).toContain("Build it");
     expect(plan?.features.map((f) => f.id)).toEqual(["list-todos", "add-todo"]);
-    expect(plan?.features.every((f) => !f.passes && f.attempts === 0)).toBe(true);
+    expect(plan?.features.every((f) => !f.passes && f.attempts === 0)).toBe(
+      true
+    );
     expect(plan?.features[1]?.steps).toHaveLength(1);
   });
 
@@ -96,10 +98,8 @@ describe("prepareState: resume-first, else plan", () => {
     await rm(dir, { recursive: true, force: true });
   });
 
-  const stubPlan =
-    (plan: IPlan | null) =>
-    async (): Promise<IPlan | null> =>
-      plan;
+  const stubPlan = (plan: IPlan | null) => async (): Promise<IPlan | null> =>
+    plan;
 
   test("plans fresh when no state exists (writes spec.md + features.json)", async () => {
     let planCalls = 0;
@@ -107,14 +107,17 @@ describe("prepareState: resume-first, else plan", () => {
       planCalls += 1;
       expect(g).toBe("build x");
 
-      return { spec: "# spec", features: [{ id: "a", desc: "do a", passes: false, attempts: 0 }] };
+      return {
+        spec: "# spec",
+        features: [{ id: "a", desc: "do a", passes: false, attempts: 0 }],
+      };
     });
 
     expect(planCalls).toBe(1);
     expect(state?.features.map((f) => f.id)).toEqual(["a"]);
-    expect(await readFile(join(greenfieldDir(dir), "spec.md"), "utf8")).toContain(
-      "spec"
-    );
+    expect(
+      await readFile(join(greenfieldDir(dir), "spec.md"), "utf8")
+    ).toContain("spec");
     expect((await loadState(dir))?.goal).toBe("build x");
   });
 

--- a/packages/core/tests/greenfield.test.ts
+++ b/packages/core/tests/greenfield.test.ts
@@ -1,0 +1,248 @@
+import { test, expect, describe, beforeEach, afterEach } from "bun:test";
+import { mkdtemp, rm, readFile, mkdir, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  runGreenfield,
+  evaluateFeature,
+  loadState,
+  saveState,
+  renderProgress,
+  greenfieldDir,
+} from "../src/loop/greenfield";
+import type {
+  IGreenfieldState,
+  IGreenfieldDeps,
+  IEvaluateDeps,
+  IFeature,
+} from "../src/loop/greenfield";
+
+function feature(id: string, passes = false): IFeature {
+  return { id, desc: `do ${id}`, passes, attempts: 0 };
+}
+
+function state(...ids: string[]): IGreenfieldState {
+  return { goal: "build a thing", features: ids.map((id) => feature(id)) };
+}
+
+let dir: string;
+
+beforeEach(async () => {
+  dir = await mkdtemp(join(tmpdir(), "tsforge-gf-"));
+});
+
+afterEach(async () => {
+  await rm(dir, { recursive: true, force: true });
+});
+
+describe("greenfield state", () => {
+  test("saveState → loadState round-trips the checklist", async () => {
+    const s = state("a", "b");
+
+    s.features[1]!.passes = true;
+    s.features[1]!.attempts = 2;
+    await saveState(dir, s);
+
+    const loaded = await loadState(dir);
+
+    expect(loaded?.goal).toBe("build a thing");
+    expect(loaded?.features.map((f) => f.id)).toEqual(["a", "b"]);
+    expect(loaded?.features[1]?.passes).toBe(true);
+    expect(loaded?.features[1]?.attempts).toBe(2);
+  });
+
+  test("loadState returns null when no state exists or it's corrupt", async () => {
+    expect(await loadState(dir)).toBeNull();
+
+    await mkdir(greenfieldDir(dir), { recursive: true });
+    await writeFile(join(greenfieldDir(dir), "features.json"), "{not json");
+    expect(await loadState(dir)).toBeNull();
+  });
+
+  test("loadState drops malformed feature entries without crashing", async () => {
+    await mkdir(greenfieldDir(dir), { recursive: true });
+    await writeFile(
+      join(greenfieldDir(dir), "features.json"),
+      JSON.stringify({
+        goal: "g",
+        features: [{ id: "ok", desc: "fine" }, { desc: "no id" }, 42],
+      })
+    );
+
+    const loaded = await loadState(dir);
+
+    expect(loaded?.features.map((f) => f.id)).toEqual(["ok"]);
+    expect(loaded?.features[0]?.passes).toBe(false); // defaulted
+  });
+
+  test("renderProgress shows a tick per verified feature + a count", () => {
+    const s = state("a", "b");
+
+    s.features[0]!.passes = true;
+
+    const md = renderProgress(s);
+
+    expect(md).toContain("1/2 features verified");
+    expect(md).toContain("- [x] a");
+    expect(md).toContain("- [ ] b");
+  });
+});
+
+describe("evaluateFeature: layered, short-circuiting", () => {
+  const ok = { ok: true, errors: [] };
+
+  function deps(over: Partial<IEvaluateDeps>): IEvaluateDeps {
+    return {
+      gate: async () => ({ passed: true, output: "" }),
+      browser: async () => ok,
+      judge: async () => ({ ok: true, notes: "good" }),
+      ...over,
+    };
+  }
+
+  test("gate failure short-circuits before browser/judge", async () => {
+    let browserCalled = false;
+    const v = await evaluateFeature(
+      feature("a"),
+      deps({
+        gate: async () => ({ passed: false, output: "TS2322 type error\nmore" }),
+        browser: async () => {
+          browserCalled = true;
+
+          return ok;
+        },
+      })
+    );
+
+    expect(v.passed).toBe(false);
+    expect(v.stage).toBe("gate");
+    expect(v.notes).toBe("TS2322 type error");
+    expect(browserCalled).toBe(false);
+  });
+
+  test("a skipped render-check does NOT block (playwright absent)", async () => {
+    const v = await evaluateFeature(
+      feature("a"),
+      deps({ browser: async () => ({ ok: false, errors: ["x"], skipped: true }) })
+    );
+
+    expect(v.passed).toBe(true);
+  });
+
+  test("a real browser failure blocks at the browser stage", async () => {
+    const v = await evaluateFeature(
+      feature("a"),
+      deps({ browser: async () => ({ ok: false, errors: ["console error: boom"] }) })
+    );
+
+    expect(v.passed).toBe(false);
+    expect(v.stage).toBe("browser");
+    expect(v.notes).toContain("boom");
+  });
+
+  test("judge is the last gate and can still fail a green build", async () => {
+    const v = await evaluateFeature(
+      feature("a"),
+      deps({ judge: async () => ({ ok: false, notes: "ugly state mgmt" }) })
+    );
+
+    expect(v.passed).toBe(false);
+    expect(v.stage).toBe("judge");
+  });
+
+  test("all green → passed", async () => {
+    const v = await evaluateFeature(feature("a"), deps({}));
+
+    expect(v.passed).toBe(true);
+    expect(v.stage).toBeUndefined();
+  });
+});
+
+describe("runGreenfield: outer loop", () => {
+  test("drives every feature to green, in order, ticking the checklist", async () => {
+    const s = state("a", "b", "c");
+    const implemented: string[] = [];
+    const deps: IGreenfieldDeps = {
+      implement: async (f) => void implemented.push(f.id),
+      evaluate: async () => ({ passed: true, notes: "ok" }),
+    };
+
+    const res = await runGreenfield(dir, s, deps);
+
+    expect(res.status).toBe("done");
+    expect(implemented).toEqual(["a", "b", "c"]); // first-unfinished order
+    expect(res.features.every((f) => f.passes)).toBe(true);
+
+    // features.json on disk reflects the all-green end state
+    const onDisk = await loadState(dir);
+
+    expect(onDisk?.features.every((f) => f.passes)).toBe(true);
+  });
+
+  test("gives up on a non-converging feature after maxAttempts (status stuck)", async () => {
+    const s = state("a", "b");
+    let aCalls = 0;
+    const deps: IGreenfieldDeps = {
+      implement: async (f) => {
+        if (f.id === "a") {
+          aCalls += 1;
+        }
+      },
+      // 'a' never passes; 'b' would, but the loop never reaches it.
+      evaluate: async (f) => ({ passed: f.id !== "a", notes: "" }),
+    };
+
+    const res = await runGreenfield(dir, s, deps, { maxAttemptsPerFeature: 3 });
+
+    expect(res.status).toBe("stuck");
+    expect(res.stuckFeature).toBe("a");
+    expect(aCalls).toBe(3); // exactly maxAttempts, then it bails
+    expect(s.features[1]?.passes).toBe(false); // 'b' never attempted
+  });
+
+  test("a feature that passes on its 2nd attempt is not counted stuck", async () => {
+    const s = state("a");
+    let calls = 0;
+    const deps: IGreenfieldDeps = {
+      implement: async () => void (calls += 1),
+      evaluate: async () => ({ passed: calls >= 2, notes: "" }),
+    };
+
+    const res = await runGreenfield(dir, s, deps, { maxAttemptsPerFeature: 3 });
+
+    expect(res.status).toBe("done");
+    expect(s.features[0]?.attempts).toBe(2);
+  });
+
+  test("resumes from persisted state (already-passing features are skipped)", async () => {
+    const s = state("a", "b");
+
+    s.features[0]!.passes = true; // 'a' already done
+    const implemented: string[] = [];
+    const deps: IGreenfieldDeps = {
+      implement: async (f) => void implemented.push(f.id),
+      evaluate: async () => ({ passed: true, notes: "" }),
+    };
+
+    await runGreenfield(dir, s, deps);
+
+    expect(implemented).toEqual(["b"]); // 'a' skipped
+  });
+
+  test("writes progress.md as it goes", async () => {
+    const s = state("a");
+    const deps: IGreenfieldDeps = {
+      implement: async () => undefined,
+      evaluate: async () => ({ passed: true, notes: "" }),
+    };
+
+    await runGreenfield(dir, s, deps);
+
+    const md = await readFile(
+      join(greenfieldDir(dir), "progress.md"),
+      "utf8"
+    );
+
+    expect(md).toContain("1/1 features verified");
+  });
+});

--- a/packages/core/tests/greenfield.test.ts
+++ b/packages/core/tests/greenfield.test.ts
@@ -105,7 +105,10 @@ describe("evaluateFeature: layered, short-circuiting", () => {
     const v = await evaluateFeature(
       feature("a"),
       deps({
-        gate: async () => ({ passed: false, output: "TS2322 type error\nmore" }),
+        gate: async () => ({
+          passed: false,
+          output: "TS2322 type error\nmore",
+        }),
         browser: async () => {
           browserCalled = true;
 
@@ -123,7 +126,9 @@ describe("evaluateFeature: layered, short-circuiting", () => {
   test("a skipped render-check does NOT block (playwright absent)", async () => {
     const v = await evaluateFeature(
       feature("a"),
-      deps({ browser: async () => ({ ok: false, errors: ["x"], skipped: true }) })
+      deps({
+        browser: async () => ({ ok: false, errors: ["x"], skipped: true }),
+      })
     );
 
     expect(v.passed).toBe(true);
@@ -132,7 +137,9 @@ describe("evaluateFeature: layered, short-circuiting", () => {
   test("a real browser failure blocks at the browser stage", async () => {
     const v = await evaluateFeature(
       feature("a"),
-      deps({ browser: async () => ({ ok: false, errors: ["console error: boom"] }) })
+      deps({
+        browser: async () => ({ ok: false, errors: ["console error: boom"] }),
+      })
     );
 
     expect(v.passed).toBe(false);
@@ -238,10 +245,7 @@ describe("runGreenfield: outer loop", () => {
 
     await runGreenfield(dir, s, deps);
 
-    const md = await readFile(
-      join(greenfieldDir(dir), "progress.md"),
-      "utf8"
-    );
+    const md = await readFile(join(greenfieldDir(dir), "progress.md"), "utf8");
 
     expect(md).toContain("1/1 features verified");
   });

--- a/packages/core/tests/judge.test.ts
+++ b/packages/core/tests/judge.test.ts
@@ -1,11 +1,27 @@
 import { test, expect } from "bun:test";
-import { judge } from "../src/eval";
-import type { IProvider } from "../src/inference";
+import { judge, JUDGE_INPUT_SHAPE } from "../src/eval";
+import type { IProvider, IChatMessage } from "../src/inference";
 
 function providerSaying(content: string): IProvider {
   return {
     async complete() {
       return { content, toolCalls: [] };
+    },
+  };
+}
+
+/** A provider that records the messages it was given, for prompt assertions. */
+function capturingProvider(): { provider: IProvider; seen: IChatMessage[] } {
+  const seen: IChatMessage[] = [];
+
+  return {
+    seen,
+    provider: {
+      async complete(messages) {
+        seen.push(...messages);
+
+        return { content: '{"overall":3}', toolCalls: [] };
+      },
     },
   };
 }
@@ -37,6 +53,48 @@ test("tolerates a fenced JSON block", async () => {
   const s = await judge(provider, { goal: "g", criteria: "c", code: "x" });
 
   expect(s.overall).toBe(2);
+});
+
+// Design-rule #2: the evaluator must NEVER see the generator's trace/reasoning.
+// JUDGE_INPUT_SHAPE is `Record<keyof IJudgeInput, true>`, so adding a field to
+// IJudgeInput forces it to appear here — and this test rejects any trace-ish name.
+test("the judge input shape carries NO trace/reasoning fields (ratchet)", () => {
+  const keys = Object.keys(JUDGE_INPUT_SHAPE).map((k) => k.toLowerCase());
+  const forbidden = [
+    "trace",
+    "toolcalls",
+    "tool_calls",
+    "reasoning",
+    "thinking",
+    "transcript",
+    "history",
+    "messages",
+    "events",
+    "steps",
+  ];
+
+  for (const bad of forbidden) {
+    expect(keys).not.toContain(bad);
+  }
+
+  // It IS exactly the artifact-only triple — if this changes, re-audit rule #2.
+  expect(keys.sort()).toEqual(["code", "criteria", "goal"]);
+});
+
+test("the judge prompt is built only from goal/criteria/code", async () => {
+  const { provider, seen } = capturingProvider();
+
+  await judge(provider, {
+    goal: "GOAL_SENTINEL",
+    criteria: "CRIT_SENTINEL",
+    code: "CODE_SENTINEL",
+  });
+
+  const user = seen.find((m) => m.role === "user")?.content ?? "";
+
+  expect(user).toContain("GOAL_SENTINEL");
+  expect(user).toContain("CRIT_SENTINEL");
+  expect(user).toContain("CODE_SENTINEL");
 });
 
 test("falls back gracefully on an unparseable response", async () => {

--- a/packages/core/tests/models-config.test.ts
+++ b/packages/core/tests/models-config.test.ts
@@ -10,6 +10,7 @@ import {
   resolveApiKey,
   envModelEntry,
   resolveActiveModel,
+  resolveModelByName,
   modelsConfigPath,
   defaultModelsConfig,
 } from "../src/models-config";
@@ -47,6 +48,24 @@ function restore(name: string, value: string | undefined): void {
     process.env[name] = value;
   }
 }
+
+test("resolveModelByName: known name, unknown name, and unset all resolve", async () => {
+  await saveModelsConfig({
+    active: "work",
+    models: {
+      work: { baseUrl: "http://w", model: "work-model" },
+      judge: { baseUrl: "http://j", model: "judge-model" },
+    },
+  });
+
+  // a known role name resolves to that entry
+  expect((await resolveModelByName("judge")).entry.model).toBe("judge-model");
+  // an unknown name falls back to the active model (never throws)
+  expect((await resolveModelByName("nope")).entry.model).toBe("work-model");
+  // unset / empty falls back to the active model too
+  expect((await resolveModelByName(undefined)).entry.model).toBe("work-model");
+  expect((await resolveModelByName("")).entry.model).toBe("work-model");
+});
 
 test("missing registry → the built-in local-qwen default (no file written)", async () => {
   const cfg = await loadModelsConfig();

--- a/packages/core/tests/recipes.test.ts
+++ b/packages/core/tests/recipes.test.ts
@@ -44,6 +44,28 @@ describe("parseRecipe", () => {
     ).toBeUndefined();
   });
 
+  test("parses the greenfield role models", () => {
+    const r = parseRecipe({
+      id: "build-app",
+      mode: "greenfield",
+      plannerModel: "big-thinker",
+      workModel: "fast-coder",
+      evaluatorModel: "harsh-judge",
+    });
+
+    expect(r?.plannerModel).toBe("big-thinker");
+    expect(r?.workModel).toBe("fast-coder");
+    expect(r?.evaluatorModel).toBe("harsh-judge");
+    expect(
+      unrecognizedKeys({
+        id: "x",
+        plannerModel: "a",
+        workModel: "b",
+        evaluatorModel: "c",
+      })
+    ).toEqual([]);
+  });
+
   test("accepts mode:greenfield and drops any other mode value", () => {
     expect(parseRecipe({ id: "build-app", mode: "greenfield" })?.mode).toBe(
       "greenfield"

--- a/packages/core/tests/recipes.test.ts
+++ b/packages/core/tests/recipes.test.ts
@@ -44,6 +44,14 @@ describe("parseRecipe", () => {
     ).toBeUndefined();
   });
 
+  test("accepts mode:greenfield and drops any other mode value", () => {
+    expect(parseRecipe({ id: "build-app", mode: "greenfield" })?.mode).toBe(
+      "greenfield"
+    );
+    expect(parseRecipe({ id: "x", mode: "spaceship" })?.mode).toBeUndefined();
+    expect(unrecognizedKeys({ id: "x", mode: "greenfield" })).toEqual([]);
+  });
+
   test("rejects a recipe with no id or a non-kebab id", () => {
     expect(parseRecipe({ gate: "x" })).toBeNull();
     expect(parseRecipe({ id: "Has Spaces" })).toBeNull();

--- a/packages/core/tests/recipes.test.ts
+++ b/packages/core/tests/recipes.test.ts
@@ -33,6 +33,17 @@ describe("parseRecipe", () => {
     expect("bogusField" in (r ?? {})).toBe(false);
   });
 
+  test("parses the withReview flag and does not flag it as unrecognized", () => {
+    const r = parseRecipe({ id: "repair-with-review", withReview: true });
+
+    expect(r?.withReview).toBe(true);
+    expect(unrecognizedKeys({ id: "x", withReview: true })).toEqual([]);
+    // a non-boolean withReview is dropped, never coerced
+    expect(
+      parseRecipe({ id: "x", withReview: "yes" })?.withReview
+    ).toBeUndefined();
+  });
+
   test("rejects a recipe with no id or a non-kebab id", () => {
     expect(parseRecipe({ gate: "x" })).toBeNull();
     expect(parseRecipe({ id: "Has Spaces" })).toBeNull();

--- a/packages/core/tests/review-repair.test.ts
+++ b/packages/core/tests/review-repair.test.ts
@@ -129,6 +129,29 @@ test("verified finding + a repair that breaks the gate → reverted, file restor
   expect(readFileSync(join(repo, "discount.ts"), "utf8")).toBe(CHANGED);
 });
 
+test("an agent that throws mid-repair still rolls the workspace back, then rethrows", async () => {
+  const throwingAgent: IAgent = {
+    async implement() {
+      // mutate, THEN throw — the half-applied edit must not survive
+      writeFileSync(join(repo, "discount.ts"), "// HALF-APPLIED\n");
+
+      throw new Error("model exploded");
+    },
+  };
+
+  await expect(
+    reviewRepair(
+      stub(ONE_FINDING, true),
+      repo,
+      task("grep -q REPAIRED discount.ts"),
+      throwingAgent
+    )
+  ).rejects.toThrow("model exploded");
+
+  // the pre-repair content is restored despite the throw
+  expect(readFileSync(join(repo, "discount.ts"), "utf8")).toBe(CHANGED);
+});
+
 test("a revert emits a `reverted` accounting event", async () => {
   const events: string[] = [];
   const agent = fakeAgent(repo, "// BROKEN\n");

--- a/packages/core/tests/review-repair.test.ts
+++ b/packages/core/tests/review-repair.test.ts
@@ -65,7 +65,10 @@ beforeEach(() => {
   git("config", "user.email", "t@t.t");
   git("config", "user.name", "t");
   git("config", "commit.gpgsign", "false");
-  writeFileSync(join(repo, "discount.ts"), "// discount\nconst x = price - off;\n");
+  writeFileSync(
+    join(repo, "discount.ts"),
+    "// discount\nconst x = price - off;\n"
+  );
   git("add", "-A");
   git("commit", "-q", "-m", "init");
   // an uncommitted change on line 2 — the diff under review
@@ -78,7 +81,12 @@ afterEach(() => {
 
 test("no verified findings → no repair, agent never called", async () => {
   const agent = fakeAgent(repo, "should not be written");
-  const res = await reviewRepair(stub(NO_FINDINGS, true), repo, task("true"), agent);
+  const res = await reviewRepair(
+    stub(NO_FINDINGS, true),
+    repo,
+    task("true"),
+    agent
+  );
 
   expect(res.findings).toBe(0);
   expect(res.repaired).toBe(false);

--- a/packages/core/tests/review-repair.test.ts
+++ b/packages/core/tests/review-repair.test.ts
@@ -1,0 +1,137 @@
+import { test, expect, beforeEach, afterEach } from "bun:test";
+import { execFileSync } from "node:child_process";
+import { mkdtempSync, rmSync, writeFileSync, readFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { IProvider } from "../src/inference";
+import type { IAgent } from "../src/agent";
+import type { ITask } from "../src/spec";
+import { reviewRepair } from "../src/loop";
+
+/** Provider that answers find + verify passes (keyed on the system prompt). */
+function stub(findings: string, verifyReal: boolean): IProvider {
+  return {
+    async complete(messages) {
+      const sys = messages.find((m) => m.role === "system")?.content ?? "";
+      const body = sys.includes("verifying a code-review finding")
+        ? JSON.stringify({ real: verifyReal, verdict: "judged" })
+        : findings;
+
+      return { content: body, toolCalls: [] };
+    },
+  };
+}
+
+const ONE_FINDING = JSON.stringify({
+  findings: [
+    {
+      line: 2,
+      severity: "error",
+      lens: "correctness",
+      claim: "subtraction is reversed",
+      reason: "returns a negative discount",
+    },
+  ],
+});
+
+const NO_FINDINGS = JSON.stringify({ findings: [] });
+
+/** A fake implement agent that writes a fixed string and records being called. */
+function fakeAgent(repo: string, write: string): IAgent & { calls: number } {
+  const agent = {
+    calls: 0,
+    async implement(): Promise<void> {
+      agent.calls += 1;
+      writeFileSync(join(repo, "discount.ts"), write);
+    },
+  };
+
+  return agent;
+}
+
+let repo: string;
+const git = (...a: string[]): void =>
+  void execFileSync("git", a, { cwd: repo, stdio: "ignore" });
+
+const CHANGED = "// discount\nconst x = off - price;\n";
+
+function task(accept: string): ITask {
+  return { id: "t", accept, files: ["discount.ts"], context: [] };
+}
+
+beforeEach(() => {
+  repo = mkdtempSync(join(tmpdir(), "tsforge-revrepair-"));
+  git("init", "-q");
+  git("config", "user.email", "t@t.t");
+  git("config", "user.name", "t");
+  git("config", "commit.gpgsign", "false");
+  writeFileSync(join(repo, "discount.ts"), "// discount\nconst x = price - off;\n");
+  git("add", "-A");
+  git("commit", "-q", "-m", "init");
+  // an uncommitted change on line 2 — the diff under review
+  writeFileSync(join(repo, "discount.ts"), CHANGED);
+});
+
+afterEach(() => {
+  rmSync(repo, { recursive: true, force: true });
+});
+
+test("no verified findings → no repair, agent never called", async () => {
+  const agent = fakeAgent(repo, "should not be written");
+  const res = await reviewRepair(stub(NO_FINDINGS, true), repo, task("true"), agent);
+
+  expect(res.findings).toBe(0);
+  expect(res.repaired).toBe(false);
+  expect(res.reverted).toBe(false);
+  expect(agent.calls).toBe(0);
+});
+
+test("verified finding + a repair that keeps the gate green → repaired, kept", async () => {
+  // gate passes only when the file contains REPAIRED; the agent writes it.
+  const agent = fakeAgent(repo, "// REPAIRED\nconst x = price - off;\n");
+  const res = await reviewRepair(
+    stub(ONE_FINDING, true),
+    repo,
+    task("grep -q REPAIRED discount.ts"),
+    agent
+  );
+
+  expect(res.findings).toBe(1);
+  expect(res.repaired).toBe(true);
+  expect(res.reverted).toBe(false);
+  expect(agent.calls).toBe(1);
+  expect(readFileSync(join(repo, "discount.ts"), "utf8")).toContain("REPAIRED");
+});
+
+test("verified finding + a repair that breaks the gate → reverted, file restored", async () => {
+  // gate requires REPAIRED, but the agent writes garbage that lacks it → revert.
+  const agent = fakeAgent(repo, "// BROKEN garbage\n");
+  const res = await reviewRepair(
+    stub(ONE_FINDING, true),
+    repo,
+    task("grep -q REPAIRED discount.ts"),
+    agent
+  );
+
+  expect(res.findings).toBe(1);
+  expect(res.repaired).toBe(false);
+  expect(res.reverted).toBe(true);
+  expect(agent.calls).toBe(1);
+  // the pre-repair (uncommitted) content is restored verbatim
+  expect(readFileSync(join(repo, "discount.ts"), "utf8")).toBe(CHANGED);
+});
+
+test("a revert emits a `reverted` accounting event", async () => {
+  const events: string[] = [];
+  const agent = fakeAgent(repo, "// BROKEN\n");
+
+  await reviewRepair(
+    stub(ONE_FINDING, true),
+    repo,
+    task("grep -q REPAIRED discount.ts"),
+    agent,
+    { onEvent: (e) => events.push(e.kind) }
+  );
+
+  expect(events).toContain("reverted");
+});

--- a/packages/core/tests/run-branches.test.ts
+++ b/packages/core/tests/run-branches.test.ts
@@ -32,6 +32,28 @@ test("red-not-confirmed when the goalpost already passes — model never runs", 
   expect(called).toBe(false);
 });
 
+// Greenfield uses requireRed:false because the global gate is often already green
+// between features — the model must still build the feature, not bail RED-first.
+test("requireRed:false runs the model even when the gate already passes", async () => {
+  let called = false;
+  const provider: IProvider = {
+    async complete() {
+      called = true;
+
+      return { content: "", toolCalls: [] };
+    },
+  };
+  const r = await runTask(
+    { id: "1", accept: "true", files: [] },
+    ".",
+    provider,
+    { requireRed: false }
+  );
+
+  expect(called).toBe(true); // the model ran despite green
+  expect(r.status).not.toBe("red-not-confirmed");
+});
+
 test("stuck when the model never makes the goalpost pass", async () => {
   const dir = await mkdtemp(join(tmpdir(), "tsforge-stuck-"));
 

--- a/packages/core/tests/trace.test.ts
+++ b/packages/core/tests/trace.test.ts
@@ -162,6 +162,88 @@ describe("trace metrics: policy counts", () => {
   });
 });
 
+describe("trace metrics: accept rate / cost per accepted change", () => {
+  // 3 edits, 1 reverted → 2 accepted; 600 completion tokens → 300/accepted.
+  function churnEvents(): ILoopEvent[] {
+    return [
+      { kind: "edit", task: "t", message: "" },
+      { kind: "edit", task: "t", message: "" },
+      {
+        kind: "usage",
+        task: "t",
+        message: "",
+        completionTokens: 600,
+      },
+      { kind: "reverted", task: "t", message: "gate broken" },
+      { kind: "create", task: "t", message: "", file: "src/new.ts" },
+    ];
+  }
+
+  test("analyzeEvents derives editsReverted, acceptRate, costPerAcceptedChange", () => {
+    const m = analyzeEvents(churnEvents());
+
+    expect(m.edits).toBe(3); // 2 edit + 1 create
+    expect(m.editsReverted).toBe(1);
+    expect(m.acceptRate).toBeCloseTo(2 / 3, 5);
+    expect(m.costPerAcceptedChange).toBe(300); // 600 tokens / 2 accepted
+  });
+
+  test("no edits ⇒ acceptRate 0 and costPerAcceptedChange 0 (no divide-by-zero)", () => {
+    const m = analyzeEvents([
+      { kind: "usage", task: "t", message: "", completionTokens: 100 },
+    ]);
+
+    expect(m.edits).toBe(0);
+    expect(m.acceptRate).toBe(0);
+    expect(m.costPerAcceptedChange).toBe(0);
+  });
+
+  test("all edits reverted ⇒ acceptRate 0 and cost 0 (nothing stuck)", () => {
+    const m = analyzeEvents([
+      { kind: "edit", task: "t", message: "" },
+      { kind: "reverted", task: "t", message: "" },
+      { kind: "usage", task: "t", message: "", completionTokens: 500 },
+    ]);
+
+    expect(m.acceptRate).toBe(0);
+    expect(m.costPerAcceptedChange).toBe(0);
+  });
+
+  test("reverted events round-trip through a real LedgerWriter --log", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "tsforge-revert-"));
+
+    try {
+      const file = join(dir, "run.jsonl");
+
+      writeLedger(file, churnEvents());
+
+      const parsed = parseEventLog(await Bun.file(file).text());
+      const m = analyzeEvents(parsed);
+
+      expect(parsed.some((e) => e.kind === "reverted")).toBe(true);
+      expect(m.editsReverted).toBe(1);
+      expect(m.costPerAcceptedChange).toBe(300);
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  test("the reverted event maps to the edit_reverted ledger type", () => {
+    expect(ledgerTypeFor({ kind: "reverted", task: "t", message: "" })).toBe(
+      "edit_reverted"
+    );
+  });
+
+  test("formatTrace surfaces the accept-rate line", () => {
+    const out = formatTrace(churnEvents());
+
+    expect(out).toContain("accept rate");
+    expect(out).toContain("67%"); // round(2/3 * 100)
+    expect(out).toContain("cost/accepted");
+    expect(out).toContain("300 tok");
+  });
+});
+
 describe("trace formatter", () => {
   test("formatTrace renders the headline run signals", () => {
     const events: ILoopEvent[] = [


### PR DESCRIPTION
## Why

Studied Anthropic's long-running-agent workshop + the Kopadze "loops" model and reviewed a Cursor-drafted roadmap. A codebase audit showed **tsforge already implements most of that plan** (deterministic gate + exit-code oracle, JSONL ledger + `/trace`, adversarial review find→verify, quality snapshot/revert, TTSR memory, browser oracle, two-phase `buildStaged`). So this PR builds only the genuinely missing, high-leverage pieces — and encodes the workshop's design rules as ratchets, not comments.

Five design rules adopted: verifier-is-the-heart, **evaluator-blind-to-generator-traces** (now test-enforced), filesystem-state > context, planner-stays-high-level, harness-co-evolves (every new layer flag/knob-gated).

## What

**Stage 1 — accept-rate metrics + post-green review-repair** (`6eca962`)
- New `reverted` loop event → `edit_reverted` ledger type; `quality.ts` emits it on both rollback paths. `analyzeEvents` derives `editsReverted` / `acceptRate` / `costPerAcceptedChange`, surfaced in `/trace`. (The data was already there — reverts just weren't reported.)
- `withReview` recipe knob / `--with-review`: after a one-shot run goes green, run the adversarial review and feed verified findings into **one** repair cycle, reverting it if it breaks the gate. New `loop/review-repair.ts`.
- Extracted shared `loop/file-snapshot.ts` (snapshot/restore) used by both quality- and review-repair.

**Stage 2 — greenfield filesystem-state outer loop** (`ba08dca`)
- `loop/greenfield/`: `runGreenfield` drives a `.tsforge/greenfield/features.json` checklist to all-green one feature at a time, persisting after every step (resumable; per-feature stuck guard so one feature can't wedge the build).
- `evaluateFeature` = layered **gate → browser(renderCheck) → judge**, short-circuiting. Gate stays authority; browser is skip-tolerant; judge sees only the built artifact.
- Recipe `mode: "greenfield"` knob — orchestration lives in a new loop entry, **not** in recipes (they stay declarative data).

**Stage 3 — planner + reject-by-default judge + model routing + trace-blindness ratchet** (`c2e0383`)
- Planner turns a one-line goal into spec + checklist; reject-by-default feature judge (mirrors review's `VERIFY_SYSTEM`, fail-closed).
- `resolveModelByName` + recipe `plannerModel`/`workModel`/`evaluatorModel` → per-role models, falling back to the active model (single-endpoint setups still work).
- **`JUDGE_INPUT_SHAPE: Record<keyof IJudgeInput, true>`** + test: adding any field to the judge input is a compile error until it's listed, where the test rejects trace-ish names. Design-rule #2 can't silently regress.
- `prepareState` (resume-first, else plan) + `greenfieldMode` CLI entry + `--greenfield` flag / recipe dispatch.

**Stage 4 — experimental contract negotiation + scheduling** (`5287648`)
- `loop/greenfield/contract.ts`: **`TSFORGE_CONTRACT`-gated (off by default)** propose↔object negotiation; the evaluator sees only the proposal + feature (rule #2). Persisted to `.tsforge/greenfield/contracts/<feature>.md`. The workshop itself flagged this as unproven, so it's opt-in.
- `--notify <cmd>`: best-effort shell ping on greenfield completion, outcome in `$TSFORGE_STATUS` (cron/unattended runs).

**Docs** (`5287648`, `1d89cb1`) — `loop/greenfield.mdx` + updates to `reference/commands`, `cli/recipes`, `observability/trace`, `reference/flags`.

## Notable scope decisions

- Did **not** rebuild what exists (no "breadcrumbs" file — the ledger already records the failure gradient; evaluator reuses gate+oracle+judge; contract seeds off `buildStaged`).
- The greenfield CLI `implement` uses `runTask` per feature against the global gate; a `Session.send`-based implement would be more precise but needs live-model testing. Noted as a follow-up.

## Verification

- `bun run validate` green — **1420 tests, 0 fail**.
- Every new regression test was **flip-and-confirm-failed** (incl. the trace-blindness ratchet, the revert logic, and the per-feature stuck guard).
- `astro build` clean — **44 pages**.
- The full greenfield end-to-end path needs a live model + Playwright; its orchestration core is fully unit-tested with mocks.
