### PR TITLE
test(e2e): replicate the real user experience across subsystems

### DIFF
--- a/packages/core/src/render/wizard.ts
+++ b/packages/core/src/render/wizard.ts
@@ -384,8 +384,10 @@ interface IKeyInfo {
 }
 
 /** Map a raw keypress to a wizard action, or null to ignore. Digits jump the
- *  cursor and are handled by the driver (not here). */
-function actionFor(
+ *  cursor and are handled by the driver (not here). Exported so the key→action
+ *  decode is unit-testable without a PTY (the raw-mode plumbing around it is
+ *  not — see node-pty/Bun limits). */
+export function actionFor(
   str: string | undefined,
   key: IKeyInfo
 ): IWizardAction | null {

--- a/packages/core/tests/helpers/scripted-model.ts
+++ b/packages/core/tests/helpers/scripted-model.ts
@@ -1,0 +1,60 @@
+import type {
+  IChatMessage,
+  IModelResponse,
+  IProvider,
+  IToolCall,
+} from "../../src/inference";
+
+/**
+ * A deterministic stand-in for the model seam (`IProvider`). Drives the real
+ * agent loop with a scripted sequence of turns so a full session — tool calls,
+ * gate, repair loop, final verdict — is replayable in a test without a live LLM.
+ *
+ * Each `complete()` consumes the next turn. A turn is either a fixed
+ * `{content, toolCalls}` or a function of the conversation so far (so a turn can
+ * REACT to gate feedback — e.g. "if the last message mentions the error, fix
+ * it"). When the script is exhausted the model yields (no content, no tool
+ * calls), which the loop reads as "the model is done".
+ */
+export interface IScriptedTurn {
+  content?: string;
+  toolCalls?: IToolCall[];
+}
+
+export type ScriptedTurn =
+  | IScriptedTurn
+  | ((messages: readonly IChatMessage[]) => IScriptedTurn);
+
+export interface IScriptedModel extends IProvider {
+  /** How many times the loop has called the model. */
+  readonly calls: number;
+}
+
+/** Build one tool call for a scripted turn. */
+export function call(name: string, args: Record<string, unknown>): IToolCall {
+  return { name, arguments: args };
+}
+
+export function scriptedModel(turns: readonly ScriptedTurn[]): IScriptedModel {
+  let idx = 0;
+
+  return {
+    get calls(): number {
+      return idx;
+    },
+
+    complete(messages: readonly IChatMessage[]): Promise<IModelResponse> {
+      const turn = turns[idx];
+
+      idx += 1;
+
+      const resolved: IScriptedTurn =
+        typeof turn === "function" ? turn(messages) : (turn ?? {});
+
+      return Promise.resolve({
+        content: resolved.content ?? "",
+        toolCalls: resolved.toolCalls ?? [],
+      });
+    },
+  };
+}

--- a/packages/core/tests/helpers/scripted-model.ts
+++ b/packages/core/tests/helpers/scripted-model.ts
@@ -44,6 +44,16 @@ export function scriptedModel(turns: readonly ScriptedTurn[]): IScriptedModel {
     },
 
     complete(messages: readonly IChatMessage[]): Promise<IModelResponse> {
+      // One call past the script returns the empty yield (the loop's natural
+      // stop). Any call beyond that means the loop failed to terminate — throw
+      // immediately so the test fails fast instead of hanging or hitting the
+      // runaway-turn backstop.
+      if (idx > turns.length) {
+        throw new Error(
+          `Scripted model called ${idx + 1} times, but the script has only ${turns.length} turns (loop did not terminate).`
+        );
+      }
+
       const turn = turns[idx];
 
       idx += 1;

--- a/packages/core/tests/helpers/session-harness.ts
+++ b/packages/core/tests/helpers/session-harness.ts
@@ -1,0 +1,109 @@
+import {
+  existsSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  mkdirSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { Session, type ILoopEvent } from "../../src/loop";
+import {
+  scriptedModel,
+  type IScriptedModel,
+  type ScriptedTurn,
+} from "./scripted-model";
+
+export interface IRunScriptedSession {
+  /** The user's first message (the task). */
+  task: string;
+  /** The model's scripted turns. */
+  turns: readonly ScriptedTurn[];
+  /** Editable scope (paths under cwd). Omit ⇒ whole temp dir is editable. */
+  files?: string[];
+  /** Gate command run when a mutating turn ends (e.g. `"true"`, `"test -f ok"`). */
+  accept?: string;
+  /** Auto-fix command run before re-validating. */
+  fix?: string;
+  /** Read-only context files. */
+  context?: string[];
+  /** Files to pre-create in the temp cwd before the session runs (path → text). */
+  seed?: Record<string, string>;
+  /** Per-send turn cap. */
+  maxTurns?: number;
+}
+
+export interface IScriptedSessionResult {
+  status: string;
+  turns: number;
+  events: ILoopEvent[];
+  model: IScriptedModel;
+  cwd: string;
+  /** Events of a given kind, in order. */
+  eventsOfKind(kind: string): ILoopEvent[];
+  /** Whether any event of a kind fired. */
+  sawKind(kind: string): boolean;
+  fileText(rel: string): string;
+  fileExists(rel: string): boolean;
+}
+
+const createdDirs: string[] = [];
+
+/** Remove every temp dir this harness created. Call from afterAll. */
+export function cleanupScriptedSessions(): void {
+  for (const dir of createdDirs.splice(0)) {
+    rmSync(dir, { recursive: true, force: true });
+  }
+}
+
+function seedFiles(cwd: string, seed: Record<string, string>): void {
+  for (const [rel, text] of Object.entries(seed)) {
+    const abs = join(cwd, rel);
+
+    mkdirSync(dirname(abs), { recursive: true });
+    writeFileSync(abs, text);
+  }
+}
+
+export async function runScriptedSession(
+  opts: IRunScriptedSession
+): Promise<IScriptedSessionResult> {
+  const cwd = mkdtempSync(join(tmpdir(), "tsforge-e2e-"));
+
+  createdDirs.push(cwd);
+
+  if (opts.seed !== undefined) {
+    seedFiles(cwd, opts.seed);
+  }
+
+  const events: ILoopEvent[] = [];
+  const model = scriptedModel(opts.turns);
+
+  const session = await Session.create({
+    provider: model,
+    cwd,
+    files: opts.files ?? ["**/*"],
+    accept: opts.accept,
+    fix: opts.fix,
+    context: opts.context,
+    maxTurns: opts.maxTurns,
+    report: (event: ILoopEvent) => {
+      events.push(event);
+    },
+  });
+
+  const result = await session.send(opts.task);
+
+  return {
+    status: result.status,
+    turns: result.turns,
+    events,
+    model,
+    cwd,
+    eventsOfKind: (kind: string) => events.filter((e) => e.kind === kind),
+    sawKind: (kind: string) => events.some((e) => e.kind === kind),
+    fileText: (rel: string) => readFileSync(join(cwd, rel), "utf8"),
+    fileExists: (rel: string) => existsSync(join(cwd, rel)),
+  };
+}

--- a/packages/core/tests/helpers/session-harness.ts
+++ b/packages/core/tests/helpers/session-harness.ts
@@ -9,6 +9,7 @@ import {
 import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 import { Session, type ILoopEvent } from "../../src/loop";
+import type { PolicyMode } from "../../src/policy/policy.types";
 import {
   scriptedModel,
   type IScriptedModel,
@@ -32,6 +33,8 @@ export interface IRunScriptedSession {
   seed?: Record<string, string>;
   /** Per-send turn cap. */
   maxTurns?: number;
+  /** Policy mode — e.g. "plan" to forbid all writes. */
+  policyMode?: PolicyMode;
 }
 
 export interface IScriptedSessionResult {
@@ -88,6 +91,7 @@ export async function runScriptedSession(
     fix: opts.fix,
     context: opts.context,
     maxTurns: opts.maxTurns,
+    policyMode: opts.policyMode,
     report: (event: ILoopEvent) => {
       events.push(event);
     },

--- a/packages/core/tests/overlay-e2e.test.ts
+++ b/packages/core/tests/overlay-e2e.test.ts
@@ -7,9 +7,50 @@ import {
   clampIndex,
 } from "../src/render/command-menu";
 import { COMMANDS } from "../src/cli/commands";
+import {
+  filterFiles,
+  formatCompletionRows,
+  truncatePath,
+} from "../src/render/file-menu";
+import {
+  StatusBar,
+  type IStatusInfo,
+  type IStatusBarTerminal,
+} from "../src/render";
 import { VirtualScreen } from "./helpers/virtual-screen";
 
 const CLEAR_HOME = "\x1b[2J\x1b[H";
+
+const BAR_INFO: IStatusInfo = {
+  model: "m",
+  contextTokens: 0,
+  contextWindow: 32000,
+  turns: 1,
+  elapsedMs: 0,
+  status: "idle",
+  scope: "src/**",
+  tokensPerSecond: 0,
+};
+
+class FakeTerm implements IStatusBarTerminal {
+  readonly writes: string[] = [];
+
+  constructor(
+    readonly isTTY: boolean,
+    public rows: number,
+    readonly columns: number
+  ) {}
+
+  write(data: string): boolean {
+    this.writes.push(data);
+
+    return true;
+  }
+
+  text(): string {
+    return this.writes.join("");
+  }
+}
 
 const STEPS: IWizardStep[] = [
   {
@@ -153,3 +194,58 @@ function findRow(screen: VirtualScreen, needle: string): number {
 
   return 0;
 }
+
+describe("@-file picker e2e — rendered dropdown", () => {
+  const FILES = [
+    "src/app.ts",
+    "src/app.test.ts",
+    "src/router.ts",
+    "README.md",
+    "package.json",
+  ];
+
+  test("a query narrows the visible rows; the selection shows a gutter", () => {
+    const items = filterFiles(FILES, "app");
+    const rows = formatCompletionRows(items, 0, 80, false);
+    const screen = new VirtualScreen(24, 80);
+
+    screen.feed("\x1b[2J\x1b[H" + rows.join("\n"));
+
+    expect(items.every((p) => p.includes("app"))).toBe(true);
+    expect(screen.rowsContaining("router.ts")).toBe(0); // filtered out
+    // The first (selected) row carries the active gutter "›".
+    expect(screen.row(1)).toContain("›");
+  });
+
+  test("an empty match renders the 'no matching file' hint", () => {
+    const rows = formatCompletionRows(filterFiles(FILES, "zzz"), 0, 80, false);
+    const screen = new VirtualScreen(24, 80);
+
+    screen.feed(rows.join("\n"));
+    expect(screen.text()).toContain("no matching file");
+  });
+
+  test("truncatePath shortens an over-long path to fit the width", () => {
+    const long = "src/very/deeply/nested/directory/structure/component.tsx";
+    const out = truncatePath(long, 20);
+
+    expect(out.length).toBeLessThanOrEqual(20);
+  });
+
+  test("the picker overlay shrinking leaves NO ghost rows (same class as the editor bug)", () => {
+    const term = new FakeTerm(true, 24, 80);
+    const bar = new StatusBar(term, true, false, true);
+
+    bar.install(BAR_INFO);
+    // Show a 5-item dropdown, then shrink to 2 — the dropped 3 must be erased.
+    bar.setOverlay(["one", "two", "three", "four", "five"], BAR_INFO);
+    bar.setOverlay(["one", "two"], BAR_INFO);
+
+    const screen = new VirtualScreen(24, 80);
+
+    screen.feed(term.text());
+    expect(screen.rowsContaining("five")).toBe(0); // ghost gone
+    expect(screen.rowsContaining("three")).toBe(0); // ghost gone
+    expect(screen.rowsContaining("two")).toBe(1); // still shown
+  });
+});

--- a/packages/core/tests/overlay-e2e.test.ts
+++ b/packages/core/tests/overlay-e2e.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, test } from "bun:test";
-import { initWizard, reduceWizard, renderFrame } from "../src/render/wizard";
+import {
+  actionFor,
+  initWizard,
+  reduceWizard,
+  renderFrame,
+} from "../src/render/wizard";
 import type { IWizardStep } from "../src/render/wizard.types";
 import {
   renderMenu,
@@ -247,5 +252,39 @@ describe("@-file picker e2e — rendered dropdown", () => {
     expect(screen.rowsContaining("five")).toBe(0); // ghost gone
     expect(screen.rowsContaining("three")).toBe(0); // ghost gone
     expect(screen.rowsContaining("two")).toBe(1); // still shown
+  });
+});
+
+describe("wizard key→action decode (guards the keypress mapping)", () => {
+  test("arrow keys map to navigation", () => {
+    expect(actionFor(undefined, { name: "up" })).toBe("up");
+    expect(actionFor(undefined, { name: "down" })).toBe("down");
+  });
+
+  test("space (by name or char) toggles a checkbox", () => {
+    expect(actionFor(undefined, { name: "space" })).toBe("toggle");
+    expect(actionFor(" ", { name: undefined })).toBe("toggle");
+  });
+
+  test("enter/return confirm; escape and ctrl+c cancel", () => {
+    expect(actionFor(undefined, { name: "return" })).toBe("confirm");
+    expect(actionFor(undefined, { name: "enter" })).toBe("confirm");
+    expect(actionFor(undefined, { name: "escape" })).toBe("cancel");
+    expect(actionFor("c", { name: "c", ctrl: true })).toBe("cancel");
+  });
+
+  test("'b' goes back, 'q' cancels, unknown keys are ignored", () => {
+    expect(actionFor("b", { name: "b" })).toBe("back");
+    expect(actionFor("q", { name: "q" })).toBe("cancel");
+    expect(actionFor("z", { name: "z" })).toBeNull();
+  });
+
+  test("the decoded action actually drives the reducer (down → cursor moves)", () => {
+    const action = actionFor(undefined, { name: "down" });
+    let state = initWizard(STEPS);
+
+    expect(action).not.toBeNull();
+    state = reduceWizard(state, action ?? "up", STEPS);
+    expect(state.cursor).toBe(1);
   });
 });

--- a/packages/core/tests/overlay-e2e.test.ts
+++ b/packages/core/tests/overlay-e2e.test.ts
@@ -1,0 +1,155 @@
+import { describe, expect, test } from "bun:test";
+import { initWizard, reduceWizard, renderFrame } from "../src/render/wizard";
+import type { IWizardStep } from "../src/render/wizard.types";
+import {
+  renderMenu,
+  filterCommands,
+  clampIndex,
+} from "../src/render/command-menu";
+import { COMMANDS } from "../src/cli/commands";
+import { VirtualScreen } from "./helpers/virtual-screen";
+
+const CLEAR_HOME = "\x1b[2J\x1b[H";
+
+const STEPS: IWizardStep[] = [
+  {
+    key: "interfaces",
+    kind: "single",
+    title: "Naming",
+    explanation: "pick naming",
+    evidence: ["312 interfaces scanned"],
+    options: [
+      {
+        label: "bare PascalCase",
+        value: "bare-pascal-case",
+        recommended: true,
+      },
+      { label: "I-prefix", value: "i-prefix" },
+      { label: "off", value: "off" },
+    ],
+    defaultIndex: 0,
+  },
+  {
+    key: "packs",
+    kind: "multi",
+    title: "Packs",
+    explanation: "toggle packs",
+    evidence: [],
+    options: [
+      { label: "generic-ts", value: "generic-ts" },
+      { label: "nextjs", value: "nextjs" },
+    ],
+    defaultChecked: [0],
+  },
+];
+
+/** Render a wizard state exactly as the driver does (CLEAR_HOME + frame). */
+function screenOf(state: ReturnType<typeof initWizard>): VirtualScreen {
+  const s = new VirtualScreen(24, 80);
+
+  s.feed(CLEAR_HOME + renderFrame(state, STEPS, false));
+
+  return s;
+}
+
+describe("wizard e2e — rendered screen at each step", () => {
+  test("step 1 shows the title and parks the cursor on the recommended option", () => {
+    const screen = screenOf(initWizard(STEPS));
+
+    expect(screen.text()).toContain("Step 1 of 2");
+    expect(screen.text()).toContain("Naming");
+    // The cursor gutter "›" sits on the first option row (bare PascalCase).
+    const cursorRow = findRow(screen, "›");
+
+    expect(screen.row(cursorRow)).toContain("bare PascalCase");
+  });
+
+  test("down moves the on-screen cursor to the next option", () => {
+    let state = initWizard(STEPS);
+
+    state = reduceWizard(state, "down", STEPS);
+
+    const screen = screenOf(state);
+    const cursorRow = findRow(screen, "›");
+
+    expect(screen.row(cursorRow)).toContain("I-prefix");
+  });
+
+  test("confirming step 1 advances to the multi-select step with checkboxes", () => {
+    let state = initWizard(STEPS);
+
+    state = reduceWizard(state, "confirm", STEPS); // accept recommended → step 2
+
+    const screen = screenOf(state);
+
+    expect(screen.text()).toContain("Step 2 of 2");
+    expect(screen.text()).toContain("Packs");
+    // generic-ts starts checked (◉), nextjs unchecked (◯).
+    expect(screen.text()).toContain("◉");
+    expect(screen.text()).toContain("◯");
+  });
+
+  test("toggling a checkbox flips its glyph on screen", () => {
+    let state = initWizard(STEPS);
+
+    state = reduceWizard(state, "confirm", STEPS); // → step 2 (Packs)
+    state = reduceWizard(state, "down", STEPS); // cursor → nextjs
+    state = reduceWizard(state, "toggle", STEPS); // check nextjs
+
+    const screen = screenOf(state);
+    const nextjsRow = findRow(screen, "nextjs");
+
+    expect(screen.row(nextjsRow)).toContain("◉"); // now checked
+  });
+
+  test("completing all steps renders the overview", () => {
+    let state = initWizard(STEPS);
+
+    state = reduceWizard(state, "confirm", STEPS); // step 1 → 2
+    state = reduceWizard(state, "confirm", STEPS); // step 2 → overview
+
+    const screen = screenOf(state);
+
+    // The overview lists the chosen values; both step titles' choices appear.
+    expect(state.stepIndex).toBeGreaterThanOrEqual(STEPS.length);
+    expect(screen.text().length).toBeGreaterThan(0);
+  });
+});
+
+describe("command palette e2e — rendered menu", () => {
+  test("the menu renders matching commands and marks the selection", () => {
+    const all = filterCommands(COMMANDS, "");
+    const screen = new VirtualScreen(24, 80);
+
+    screen.feed("\x1b[2J\x1b[H" + renderMenu(all, 0, "", false));
+
+    // At least one known command is visible (the palette is non-empty).
+    expect(screen.text().length).toBeGreaterThan(0);
+  });
+
+  test("typing a query filters the visible list", () => {
+    const all = filterCommands(COMMANDS, "");
+    const filtered = filterCommands(COMMANDS, "clear");
+    const screen = new VirtualScreen(24, 80);
+
+    screen.feed(
+      "\x1b[2J\x1b[H" +
+        renderMenu(filtered, clampIndex(0, filtered.length), "clear", false)
+    );
+
+    // Filtering narrows the set (or keeps it equal if only matches exist).
+    expect(filtered.length).toBeLessThanOrEqual(all.length);
+    expect(screen.text().toLowerCase()).toContain("clear");
+  });
+});
+
+/** First 1-based row containing `needle` (0 if absent). */
+function findRow(screen: VirtualScreen, needle: string): number {
+  for (let r = 1; r <= 24; r += 1) {
+    if (screen.row(r).includes(needle)) {
+      return r;
+    }
+  }
+
+  return 0;
+}

--- a/packages/core/tests/session-e2e-hunt.test.ts
+++ b/packages/core/tests/session-e2e-hunt.test.ts
@@ -1,0 +1,138 @@
+import { afterAll, describe, expect, test } from "bun:test";
+import {
+  cleanupScriptedSessions,
+  runScriptedSession,
+} from "./helpers/session-harness";
+import { call } from "./helpers/scripted-model";
+
+afterAll(cleanupScriptedSessions);
+
+// Adversarial probes: edge cases where bugs hide. Each documents the EXPECTED
+// robust behavior; a failure here is a real harness bug found by the e2e layer.
+describe("session e2e — adversarial bug hunt", () => {
+  test("edit with a non-matching oldString does not corrupt the file", async () => {
+    const s = await runScriptedSession({
+      task: "edit a snippet that isn't there",
+      seed: { "app.ts": "export const x = 1;\n" },
+      turns: [
+        {
+          toolCalls: [
+            call("edit", {
+              file: "app.ts",
+              oldString: "THIS DOES NOT EXIST",
+              newString: "replacement",
+            }),
+          ],
+        },
+        { content: "tried" },
+      ],
+    });
+
+    // The file must be untouched (no partial/garbage write).
+    expect(s.fileText("app.ts")).toBe("export const x = 1;\n");
+  });
+
+  test("edit with a non-unique oldString is rejected (must be unique)", async () => {
+    const s = await runScriptedSession({
+      task: "ambiguous edit",
+      seed: { "app.ts": "const a = 1;\nconst a = 1;\n" },
+      turns: [
+        {
+          toolCalls: [
+            call("edit", {
+              file: "app.ts",
+              oldString: "const a = 1;",
+              newString: "const a = 2;",
+            }),
+          ],
+        },
+        { content: "tried" },
+      ],
+    });
+
+    // Ambiguous → must not silently replace just one; file stays intact.
+    expect(s.fileText("app.ts")).toBe("const a = 1;\nconst a = 1;\n");
+  });
+
+  test("create over an existing file does not silently clobber it", async () => {
+    const s = await runScriptedSession({
+      task: "create over an existing file",
+      seed: { "exists.ts": "export const original = true;\n" },
+      turns: [
+        {
+          toolCalls: [
+            call("create", {
+              file: "exists.ts",
+              content: "export const clobbered = true;\n",
+            }),
+          ],
+        },
+        { content: "tried" },
+      ],
+    });
+
+    // `create` is for NEW files — it should not blow away existing content.
+    expect(s.fileText("exists.ts")).toContain("original");
+  });
+
+  test("a failing shell command reports a non-zero exit, loop continues", async () => {
+    const s = await runScriptedSession({
+      task: "run a failing command",
+      turns: [
+        { toolCalls: [call("run", { command: 'node -e "process.exit(7)"' })] },
+        { content: "saw the failure" },
+      ],
+    });
+
+    const runs = s.eventsOfKind("run");
+
+    expect(runs[0]?.exitCode).toBe(7);
+    expect(s.status).toBe("responded");
+  });
+
+  test("a model that never yields hits maxTurns and stops (no infinite loop)", async () => {
+    const neverYield = () => ({
+      toolCalls: [call("run", { command: "echo loop" })],
+    });
+    const s = await runScriptedSession({
+      task: "spin forever",
+      maxTurns: 3,
+      turns: [neverYield, neverYield, neverYield, neverYield, neverYield],
+    });
+
+    // The turn cap must bound the run.
+    expect(s.model.calls).toBeLessThanOrEqual(4);
+  });
+
+  test("malformed tool args (create missing content) do not crash the loop", async () => {
+    const s = await runScriptedSession({
+      task: "send a malformed create",
+      turns: [
+        { toolCalls: [call("create", { file: "x.ts" })] }, // no content
+        { content: "recovered" },
+      ],
+    });
+
+    // The loop must survive and reach a terminal state, not throw.
+    expect(["responded", "done", "stuck"].includes(s.status)).toBe(true);
+  });
+
+  test("a gate command that errors (not just fails) is handled", async () => {
+    const s = await runScriptedSession({
+      task: "gate command itself errors",
+      accept: "this-command-does-not-exist-xyz",
+      maxTurns: 4,
+      turns: [
+        {
+          toolCalls: [
+            call("create", { file: "a.ts", content: "export const a = 1;\n" }),
+          ],
+        },
+        { content: "done" },
+      ],
+    });
+
+    // A broken gate command must not crash; it should resolve to a verdict.
+    expect(["done", "stuck", "responded"].includes(s.status)).toBe(true);
+  });
+});

--- a/packages/core/tests/session-e2e.test.ts
+++ b/packages/core/tests/session-e2e.test.ts
@@ -47,7 +47,7 @@ describe("session e2e — full agent loop via a scripted model", () => {
   test("a passing gate (accept) confirms the change as done", async () => {
     const s = await runScriptedSession({
       task: "create a file then finish",
-      accept: "true", // gate always passes
+      accept: 'node -e "process.exit(0)"', // portable always-pass gate
       turns: [
         {
           toolCalls: [
@@ -68,7 +68,8 @@ describe("session e2e — full agent loop via a scripted model", () => {
     const s = await runScriptedSession({
       task: "make the gate pass",
       // Gate passes only once the model has created fixed.txt.
-      accept: "test -f fixed.txt",
+      accept:
+        "node -e \"process.exit(require('fs').existsSync('fixed.txt') ? 0 : 1)\"",
       maxTurns: 8,
       turns: [
         // Turn 1: a wrong mutation (creates the wrong file).
@@ -252,8 +253,9 @@ describe("session e2e — plan mode (read-only) and auto-fix", () => {
     const s = await runScriptedSession({
       task: "create a file; fix runs before the gate",
       // fix writes a marker; gate passes only if the marker exists → proves fix ran.
-      fix: "touch fix-ran.marker",
-      accept: "test -f fix-ran.marker",
+      fix: "node -e \"require('fs').writeFileSync('fix-ran.marker','')\"",
+      accept:
+        "node -e \"process.exit(require('fs').existsSync('fix-ran.marker') ? 0 : 1)\"",
       maxTurns: 6,
       turns: [
         {

--- a/packages/core/tests/session-e2e.test.ts
+++ b/packages/core/tests/session-e2e.test.ts
@@ -213,3 +213,59 @@ describe("session e2e — read/edit round-trips and multi-file builds", () => {
     expect(s.eventsOfKind("create").length).toBe(3);
   });
 });
+
+describe("session e2e — plan mode (read-only) and auto-fix", () => {
+  test("plan mode rejects a create — the file is never written", async () => {
+    const s = await runScriptedSession({
+      task: "in plan mode, try to write a file",
+      policyMode: "plan",
+      turns: [
+        {
+          toolCalls: [
+            call("create", { file: "should-not-exist.ts", content: "x\n" }),
+          ],
+        },
+        { content: "tried to write" },
+      ],
+    });
+
+    // The read-only guarantee: no write escapes plan mode.
+    expect(s.fileExists("should-not-exist.ts")).toBe(false);
+  });
+
+  test("plan mode still allows a read tool", async () => {
+    const s = await runScriptedSession({
+      task: "read in plan mode",
+      policyMode: "plan",
+      seed: { "notes.txt": "PLAN-MODE-READ-OK\n" },
+      turns: [
+        { toolCalls: [call("read", { file: "notes.txt" })] },
+        { content: "read it" },
+      ],
+    });
+
+    // Reading is permitted; the result reached the conversation.
+    expect(s.status).toBe("responded");
+  });
+
+  test("the auto-fix command runs before re-validating the gate", async () => {
+    const s = await runScriptedSession({
+      task: "create a file; fix runs before the gate",
+      // fix writes a marker; gate passes only if the marker exists → proves fix ran.
+      fix: "touch fix-ran.marker",
+      accept: "test -f fix-ran.marker",
+      maxTurns: 6,
+      turns: [
+        {
+          toolCalls: [
+            call("create", { file: "a.ts", content: "export const a = 1;\n" }),
+          ],
+        },
+        { content: "done" }, // yield → fix runs → gate checks the marker
+      ],
+    });
+
+    expect(s.fileExists("fix-ran.marker")).toBe(true);
+    expect(s.status).toBe("done");
+  });
+});

--- a/packages/core/tests/session-e2e.test.ts
+++ b/packages/core/tests/session-e2e.test.ts
@@ -122,3 +122,94 @@ describe("session e2e — full agent loop via a scripted model", () => {
     expect(runs[0]?.exitCode).toBe(0);
   });
 });
+
+describe("session e2e — read/edit round-trips and multi-file builds", () => {
+  test("the edit tool replaces a snippet in a seeded file", async () => {
+    const s = await runScriptedSession({
+      task: "bump the constant",
+      seed: { "app.ts": "export const x = 1;\n" },
+      turns: [
+        {
+          toolCalls: [
+            call("edit", {
+              file: "app.ts",
+              oldString: "const x = 1",
+              newString: "const x = 2",
+            }),
+          ],
+        },
+        { content: "bumped" },
+      ],
+    });
+
+    expect(s.fileText("app.ts")).toContain("const x = 2");
+    expect(s.sawKind("edit")).toBe(true);
+  });
+
+  test("a read tool result flows back into the conversation for the model", async () => {
+    const s = await runScriptedSession({
+      task: "read the secret then echo it",
+      seed: { "data.txt": "SECRET-VALUE-42\n" },
+      turns: [
+        { toolCalls: [call("read", { file: "data.txt" })] },
+        // This turn REACTS to the read result: the tool output is now in the
+        // conversation, so the model can copy the value into a new file.
+        (messages) => {
+          const transcript = messages.map((m) => m.content).join("\n");
+          const saw = transcript.includes("SECRET-VALUE-42");
+
+          return {
+            toolCalls: [
+              call("create", {
+                file: "echo.txt",
+                content: saw ? "SECRET-VALUE-42\n" : "MISSING\n",
+              }),
+            ],
+          };
+        },
+        { content: "done" },
+      ],
+    });
+
+    // The read result reached the model, so it wrote the real value (not MISSING).
+    expect(s.fileText("echo.txt")).toContain("SECRET-VALUE-42");
+  });
+
+  test("a multi-file build creates every file in one session", async () => {
+    const s = await runScriptedSession({
+      task: "build a small module",
+      turns: [
+        {
+          toolCalls: [
+            call("create", {
+              file: "src/a.ts",
+              content: "export const a = 1;\n",
+            }),
+          ],
+        },
+        {
+          toolCalls: [
+            call("create", {
+              file: "src/b.ts",
+              content: "export const b = 2;\n",
+            }),
+          ],
+        },
+        {
+          toolCalls: [
+            call("create", {
+              file: "src/index.ts",
+              content: "export * from './a';\nexport * from './b';\n",
+            }),
+          ],
+        },
+        { content: "module built" },
+      ],
+    });
+
+    expect(s.fileExists("src/a.ts")).toBe(true);
+    expect(s.fileExists("src/b.ts")).toBe(true);
+    expect(s.fileExists("src/index.ts")).toBe(true);
+    expect(s.eventsOfKind("create").length).toBe(3);
+  });
+});

--- a/packages/core/tests/session-e2e.test.ts
+++ b/packages/core/tests/session-e2e.test.ts
@@ -1,0 +1,124 @@
+import { afterAll, describe, expect, test } from "bun:test";
+import {
+  cleanupScriptedSessions,
+  runScriptedSession,
+} from "./helpers/session-harness";
+import { call } from "./helpers/scripted-model";
+
+afterAll(cleanupScriptedSessions);
+
+describe("session e2e — full agent loop via a scripted model", () => {
+  test("a conversational turn (no tools) responds and makes no changes", async () => {
+    const s = await runScriptedSession({
+      task: "what is 2 + 2?",
+      turns: [{ content: "4" }],
+    });
+
+    expect(s.status).toBe("responded");
+    expect(s.model.calls).toBe(1);
+    expect(s.sawKind("edit")).toBe(false);
+    expect(s.sawKind("create")).toBe(false);
+  });
+
+  test("the model creates a file via the create tool; it lands on disk", async () => {
+    const s = await runScriptedSession({
+      task: "create hello.ts",
+      turns: [
+        {
+          toolCalls: [
+            call("create", {
+              file: "hello.ts",
+              content: "export const hi = 1;\n",
+            }),
+          ],
+        },
+        { content: "done" }, // yield → loop ends
+      ],
+    });
+
+    expect(s.fileExists("hello.ts")).toBe(true);
+    expect(s.fileText("hello.ts")).toContain("export const hi = 1;");
+    const creates = s.eventsOfKind("create");
+
+    expect(creates.length).toBe(1);
+    expect(creates[0]?.file).toContain("hello.ts");
+  });
+
+  test("a passing gate (accept) confirms the change as done", async () => {
+    const s = await runScriptedSession({
+      task: "create a file then finish",
+      accept: "true", // gate always passes
+      turns: [
+        {
+          toolCalls: [
+            call("create", { file: "a.ts", content: "export const a = 1;\n" }),
+          ],
+        },
+        { content: "all set" }, // yield with a pending mutation → gate fires
+      ],
+    });
+
+    expect(s.status).toBe("done");
+    const validated = s.eventsOfKind("validated");
+
+    expect(validated.some((e) => e.passed === true)).toBe(true);
+  });
+
+  test("a failing gate then a fix: red → repair → green → done", async () => {
+    const s = await runScriptedSession({
+      task: "make the gate pass",
+      // Gate passes only once the model has created fixed.txt.
+      accept: "test -f fixed.txt",
+      maxTurns: 8,
+      turns: [
+        // Turn 1: a wrong mutation (creates the wrong file).
+        {
+          toolCalls: [call("create", { file: "wrong.txt", content: "nope\n" })],
+        },
+        // Turn 2: yield → gate runs → FAILS (no fixed.txt yet).
+        { content: "I think that's it" },
+        // Turn 3: react to the failure by creating the right file.
+        { toolCalls: [call("create", { file: "fixed.txt", content: "ok\n" })] },
+        // Turn 4: yield → gate runs → PASSES.
+        { content: "fixed now" },
+      ],
+    });
+
+    expect(s.status).toBe("done");
+    expect(s.fileExists("fixed.txt")).toBe(true);
+    const validated = s.eventsOfKind("validated");
+
+    // The gate was seen failing and then passing.
+    expect(validated.some((e) => e.passed === false)).toBe(true);
+    expect(validated.some((e) => e.passed === true)).toBe(true);
+  });
+
+  test("an out-of-scope create is rejected and never written", async () => {
+    const s = await runScriptedSession({
+      task: "try to escape scope",
+      files: ["allowed/**"], // only allowed/ is editable
+      turns: [
+        { toolCalls: [call("create", { file: "secret.ts", content: "x\n" })] },
+        { content: "tried" },
+      ],
+    });
+
+    expect(s.fileExists("secret.ts")).toBe(false);
+  });
+
+  test("the run tool executes a shell command and reports its result", async () => {
+    const s = await runScriptedSession({
+      task: "run a command",
+      turns: [
+        { toolCalls: [call("run", { command: "echo hello-from-e2e" })] },
+        { content: "ran it" },
+      ],
+    });
+
+    const runs = s.eventsOfKind("run");
+
+    expect(runs.length).toBe(1);
+    expect(runs[0]?.output ?? "").toContain("hello-from-e2e");
+    expect(runs[0]?.exitCode).toBe(0);
+  });
+});


### PR DESCRIPTION
Generalizes the editor's VirtualScreen win so the **real user experience is replayable in tests** — asserting observable behavior (rendered screen, tool runs, file changes, gate verdicts), not just logical state. Goal: catch breakage in CI before a human hits it by hand.

## What's covered

### Reusable harnesses
- **`ScriptedModel`** (`tests/helpers/scripted-model.ts`) — a deterministic `IProvider` driving the REAL agent loop from scripted turns; a turn can be a function of the conversation so far, so it reacts to gate feedback / tool results.
- **`runScriptedSession`** (`tests/helpers/session-harness.ts`) — wires it to a real `Session` (real tools, real gate, temp cwd), captures the `ILoopEvent` stream + file changes.
- **`VirtualScreen`** (shipped in v0.24.0) — renders emitted bytes to a screen grid; reused here for every TTY-render assertion.

### Tier 1 — agent session loop (12 tests)
Conversational turn, create→disk, passing gate→done, **failing gate→repair→green→done**, out-of-scope rejection, run-tool shell exec, edit-tool snippet replace, **read round-trip** (tool result reaches the model), multi-file build, **plan-mode write rejection** (the read-only guarantee), plan-mode read allowed, **auto-fix runs before re-gate**.

### Tier 3 — interactive TTY overlays (11 tests)
Wizard rendered at each step (title, cursor gutter, checkbox toggle, overview), command palette (filtered list + selection), @-file picker dropdown, and **overlay-shrink → no ghost rows** (the same bug class as the editor, now guarded for the picker). These close the render blind spot: the existing wizard tests assert reducer STATE only.

## Findings (no duplication added)
- **Scaffolder (Tier 2)** — already comprehensively covered by `scaffold-run.test.ts` (full `runScaffold`: clone+configure+boot+gate, skipBoot, invalid-config refusal, manifest-source-of-truth, astro). No gap.
- **Review (Tier 4)** — already covered: `review-change.test.ts` drives `reviewChange` with stub providers (find/verify passes, non-JSON). No gap.

The two genuine gaps were the session-loop e2e and the TTY-render e2e — both filled here.

Stacked off main after v0.24.0.