### PR TITLE
fix: harden greenfield + repair paths (2nd-pass review — 2×P1, 2×P2)

### DIFF
--- a/packages/core/src/cli.ts
+++ b/packages/core/src/cli.ts
@@ -2078,7 +2078,12 @@ function greenfieldDeps(
         browser: async () =>
           args.browser.length > 0
             ? renderCheck({
-                file: args.browser,
+                // Resolve a relative --browser against the RUN dir (--dir), not the
+                // launcher's cwd — greenfield checks run in-process, unlike the
+                // normal gate which already runs inside --dir.
+                file: isAbsolute(args.browser)
+                  ? args.browser
+                  : join(args.dir, args.browser),
                 smoke: true,
                 ...(feature.steps === undefined
                   ? {}

--- a/packages/core/src/eval/metrics.ts
+++ b/packages/core/src/eval/metrics.ts
@@ -131,7 +131,10 @@ function tallyEvent(m: IRunMetrics, event: ILoopEvent, acc: IAccum): void {
       m.edits += 1;
       break;
     case "reverted":
-      m.editsReverted += 1;
+      // A reverted batch may have rolled back several mutations; subtract them
+      // all (default 1 for an older/countless event) so accept-rate isn't
+      // optimistic on multi-file repairs.
+      m.editsReverted += event.count ?? 1;
       break;
     case "timing":
       acc.wallMs += event.ms ?? 0;

--- a/packages/core/src/eval/parse-log.ts
+++ b/packages/core/src/eval/parse-log.ts
@@ -102,7 +102,13 @@ function assignText(event: ILoopEvent, src: Record<string, unknown>): void {
 }
 
 function assignNumbers(event: ILoopEvent, src: Record<string, unknown>): void {
+  const count = optionalNumber(src.count);
   const ms = optionalNumber(src.ms);
+
+  if (count !== undefined) {
+    event.count = count;
+  }
+
   const promptTokens = optionalNumber(src.promptTokens);
   const completionTokens = optionalNumber(src.completionTokens);
   const totalTokens = optionalNumber(src.totalTokens);

--- a/packages/core/src/lib/fs/fs.ts
+++ b/packages/core/src/lib/fs/fs.ts
@@ -33,26 +33,31 @@ function isGlobPattern(path: string): boolean {
   return /[*?[\]{}]/.test(path);
 }
 
-function ignored(rel: string): boolean {
-  return (
-    rel.split("/").some((seg) => IGNORE_SEGMENTS.has(seg)) ||
-    BINARY_EXT.test(rel)
-  );
+/** In a dependency/build/vcs dir we never read OR mutate (so never tombstone). */
+function inIgnoredDir(rel: string): boolean {
+  return rel.split("/").some((seg) => IGNORE_SEGMENTS.has(seg));
 }
 
-/** Expand a glob scope to the concrete, readable files under `cwd` (sorted),
- *  skipping ignored dirs and binary files, capped at `limit` (default
- *  MAX_GLOB_FILES — the prompt-safety bound). Pass `Infinity` when completeness
- *  matters more than prompt size (e.g. a rollback snapshot must see every file). */
+function ignored(rel: string): boolean {
+  return inIgnoredDir(rel) || BINARY_EXT.test(rel);
+}
+
+/** Expand a glob scope to the concrete files under `cwd` (sorted), capped at
+ *  `limit` (default MAX_GLOB_FILES — the prompt-safety bound; pass `Infinity` when
+ *  completeness matters more than prompt size). `skip` decides what to exclude:
+ *  the default drops ignored dirs AND binaries (prompt/context use); rollback
+ *  passes `inIgnoredDir` so it still SEES created assets (`.svg`, images) it must
+ *  delete — filtering those out would leave them behind on a revert. */
 async function expandGlob(
   cwd: string,
   pattern: string,
-  limit = MAX_GLOB_FILES
+  limit = MAX_GLOB_FILES,
+  skip: (rel: string) => boolean = ignored
 ): Promise<string[]> {
   const found: string[] = [];
 
   for await (const rel of new Glob(pattern).scan({ cwd, onlyFiles: true })) {
-    if (!ignored(rel)) {
+    if (!skip(rel)) {
       found.push(rel);
     }
 
@@ -195,6 +200,40 @@ export async function resolveScopeFiles(
   for (const path of paths) {
     if (isGlobPattern(path)) {
       for (const match of await expandGlob(cwd, path, limit)) {
+        out.add(match);
+      }
+    } else {
+      out.add(path);
+    }
+  }
+
+  return [...out];
+}
+
+/**
+ * Resolve a scope for ROLLBACK: every file under `cwd` (uncapped) excluding only
+ * ignored dirs (node_modules, dist, .git…) — but INCLUDING binaries/assets the
+ * prompt-facing resolver drops. A failed repair can create `icon.svg` under a
+ * `**\/*` scope; rollback must see it to delete it, or it reports "reverted" while
+ * leaving the file behind. Separate from `resolveScopeFiles` precisely so the
+ * prompt/context filtering never silently narrows what a revert can clean up.
+ */
+export async function resolveScopeFilesForRollback(
+  cwd: string,
+  paths: readonly string[]
+): Promise<string[]> {
+  const out = new Set<string>();
+
+  for (const path of paths) {
+    if (isGlobPattern(path)) {
+      const matches = await expandGlob(
+        cwd,
+        path,
+        Number.POSITIVE_INFINITY,
+        inIgnoredDir
+      );
+
+      for (const match of matches) {
         out.add(match);
       }
     } else {

--- a/packages/core/src/loop/file-snapshot.ts
+++ b/packages/core/src/loop/file-snapshot.ts
@@ -1,6 +1,6 @@
 import { join } from "node:path";
 import { rm } from "node:fs/promises";
-import { resolveScopeFiles } from "../lib/fs";
+import { resolveScopeFiles, resolveScopeFilesForRollback } from "../lib/fs";
 
 /** Per-file size cap on snapshot CONTENT (matches readFiles' MAX_FILE_BYTES): a
  *  source file we'd ever edit is well under this. Oversize files are still
@@ -23,18 +23,26 @@ export interface IFileSnapshot {
   contents: Map<string, string>;
 }
 
-/** Resolve a scope to concrete files WITHOUT the prompt-safety cap — a rollback
- *  must see every file, or a large repo would snapshot/tombstone incompletely. */
-function resolveAll(cwd: string, scope: readonly string[]): Promise<string[]> {
+/** Every TEXT file in scope (uncapped) — the files whose content a revert can
+ *  rewrite. Binaries are intentionally excluded here (writing back `.text()` of a
+ *  binary would corrupt it); they're tracked for tombstoning via `existedSet`. */
+function textFiles(cwd: string, scope: readonly string[]): Promise<string[]> {
   return resolveScopeFiles(cwd, scope, Number.POSITIVE_INFINITY);
+}
+
+/** Every file in scope (uncapped) INCLUDING binaries/assets — the complete set a
+ *  revert must reason about, so a created `.svg`/image gets tombstoned and a
+ *  pre-existing one is never mistaken for newly-created. */
+function existedSet(cwd: string, scope: readonly string[]): Promise<string[]> {
+  return resolveScopeFilesForRollback(cwd, scope);
 }
 
 /**
  * Capture a rollback point for `scope` (which may contain globs — e.g. the
- * whole-repo `**\/*`). Records pre-existing contents AND the pre-existing path
- * set so a later `restoreFiles` can both rewrite edits and remove files the
- * attempt created. The shared substrate for quality- and review-repair, so the
- * revert semantics can't drift between them.
+ * whole-repo `**\/*`). Records pre-existing contents (text only) AND the full
+ * pre-existing path set (incl. binaries) so a later `restoreFiles` can both
+ * rewrite edits and remove files the attempt created. The shared substrate for
+ * quality- and review-repair, so the revert semantics can't drift between them.
  */
 export async function snapshotFiles(
   cwd: string,
@@ -43,16 +51,16 @@ export async function snapshotFiles(
   const existed = new Set<string>();
   const contents = new Map<string, string>();
 
-  for (const file of await resolveAll(cwd, scope)) {
+  for (const file of await existedSet(cwd, scope)) {
+    if (await Bun.file(join(cwd, file)).exists()) {
+      existed.add(file);
+    }
+  }
+
+  for (const file of await textFiles(cwd, scope)) {
     const handle = Bun.file(join(cwd, file));
 
-    if (!(await handle.exists())) {
-      continue;
-    }
-
-    existed.add(file);
-
-    if (handle.size <= MAX_SNAPSHOT_BYTES) {
+    if ((await handle.exists()) && handle.size <= MAX_SNAPSHOT_BYTES) {
       contents.set(file, await handle.text());
     }
   }
@@ -63,8 +71,9 @@ export async function snapshotFiles(
 /**
  * Roll the workspace back to a snapshot: rewrite every captured file, then delete
  * any file now present in scope that did NOT exist at snapshot time (a tombstone
- * for a helper/test the failed attempt created). Without the tombstone pass a
- * reverted repair would leave new files behind.
+ * for a helper/test/asset the failed attempt created). The tombstone scan is
+ * binary-inclusive and uncapped, or a created asset would report "reverted" while
+ * surviving on disk.
  */
 export async function restoreFiles(snapshot: IFileSnapshot): Promise<void> {
   const { cwd, scope, existed, contents } = snapshot;
@@ -73,7 +82,7 @@ export async function restoreFiles(snapshot: IFileSnapshot): Promise<void> {
     await Bun.write(join(cwd, file), content);
   }
 
-  for (const file of await resolveAll(cwd, scope)) {
+  for (const file of await existedSet(cwd, scope)) {
     if (!existed.has(file)) {
       await rm(join(cwd, file), { force: true });
     }

--- a/packages/core/src/loop/greenfield/contract.ts
+++ b/packages/core/src/loop/greenfield/contract.ts
@@ -1,9 +1,9 @@
 import { mkdir, writeFile } from "node:fs/promises";
-import { join } from "node:path";
+import { basename, join } from "node:path";
 import type { IProvider } from "../../inference";
 import { isRecord } from "../../lib/guards";
 import { extractJson } from "../../lib/json";
-import { greenfieldDir } from "./state";
+import { greenfieldDir, isFeatureId } from "./state";
 import type { IFeature } from "./greenfield.types";
 
 /**
@@ -181,5 +181,10 @@ export async function writeContract(
     ...result.transcript.map((t) => `### ${t.role}\n\n${t.content}\n`),
   ].join("\n");
 
-  await writeFile(join(dir, `${feature.id}.md`), `${body}\n`);
+  // Defence in depth: ids are validated kebab at parse/load, but derive the
+  // filename from a basename anyway so a path-like id can never escape `dir`
+  // (`../../README` → `README`). A non-conforming id falls back to "feature".
+  const safeId = isFeatureId(feature.id) ? feature.id : "feature";
+
+  await writeFile(join(dir, `${basename(safeId)}.md`), `${body}\n`);
 }

--- a/packages/core/src/loop/greenfield/plan.ts
+++ b/packages/core/src/loop/greenfield/plan.ts
@@ -2,6 +2,7 @@ import type { IProvider } from "../../inference";
 import { isRecord } from "../../lib/guards";
 import { extractJson } from "../../lib/json";
 import type { IStep } from "../../browser";
+import { isFeatureId } from "./state";
 import type { IFeature } from "./greenfield.types";
 
 /** The planner's output: a human-readable spec + a fresh feature checklist. */
@@ -33,7 +34,7 @@ function toFeature(value: unknown): IFeature | null {
 
   const { id, desc, steps } = value;
 
-  if (typeof id !== "string" || typeof desc !== "string") {
+  if (typeof id !== "string" || typeof desc !== "string" || !isFeatureId(id)) {
     return null;
   }
 

--- a/packages/core/src/loop/greenfield/state.ts
+++ b/packages/core/src/loop/greenfield/state.ts
@@ -9,6 +9,17 @@ export function greenfieldDir(cwd: string): string {
   return join(cwd, ".tsforge", "greenfield");
 }
 
+/**
+ * A safe feature id: kebab-case, no slashes or dots. Feature ids come from the
+ * model (the planner) and are later used to build file paths
+ * (`contracts/<id>.md`), so an id like `../../README` would escape the state dir.
+ * Validate at parse/load time so a malicious/hallucinated id is dropped, never
+ * trusted as a path component.
+ */
+export function isFeatureId(id: string): boolean {
+  return /^[a-z0-9][a-z0-9-]*$/u.test(id);
+}
+
 function featuresPath(cwd: string): string {
   return join(greenfieldDir(cwd), "features.json");
 }
@@ -31,7 +42,7 @@ function toFeature(value: unknown): IFeature | null {
 
   const { id, desc, passes, attempts, steps } = value;
 
-  if (typeof id !== "string" || typeof desc !== "string") {
+  if (typeof id !== "string" || typeof desc !== "string" || !isFeatureId(id)) {
     return null;
   }
 

--- a/packages/core/src/loop/loop.types.ts
+++ b/packages/core/src/loop/loop.types.ts
@@ -28,7 +28,8 @@ export interface ILoopEvent {
     // An edit batch was rolled back because it broke the gate or failed to raise
     // quality (accounting-only; renders to nothing — the human-facing message
     // rides a `fix` event). Feeds the accept-rate / cost-per-accepted-change
-    // metrics: a reverted edit was spent but never accepted.
+    // metrics: the reverted edits were spent but never accepted. Carries `count`
+    // = how many mutations the batch rolled back (defaults to 1 if absent).
     | "reverted"
     // A unified-policy verdict for one proposed action (ledger-only; renders to
     // nothing on the terminal — a deny is already surfaced via its `tool` event).
@@ -37,6 +38,9 @@ export interface ILoopEvent {
   message: string;
   cycle?: number;
   cycles?: number;
+  /** For `reverted` events: how many file mutations the rolled-back batch
+   *  contained, so the accept-rate metric subtracts the whole batch, not just 1. */
+  count?: number;
   /** For `timing` events: how long the turn took, in milliseconds. */
   ms?: number;
   errors?: number;

--- a/packages/core/src/loop/quality.ts
+++ b/packages/core/src/loop/quality.ts
@@ -71,6 +71,18 @@ export async function qualityRepair(
         ? `\n\nConcrete fixes for the idioms it named:\n${hints}`
         : "";
 
+    // Count this attempt's mutations so a revert subtracts the whole batch from
+    // the accept rate, not just 1.
+    let mutations = 0;
+
+    const countingReport: Reporter = (event) => {
+      if (event.kind === "edit" || event.kind === "create") {
+        mutations += 1;
+      }
+
+      report(event);
+    };
+
     await agent.implement({
       cwd,
       task,
@@ -81,7 +93,7 @@ export async function qualityRepair(
         },
       ],
       cycle: attempts,
-      report,
+      report: countingReport,
     });
 
     if (task.fix !== undefined && task.fix.length > 0) {
@@ -92,7 +104,12 @@ export async function qualityRepair(
 
     if (!gate.passed) {
       await restoreFiles(snapshot);
-      report({ kind: "reverted", task: task.id, message: "gate broken" });
+      report({
+        kind: "reverted",
+        task: task.id,
+        count: mutations,
+        message: "gate broken",
+      });
       report({
         kind: "fix",
         task: task.id,
@@ -112,7 +129,12 @@ export async function qualityRepair(
       });
     } else {
       await restoreFiles(snapshot);
-      report({ kind: "reverted", task: task.id, message: "no quality gain" });
+      report({
+        kind: "reverted",
+        task: task.id,
+        count: mutations,
+        message: "no quality gain",
+      });
       report({
         kind: "fix",
         task: task.id,

--- a/packages/core/src/loop/review-repair.ts
+++ b/packages/core/src/loop/review-repair.ts
@@ -88,6 +88,18 @@ export async function reviewRepair(
   // must restore.
   const snapshot = await snapshotFiles(cwd, task.files);
 
+  // Count the mutations this attempt applies, so a revert subtracts the whole
+  // batch from the accept rate (not just 1).
+  let mutations = 0;
+
+  const countingReport: Reporter = (event) => {
+    if (event.kind === "edit" || event.kind === "create") {
+      mutations += 1;
+    }
+
+    report(event);
+  };
+
   // A throw mid-repair (agent error, fix-command crash, gate runner failure)
   // must still roll the workspace back — otherwise a half-applied edit batch is
   // left on disk. Restore, then rethrow so the caller still sees the failure.
@@ -97,7 +109,7 @@ export async function reviewRepair(
       task,
       errors: findingsToErrors(findings),
       cycle: 1,
-      report,
+      report: countingReport,
     });
 
     if (task.fix !== undefined && task.fix.length > 0) {
@@ -125,6 +137,7 @@ export async function reviewRepair(
   report({
     kind: "reverted",
     task: task.id,
+    count: mutations,
     message: "review repair broke the gate",
   });
   report({

--- a/packages/core/tests/file-snapshot.test.ts
+++ b/packages/core/tests/file-snapshot.test.ts
@@ -70,6 +70,34 @@ test("restoreFiles tombstones files created after the snapshot", async () => {
   expect(existsSync(join(dir, "src", "b.ts"))).toBe(true);
 });
 
+// Regression: the prompt-facing resolver skips binaries/assets (.svg, images),
+// so tombstoning through it left a failed repair's created icon.svg on disk.
+// Rollback must use the binary-inclusive resolver.
+test("restoreFiles tombstones a created binary/asset file (svg)", async () => {
+  const snap = await snapshotFiles(dir, ["**/*"]);
+
+  writeFileSync(join(dir, "src", "icon.svg"), "<svg></svg>");
+  writeFileSync(join(dir, "logo.png"), "PNGDATA");
+
+  await restoreFiles(snap);
+
+  expect(existsSync(join(dir, "src", "icon.svg"))).toBe(false);
+  expect(existsSync(join(dir, "logo.png"))).toBe(false);
+});
+
+test("restoreFiles preserves a PRE-EXISTING asset file (not tombstoned)", async () => {
+  writeFileSync(join(dir, "src", "keep.svg"), "<svg>keep</svg>");
+
+  const snap = await snapshotFiles(dir, ["**/*"]);
+
+  writeFileSync(join(dir, "src", "new.ts"), "// new\n");
+  await restoreFiles(snap);
+
+  // the asset that existed at snapshot time survives; the new .ts is tombstoned
+  expect(existsSync(join(dir, "src", "keep.svg"))).toBe(true);
+  expect(existsSync(join(dir, "src", "new.ts"))).toBe(false);
+});
+
 test("a literal scope still snapshots exactly those files", async () => {
   const snap = await snapshotFiles(dir, ["src/a.ts"]);
 

--- a/packages/core/tests/greenfield-contract.test.ts
+++ b/packages/core/tests/greenfield-contract.test.ts
@@ -1,5 +1,6 @@
 import { test, expect, describe, afterEach } from "bun:test";
 import { mkdtemp, rm, readFile } from "node:fs/promises";
+import { existsSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import type { IProvider, IChatMessage } from "../src/inference";
@@ -172,6 +173,28 @@ describe("writeContract", () => {
 
   afterEach(async () => {
     await rm(dir, { recursive: true, force: true });
+  });
+
+  test("a path-like feature id cannot escape the contracts dir", async () => {
+    dir = await mkdtemp(join(tmpdir(), "tsforge-contract-esc-"));
+    const evil = {
+      id: "../../../README",
+      desc: "x",
+      passes: false,
+      attempts: 0,
+    };
+    const res = await negotiateContract(generator("p"), evaluator(0), evil);
+
+    await writeContract(dir, evil, res);
+
+    // nothing written outside .tsforge/greenfield/contracts (no clobbered README)
+    const escaped = join(dir, "..", "..", "..", "README.md");
+
+    expect(existsSync(escaped)).toBe(false);
+    // an unsafe id falls back to a safe name inside the contracts dir
+    expect(
+      existsSync(join(greenfieldDir(dir), "contracts", "feature.md"))
+    ).toBe(true);
   });
 
   test("persists a transcript under .tsforge/greenfield/contracts", async () => {

--- a/packages/core/tests/greenfield-planner.test.ts
+++ b/packages/core/tests/greenfield-planner.test.ts
@@ -50,6 +50,22 @@ describe("planner: parsePlan / planFeatures", () => {
     expect(parsePlan(JSON.stringify({ spec: "x" }))).toBeNull();
   });
 
+  test("drops features with unsafe (non-kebab / path-like) ids", () => {
+    const plan = parsePlan(
+      JSON.stringify({
+        spec: "x",
+        features: [
+          { id: "../../../README", desc: "path traversal" },
+          { id: "has/slash", desc: "slash" },
+          { id: "Has Space", desc: "space" },
+          { id: "good-feature", desc: "fine" },
+        ],
+      })
+    );
+
+    expect(plan?.features.map((f) => f.id)).toEqual(["good-feature"]);
+  });
+
   test("planFeatures tolerates a fenced JSON block", async () => {
     const plan = await planFeatures(
       providerSaying("```json\n" + GOOD + "\n```"),

--- a/packages/core/tests/review-repair.test.ts
+++ b/packages/core/tests/review-repair.test.ts
@@ -152,6 +152,37 @@ test("an agent that throws mid-repair still rolls the workspace back, then rethr
   expect(readFileSync(join(repo, "discount.ts"), "utf8")).toBe(CHANGED);
 });
 
+test("a reverted batch reports its mutation count (multi-file accounting)", async () => {
+  // An agent that emits 3 edit events (then leaves the gate failing) → the
+  // reverted event must carry count:3, not 1.
+  const multiEditAgent: IAgent = {
+    async implement(ctx) {
+      for (const f of ["a", "b", "c"]) {
+        ctx.report?.({ kind: "edit", task: ctx.task.id, message: f });
+      }
+
+      writeFileSync(join(repo, "discount.ts"), "// still broken\n");
+    },
+  };
+  const reverts: number[] = [];
+
+  await reviewRepair(
+    stub(ONE_FINDING, true),
+    repo,
+    task("grep -q REPAIRED discount.ts"),
+    multiEditAgent,
+    {
+      onEvent: (e) => {
+        if (e.kind === "reverted") {
+          reverts.push(e.count ?? -1);
+        }
+      },
+    }
+  );
+
+  expect(reverts).toEqual([3]);
+});
+
 test("a revert emits a `reverted` accounting event", async () => {
   const events: string[] = [];
   const agent = fakeAgent(repo, "// BROKEN\n");

--- a/packages/core/tests/trace.test.ts
+++ b/packages/core/tests/trace.test.ts
@@ -188,6 +188,34 @@ describe("trace metrics: accept rate / cost per accepted change", () => {
     expect(m.costPerAcceptedChange).toBe(300); // 600 tokens / 2 accepted
   });
 
+  test("a reverted batch subtracts its full mutation count, not just 1", () => {
+    // 5 mutations, one reverted batch of 4 → 1 accepted (not 4).
+    const m = analyzeEvents([
+      { kind: "edit", task: "t", message: "" },
+      { kind: "edit", task: "t", message: "" },
+      { kind: "edit", task: "t", message: "" },
+      { kind: "edit", task: "t", message: "" },
+      { kind: "create", task: "t", message: "", file: "src/n.ts" },
+      { kind: "reverted", task: "t", message: "", count: 4 },
+      { kind: "usage", task: "t", message: "", completionTokens: 500 },
+    ]);
+
+    expect(m.edits).toBe(5);
+    expect(m.editsReverted).toBe(4);
+    expect(m.acceptRate).toBeCloseTo(1 / 5, 5);
+    expect(m.costPerAcceptedChange).toBe(500); // 500 tokens / 1 accepted
+  });
+
+  test("a reverted event with no count falls back to 1 (back-compat)", () => {
+    const m = analyzeEvents([
+      { kind: "edit", task: "t", message: "" },
+      { kind: "edit", task: "t", message: "" },
+      { kind: "reverted", task: "t", message: "" },
+    ]);
+
+    expect(m.editsReverted).toBe(1);
+  });
+
   test("no edits ⇒ acceptRate 0 and costPerAcceptedChange 0 (no divide-by-zero)", () => {
     const m = analyzeEvents([
       { kind: "usage", task: "t", message: "", completionTokens: 100 },
@@ -226,6 +254,20 @@ describe("trace metrics: accept rate / cost per accepted change", () => {
     } finally {
       await rm(dir, { recursive: true, force: true });
     }
+  });
+
+  test("the reverted batch count round-trips through the ledger", () => {
+    const line = JSON.stringify({
+      eventId: "e1",
+      runId: "r1",
+      timestamp: "2026-06-22T00:00:00.000Z",
+      type: ledgerTypeFor({ kind: "reverted", task: "t", message: "" }),
+      payload: { kind: "reverted", task: "t", message: "", count: 3 },
+    });
+    const parsed = parseEventLog(line);
+
+    expect(parsed[0]?.count).toBe(3);
+    expect(analyzeEvents(parsed).editsReverted).toBe(3);
   });
 
   test("the reverted event maps to the edit_reverted ledger type", () => {


### PR DESCRIPTION
## Why

A second-pass review of the greenfield/repair paths (shipped in 0.20.0 via #44) found four real issues — two security/correctness P1s and two P2s. This is the hardening pass before the feature is settled.

## Fixes

**[P1] Contract persistence trusted model-controlled feature IDs as paths.**
`writeContract` did `join(dir, \`${feature.id}.md\`)`, and the planner accepted any string id — so with `TSFORGE_CONTRACT=1` a feature id like `../../../README` escaped the state dir (reproduced in a temp repo). Now: feature ids are validated kebab-case (`isFeatureId`) at **both** parse (`plan.ts`) and load (`state.ts`), so a path-like id is dropped; `writeContract` additionally derives the filename from a `basename` with a safe `"feature"` fallback (defence-in-depth).

**[P1] Rollback left newly-created binary/asset files behind.**
`restoreFiles` tombstoned through `resolveScopeFiles`, which intentionally filters out `.svg`/images/fonts for prompt safety — so a failed repair that created `icon.svg` reported "reverted" while leaving it on disk (reproduced). Added `resolveScopeFilesForRollback` (uncapped, ignored-**dirs**-only, **binary-inclusive**); the snapshot's existed-set and the tombstone scan use it, while text content is still captured via the filtered resolver (writing back `.text()` of a binary would corrupt it).

**[P2] Greenfield `--browser` resolved relative paths from the launcher cwd, not `--dir`.**
Normal gate checks run inside `--dir`, but greenfield's in-process `renderCheck` did not. Relative `--browser` is now resolved against `args.dir`.

**[P2] Accept-rate metrics undercounted multi-file reverts.**
One `reverted` event subtracted only 1, but a failed batch may roll back N edits — making `/trace` optimistic. The `reverted` event now carries a batch mutation `count` (review-repair + quality tally `edit`/`create` events during the attempt); `analyzeEvents` subtracts `event.count` (default 1), and `count` round-trips through the ledger.

## Verification

- `bun run validate` green — **1421 pass / 0 fail**.
- New regression tests for each fix; both P1s flip-and-confirm-failed (svg-tombstone and path-traversal-id).
- Targets the same merged feature; no behavior change outside the greenfield/repair paths.
