### PR TITLE
feat(render): borrow OpenTUI ideas — width, diff, layout, damage buffer

### DIFF
--- a/packages/core/src/editor/view.ts
+++ b/packages/core/src/editor/view.ts
@@ -2,6 +2,17 @@ import { graphemes } from "./segments";
 import { paint, STYLE } from "../render/style";
 import { displayWidth } from "../render/width";
 
+/** Columns a hard tab advances to (next multiple of 8) — terminals expand a
+ *  literal `\t` to the next tab stop, and `displayWidth` can't know the column,
+ *  so the editor's wrap math computes the advance here from the row position. */
+const TAB_STOP = 8;
+
+/** Display columns a grapheme occupies on the current visual row. A tab advances
+ *  to the next tab stop from `col`; everything else is its intrinsic width. */
+function cellWidth(g: string, col: number): number {
+  return g === "\t" ? TAB_STOP - (col % TAB_STOP) : displayWidth(g);
+}
+
 export interface IEditorInput {
   lines: string[];
   cursorLine: number;
@@ -59,7 +70,7 @@ function wrapLine(
 
   for (let i = 0; i < graphemeList.length; i += 1) {
     const g = graphemeList[i] ?? "";
-    const w = displayWidth(g);
+    let w = cellWidth(g, rowWidth);
 
     // Wrap before a grapheme that would overflow the row (but never flush an
     // empty row, so a lone cell wider than `columns` still gets placed).
@@ -73,6 +84,8 @@ function wrapLine(
       rowWidth = 0;
       rowCursorCol = undefined;
       visualRow += 1;
+      // A tab's advance depends on the column, so recompute it at the row start.
+      w = cellWidth(g, rowWidth);
     }
 
     if (i === cursorCol) {

--- a/packages/core/src/editor/view.ts
+++ b/packages/core/src/editor/view.ts
@@ -1,5 +1,6 @@
 import { graphemes } from "./segments";
 import { paint, STYLE } from "../render/style";
+import { displayWidth } from "../render/width";
 
 export interface IEditorInput {
   lines: string[];
@@ -50,38 +51,41 @@ function wrapLine(
   const graphemeList = graphemes(line);
   const rows: IWrappedRow[] = [];
   let row = "";
-  let rowGraphemeCount = 0;
+  // Column width consumed by the current visual row, so wide (CJK/emoji) cells
+  // wrap at the true edge and the cursor column reflects display columns.
+  let rowWidth = 0;
   let rowCursorCol: number | undefined;
   let visualRow = 0;
 
   for (let i = 0; i < graphemeList.length; i += 1) {
-    const g = graphemeList[i];
+    const g = graphemeList[i] ?? "";
+    const w = displayWidth(g);
 
-    if (rowGraphemeCount >= columns) {
+    // Wrap before a grapheme that would overflow the row (but never flush an
+    // empty row, so a lone cell wider than `columns` still gets placed).
+    if (rowWidth + w > columns && rowWidth > 0) {
       rows.push({
         text: row,
         cursorRow: rowCursorCol !== undefined ? visualRow : undefined,
         cursorCol: rowCursorCol,
       });
       row = "";
-      rowGraphemeCount = 0;
+      rowWidth = 0;
       rowCursorCol = undefined;
       visualRow += 1;
     }
 
     if (i === cursorCol) {
-      rowCursorCol = rowGraphemeCount;
+      rowCursorCol = rowWidth;
     }
 
-    if (g !== undefined) {
-      row += g;
-      rowGraphemeCount += 1;
-    }
+    row += g;
+    rowWidth += w;
   }
 
   // Handle cursor at end of line
   if (graphemeList.length === cursorCol) {
-    rowCursorCol = rowGraphemeCount;
+    rowCursorCol = rowWidth;
   }
 
   // Push final row

--- a/packages/core/src/render/ansi.ts
+++ b/packages/core/src/render/ansi.ts
@@ -5,6 +5,7 @@ import { STYLE, paint } from "./style";
 import { box, GLYPH } from "./box";
 import { renderMarkdown, highlightCode } from "./markdown";
 import { StreamingMarkdown } from "./stream-markdown";
+import { renderDiff } from "./diff";
 
 /** Split highlighted/plain text into the body-line array a box expects. */
 function bodyLines(text: string): string[] {
@@ -127,19 +128,6 @@ export function renderMessage(
 
 function highlightTs(code: string, color: boolean): string {
   return highlightCode(code, "typescript", color);
-}
-
-function diff(oldString: string, newString: string, color: boolean): string {
-  const minus = oldString
-    .split("\n")
-    .map((l) => paint(`- ${l}`, STYLE.red, color))
-    .join("\n");
-  const plus = newString
-    .split("\n")
-    .map((l) => paint(`+ ${l}`, STYLE.green, color))
-    .join("\n");
-
-  return `${minus}\n${plus}`;
 }
 
 /**
@@ -265,7 +253,9 @@ function renderEventBody(event: ILoopEvent, color: boolean): string {
         return glyphLine(GLYPH.edit, event.message, STYLE.brand, color);
       }
 
-      const body = bodyLines(diff(event.oldString, event.newString, color));
+      const body = bodyLines(
+        renderDiff(event.oldString, event.newString, { color })
+      );
 
       return `\n${box(event.message, body, { glyph: GLYPH.edit, accent: STYLE.brand, color })}\n`;
     }

--- a/packages/core/src/render/box.ts
+++ b/packages/core/src/render/box.ts
@@ -1,4 +1,5 @@
 import { STYLE, paint } from "./style";
+import { displayWidth, padToWidth } from "./width";
 
 /**
  * Terminal drawing primitives — title-tabbed boxes and box-drawn tables, the look
@@ -66,7 +67,9 @@ export function box(
   }
 
   const opener = "┌─ ";
-  const rule = "─".repeat(Math.max(0, width - opener.length - head.length - 1));
+  const rule = "─".repeat(
+    Math.max(0, width - opener.length - displayWidth(head) - 1)
+  );
   const top = `${paint(opener, STYLE.dim, color)}${paint(head, `${accent}${STYLE.bold}`, color)} ${paint(rule, STYLE.dim, color)}`;
   const bar = paint("│", STYLE.dim, color);
   const bottom = paint(
@@ -99,7 +102,7 @@ export function table(
 
   const cols = Math.max(...rows.map((r) => r.length));
   const widths = Array.from({ length: cols }, (_, c) =>
-    Math.max(1, ...rows.map((r) => (r[c] ?? "").length))
+    Math.max(1, ...rows.map((r) => displayWidth(r[c] ?? "")))
   );
   const bar = paint("│", STYLE.dim, color);
 
@@ -113,7 +116,7 @@ export function table(
   const renderRow = (cells: readonly string[], header: boolean): string => {
     const inner = widths
       .map((w, c) => {
-        const cell = (cells[c] ?? "").padEnd(w);
+        const cell = padToWidth(cells[c] ?? "", w);
 
         return ` ${header ? paint(cell, `${STYLE.brand}${STYLE.bold}`, color) : cell} `;
       })

--- a/packages/core/src/render/diff.ts
+++ b/packages/core/src/render/diff.ts
@@ -1,0 +1,305 @@
+import { STYLE, paint } from "./style";
+import { displayWidth, padToWidth, sliceToWidth } from "./width";
+
+/**
+ * Line-level diff rendering. The old renderer dumped *every* old line as `-` then
+ * *every* new line as `+`, so a one-word change in a 40-line block printed 80
+ * noisy lines. This computes a longest-common-subsequence line diff, so unchanged
+ * lines show once as dim context and only the genuinely changed lines carry `-`/`+`
+ * — with optional intra-line word highlighting and a side-by-side mode.
+ */
+
+export interface IDiffOptions {
+  /** Emit ANSI color (terminal) vs plain `-`/`+` text (logs). Default true. */
+  color?: boolean;
+  /** Unchanged lines kept around each change; longer runs collapse to `⋯`. Default 3. */
+  context?: number;
+  /** Render old/new as two aligned columns instead of a unified `-`/`+` list. */
+  sideBySide?: boolean;
+  /** Total columns for side-by-side layout. Default 80. */
+  columns?: number;
+  /** Highlight the changed words within a one-line replacement. Default true. */
+  wordLevel?: boolean;
+}
+
+type OpType = "eq" | "del" | "add";
+
+interface IOp {
+  readonly type: OpType;
+  readonly text: string;
+}
+
+const SEP = " │ ";
+
+/** A longest-common-subsequence line diff: unchanged lines become `eq`, removed
+ *  `del`, added `add`, in original order. O(n·m) DP — fine for edit-sized snippets. */
+function diffLines(a: readonly string[], b: readonly string[]): IOp[] {
+  const n = a.length;
+  const m = b.length;
+  const dp: number[][] = Array.from({ length: n + 1 }, () =>
+    new Array<number>(m + 1).fill(0)
+  );
+
+  for (let i = n - 1; i >= 0; i -= 1) {
+    for (let j = m - 1; j >= 0; j -= 1) {
+      const row = dp[i] ?? [];
+      const next = dp[i + 1] ?? [];
+
+      row[j] =
+        a[i] === b[j]
+          ? (next[j + 1] ?? 0) + 1
+          : Math.max(next[j] ?? 0, row[j + 1] ?? 0);
+    }
+  }
+
+  const ops: IOp[] = [];
+  let i = 0;
+  let j = 0;
+
+  while (i < n && j < m) {
+    if (a[i] === b[j]) {
+      ops.push({ type: "eq", text: a[i] ?? "" });
+      i += 1;
+      j += 1;
+    } else if ((dp[i + 1]?.[j] ?? 0) >= (dp[i]?.[j + 1] ?? 0)) {
+      ops.push({ type: "del", text: a[i] ?? "" });
+      i += 1;
+    } else {
+      ops.push({ type: "add", text: b[j] ?? "" });
+      j += 1;
+    }
+  }
+
+  while (i < n) {
+    ops.push({ type: "del", text: a[i] ?? "" });
+    i += 1;
+  }
+
+  while (j < m) {
+    ops.push({ type: "add", text: b[j] ?? "" });
+    j += 1;
+  }
+
+  return ops;
+}
+
+/** Collapse runs of `eq` lines longer than `2·context` to the leading/trailing
+ *  `context` lines plus a `⋯` gap marker, so large unchanged regions don't drown
+ *  the actual change. Boundary runs (start/end of file) keep only the inner side. */
+function collapseContext(ops: readonly IOp[], context: number): IOp[] {
+  const out: IOp[] = [];
+  let run: IOp[] = [];
+
+  const flush = (atStart: boolean, atEnd: boolean): void => {
+    if (run.length <= context * 2) {
+      out.push(...run);
+    } else {
+      if (!atStart) {
+        out.push(...run.slice(0, context));
+      }
+
+      out.push({ type: "eq", text: "⋯" });
+
+      if (!atEnd) {
+        out.push(...run.slice(run.length - context));
+      }
+    }
+
+    run = [];
+  };
+
+  for (const op of ops) {
+    if (op.type === "eq") {
+      run.push(op);
+    } else {
+      flush(out.length === 0, false);
+      out.push(op);
+    }
+  }
+
+  flush(out.length === 0, true);
+
+  return out;
+}
+
+/** Tokenize into words and the whitespace between them, both kept so a rejoin is
+ *  loss-less — the unit a word-level diff compares. */
+function tokenize(line: string): string[] {
+  return line.split(/(\s+)/u).filter((t) => t.length > 0);
+}
+
+/** Paint the tokens of `from`→`to` that differ, leaving shared tokens plain, so a
+ *  one-line edit shows *which* words changed. Returns the two rendered lines. */
+function highlightPair(
+  from: string,
+  to: string,
+  color: boolean
+): { del: string; add: string } {
+  const ops = diffLines(tokenize(from), tokenize(to));
+  let del = "";
+  let add = "";
+
+  for (const op of ops) {
+    if (op.type === "eq") {
+      del += op.text;
+      add += op.text;
+    } else if (op.type === "del") {
+      del += paint(op.text, STYLE.red + STYLE.bold, color);
+    } else {
+      add += paint(op.text, STYLE.green + STYLE.bold, color);
+    }
+  }
+
+  return { del, add };
+}
+
+/** True when ops[idx] starts an isolated one-line replacement (single del then
+ *  single add), the case worth a word-level highlight. */
+function isOneLineSwap(ops: readonly IOp[], idx: number): boolean {
+  return (
+    ops[idx]?.type === "del" &&
+    ops[idx + 1]?.type === "add" &&
+    ops[idx - 1]?.type !== "del" &&
+    ops[idx + 2]?.type !== "add"
+  );
+}
+
+/** Render the unified `-`/`+` view with dim context and optional word highlights. */
+function renderUnified(
+  ops: readonly IOp[],
+  wordLevel: boolean,
+  color: boolean
+): string {
+  const lines: string[] = [];
+
+  for (let k = 0; k < ops.length; k += 1) {
+    const op = ops[k];
+
+    if (op === undefined) {
+      continue;
+    }
+
+    if (op.type === "eq") {
+      lines.push(paint(`  ${op.text}`, STYLE.dim, color));
+      continue;
+    }
+
+    if (wordLevel && isOneLineSwap(ops, k)) {
+      const { del, add } = highlightPair(
+        op.text,
+        ops[k + 1]?.text ?? "",
+        color
+      );
+
+      lines.push(`${paint("-", STYLE.red, color)} ${del}`);
+      lines.push(`${paint("+", STYLE.green, color)} ${add}`);
+      k += 1; // consume the paired add
+      continue;
+    }
+
+    lines.push(
+      op.type === "del"
+        ? paint(`- ${op.text}`, STYLE.red, color)
+        : paint(`+ ${op.text}`, STYLE.green, color)
+    );
+  }
+
+  return lines.join("\n");
+}
+
+/** Group ops into aligned rows for the two-column view: an `eq` fills both sides,
+ *  while a block of dels/adds between two `eq`s is zipped row-by-row. */
+function pairRows(ops: readonly IOp[]): { left?: string; right?: string }[] {
+  const rows: { left?: string; right?: string }[] = [];
+  let dels: string[] = [];
+  let adds: string[] = [];
+
+  const flushBlock = (): void => {
+    const n = Math.max(dels.length, adds.length);
+
+    for (let i = 0; i < n; i += 1) {
+      rows.push({ left: dels[i], right: adds[i] });
+    }
+
+    dels = [];
+    adds = [];
+  };
+
+  for (const op of ops) {
+    if (op.type === "del") {
+      dels.push(op.text);
+    } else if (op.type === "add") {
+      adds.push(op.text);
+    } else {
+      flushBlock();
+      rows.push({ left: op.text, right: op.text });
+    }
+  }
+
+  flushBlock();
+
+  return rows;
+}
+
+/** Fit one cell to `colW` columns and paint it by side (red left / green right). */
+function cell(
+  text: string | undefined,
+  colW: number,
+  code: string,
+  color: boolean
+): string {
+  const fitted = padToWidth(sliceToWidth(text ?? "", colW).text, colW);
+
+  return text === undefined ? fitted : paint(fitted, code, color);
+}
+
+/** Render the side-by-side view: old on the left, new on the right, `│`-separated. */
+function renderSideBySide(
+  ops: readonly IOp[],
+  columns: number,
+  color: boolean
+): string {
+  const colW = Math.max(1, Math.floor((columns - displayWidth(SEP)) / 2));
+
+  return pairRows(ops)
+    .map(({ left, right }) => {
+      const same = left === right;
+      const leftCode = same ? STYLE.dim : STYLE.red;
+      const rightCode = same ? STYLE.dim : STYLE.green;
+
+      return (
+        cell(left, colW, leftCode, color) +
+        SEP +
+        cell(right, colW, rightCode, color)
+      );
+    })
+    .join("\n");
+}
+
+/**
+ * Render a diff between `oldText` and `newText` for the terminal. Defaults to a
+ * unified `-`/`+` view with dim context and word-level highlighting; pass
+ * `sideBySide` for two columns. `color: false` yields plain `-`/`+` text for logs.
+ */
+export function renderDiff(
+  oldText: string,
+  newText: string,
+  opts: IDiffOptions = {}
+): string {
+  const {
+    color = true,
+    context = 3,
+    sideBySide = false,
+    columns = 80,
+    wordLevel = true,
+  } = opts;
+
+  const ops = collapseContext(
+    diffLines(oldText.split("\n"), newText.split("\n")),
+    context
+  );
+
+  return sideBySide
+    ? renderSideBySide(ops, columns, color)
+    : renderUnified(ops, wordLevel, color);
+}

--- a/packages/core/src/render/diff.ts
+++ b/packages/core/src/render/diff.ts
@@ -107,6 +107,10 @@ function collapseContext(ops: readonly IOp[], context: number): IOp[] {
   const flush = (atStart: boolean, atEnd: boolean): void => {
     if (run.length <= context * 2) {
       out.push(...run);
+    } else if (atStart && atEnd) {
+      // The whole diff is one unchanged run (a no-op diff): show leading context
+      // then collapse, rather than a bare "⋯" that hides that nothing changed.
+      out.push(...run.slice(0, context), { type: "eq", text: "⋯" });
     } else {
       if (!atStart) {
         out.push(...run.slice(0, context));

--- a/packages/core/src/render/diff.ts
+++ b/packages/core/src/render/diff.ts
@@ -31,11 +31,25 @@ interface IOp {
 
 const SEP = " │ ";
 
+/** Above this many DP cells (n·m) the LCS matrix would cost too much memory/CPU,
+ *  so we fall back to a plain replacement rather than freeze the terminal. */
+const MAX_DIFF_CELLS = 250_000;
+
 /** A longest-common-subsequence line diff: unchanged lines become `eq`, removed
- *  `del`, added `add`, in original order. O(n·m) DP — fine for edit-sized snippets. */
+ *  `del`, added `add`, in original order. O(n·m) DP — fine for edit-sized snippets.
+ *  Past `MAX_DIFF_CELLS` it degrades to "all old removed, all new added" (the
+ *  pre-LCS behaviour) so a huge input can't allocate a giant matrix or hang. */
 function diffLines(a: readonly string[], b: readonly string[]): IOp[] {
   const n = a.length;
   const m = b.length;
+
+  if (n * m > MAX_DIFF_CELLS) {
+    return [
+      ...a.map((text): IOp => ({ type: "del", text })),
+      ...b.map((text): IOp => ({ type: "add", text })),
+    ];
+  }
+
   const dp: number[][] = Array.from({ length: n + 1 }, () =>
     new Array<number>(m + 1).fill(0)
   );

--- a/packages/core/src/render/file-menu.ts
+++ b/packages/core/src/render/file-menu.ts
@@ -1,6 +1,7 @@
 import { emitKeypressEvents } from "node:readline";
 import { STYLE, paint } from "./style";
 import { clampIndex } from "./command-menu";
+import { displayWidth, graphemes } from "./width";
 
 /** Rows shown in the popup at once — a tight dropdown above the prompt, never a
  *  whole-tree dump. On an empty query these are the most-recently-modified files. */
@@ -56,11 +57,28 @@ export function truncatePath(path: string, max: number): string {
     return "";
   }
 
-  if (path.length <= max) {
+  if (displayWidth(path) <= max) {
     return path;
   }
 
-  return `…${path.slice(-(max - 1))}`;
+  // Keep the grapheme-aligned tail that fits in `max - 1` columns (the `…` takes
+  // one), so a wide cell at the clip boundary is never split.
+  const gs = graphemes(path);
+  let cols = 0;
+  let startG = gs.length;
+
+  for (let i = gs.length - 1; i >= 0; i -= 1) {
+    const w = displayWidth(gs[i] ?? "");
+
+    if (cols + w > max - 1) {
+      break;
+    }
+
+    cols += w;
+    startG = i;
+  }
+
+  return `…${gs.slice(startG).join("")}`;
 }
 
 /**

--- a/packages/core/src/render/layout.ts
+++ b/packages/core/src/render/layout.ts
@@ -1,0 +1,56 @@
+/**
+ * The geometry of the pinned bottom region, in one place. The status bar used to
+ * recompute `rows - 1`, `rows - 2`, `rows - reserved - editorRows` inline at every
+ * paint and resize site — and resize bugs kept landing in exactly those scattered
+ * expressions (e.g. commit a255898). `computeRegions` derives every absolute row
+ * once, bottom-anchored, so the bar, input row, editor block, and scroll-region
+ * boundary can never drift out of agreement.
+ *
+ * The bottom-anchored stack, from the terminal's last row upward:
+ *
+ *   segRow    rows       the status segments line (always the last row)
+ *   borderRow rows - 1   the dim top-border rule of the bar
+ *   inputRow  rows - 2   the editable prompt (input-row mode only)
+ *   editorTop ↑          top of the multi-row editor block (grows upward)
+ *   regionEnd ↑          last row the scroll region may use (output scrolls above)
+ */
+export interface IRegionLayout {
+  /** Last scrollable row; streamed output stays at or above it. */
+  readonly regionEnd: number;
+  /** Row of the bar's top-border rule. */
+  readonly borderRow: number;
+  /** Row of the bar's status segments (the bottom-most row). */
+  readonly segRow: number;
+  /** Row of the editable input prompt (input-row mode). */
+  readonly inputRow: number;
+  /** Top row of the pinned editor block (just below the scroll region). */
+  readonly editorTop: number;
+}
+
+export interface IRegionInput {
+  /** Total terminal rows. */
+  readonly rows: number;
+  /** Rows the bar reserves at the bottom: 2 bar rows, +1 for the input row.
+   *  Defaults to the 2 bar rows — `borderRow`/`segRow`/`inputRow` don't depend on
+   *  it, so paint sites that only need those can omit it; only `regionEnd` does. */
+  readonly reserved?: number;
+  /** Height of the pinned multi-row editor block above the input row (0 = none). */
+  readonly editorRows?: number;
+}
+
+/**
+ * Absolute 1-based rows for the pinned bottom region. Every value is clamped to
+ * row ≥ 1 so a terminal shrunk below `reserved` can never emit an invalid
+ * `ESC[0;1H` / negative scroll-region sequence — the same guard the call sites
+ * applied by hand.
+ */
+export function computeRegions(input: IRegionInput): IRegionLayout {
+  const { rows, reserved = 2, editorRows = 0 } = input;
+  const segRow = Math.max(1, rows);
+  const borderRow = Math.max(1, rows - 1);
+  const inputRow = Math.max(1, rows - 2);
+  const regionEnd = Math.max(1, rows - reserved - editorRows);
+  const editorTop = Math.max(1, inputRow - editorRows);
+
+  return { regionEnd, borderRow, segRow, inputRow, editorTop };
+}

--- a/packages/core/src/render/screen.ts
+++ b/packages/core/src/render/screen.ts
@@ -68,27 +68,33 @@ class FrameApplier {
   ) {}
 
   apply(frame: string): void {
+    // Segment the whole frame into graphemes ONCE (so a surrogate pair / ZWJ
+    // cluster stays intact), then iterate — control bytes and CSI punctuation are
+    // each their own single-char grapheme. The earlier per-char `slice` + segment
+    // was O(n²) on every flush.
+    const segs = graphemes(frame);
     let i = 0;
 
-    while (i < frame.length) {
-      const ch = frame[i] ?? "";
+    while (i < segs.length) {
+      const g = segs[i] ?? "";
 
-      if (ch === ESC) {
-        i = frame[i + 1] === "[" ? this.csi(frame, i + 2) : i + 2;
+      if (g === ESC) {
+        i = segs[i + 1] === "[" ? this.csi(segs, i + 2) : i + 2;
 
         continue;
       }
 
-      i = this.plain(frame, i);
+      this.plain(g);
+      i += 1;
     }
   }
 
-  private csi(frame: string, start: number): number {
+  private csi(segs: readonly string[], start: number): number {
     let j = start;
     let params = "";
 
-    while (j < frame.length) {
-      const c = frame[j] ?? "";
+    while (j < segs.length) {
+      const c = segs[j] ?? "";
 
       if ((c >= "0" && c <= "9") || c === ";") {
         params += c;
@@ -98,7 +104,7 @@ class FrameApplier {
       }
     }
 
-    this.applyCsi(frame[j] ?? "", params);
+    this.applyCsi(segs[j] ?? "", params);
 
     return j + 1;
   }
@@ -134,31 +140,21 @@ class FrameApplier {
     }
   }
 
-  /** Consume one printable grapheme (multi-byte safe) and place it, widening for
-   *  CJK/emoji by marking the trailing cell as a continuation. */
-  private plain(frame: string, i: number): number {
-    const ch = frame[i] ?? "";
-
-    if (ch === "\r") {
+  /** Place one printable grapheme, widening for CJK/emoji by marking the trailing
+   *  cell as a continuation. Control bytes (incl. LF) don't occur in the absolute-
+   *  positioned bar frames, so they're ignored rather than modelled as scrolling. */
+  private plain(grapheme: string): void {
+    if (grapheme === "\r") {
       this.cursor.col = 1;
 
-      return i + 1;
+      return;
     }
 
-    if (ch < " ") {
-      // LF and other control bytes don't occur in the absolute-positioned bar
-      // frames; ignore them rather than model region scrolling here.
-      return i + 1;
+    if (grapheme < " ") {
+      return;
     }
-
-    // Read a whole grapheme starting at i (so a surrogate pair / ZWJ stays intact).
-    const rest = frame.slice(i);
-    const [g] = graphemes(rest);
-    const grapheme = g ?? ch;
 
     this.put(grapheme);
-
-    return i + grapheme.length;
   }
 
   private put(grapheme: string): void {

--- a/packages/core/src/render/screen.ts
+++ b/packages/core/src/render/screen.ts
@@ -164,20 +164,35 @@ class FrameApplier {
   private put(grapheme: string): void {
     const line = this.grid[this.cursor.row - 1];
     const col = this.cursor.col - 1;
+    const w = displayWidth(grapheme);
 
     if (line === undefined || col < 0 || col >= this.cols) {
-      this.cursor.col += Math.max(1, displayWidth(grapheme));
+      this.cursor.col += Math.max(1, w);
 
       return;
     }
 
+    // Partially overwriting an existing wide (2-column) cell would orphan its
+    // other half. Clear that half so the grid stays self-consistent — otherwise
+    // a leftover continuation cell mis-renders or mis-diffs. The two cases (this
+    // cell is a continuation vs a wide head) are mutually exclusive.
+    const existing = line[col];
+
+    if (existing !== undefined) {
+      if (existing.ch === "" && col > 0) {
+        line[col - 1] = blank(); // overwriting the right half: clear the left
+      } else if (displayWidth(existing.ch) === 2 && col + 1 < this.cols) {
+        line[col + 1] = blank(); // overwriting a wide cell: clear its right half
+      }
+    }
+
     line[col] = { ch: grapheme, sgr: this.sgr };
 
-    if (displayWidth(grapheme) === 2 && col + 1 < this.cols) {
+    if (w === 2 && col + 1 < this.cols) {
       line[col + 1] = { ch: "", sgr: this.sgr };
     }
 
-    this.cursor.col += Math.max(1, displayWidth(grapheme));
+    this.cursor.col += Math.max(1, w);
   }
 }
 

--- a/packages/core/src/render/screen.ts
+++ b/packages/core/src/render/screen.ts
@@ -1,0 +1,317 @@
+import { displayWidth, graphemes } from "./width";
+
+/**
+ * A double-buffered virtual screen with damage tracking — the idea OpenTUI's
+ * native core is built on, here in plain TypeScript and scoped to the bottom
+ * pinned region. The status bar previously repainted every pinned row with
+ * `ESC[2K` + a full rewrite on every state change (a token tick, a keystroke),
+ * which flickers and ships bytes for cells that did not change.
+ *
+ * `ScreenBuffer` sits in front of the existing frame builders: you hand it the
+ * ANSI frame they already produce, it interprets that frame onto a cell grid,
+ * diffs the grid against what is currently on screen, and emits ONLY the changed
+ * cells (plus a final cursor park). Same pixels, far fewer bytes, no flicker.
+ *
+ * It interprets the subset of VT100 the render layer emits — CUP (`ESC[r;cH`),
+ * EL (`ESC[nK`), SGR colour (`ESC[…m`, captured per cell), and printable text
+ * with display-width awareness. Structural sequences the bar emits directly
+ * (the DECSTBM scroll region, cursor save/restore) never pass through here.
+ */
+
+const ESC = "\x1b";
+const RESET_SGR = `${ESC}[0m`;
+
+/** One terminal cell. `ch === " "` is blank; `ch === ""` is the right half of a
+ *  preceding wide (2-column) cell and is never emitted on its own. */
+interface ICell {
+  ch: string;
+  sgr: string;
+}
+
+interface ICursor {
+  row: number;
+  col: number;
+}
+
+const blank = (): ICell => ({ ch: " ", sgr: "" });
+
+function blankGrid(rows: number, cols: number): ICell[][] {
+  return Array.from({ length: rows }, () =>
+    Array.from({ length: cols }, blank)
+  );
+}
+
+function cloneGrid(grid: ICell[][]): ICell[][] {
+  return grid.map((row) => row.map((cell) => ({ ch: cell.ch, sgr: cell.sgr })));
+}
+
+function toInt(value: string | undefined, fallback: number): number {
+  if (value === undefined || value === "") {
+    return fallback;
+  }
+
+  const n = Number.parseInt(value, 10);
+
+  return Number.isNaN(n) ? fallback : n;
+}
+
+/** Applies one ANSI frame onto a grid, tracking the cursor and the active SGR so
+ *  every written cell records the colour it was painted with. */
+class FrameApplier {
+  cursor: ICursor = { row: 1, col: 1 };
+  private sgr = "";
+
+  constructor(
+    private readonly grid: ICell[][],
+    private readonly rows: number,
+    private readonly cols: number
+  ) {}
+
+  apply(frame: string): void {
+    let i = 0;
+
+    while (i < frame.length) {
+      const ch = frame[i] ?? "";
+
+      if (ch === ESC) {
+        i = frame[i + 1] === "[" ? this.csi(frame, i + 2) : i + 2;
+
+        continue;
+      }
+
+      i = this.plain(frame, i);
+    }
+  }
+
+  private csi(frame: string, start: number): number {
+    let j = start;
+    let params = "";
+
+    while (j < frame.length) {
+      const c = frame[j] ?? "";
+
+      if ((c >= "0" && c <= "9") || c === ";") {
+        params += c;
+        j += 1;
+      } else {
+        break;
+      }
+    }
+
+    this.applyCsi(frame[j] ?? "", params);
+
+    return j + 1;
+  }
+
+  private applyCsi(final: string, params: string): void {
+    const parts = params.split(";");
+
+    if (final === "H" || final === "f") {
+      this.cursor = {
+        row: clamp(toInt(parts[0], 1), this.rows),
+        col: clamp(toInt(parts[1], 1), this.cols),
+      };
+    } else if (final === "K") {
+      this.eraseLine(toInt(parts[0], 0));
+    } else if (final === "m") {
+      this.sgr =
+        params === "" || params === "0" ? "" : this.sgr + `${ESC}[${params}m`;
+    }
+  }
+
+  private eraseLine(mode: number): void {
+    const line = this.grid[this.cursor.row - 1];
+
+    if (line === undefined) {
+      return;
+    }
+
+    const from = mode === 0 ? this.cursor.col - 1 : 0;
+    const to = mode === 1 ? this.cursor.col : this.cols;
+
+    for (let c = from; c < to && c < this.cols; c += 1) {
+      line[c] = blank();
+    }
+  }
+
+  /** Consume one printable grapheme (multi-byte safe) and place it, widening for
+   *  CJK/emoji by marking the trailing cell as a continuation. */
+  private plain(frame: string, i: number): number {
+    const ch = frame[i] ?? "";
+
+    if (ch === "\r") {
+      this.cursor.col = 1;
+
+      return i + 1;
+    }
+
+    if (ch < " ") {
+      // LF and other control bytes don't occur in the absolute-positioned bar
+      // frames; ignore them rather than model region scrolling here.
+      return i + 1;
+    }
+
+    // Read a whole grapheme starting at i (so a surrogate pair / ZWJ stays intact).
+    const rest = frame.slice(i);
+    const [g] = graphemes(rest);
+    const grapheme = g ?? ch;
+
+    this.put(grapheme);
+
+    return i + grapheme.length;
+  }
+
+  private put(grapheme: string): void {
+    const line = this.grid[this.cursor.row - 1];
+    const col = this.cursor.col - 1;
+
+    if (line === undefined || col < 0 || col >= this.cols) {
+      this.cursor.col += Math.max(1, displayWidth(grapheme));
+
+      return;
+    }
+
+    line[col] = { ch: grapheme, sgr: this.sgr };
+
+    if (displayWidth(grapheme) === 2 && col + 1 < this.cols) {
+      line[col + 1] = { ch: "", sgr: this.sgr };
+    }
+
+    this.cursor.col += Math.max(1, displayWidth(grapheme));
+  }
+}
+
+function clamp(n: number, max: number): number {
+  return Math.min(Math.max(1, n), max);
+}
+
+/** Emit the minimal escape sequence that turns `prev` into `next`, cell by cell. */
+function diffGrids(
+  prev: ICell[][],
+  next: ICell[][],
+  rows: number,
+  cols: number
+): string {
+  let out = "";
+
+  for (let r = 0; r < rows; r += 1) {
+    out += diffRow(prev[r] ?? [], next[r] ?? [], r + 1, cols);
+  }
+
+  return out;
+}
+
+/** Emit changed runs for one row: a CUP to each run's start, then its cells. */
+function diffRow(
+  prev: ICell[],
+  next: ICell[],
+  row: number,
+  cols: number
+): string {
+  let out = "";
+  let c = 0;
+
+  while (c < cols) {
+    if (cellsEqual(prev[c], next[c])) {
+      c += 1;
+      continue;
+    }
+
+    // Start of a damaged run — find its end.
+    let end = c;
+
+    while (end < cols && !cellsEqual(prev[end], next[end])) {
+      end += 1;
+    }
+
+    out += `${ESC}[${row};${c + 1}H${runText(next, c, end)}`;
+    c = end;
+  }
+
+  return out;
+}
+
+function cellsEqual(a: ICell | undefined, b: ICell | undefined): boolean {
+  const x = a ?? blank();
+  const y = b ?? blank();
+
+  return x.ch === y.ch && x.sgr === y.sgr;
+}
+
+/** Render cells [from, to) of a row as text, switching SGR only when it changes
+ *  and resetting at the end so colour never bleeds past the run. */
+function runText(cells: ICell[], from: number, to: number): string {
+  let out = "";
+  let activeSgr = "";
+
+  for (let c = from; c < to; c += 1) {
+    const cell = cells[c] ?? blank();
+
+    // The right half of a wide cell was already written by its left half.
+    if (cell.ch === "") {
+      continue;
+    }
+
+    if (cell.sgr !== activeSgr) {
+      out += cell.sgr === "" ? RESET_SGR : cell.sgr;
+      activeSgr = cell.sgr;
+    }
+
+    out += cell.ch;
+  }
+
+  if (activeSgr !== "") {
+    out += RESET_SGR;
+  }
+
+  return out;
+}
+
+/**
+ * A committed cell grid plus the cursor. `flush(frame)` applies the frame to a
+ * working copy, returns the minimal delta from the committed grid to it (ending
+ * with a cursor park), and commits — so successive identical frames emit nothing
+ * but the cursor move.
+ */
+export class ScreenBuffer {
+  private committed: ICell[][];
+  private cursor: ICursor = { row: 1, col: 1 };
+
+  constructor(
+    private rows: number,
+    private cols: number
+  ) {
+    this.committed = blankGrid(rows, cols);
+  }
+
+  /** Resize the grid (terminal resize); drops the committed state so the next
+   *  flush repaints in full against a blank screen of the new size. */
+  resize(rows: number, cols: number): void {
+    this.rows = rows;
+    this.cols = cols;
+    this.committed = blankGrid(rows, cols);
+    this.cursor = { row: 1, col: 1 };
+  }
+
+  /** Apply `frame`, commit it, and return the minimal delta that realises it —
+   *  WITHOUT a trailing cursor move. The caller parks the cursor (`parkSequence`)
+   *  or wraps the delta in save/restore, depending on whether it owns the cursor. */
+  flush(frame: string): string {
+    const working = cloneGrid(this.committed);
+    const applier = new FrameApplier(working, this.rows, this.cols);
+
+    applier.apply(frame);
+
+    const delta = diffGrids(this.committed, working, this.rows, this.cols);
+
+    this.committed = working;
+    this.cursor = applier.cursor;
+
+    return delta;
+  }
+
+  /** A CUP sequence to the cursor position the last flushed frame parked at. */
+  parkSequence(): string {
+    return `${ESC}[${this.cursor.row};${this.cursor.col}H`;
+  }
+}

--- a/packages/core/src/render/status-bar.ts
+++ b/packages/core/src/render/status-bar.ts
@@ -636,6 +636,14 @@ export class StatusBar {
     }
 
     const rows = this.out.rows ?? 0;
+    const columns = this.out.columns ?? 0;
+
+    // Terminals emit transient 0×0 sizes on minimize/resize; resizing the buffer
+    // to 0 rows would drop its committed state and wedge later paints. Skip until
+    // a real size arrives (the editor path guards the same way in cli.ts).
+    if (rows <= 0 || columns <= 0) {
+      return;
+    }
 
     // computeRegions clamps to row 1: a resize BELOW `reserved` (a terminal
     // shrunk after install) would otherwise make the boundary non-positive and
@@ -651,7 +659,7 @@ export class StatusBar {
 
     // The terminal reflowed: resize the damage buffer to the new dimensions and
     // drop its committed state so the next update repaints the bar in full.
-    this.screen?.resize(rows, this.out.columns ?? 80);
+    this.screen?.resize(rows, columns);
 
     // The saved stream cursor may now point off-screen — re-anchor it to the
     // bottom of the (resized) region so output continues there.

--- a/packages/core/src/render/status-bar.ts
+++ b/packages/core/src/render/status-bar.ts
@@ -1,5 +1,8 @@
 import type { IStatusInfo } from "./render.types";
 import { STYLE, paint } from "./style";
+import { displayWidth, graphemes } from "./width";
+import { computeRegions } from "./layout";
+import { ScreenBuffer } from "./screen";
 
 const ESC = "\x1b";
 
@@ -115,7 +118,7 @@ function assemble(segs: ISegment[], columns: number, color: boolean): string {
   let width = 1; // leading space
 
   for (const seg of segs) {
-    const add = (painted.length > 0 ? sep.length : 0) + seg.text.length;
+    const add = (painted.length > 0 ? sep.length : 0) + displayWidth(seg.text);
 
     if (width + add > columns) {
       break;
@@ -146,11 +149,9 @@ function buildBarBody(
   rows: number,
   color: boolean
 ): string {
-  // Clamp to row 1 so a terminal shrunk below the reserved height can never emit
-  // an invalid `${ESC}[0;1H` / `${ESC}[-1;1H` (normal terminals are >= MIN_ROWS,
-  // where the clamp is a no-op).
-  const segRow = Math.max(1, rows);
-  const borderRow = Math.max(1, rows - 1);
+  // Absolute rows come from the shared layout helper (clamped to row 1, so a
+  // terminal shrunk below the reserved height never emits an invalid sequence).
+  const { segRow, borderRow } = computeRegions({ rows });
   const segs = assemble(barSegments(info), columns, color);
 
   return (
@@ -189,15 +190,63 @@ function clipInput(
     return { visible: "", cursorCol: 0 };
   }
 
-  if (line.length <= avail) {
-    return { visible: line, cursorCol: cursor };
+  // `cursor` is a code-unit offset (from readline); its on-screen column is the
+  // display width of the text before it.
+  const cursorCol = displayWidth(line.slice(0, cursor));
+
+  if (displayWidth(line) <= avail) {
+    return { visible: line, cursorCol };
   }
 
-  const start = Math.max(0, cursor - avail + 1);
+  // Wider than the window: show a grapheme-aligned window of `avail` columns with
+  // the cursor parked near the right edge. The cursor's grapheme index is found
+  // from its code-unit offset, then we keep up to `avail - 1` columns to its left
+  // (reserving the last column for the cursor / one cell of look-ahead) and fill
+  // the window rightward — so a wide cell is never split.
+  const gs = graphemes(line);
+  let cursorG = gs.length;
+  let consumed = 0;
+
+  for (let i = 0; i < gs.length; i += 1) {
+    if (consumed >= cursor) {
+      cursorG = i;
+      break;
+    }
+
+    consumed += (gs[i] ?? "").length;
+  }
+
+  let leftCols = 0;
+  let startG = cursorG;
+
+  for (let i = cursorG - 1; i >= 0; i -= 1) {
+    const w = displayWidth(gs[i] ?? "");
+
+    if (leftCols + w > avail - 1) {
+      break;
+    }
+
+    leftCols += w;
+    startG = i;
+  }
+
+  let windowCols = 0;
+  let endG = startG;
+
+  for (let i = startG; i < gs.length; i += 1) {
+    const w = displayWidth(gs[i] ?? "");
+
+    if (windowCols + w > avail) {
+      break;
+    }
+
+    windowCols += w;
+    endG = i + 1;
+  }
 
   return {
-    visible: line.slice(start, start + avail),
-    cursorCol: cursor - start,
+    visible: gs.slice(startG, endG).join(""),
+    cursorCol: leftCols,
   };
 }
 
@@ -214,9 +263,7 @@ export function buildInputFrame(
   rows: number,
   color: boolean
 ): string {
-  // Clamp to row 1 so a shrunk terminal can't emit an invalid `${ESC}[0;1H`
-  // (normal terminals are >= MIN_ROWS, where this is a no-op).
-  const inputRow = Math.max(1, rows - 2);
+  const { inputRow } = computeRegions({ rows });
   const avail = Math.max(0, columns - PROMPT_COLS);
   const { visible, cursorCol } = clipInput(line, cursor, avail);
 
@@ -251,7 +298,7 @@ export function buildEditorFrame(
 
   void color;
 
-  const inputRow = Math.max(1, rows - 2);
+  const { inputRow } = computeRegions({ rows });
   const maxSpan = Math.max(0, inputRow - 1);
 
   // The block is BOTTOM-anchored: content always occupies the bottom
@@ -296,7 +343,7 @@ export function buildOverlayFrame(
   clearRows: number,
   rows: number
 ): string {
-  const inputRow = Math.max(1, rows - 2);
+  const { inputRow } = computeRegions({ rows });
   const count = Math.min(
     Math.max(lines.length, clearRows),
     Math.max(0, inputRow - 1)
@@ -333,6 +380,12 @@ export class StatusBar {
   /** Height of the multi-row editor block currently painted above the input row (0 = none),
    *  so the next paint knows how many old rows to erase when the block shrinks. */
   private editorRows = 0;
+  /** Damage buffer for the bar-owned rows (border, segments, input row). The bar
+   *  frames are flushed through it so a repaint emits only the cells that changed
+   *  — no full-row `ESC[2K` rewrites, no flicker. The editor block and `@`-picker
+   *  popup paint directly (they reclaim scroll-region rows and need explicit
+   *  clears), so the buffer never owns those rows. Undefined until install. */
+  private screen: ScreenBuffer | undefined;
 
   constructor(
     private readonly out: IStatusBarTerminal,
@@ -369,11 +422,15 @@ export class StatusBar {
     }
 
     const rows = this.out.rows ?? 0;
+    const { regionEnd } = computeRegions({ rows, reserved: this.reserved });
 
     this.out.write("\n".repeat(this.reserved)); // make room for the bar
-    this.out.write(`${ESC}[1;${rows - this.reserved}r`); // confine scrolling
-    this.out.write(`${ESC}[${rows - this.reserved};1H`); // cursor back in-region
+    this.out.write(`${ESC}[1;${regionEnd}r`); // confine scrolling
+    this.out.write(`${ESC}[${regionEnd};1H`); // cursor back in-region
     this.installed = true;
+    // The bar rows we just made room for are blank, matching the buffer's blank
+    // committed grid, so the first repaint emits content with no spurious clears.
+    this.screen = new ScreenBuffer(rows, this.out.columns ?? 80);
 
     // Save the in-region cursor as the STREAM cursor; writeStream restores to it
     // before each chunk and re-saves after, so output scrolls in-region while the
@@ -383,6 +440,29 @@ export class StatusBar {
     }
 
     this.update(info);
+  }
+
+  /**
+   * Flush a bar-owned frame (border, segments, input row) through the damage
+   * buffer, writing only the cells that changed. `parkOnInput` parks the cursor
+   * where the frame left it (the input row); otherwise the delta is wrapped in
+   * save/restore so the user's cursor never moves (bar-only mode). Falls back to
+   * a direct write if the buffer isn't installed.
+   */
+  private flushPinned(content: string, parkOnInput: boolean): void {
+    if (this.screen === undefined) {
+      this.out.write(content);
+
+      return;
+    }
+
+    const delta = this.screen.flush(content);
+
+    this.out.write(
+      parkOnInput
+        ? `${delta}${this.screen.parkSequence()}`
+        : `${ESC}7${delta}${ESC}8`
+    );
   }
 
   /** Repaint the bar with the latest state (and the input row, in input mode). */
@@ -395,15 +475,18 @@ export class StatusBar {
     const rows = this.out.rows ?? 0;
 
     if (this.withInput) {
-      // Absolute-positioned body (no save/restore — that slot holds the stream
-      // cursor), then re-park the cursor on the input row.
-      this.out.write(buildBarBody(info, columns, rows, this.color));
-      this.paintInput();
+      // Bar body + input row in one damage-diffed flush, parking on the input row
+      // (the stream-cursor slot is left untouched — it isn't part of this frame).
+      this.flushPinned(
+        buildBarBody(info, columns, rows, this.color) +
+          buildInputFrame(this.line, this.cursorPos, columns, rows, this.color),
+        true
+      );
 
       return;
     }
 
-    this.out.write(buildBarFrame(info, columns, rows, this.color));
+    this.flushPinned(buildBarBody(info, columns, rows, this.color), false);
   }
 
   /** Update the editable buffer mirror and repaint the input row (input mode). */
@@ -445,10 +528,11 @@ export class StatusBar {
     const columns = this.out.columns ?? 80;
     const rows = this.out.rows ?? 0;
 
+    // The popup paints directly (it reclaims scroll-region rows above the input
+    // row); the bar + input row repaint goes through the damage buffer.
     this.out.write(buildOverlayFrame(lines, this.overlayRows, rows));
     this.overlayRows = lines.length;
-    this.out.write(buildBarBody(info, columns, rows, this.color));
-    this.paintInput();
+    this.repaintBarAndInput(info, columns, rows);
   }
 
   /** Erase the `@`-picker dropdown and repaint the bar + input row. Idempotent. */
@@ -462,19 +546,32 @@ export class StatusBar {
 
     this.out.write(buildOverlayFrame([], this.overlayRows, rows));
     this.overlayRows = 0;
-    this.out.write(buildBarBody(info, columns, rows, this.color));
-    this.paintInput();
+    this.repaintBarAndInput(info, columns, rows);
+  }
+
+  /** Bar body + input row in one damage-diffed flush (parking on the input row). */
+  private repaintBarAndInput(
+    info: IStatusInfo,
+    columns: number,
+    rows: number
+  ): void {
+    this.flushPinned(
+      buildBarBody(info, columns, rows, this.color) +
+        buildInputFrame(this.line, this.cursorPos, columns, rows, this.color),
+      true
+    );
   }
 
   private paintInput(): void {
-    this.out.write(
+    this.flushPinned(
       buildInputFrame(
         this.line,
         this.cursorPos,
         this.out.columns ?? 80,
         this.out.rows ?? 0,
         this.color
-      )
+      ),
+      true
     );
   }
 
@@ -497,7 +594,7 @@ export class StatusBar {
     const rows = this.out.rows ?? 0;
 
     // Clamp the block height to the available rows above the input row
-    const inputRow = Math.max(1, rows - 2);
+    const { inputRow } = computeRegions({ rows });
     const maxRows = Math.max(0, inputRow - 1);
     const clamped = lines.slice(0, maxRows);
     const newHeight = clamped.length;
@@ -505,7 +602,11 @@ export class StatusBar {
     // If editor height changes, update the scroll region to exclude the new height.
     // This pins the editor block (and bar + input) so they never scroll.
     if (newHeight !== this.editorRows) {
-      const regionEnd = Math.max(1, rows - this.reserved - newHeight);
+      const { regionEnd } = computeRegions({
+        rows,
+        reserved: this.reserved,
+        editorRows: newHeight,
+      });
 
       this.out.write(`${ESC}[1;${regionEnd}r`);
 
@@ -536,13 +637,21 @@ export class StatusBar {
 
     const rows = this.out.rows ?? 0;
 
-    // Clamp to row 1: a resize BELOW `reserved` (a terminal shrunk after install)
-    // would otherwise make `rows - reserved` non-positive and emit invalid
-    // `${ESC}[1;-1r` / `${ESC}[-1;1H` sequences. Mirrors teardown()'s clamp.
-    // Also exclude the editor block from the scrollable region.
-    const regionEnd = Math.max(1, rows - this.reserved - this.editorRows);
+    // computeRegions clamps to row 1: a resize BELOW `reserved` (a terminal
+    // shrunk after install) would otherwise make the boundary non-positive and
+    // emit invalid `${ESC}[1;-1r` / `${ESC}[-1;1H` sequences. The editor block is
+    // excluded from the scrollable region.
+    const { regionEnd } = computeRegions({
+      rows,
+      reserved: this.reserved,
+      editorRows: this.editorRows,
+    });
 
     this.out.write(`${ESC}[1;${regionEnd}r`);
+
+    // The terminal reflowed: resize the damage buffer to the new dimensions and
+    // drop its committed state so the next update repaints the bar in full.
+    this.screen?.resize(rows, this.out.columns ?? 80);
 
     // The saved stream cursor may now point off-screen — re-anchor it to the
     // bottom of the (resized) region so output continues there.
@@ -575,5 +684,6 @@ export class StatusBar {
     this.out.write(`${ESC}[?25h`); // ensure the cursor is visible
     this.installed = false;
     this.editorRows = 0; // reset editor block height
+    this.screen = undefined; // next install starts a fresh damage buffer
   }
 }

--- a/packages/core/src/render/width.ts
+++ b/packages/core/src/render/width.ts
@@ -1,0 +1,186 @@
+import { graphemes } from "../editor/segments";
+
+export { graphemes } from "../editor/segments";
+
+/**
+ * Terminal display-width helpers. A monospace cell is one column, but a CJK
+ * ideograph, a fullwidth form, or an emoji occupies TWO, and combining /
+ * zero-width marks occupy NONE. Everywhere we size a box, pad a table cell, fit
+ * status segments, or wrap an editor line we previously counted `.length`
+ * (UTF-16 code units) or grapheme count — both wrong for wide text, which then
+ * overflowed or mis-aligned. These functions count *columns*, building on the
+ * existing grapheme segmenter so a cluster is measured as one unit.
+ */
+
+/** Half-open `[start, end)` code-point ranges, kept sorted for a binary search. */
+type Range = readonly [start: number, end: number];
+
+/** Code points that render two columns wide: East Asian Wide/Fullwidth plus the
+ *  emoji blocks that terminals draw double-width. Sorted ascending. */
+const WIDE: readonly Range[] = [
+  [0x1100, 0x1160], // Hangul Jamo
+  [0x2329, 0x232b], // angle brackets
+  [0x2e80, 0x303f], // CJK radicals … Kangxi
+  [0x3041, 0x33ff], // Hiragana … CJK compatibility
+  [0x3400, 0x4dc0], // CJK Extension A
+  [0x4e00, 0xa000], // CJK Unified Ideographs
+  [0xa000, 0xa4d0], // Yi
+  [0xac00, 0xd7a4], // Hangul Syllables
+  [0xf900, 0xfb00], // CJK Compatibility Ideographs
+  [0xfe10, 0xfe1a], // Vertical forms
+  [0xfe30, 0xfe70], // CJK compatibility / small forms
+  [0xff00, 0xff61], // Fullwidth forms
+  [0xffe0, 0xffe7], // Fullwidth signs
+  [0x1f1e6, 0x1f200], // Regional indicators (flags)
+  [0x1f300, 0x1f650], // Misc symbols, emoticons
+  [0x1f680, 0x1f700], // Transport & map
+  [0x1f900, 0x1fa00], // Supplemental symbols & pictographs
+  [0x20000, 0x3fffe], // CJK Extension B and beyond
+];
+
+/** Code points that render zero columns: combining marks and zero-width
+ *  formatting characters. Sorted ascending. */
+const ZERO: readonly Range[] = [
+  [0x0300, 0x0370], // Combining diacritical marks
+  [0x0483, 0x048a], // Cyrillic combining
+  [0x0591, 0x05c8], // Hebrew points/marks
+  [0x0610, 0x061b], // Arabic marks
+  [0x064b, 0x0660], // Arabic harakat
+  [0x0670, 0x0671], // Arabic superscript alef
+  [0x06d6, 0x06ed], // Arabic small high marks
+  [0x0e31, 0x0e32], // Thai vowel
+  [0x0e34, 0x0e3b], // Thai vowels/tones
+  [0x1ab0, 0x1b00], // Combining diacritical extended
+  [0x1dc0, 0x1e00], // Combining diacritical supplement
+  [0x200b, 0x2010], // Zero-width space, ZWNJ, ZWJ, LTR/RTL marks
+  [0x202a, 0x202f], // Bidi embedding/override
+  [0x2060, 0x2065], // Word joiner, invisibles
+  [0x20d0, 0x2100], // Combining marks for symbols
+  [0xfe00, 0xfe10], // Variation selectors (see VS16 note below)
+  [0xfe20, 0xfe30], // Combining half marks
+];
+
+/** Variation Selector-16 forces emoji (wide) presentation of the preceding
+ *  base character, so a cluster containing it is two columns regardless of the
+ *  base's own width (e.g. `#️`, `❤️`). */
+const VS16 = 0xfe0f;
+
+/** True if `cp` falls in any of the sorted half-open ranges (binary search). */
+function inRanges(cp: number, ranges: readonly Range[]): boolean {
+  let lo = 0;
+  let hi = ranges.length - 1;
+
+  while (lo <= hi) {
+    const mid = (lo + hi) >> 1;
+    const range = ranges[mid];
+
+    if (range === undefined) {
+      break;
+    }
+
+    const [start, end] = range;
+
+    if (cp < start) {
+      hi = mid - 1;
+    } else if (cp >= end) {
+      lo = mid + 1;
+    } else {
+      return true;
+    }
+  }
+
+  return false;
+}
+
+/** The column width of a single code point: 0 (combining / zero-width / C0–C1
+ *  control), 2 (wide / fullwidth / emoji), or 1 (everything else). */
+export function codePointWidth(cp: number): 0 | 1 | 2 {
+  // C0 controls, DEL, and C1 controls render nothing meaningful here.
+  if (cp < 0x20 || (cp >= 0x7f && cp < 0xa0)) {
+    return 0;
+  }
+
+  if (inRanges(cp, ZERO)) {
+    return 0;
+  }
+
+  if (inRanges(cp, WIDE)) {
+    return 2;
+  }
+
+  return 1;
+}
+
+/** The column width of one grapheme cluster: zero-width if its base is, two if
+ *  it carries VS16 or any wide code point, else the base width. Combining marks
+ *  contribute nothing, so `e` + accent is still one column. */
+function clusterWidth(cluster: string): number {
+  let width = 0;
+  let hasVs16 = false;
+
+  for (const ch of cluster) {
+    const cp = ch.codePointAt(0) ?? 0;
+
+    if (cp === VS16) {
+      hasVs16 = true;
+    }
+
+    // The cluster's width is the widest of its code points: a base (1 or 2)
+    // dominates its trailing combining marks (0).
+    width = Math.max(width, codePointWidth(cp));
+  }
+
+  return hasVs16 ? 2 : width;
+}
+
+/** Total terminal columns `str` occupies, measured per grapheme cluster. */
+export function displayWidth(str: string): number {
+  let width = 0;
+
+  for (const cluster of graphemes(str)) {
+    width += clusterWidth(cluster);
+  }
+
+  return width;
+}
+
+/**
+ * The leading slice of `str` that fits in `maxWidth` columns, never splitting a
+ * grapheme or landing half-way through a wide cell. Returns the slice and its
+ * exact column width (≤ `maxWidth`).
+ */
+export function sliceToWidth(
+  str: string,
+  maxWidth: number
+): { text: string; width: number } {
+  if (maxWidth <= 0) {
+    return { text: "", width: 0 };
+  }
+
+  let text = "";
+  let width = 0;
+
+  for (const cluster of graphemes(str)) {
+    const w = clusterWidth(cluster);
+
+    if (width + w > maxWidth) {
+      break;
+    }
+
+    text += cluster;
+    width += w;
+  }
+
+  return { text, width };
+}
+
+/**
+ * Pad `str` with trailing spaces to exactly `width` columns (display width, not
+ * `.length`). Strings already at or over the target are returned unchanged — the
+ * column-aware analogue of `String.prototype.padEnd`.
+ */
+export function padToWidth(str: string, width: number): string {
+  const pad = width - displayWidth(str);
+
+  return pad > 0 ? str + " ".repeat(pad) : str;
+}

--- a/packages/core/tests/diff.test.ts
+++ b/packages/core/tests/diff.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, test } from "bun:test";
+import { renderDiff } from "../src/render/diff";
+import { displayWidth } from "../src/render/width";
+
+const ESC = String.fromCharCode(27);
+const SGR = new RegExp(`${ESC}\\[[0-9;]*m`, "g");
+const strip = (s: string): string => s.replace(SGR, "");
+
+describe("renderDiff — unified", () => {
+  test("shows unchanged lines as context, not as -/+ churn", () => {
+    const old = "a\nb\nc";
+    const next = "a\nB\nc";
+    const out = strip(renderDiff(old, next, { color: false }));
+    const lines = out.split("\n");
+
+    // The naive renderer printed all of old then all of new (6 lines); the LCS
+    // diff keeps `a` and `c` as single context lines and changes only `b`.
+    expect(lines).toContain("  a");
+    expect(lines).toContain("  c");
+    expect(lines.filter((l) => l.startsWith("- "))).toEqual(["- b"]);
+    expect(lines.filter((l) => l.startsWith("+ "))).toEqual(["+ B"]);
+  });
+
+  test("a pure addition emits only + lines plus context", () => {
+    const out = strip(renderDiff("a\nc", "a\nb\nc", { color: false }));
+
+    expect(out.split("\n").filter((l) => l.startsWith("+ "))).toEqual(["+ b"]);
+    expect(out.split("\n").filter((l) => l.startsWith("- "))).toEqual([]);
+  });
+
+  test("collapses large unchanged runs to a gap marker", () => {
+    const common = Array.from({ length: 20 }, (_, i) => `line${i}`).join("\n");
+    const out = strip(
+      renderDiff(`${common}\nX`, `${common}\nY`, { color: false, context: 2 })
+    );
+
+    expect(out).toContain("⋯");
+    // Only the inner context survives, not all 20 unchanged lines.
+    expect(out.split("\n").length).toBeLessThan(10);
+  });
+
+  test("color:false carries no ANSI escapes", () => {
+    const out = renderDiff("foo", "bar", { color: false });
+
+    expect(out).toBe("- foo\n+ bar");
+  });
+});
+
+describe("renderDiff — word level", () => {
+  test("highlights only the changed word in a one-line swap", () => {
+    const out = renderDiff("the quick fox", "the slow fox", { color: true });
+
+    // Shared words are not bolded; the changed word is painted bold.
+    expect(out).toContain("\x1b[1m"); // bold appears (changed word)
+    expect(strip(out)).toContain("the quick fox");
+    expect(strip(out)).toContain("the slow fox");
+  });
+});
+
+describe("renderDiff — side by side", () => {
+  test("aligns two equal-width columns, never splitting wide cells", () => {
+    const out = strip(
+      renderDiff("a\n世界x", "a\nb", {
+        color: false,
+        sideBySide: true,
+        columns: 20,
+      })
+    );
+    const widths = out.split("\n").map((l) => displayWidth(l));
+
+    expect(new Set(widths).size).toBe(1); // every row the same display width
+  });
+});

--- a/packages/core/tests/diff.test.ts
+++ b/packages/core/tests/diff.test.ts
@@ -28,6 +28,19 @@ describe("renderDiff — unified", () => {
     expect(out.split("\n").filter((l) => l.startsWith("- "))).toEqual([]);
   });
 
+  test("a no-op diff keeps leading context, not just a bare gap marker", () => {
+    const same = Array.from({ length: 20 }, (_, i) => `line${i}`).join("\n");
+    const lines = strip(renderDiff(same, same, { color: false, context: 3 }))
+      .split("\n")
+      .filter((l) => l.length > 0);
+
+    // Not collapsed to a single "⋯": some real context survives.
+    expect(lines.some((l) => l.includes("line0"))).toBe(true);
+    expect(lines.length).toBeGreaterThan(1);
+    expect(lines.filter((l) => l.startsWith("- ")).length).toBe(0);
+    expect(lines.filter((l) => l.startsWith("+ ")).length).toBe(0);
+  });
+
   test("collapses large unchanged runs to a gap marker", () => {
     const common = Array.from({ length: 20 }, (_, i) => `line${i}`).join("\n");
     const out = strip(

--- a/packages/core/tests/diff.test.ts
+++ b/packages/core/tests/diff.test.ts
@@ -44,6 +44,19 @@ describe("renderDiff — unified", () => {
 
     expect(out).toBe("- foo\n+ bar");
   });
+
+  test("falls back to a plain replacement on very large inputs (no O(n·m) blowup)", () => {
+    // 600×600 = 360k DP cells, past the guard — must not allocate the matrix or
+    // hang; it degrades to all-old-removed then all-new-added.
+    const old = Array.from({ length: 600 }, (_, i) => `a${i}`).join("\n");
+    const next = Array.from({ length: 600 }, (_, i) => `b${i}`).join("\n");
+    const lines = strip(
+      renderDiff(old, next, { color: false, wordLevel: false })
+    ).split("\n");
+
+    expect(lines.filter((l) => l.startsWith("- ")).length).toBe(600);
+    expect(lines.filter((l) => l.startsWith("+ ")).length).toBe(600);
+  });
 });
 
 describe("renderDiff — word level", () => {

--- a/packages/core/tests/editor-view.test.ts
+++ b/packages/core/tests/editor-view.test.ts
@@ -73,19 +73,19 @@ test("single line renders one row", () => {
 
 // region: Gemini PR #52 regression tests
 
-test("emoji wrap and cursor positioning is grapheme-correct", () => {
-  // Emoji 👍 is 1 grapheme but multiple UTF-16 units
-  // Line: "hello 👍" (7 graphemes) + "world" (5 graphemes)
-  // Wrap at 8 columns: "hello 👍" = 8 graphemes → fits exactly
-  // "world" on next row
+test("emoji wrap and cursor positioning is display-width-correct", () => {
+  // 👍 is one grapheme (multiple UTF-16 units) that occupies TWO columns.
+  // Line: "hello " (6 cols) + 👍 (2 cols) = 8 cols → fills an 8-column row exactly,
+  // so "world" wraps to the second row. Cursor at grapheme 7 = start of "world".
   const line = "hello 👍world";
   const r = renderEditor(
-    { lines: [line], cursorLine: 0, cursorCol: 8 }, // cursor at start of "world" (grapheme 8)
+    { lines: [line], cursorLine: 0, cursorCol: 7 },
     { columns: 8, maxRows: 6, color: false }
   );
 
-  // The line should wrap into 2 rows
+  // The line wraps into 2 rows, and the emoji is NOT crowded past the edge.
   expect(r.rows).toBe(2);
-  expect(r.cursorRow).toBe(1); // cursor is on second visual row
-  expect(r.cursorCol).toBe(0); // at column 0 of the second row
+  expect(r.frame.split("\n")[0]).toBe("hello 👍");
+  expect(r.cursorRow).toBe(1); // cursor is on the second visual row
+  expect(r.cursorCol).toBe(0); // at column 0 of the second row ("world")
 });

--- a/packages/core/tests/editor-view.test.ts
+++ b/packages/core/tests/editor-view.test.ts
@@ -73,6 +73,17 @@ test("single line renders one row", () => {
 
 // region: Gemini PR #52 regression tests
 
+test("a hard tab advances the cursor to the next tab stop", () => {
+  // "\tab": the tab expands to column 8 (a terminal's default tab stop), then
+  // "a","b" → the cursor sits at display column 10, not 2.
+  const r = renderEditor(
+    { lines: ["\tab"], cursorLine: 0, cursorCol: 3 },
+    { columns: 40, maxRows: 6, color: false }
+  );
+
+  expect(r.cursorCol).toBe(10);
+});
+
 test("emoji wrap and cursor positioning is display-width-correct", () => {
   // 👍 is one grapheme (multiple UTF-16 units) that occupies TWO columns.
   // Line: "hello " (6 cols) + 👍 (2 cols) = 8 cols → fills an 8-column row exactly,

--- a/packages/core/tests/layout.test.ts
+++ b/packages/core/tests/layout.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, test } from "bun:test";
+import { computeRegions } from "../src/render/layout";
+
+describe("computeRegions", () => {
+  test("bottom-anchors the bar on a normal terminal", () => {
+    const r = computeRegions({ rows: 24, reserved: 3 });
+
+    expect(r.segRow).toBe(24); // last row
+    expect(r.borderRow).toBe(23); // border just above
+    expect(r.inputRow).toBe(22); // prompt above the border
+    expect(r.regionEnd).toBe(21); // scroll region ends above the reserved block
+    expect(r.editorTop).toBe(22); // no editor block ⇒ equals inputRow
+  });
+
+  test("an editor block lifts the scroll-region boundary and editor top", () => {
+    const r = computeRegions({ rows: 24, reserved: 3, editorRows: 4 });
+
+    expect(r.regionEnd).toBe(17); // 24 - 3 - 4
+    expect(r.editorTop).toBe(18); // inputRow(22) - 4
+    expect(r.inputRow).toBe(22); // input row itself is unchanged
+    expect(r.segRow).toBe(24);
+  });
+
+  test("clamps every row to >= 1 when the terminal is shrunk below reserved", () => {
+    const r = computeRegions({ rows: 2, reserved: 3, editorRows: 5 });
+
+    expect(r.regionEnd).toBeGreaterThanOrEqual(1);
+    expect(r.borderRow).toBeGreaterThanOrEqual(1);
+    expect(r.segRow).toBeGreaterThanOrEqual(1);
+    expect(r.inputRow).toBeGreaterThanOrEqual(1);
+    expect(r.editorTop).toBeGreaterThanOrEqual(1);
+  });
+
+  test("re-windows monotonically as the editor block grows (a255898 class)", () => {
+    const grow = [0, 1, 2, 3, 4].map(
+      (h) => computeRegions({ rows: 24, reserved: 3, editorRows: h }).regionEnd
+    );
+
+    // Each extra editor row pushes the scroll-region boundary up by exactly one.
+    expect(grow).toEqual([21, 20, 19, 18, 17]);
+  });
+
+  test("border/seg/input rows do not depend on reserved or editorRows", () => {
+    const a = computeRegions({ rows: 40 });
+    const b = computeRegions({ rows: 40, reserved: 3, editorRows: 6 });
+
+    expect(a.segRow).toBe(b.segRow);
+    expect(a.borderRow).toBe(b.borderRow);
+    expect(a.inputRow).toBe(b.inputRow);
+  });
+});

--- a/packages/core/tests/screen.test.ts
+++ b/packages/core/tests/screen.test.ts
@@ -49,6 +49,17 @@ describe("ScreenBuffer — damage diff", () => {
     expect(delta).not.toContain(clear);
   });
 
+  test("overwriting a wide cell's half clears the orphaned half", () => {
+    const buf = new ScreenBuffer(3, 10);
+
+    buf.flush(`${at(1, 1)}世`); // col1 wide char, col2 its continuation
+    const delta = buf.flush(`${at(1, 1)}x`); // overwrite the left half with a narrow char
+
+    // The diff must also blank the orphaned continuation column (write a space at
+    // col2), not leave a dangling right half — so the run is "x " not "x".
+    expect(delta).toContain(`${at(1, 1)}x `);
+  });
+
   test("wide characters occupy two columns and realign following cells", () => {
     const buf = new ScreenBuffer(5, 20);
 

--- a/packages/core/tests/screen.test.ts
+++ b/packages/core/tests/screen.test.ts
@@ -1,0 +1,105 @@
+import { describe, expect, test } from "bun:test";
+import { ScreenBuffer } from "../src/render/screen";
+import { VirtualScreen } from "./helpers/virtual-screen";
+
+const ESC = "\x1b";
+const at = (r: number, c: number): string => `${ESC}[${r};${c}H`;
+const clear = `${ESC}[2K`;
+
+describe("ScreenBuffer — damage diff", () => {
+  test("an unchanged repaint emits no cell writes", () => {
+    const buf = new ScreenBuffer(5, 20);
+    const frame = `${at(1, 1)}${clear}hello`;
+
+    buf.flush(frame); // first paint
+    const second = buf.flush(frame); // identical repaint
+
+    // The delta is empty — nothing on screen changed. The cursor park is a
+    // separate, explicit step the caller adds.
+    expect(second).toBe("");
+    expect(buf.parkSequence()).toMatch(/\[\d+;\d+H/);
+  });
+
+  test("emits only the cells that actually changed", () => {
+    const buf = new ScreenBuffer(5, 20);
+
+    buf.flush(`${at(1, 1)}${clear}hello world`);
+    const delta = buf.flush(`${at(1, 1)}${clear}hello WORLD`);
+
+    // Only "WORLD" (from column 7) is redrawn, not the unchanged "hello ".
+    expect(delta).toContain("WORLD");
+    expect(delta).not.toContain("hello");
+    // The damaged run starts at column 7.
+    expect(delta).toContain(`${ESC}[1;7H`);
+  });
+
+  test("clears vacated cells by writing spaces (no ESC[2K needed)", () => {
+    const buf = new ScreenBuffer(5, 20);
+
+    const first = buf.flush(`${at(1, 1)}${clear}longer text`);
+    const delta = buf.flush(`${at(1, 1)}${clear}short`);
+
+    // Applying both deltas to a real terminal leaves only "short" — the tail
+    // "er text" was erased by writing spaces, with no ESC[2K in the delta.
+    const v = new VirtualScreen(5, 20);
+
+    v.feed(first);
+    v.feed(delta);
+    expect(v.row(1)).toBe("short");
+    expect(delta).not.toContain(clear);
+  });
+
+  test("wide characters occupy two columns and realign following cells", () => {
+    const buf = new ScreenBuffer(5, 20);
+
+    buf.flush(`${at(1, 1)}${clear}世界x`);
+    const delta = buf.flush(`${at(1, 1)}${clear}ab`);
+
+    // "世界x" (5 cols) → "ab": the diff must clear the extra trailing columns.
+    const v = new VirtualScreen(5, 20);
+
+    v.feed(`${at(1, 1)}${clear}世界x`);
+    v.feed(delta);
+    expect(v.row(1)).toBe("ab");
+  });
+});
+
+describe("ScreenBuffer — fidelity vs a real terminal", () => {
+  const frames = [
+    `${at(2, 1)}${clear}status: idle`,
+    `${at(1, 1)}${clear}› hello${at(1, 9)}`,
+    `${at(2, 1)}${clear}status: running 世界`,
+    `${at(1, 1)}${clear}› hello world${at(1, 15)}`,
+  ];
+
+  test("applying the deltas reproduces the same grid as the raw frames", () => {
+    const raw = new VirtualScreen(5, 40);
+    const diffed = new VirtualScreen(5, 40);
+    const buf = new ScreenBuffer(5, 40);
+
+    for (const frame of frames) {
+      raw.feed(frame);
+      diffed.feed(buf.flush(frame) + buf.parkSequence());
+    }
+
+    expect(diffed.text()).toBe(raw.text());
+    expect(diffed.cursorPosition()).toEqual(raw.cursorPosition());
+  });
+
+  test("the diffed stream is never longer than re-sending every frame", () => {
+    const buf = new ScreenBuffer(5, 40);
+    let diffedBytes = 0;
+    let rawBytes = 0;
+
+    // Re-send the SAME frame repeatedly: raw cost is constant, diffed collapses
+    // to just cursor parks after the first paint.
+    for (let i = 0; i < 5; i += 1) {
+      const frame = `${at(2, 1)}${clear}status: idle`;
+
+      rawBytes += frame.length;
+      diffedBytes += (buf.flush(frame) + buf.parkSequence()).length;
+    }
+
+    expect(diffedBytes).toBeLessThan(rawBytes);
+  });
+});

--- a/packages/core/tests/screen.test.ts
+++ b/packages/core/tests/screen.test.ts
@@ -66,7 +66,13 @@ describe("ScreenBuffer — damage diff", () => {
     buf.flush(`${at(1, 1)}${clear}世界x`);
     const delta = buf.flush(`${at(1, 1)}${clear}ab`);
 
-    // "世界x" (5 cols) → "ab": the diff must clear the extra trailing columns.
+    // "世界x" is FIVE columns (世=2, 界=2, x=1). Replacing it with "ab" must
+    // clear the three trailing columns it occupied — assert on the delta directly,
+    // since VirtualScreen models every glyph as one column and so can't tell a
+    // width-2 cell from a width-1 one. The damaged run is "ab" + three spaces.
+    expect(delta).toContain(`${at(1, 1)}ab   `);
+
+    // And the rendered grid still shows just "ab".
     const v = new VirtualScreen(5, 20);
 
     v.feed(`${at(1, 1)}${clear}世界x`);

--- a/packages/core/tests/status-bar.test.ts
+++ b/packages/core/tests/status-bar.test.ts
@@ -8,6 +8,7 @@ import {
   type IStatusInfo,
   type IStatusBarTerminal,
 } from "../src/render";
+import { VirtualScreen } from "./helpers/virtual-screen";
 
 const INFO: IStatusInfo = {
   model: "qwen3.6-27b",
@@ -115,7 +116,14 @@ describe("StatusBar activation", () => {
 
     expect(bar.active).toBe(true);
     expect(term.text()).toContain("\x1b[1;22r"); // reserve bottom 2 rows (rows-2)
-    expect(term.text()).toContain("\x1b[24;1H"); // segments drawn on row 24
+
+    // The bar paints through the damage buffer, so assert the rendered screen
+    // (not exact bytes): the segments land on the bottom row.
+    const screen = new VirtualScreen(24, 80);
+
+    screen.feed(term.text());
+    expect(screen.row(24)).toContain("done");
+    expect(screen.row(24)).toContain("qwen3.6-27b");
   });
 
   test("teardown resets the scroll region and deactivates", () => {
@@ -185,32 +193,49 @@ describe("StatusBar with input row", () => {
 
     withInput(term).install(INFO);
 
-    expect(term.text()).toContain("\x1b[1;21r"); // region = rows-3 (24-3)
-    expect(term.text()).toContain("\x1b7"); // stream cursor saved for writeStream
-    expect(term.text()).toContain("\x1b[22;1H"); // input row painted (rows-2)
-    expect(term.text()).toContain("\x1b[24;1H"); // segments row still on row 24
+    const out = term.text();
+
+    expect(out).toContain("\x1b[1;21r"); // region = rows-3 (24-3), structural
+    expect(out).toContain("\x1b7"); // stream cursor saved for writeStream
+
+    // Rendered screen: the prompt sits on the input row (22) and the segments on
+    // the bottom row (24).
+    const screen = new VirtualScreen(24, 80);
+
+    screen.feed(out);
+    expect(screen.row(22)).toContain("›"); // input row prompt
+    expect(screen.row(24)).toContain("done"); // segments row
   });
 
-  test("writeStream restores into the region, writes, re-saves, repaints the row", () => {
+  test("writeStream restores into the region, writes, re-saves, then re-parks", () => {
     const term = new FakeTerm(true, 24, 80);
     const bar = withInput(term);
 
     bar.install(INFO);
     bar.setInput("typed", 5);
-    term.writes.length = 0;
+
+    const before = term.writes.length;
+
     bar.writeStream("agent output\n");
 
-    const out = term.text();
-    const order = [
-      out.indexOf("\x1b8"), // restore stream cursor (into region)
-      out.indexOf("agent output"), // the streamed text
-      out.lastIndexOf("\x1b7"), // re-save advanced stream cursor
-      out.indexOf("\x1b[22;1H"), // repaint input row afterwards
-    ];
+    // The structural save/restore dance still brackets the streamed text.
+    const streamOut = term.writes.slice(before).join("");
 
-    expect(order.every((i) => i >= 0)).toBe(true);
-    expect(order).toEqual([...order].sort((a, b) => a - b)); // strictly ordered
-    expect(out).toContain("› typed"); // the typed buffer survives the stream
+    expect(streamOut.indexOf("\x1b8")).toBeGreaterThanOrEqual(0); // restore stream cursor
+    expect(streamOut.indexOf("agent output")).toBeGreaterThan(
+      streamOut.indexOf("\x1b8")
+    );
+    expect(streamOut.lastIndexOf("\x1b7")).toBeGreaterThan(
+      streamOut.indexOf("agent output")
+    );
+
+    // Rendered screen: the typed buffer survives on the input row and the output
+    // landed in the scrolling region above it.
+    const screen = new VirtualScreen(24, 80);
+
+    screen.feed(term.text());
+    expect(screen.row(22)).toContain("typed");
+    expect(screen.text()).toContain("agent output");
   });
 
   test("a plain write falls back when not installed (non-TTY / small term)", () => {
@@ -221,7 +246,7 @@ describe("StatusBar with input row", () => {
     expect(term.text()).toBe("hi");
   });
 
-  test("update repaints the bar body without clobbering the stream-cursor slot", () => {
+  test("update does not clobber the stream-cursor slot and parks on the input row", () => {
     const term = new FakeTerm(true, 24, 80);
     const bar = withInput(term);
 
@@ -232,10 +257,19 @@ describe("StatusBar with input row", () => {
     const out = term.text();
 
     // Must NOT wrap in save/restore (that slot holds the stream cursor); it ends
-    // by parking on the input row instead.
+    // by parking the cursor on the input row (row 22).
+    const parkOnInputRow = new RegExp(`${String.fromCharCode(27)}\\[22;\\d+H$`);
+
     expect(out.startsWith("\x1b7")).toBe(false);
-    expect(out).toContain("\x1b[24;1H"); // segments repainted
-    expect(out).toContain("\x1b[22;1H"); // input row repainted last
+    expect(parkOnInputRow.test(out)).toBe(true);
+
+    // A changed update redraws the affected bottom-row content.
+    bar.update({ ...INFO, status: "stuck" });
+
+    const screen = new VirtualScreen(24, 80);
+
+    screen.feed(term.text());
+    expect(screen.row(24)).toContain("stuck");
   });
 
   test("teardown after a shrink below the reserved height emits no row index < 1", () => {

--- a/packages/core/tests/width.test.ts
+++ b/packages/core/tests/width.test.ts
@@ -1,0 +1,101 @@
+import { describe, expect, test } from "bun:test";
+import {
+  codePointWidth,
+  displayWidth,
+  padToWidth,
+  sliceToWidth,
+} from "../src/render/width";
+import { table } from "../src/render/box";
+
+describe("codePointWidth", () => {
+  test("ASCII is one column", () => {
+    expect(codePointWidth("a".codePointAt(0)!)).toBe(1);
+  });
+
+  test("CJK ideographs are two columns", () => {
+    expect(codePointWidth("世".codePointAt(0)!)).toBe(2);
+    expect(codePointWidth("界".codePointAt(0)!)).toBe(2);
+  });
+
+  test("fullwidth forms are two columns", () => {
+    expect(codePointWidth("Ａ".codePointAt(0)!)).toBe(2); // U+FF21
+  });
+
+  test("combining marks and controls are zero columns", () => {
+    expect(codePointWidth(0x0301)).toBe(0); // combining acute accent
+    expect(codePointWidth(0x200b)).toBe(0); // zero-width space
+    expect(codePointWidth(0x09)).toBe(0); // tab (control)
+  });
+});
+
+describe("displayWidth", () => {
+  test("counts plain ASCII as its length", () => {
+    expect(displayWidth("hello")).toBe(5);
+  });
+
+  test("counts CJK as two columns each", () => {
+    expect(displayWidth("世界")).toBe(4);
+    expect(displayWidth("a世b")).toBe(4);
+  });
+
+  test("a base + combining mark is one column", () => {
+    expect(displayWidth("é")).toBe(1); // é as two code points
+  });
+
+  test("emoji and ZWJ sequences are two columns", () => {
+    expect(displayWidth("😀")).toBe(2);
+    expect(displayWidth("👨‍👩‍👧")).toBe(2); // single grapheme via ZWJ
+  });
+
+  test("VS16 forces a wide cell for an otherwise-narrow base", () => {
+    expect(displayWidth("❤️")).toBe(2); // U+2764 U+FE0F
+  });
+
+  test("flags (regional indicator pairs) are two columns", () => {
+    expect(displayWidth("🇯🇵")).toBe(2);
+  });
+});
+
+describe("sliceToWidth", () => {
+  test("never splits a wide cell", () => {
+    // "a世" is 3 columns; a budget of 2 must stop before 世, not inside it.
+    expect(sliceToWidth("a世b", 2)).toEqual({ text: "a", width: 1 });
+    expect(sliceToWidth("a世b", 3)).toEqual({ text: "a世", width: 3 });
+  });
+
+  test("returns the whole string when it fits", () => {
+    expect(sliceToWidth("hi", 10)).toEqual({ text: "hi", width: 2 });
+  });
+
+  test("empty for non-positive budget", () => {
+    expect(sliceToWidth("hi", 0)).toEqual({ text: "", width: 0 });
+  });
+});
+
+describe("table alignment (box.ts integration)", () => {
+  test("columns stay aligned when a cell holds wide characters", () => {
+    // Column 0 mixes a 1-col cell and a 2-col CJK cell; every rendered row must
+    // be the same display width, or the right border would zig-zag.
+    const out = table(
+      [
+        ["a", "b"],
+        ["世", "x"],
+      ],
+      false
+    );
+    const widths = out.split("\n").map((line) => displayWidth(line));
+
+    expect(new Set(widths).size).toBe(1);
+  });
+});
+
+describe("padToWidth", () => {
+  test("pads by columns, not code units", () => {
+    expect(padToWidth("世", 4)).toBe("世  "); // 2 columns + 2 spaces
+    expect(padToWidth("ab", 4)).toBe("ab  ");
+  });
+
+  test("leaves already-wide strings untouched", () => {
+    expect(padToWidth("hello", 3)).toBe("hello");
+  });
+});


### PR DESCRIPTION
## Why

We've never used [OpenTUI](https://opentui.com/) for tsforge — and we don't want its architecture (native Zig core, retained tree, Yoga flexbox). But four *problems it solves* are ones our hand-rolled immediate-mode renderer solves badly or not at all. This PR borrows those four ideas, each as a small pure-TypeScript module with **no native dependency**.

## What

### 1. Unicode display width — `render/width.ts`
Both subsystems assumed every grapheme is one column, so CJK / emoji / combining marks overflowed and misaligned. New `displayWidth` / `sliceToWidth` / `padToWidth` / `codePointWidth` (built on the existing grapheme segmenter), wired into:
- `box.ts` — table column sizing + box rule math
- `status-bar.ts` — segment fit + input-row horizontal scroll
- `file-menu.ts` — path truncation
- `editor/view.ts` — line wrapping + **cursor display column**

### 2. Diff renderer — `render/diff.ts`
The old `diff()` dumped *every* old line as `-` then *every* new line as `+`. Replaced with an LCS line diff: dim context, word-level intra-line highlighting on one-line swaps, large-run collapsing, and an optional side-by-side mode. Edit events already carried `oldString`/`newString` — no event-shape change.

### 3. Layout primitive — `render/layout.ts`
`computeRegions()` derives every pinned bottom-row anchor once (bottom-anchored, clamped ≥ 1), replacing the scattered `rows-1` / `rows-2` / `rows-reserved-editorRows` arithmetic in `status-bar.ts` — the spots resize bugs keep landing in (cf. #54 / commit a255898).

### 4. Screen buffer + damage diff — `render/screen.ts`
A double-buffered cell grid that flushes the existing bar frames as **minimal cell deltas** — no per-row `ESC[2K`, no flicker. Scoped to the 3 bar-owned rows; the editor block and `@`-picker keep their explicit clears. Verified for fidelity against the `VirtualScreen` emulator.

## Testing
- New suites: `width` / `diff` / `layout` / `screen` (incl. a VirtualScreen fidelity check that applying the deltas reproduces the same grid as the raw frames).
- The **47 semantic e2e tests pass unchanged** — the strongest evidence the damage-diff rewire is behaviorally identical.
- Two `editor-view` tests corrected off the old "emoji = 1 column" assumption; four byte-exact `status-bar` unit tests converted to semantic VirtualScreen assertions.
- `bun run validate` (check:bun + typecheck + lint + format + 1799 tests) is green.

## Not adopted (deliberately)
tree-sitter highlighting, focus management, ScrollBox, animation timeline — and OpenTUI's framework architecture itself.