### PR TITLE
feat(inference): force well-formed tool calls on guided-decoding endpoints

### DIFF
--- a/docs/borrowed-ideas.md
+++ b/docs/borrowed-ideas.md
@@ -1,0 +1,107 @@
+# Borrowed ideas — harness improvements
+
+Ideas worth taking from other projects, framed the way we approached OpenTUI:
+not "cool repo" but "this repo solves a problem one of our subsystems solves
+badly — here's the borrowable *mechanism* and where it lands in our tree."
+
+Guiding principle (north star): **lift local models by removing harness
+friction** — fix the turn-multiplying ergonomics, don't blame model "slowness".
+
+**Already shipped:** OpenTUI ideas (Unicode display width, LCS diff renderer,
+layout primitive, damage-tracking screen buffer) — released in `0.25.0`.
+
+**Already in the tree (don't re-add):** ranked repo map (`codebase/build-map.ts`,
+`rank-hubs.ts`), LSP integration (`lsp/`), property testing (`proptest/`), eval
+suite (`eval/`, `sweep`), ast-grep gate, MCP, browser oracle, post-hoc tool-call
+salvage.
+
+---
+
+## ⭐ Top 3 — execute now
+
+### 1. Constrained / structured decoding (vLLM structured outputs)
+
+**Status: feasibility VERIFIED** against the live endpoint (`192.168.20.108:8000`,
+DeepSeek-V4-Flash, vLLM nightly). Both `response_format: {type:"json_schema",
+strict}` and native `tools` + `tool_choice` work — even with MTP speculative
+decoding — returning schema-conformant output. See memory
+`vllm-constrained-decoding-supported`.
+
+- **Borrow:** constrain tool-call / structured output *at generation time* instead
+  of only repairing malformed output afterward. `salvage-toolcall` becomes the
+  fallback for endpoints without guided decoding, not the primary path.
+- **Inspiration:** vLLM structured outputs (xgrammar), llama.cpp GBNF, BAML.
+- **Where:** `inference/request.ts`, `inference/wire.ts`,
+  `inference/openai-compatible.ts`, `inference/inference.types.ts`;
+  `loop/session.ts`; `loop/tools/execute-tool.ts`.
+- **Plan:**
+  1. Capability probe: detect guided-decoding support per endpoint (cache it;
+     a `/v1/models` ping + a tiny `response_format` smoke test, or config opt-in).
+  2. When supported, emit `tools` + `tool_choice` (and/or `response_format`
+     json_schema) on the wire for tool-call turns; keep salvage as fallback.
+  3. Add a config/env switch so cloud endpoints without it degrade gracefully.
+- **Effort:** M. **Risk:** low (additive; fallback preserved). **ROI:** highest.
+- **Done when:** a tool-call turn against the local endpoint returns a
+  schema-valid call without invoking salvage, and salvage still covers a
+  capability-off endpoint (test both paths).
+
+### 2. SWE-agent Agent-Computer Interface (tool ergonomics)
+
+- **Borrow:** the thesis that *tool ergonomics decide success more than the model*.
+  A bounded, line-numbered file viewer with a scroll window (not raw dumps); edit
+  tools that **echo back the changed window + the lint/gate result** in the tool
+  response; malformed edits rejected with a corrective message, not a silent fail.
+- **Inspiration:** `princeton-nlp/SWE-agent` (ACI), Codex CLI tool design.
+- **Where:** `loop/tools/file-ops.ts`, `loop/tools/edit-hashline.ts`,
+  `files/edit.ts`, `loop/tools/execute-tool.ts`, `loop/tools/tool-context.ts`.
+- **Effort:** M. **Risk:** low. **ROI:** high (no endpoint dependency).
+- **Done when:** read/edit tool responses carry window + outcome context, and an
+  eval shows fewer wasted "re-read the file" turns.
+
+### 3. Robust edit application + lenient output parsing
+
+- **Borrow (a):** aider's search/replace edit format with **whitespace-tolerant /
+  fuzzy matching** and a precise "that block didn't match, here's the closest
+  context" retry — far more forgiving than exact-string replace.
+- **Borrow (b):** BAML's **Schema-Aligned Parsing** — coerce almost-valid model
+  output (trailing commas, prose around JSON, wrong quoting) into a typed result;
+  upgrades the salvage path.
+- **Inspiration:** `Aider-AI/aider`, `BoundaryML/baml`.
+- **Where:** `files/edit.ts`, `loop/tools/edit-hashline.ts`;
+  `inference/openai-compatible.ts`, `inference/wire.ts` (salvage).
+- **Effort:** M. **Risk:** medium (touches the edit hot path — gate with the
+  existing `files-edit` / `salvage-toolcall` tests). **ROI:** high.
+- **Done when:** near-miss edits (whitespace/indent drift) apply instead of
+  failing, and malformed-but-recoverable tool calls parse without a retry.
+
+---
+
+## Backlog (by subsystem)
+
+### Edit / diff rendering
+- **difftastic** (`Wilfred/difftastic`) — structural, tree-sitter diffing. Renders
+  a one-token change as one token, not whole-line churn. Enhances `render/diff.ts`
+  and gives the model tighter change context. *Effort M, ROI medium.*
+
+### TUI / rendering
+- **Charm Glamour / Bubble Tea / Lipgloss** (`charmbracelet`) — Glamour is a polished
+  terminal Markdown renderer (compare `render/markdown.ts`, `stream-markdown.ts`);
+  Bubble Tea's Elm update/view discipline is a design reference. *ROI low–med.*
+- **Ratatui** (Rust) — constraint-solver layout (`Length/Min/Ratio`); the mature
+  form of our `render/layout.ts` `computeRegions`, if layout grows to split panes.
+
+### Gate / guardrails
+- **oxc / oxlint** — Rust JS/TS linter ~50–100× faster than ESLint; a fast first-pass
+  to shorten build→fix latency (ESLint only for rules it lacks). `detect-gate.ts`,
+  `validate/`. *ROI med if gate latency bites.*
+- **knip** — unused exports/deps detection → new gate check.
+- **dependency-cruiser** — module-boundary / architectural rules → new gate check.
+
+### Eval / benchmarking
+- **inspect_ai** (`UKGovernmentBEIS/inspect_ai`) — clean `solver`/`scorer`/`dataset`
+  separation and structured logs; mirror the abstractions in `eval/` + `sweep`.
+- **SWE-bench harness** — patch-apply-then-run-tests verification model for `eval/`.
+
+### Structured output / decoding (beyond Top-3 #1)
+- **llama.cpp GBNF / outlines / guidance** — grammar backends if we want grammar
+  constraints richer than JSON Schema (e.g. constrained DSLs).

--- a/docs/borrowed-ideas.md
+++ b/docs/borrowed-ideas.md
@@ -39,18 +39,20 @@ decoding — returning schema-conformant output. See memory
      a `/v1/models` ping + a tiny `response_format` smoke test, or config opt-in).
   2. When supported, emit `tools` + `tool_choice` (and/or `response_format`
      json_schema) on the wire for tool-call turns; keep salvage as fallback.
-  3. Add a config/env switch so cloud endpoints without it degrade gracefully.
+  3. **Auto-detect — no user knob.** The harness sends `tool_choice` by default;
+     it's suppressed ONLY for DeepSeek's cloud host (api.deepseek.com), which 400s
+     on it. A regular user configures nothing.
 - **Effort:** M. **Risk:** low (additive; fallback preserved). **ROI:** highest.
-- **Done when:** a tool-call turn against the local endpoint returns a
-  schema-valid call without invoking salvage, and salvage still covers a
-  capability-off endpoint (test both paths).
-- **Status (PR #56):** shipped via a `guidedDecoding` flag (registry entry or
-  `TSFORGE_GUIDED_DECODING` env, since the registry is gated). **Verified end-to-end**
-  on the live endpoint through the real provider + `toolsFor` schemas: guided-on
-  forces a structured `read(...)` call with `salvaged: 0` and empty content (no
-  narration); guided-off narrates first. Salvage remains the fallback for
-  non-guided endpoints. (`response_format: json_schema` passthrough is a noted
-  follow-up — tool calls cover the current need.)
+- **Done when:** a tool-call turn against a local endpoint returns a schema-valid
+  call without invoking salvage, with zero configuration, and the DeepSeek cloud
+  path still works.
+- **Status (PR #56):** shipped as **auto-detection by endpoint host** — local/self-
+  hosted endpoints send `tool_choice`, the DeepSeek cloud API is auto-suppressed.
+  No flag or env required (an optional `guidedDecoding` override exists only to
+  correct a misdetection). **Verified end-to-end, zero config**, through the real
+  provider + `toolsFor` schemas: a local DeepSeek endpoint forces a structured
+  `read(...)` call with `salvaged: 0` and no narration. Salvage remains the
+  fallback. (`response_format: json_schema` passthrough is a noted follow-up.)
 
 ### 2. SWE-agent Agent-Computer Interface (tool ergonomics)
 

--- a/docs/borrowed-ideas.md
+++ b/docs/borrowed-ideas.md
@@ -44,6 +44,13 @@ decoding — returning schema-conformant output. See memory
 - **Done when:** a tool-call turn against the local endpoint returns a
   schema-valid call without invoking salvage, and salvage still covers a
   capability-off endpoint (test both paths).
+- **Status (PR #56):** shipped via a `guidedDecoding` flag (registry entry or
+  `TSFORGE_GUIDED_DECODING` env, since the registry is gated). **Verified end-to-end**
+  on the live endpoint through the real provider + `toolsFor` schemas: guided-on
+  forces a structured `read(...)` call with `salvaged: 0` and empty content (no
+  narration); guided-off narrates first. Salvage remains the fallback for
+  non-guided endpoints. (`response_format: json_schema` passthrough is a noted
+  follow-up — tool calls cover the current need.)
 
 ### 2. SWE-agent Agent-Computer Interface (tool ergonomics)
 

--- a/packages/core/src/cli.ts
+++ b/packages/core/src/cli.ts
@@ -295,6 +295,9 @@ export function providerConfig(entry: IModelEntry): IOpenAICompatibleConfig {
     ...(entry.reasoningEffort === undefined
       ? {}
       : { reasoningEffort: entry.reasoningEffort }),
+    ...(entry.guidedDecoding === undefined
+      ? {}
+      : { guidedDecoding: entry.guidedDecoding }),
     ...(entry.extraBody === undefined ? {} : { extraBody: entry.extraBody }),
     ...(entry.extraHeaders === undefined
       ? {}

--- a/packages/core/src/cli.ts
+++ b/packages/core/src/cli.ts
@@ -269,6 +269,18 @@ function envNumber(name: string): number | undefined {
   return Number.isFinite(value) ? value : undefined;
 }
 
+/** Read a boolean env flag: `1`/`true`/`yes`/`on` ⇒ true, anything else set ⇒
+ *  false, unset ⇒ undefined (so it doesn't override a registry value). */
+function envBool(name: string): boolean | undefined {
+  const raw = process.env[name]?.trim().toLowerCase();
+
+  if (raw === undefined || raw.length === 0) {
+    return undefined;
+  }
+
+  return raw === "1" || raw === "true" || raw === "yes" || raw === "on";
+}
+
 /** Wire-config from a registry entry: API key resolved at use time (inline or
  *  via apiKeyEnv); env still tunes maxTokens/penalty. Shared by initial
  *  construction, `/model` hot-swap, and the interactive eval script — so they
@@ -295,9 +307,15 @@ export function providerConfig(entry: IModelEntry): IOpenAICompatibleConfig {
     ...(entry.reasoningEffort === undefined
       ? {}
       : { reasoningEffort: entry.reasoningEffort }),
-    ...(entry.guidedDecoding === undefined
+    // Registry value wins; `TSFORGE_GUIDED_DECODING` is the env escape hatch
+    // (the registry lives in a gated home dir, so env is how a run/eval flips it).
+    ...((entry.guidedDecoding ?? envBool("TSFORGE_GUIDED_DECODING")) ===
+    undefined
       ? {}
-      : { guidedDecoding: entry.guidedDecoding }),
+      : {
+          guidedDecoding:
+            entry.guidedDecoding ?? envBool("TSFORGE_GUIDED_DECODING"),
+        }),
     ...(entry.extraBody === undefined ? {} : { extraBody: entry.extraBody }),
     ...(entry.extraHeaders === undefined
       ? {}

--- a/packages/core/src/cli.ts
+++ b/packages/core/src/cli.ts
@@ -269,18 +269,6 @@ function envNumber(name: string): number | undefined {
   return Number.isFinite(value) ? value : undefined;
 }
 
-/** Read a boolean env flag: `1`/`true`/`yes`/`on` ⇒ true, anything else set ⇒
- *  false, unset ⇒ undefined (so it doesn't override a registry value). */
-function envBool(name: string): boolean | undefined {
-  const raw = process.env[name]?.trim().toLowerCase();
-
-  if (raw === undefined || raw.length === 0) {
-    return undefined;
-  }
-
-  return raw === "1" || raw === "true" || raw === "yes" || raw === "on";
-}
-
 /** Wire-config from a registry entry: API key resolved at use time (inline or
  *  via apiKeyEnv); env still tunes maxTokens/penalty. Shared by initial
  *  construction, `/model` hot-swap, and the interactive eval script — so they
@@ -307,15 +295,11 @@ export function providerConfig(entry: IModelEntry): IOpenAICompatibleConfig {
     ...(entry.reasoningEffort === undefined
       ? {}
       : { reasoningEffort: entry.reasoningEffort }),
-    // Registry value wins; `TSFORGE_GUIDED_DECODING` is the env escape hatch
-    // (the registry lives in a gated home dir, so env is how a run/eval flips it).
-    ...((entry.guidedDecoding ?? envBool("TSFORGE_GUIDED_DECODING")) ===
-    undefined
+    // Optional override only — guided decoding is auto-detected by endpoint
+    // (local on, DeepSeek cloud off). Passed through when a model entry sets it.
+    ...(entry.guidedDecoding === undefined
       ? {}
-      : {
-          guidedDecoding:
-            entry.guidedDecoding ?? envBool("TSFORGE_GUIDED_DECODING"),
-        }),
+      : { guidedDecoding: entry.guidedDecoding }),
     ...(entry.extraBody === undefined ? {} : { extraBody: entry.extraBody }),
     ...(entry.extraHeaders === undefined
       ? {}

--- a/packages/core/src/inference/inference.types.ts
+++ b/packages/core/src/inference/inference.types.ts
@@ -144,6 +144,15 @@ export interface IOpenAICompatibleConfig {
   reasoning?: ReasoningStyle;
   /** Reasoning effort for `deepseek`/`openai` styles (maps to `reasoning_effort`). */
   reasoningEffort?: "low" | "medium" | "high";
+  /**
+   * The endpoint supports OpenAI structured outputs (guided decoding) — i.e. it
+   * grammar-constrains tool calls to the advertised schema. vLLM/SGLang/llama.cpp
+   * local servers do; DeepSeek's CLOUD thinking API does NOT (it 400s on an
+   * explicit `tool_choice`). When true, the `deepseek` reasoning style is allowed
+   * to send `tool_choice` (forcing a well-formed call instead of free-form text
+   * the harness must salvage). Default false — preserves cloud-DeepSeek safety.
+   */
+  guidedDecoding?: boolean;
   /** Arbitrary fields merged into the request body LAST (override anything above) —
    *  the escape hatch for any provider-specific param. */
   extraBody?: Record<string, unknown>;

--- a/packages/core/src/inference/inference.types.ts
+++ b/packages/core/src/inference/inference.types.ts
@@ -136,8 +136,9 @@ export interface IOpenAICompatibleConfig {
   /**
    * How this provider wants reasoning/thinking expressed on the wire:
    *  - `qwen` (default): `chat_template_kwargs.enable_thinking` + `thinking_token_budget` (vLLM).
-   *  - `deepseek`: top-level `thinking: { type }` + `reasoning_effort`; never sends
-   *    `tool_choice: "required"` (DeepSeek's thinking mode rejects it).
+   *  - `deepseek`: top-level `thinking: { type }` + `reasoning_effort`; `tool_choice`
+   *    is suppressed ONLY on the DeepSeek CLOUD host (api.deepseek.com), which 400s
+   *    on it — a local/self-hosted DeepSeek still gets it.
    *  - `openai`: `reasoning_effort`; uses `max_completion_tokens` and omits `temperature` (o-series).
    *  - `none`: no reasoning fields.
    */

--- a/packages/core/src/inference/inference.types.ts
+++ b/packages/core/src/inference/inference.types.ts
@@ -145,12 +145,10 @@ export interface IOpenAICompatibleConfig {
   /** Reasoning effort for `deepseek`/`openai` styles (maps to `reasoning_effort`). */
   reasoningEffort?: "low" | "medium" | "high";
   /**
-   * The endpoint supports OpenAI structured outputs (guided decoding) — i.e. it
-   * grammar-constrains tool calls to the advertised schema. vLLM/SGLang/llama.cpp
-   * local servers do; DeepSeek's CLOUD thinking API does NOT (it 400s on an
-   * explicit `tool_choice`). When true, the `deepseek` reasoning style is allowed
-   * to send `tool_choice` (forcing a well-formed call instead of free-form text
-   * the harness must salvage). Default false — preserves cloud-DeepSeek safety.
+   * OPTIONAL override for guided-decoding (structured tool-call) support. Normally
+   * unset: the harness auto-detects it — every local/self-hosted endpoint sends
+   * `tool_choice`, and only DeepSeek's CLOUD thinking API (api.deepseek.com), which
+   * 400s on it, is suppressed. Set `true`/`false` only to override a misdetection.
    */
   guidedDecoding?: boolean;
   /** Arbitrary fields merged into the request body LAST (override anything above) —

--- a/packages/core/src/inference/request.ts
+++ b/packages/core/src/inference/request.ts
@@ -98,8 +98,12 @@ function tokenCapField(cfg: IOpenAICompatibleConfig): Record<string, number> {
 }
 
 /** The `tools` (+ `tool_choice`) request fields, with provider constraints
- *  applied: DeepSeek's thinking mode rejects an explicit `tool_choice`, so omit
- *  it entirely there (the model still gets the tools and decides). */
+ *  applied: DeepSeek's CLOUD thinking API rejects an explicit `tool_choice`, so
+ *  omit it there (the model still gets the tools and decides). A guided-decoding-
+ *  capable endpoint (local vLLM serving e.g. DeepSeek-V4-Flash) accepts it and
+ *  grammar-constrains the call — so `guidedDecoding` opts that endpoint back into
+ *  sending `tool_choice`, which forces a well-formed call instead of free-form
+ *  text the harness would otherwise have to salvage. */
 function toolsBlock(
   cfg: IOpenAICompatibleConfig,
   opts: ICompleteOptions
@@ -108,7 +112,7 @@ function toolsBlock(
     return {};
   }
 
-  if (style(cfg) === "deepseek") {
+  if (style(cfg) === "deepseek" && cfg.guidedDecoding !== true) {
     return { tools: opts.tools };
   }
 

--- a/packages/core/src/inference/request.ts
+++ b/packages/core/src/inference/request.ts
@@ -112,20 +112,53 @@ function toolsBlock(
     return {};
   }
 
-  if (style(cfg) === "deepseek" && !isGuided(cfg)) {
+  if (style(cfg) === "deepseek" && suppressesToolChoice(cfg)) {
     return { tools: opts.tools };
   }
 
   return { tools: opts.tools, tool_choice: opts.toolChoice ?? "auto" };
 }
 
-/** Whether guided decoding is enabled, tolerating a hand-edited `models.json`
- *  that set the flag as the string `"true"` (a non-boolean JSON value would
- *  otherwise silently disable it — a confusing footgun). */
-function isGuided(cfg: IOpenAICompatibleConfig): boolean {
+/** Whether to omit `tool_choice` for a deepseek-style endpoint. AUTO by default,
+ *  so a normal user never configures anything: only DeepSeek's CLOUD thinking API
+ *  (api.deepseek.com) 400s on an explicit `tool_choice`; a local / self-hosted
+ *  DeepSeek (vLLM/SGLang/llama.cpp) accepts it and grammar-constrains the call, so
+ *  it's sent. The optional `guidedDecoding` flag only exists to override a
+ *  misdetection (true = always send, false = always omit). */
+function suppressesToolChoice(cfg: IOpenAICompatibleConfig): boolean {
+  const override = guidedOverride(cfg);
+
+  if (override !== undefined) {
+    return !override;
+  }
+
+  return isDeepSeekCloudHost(cfg.baseUrl);
+}
+
+/** Normalize the optional `guidedDecoding` override — tolerates a stringified
+ *  boolean from a hand-edited models.json; undefined ⇒ auto-detect by host. */
+function guidedOverride(cfg: IOpenAICompatibleConfig): boolean | undefined {
   const value: unknown = cfg.guidedDecoding;
 
-  return value === true || value === "true";
+  if (value === true || value === "true") {
+    return true;
+  }
+
+  if (value === false || value === "false") {
+    return false;
+  }
+
+  return undefined;
+}
+
+/** True for the DeepSeek CLOUD API host (api.deepseek.com / *.deepseek.com) — the
+ *  only endpoint known to reject an explicit `tool_choice`. */
+function isDeepSeekCloudHost(baseUrl: string): boolean {
+  try {
+    return /(^|\.)deepseek\.com$/iu.test(new URL(baseUrl).hostname);
+  } catch {
+    return false;
+  }
 }
 
 /** Build the request body object (pure). Field order keeps the qwen default

--- a/packages/core/src/inference/request.ts
+++ b/packages/core/src/inference/request.ts
@@ -112,11 +112,20 @@ function toolsBlock(
     return {};
   }
 
-  if (style(cfg) === "deepseek" && cfg.guidedDecoding !== true) {
+  if (style(cfg) === "deepseek" && !isGuided(cfg)) {
     return { tools: opts.tools };
   }
 
   return { tools: opts.tools, tool_choice: opts.toolChoice ?? "auto" };
+}
+
+/** Whether guided decoding is enabled, tolerating a hand-edited `models.json`
+ *  that set the flag as the string `"true"` (a non-boolean JSON value would
+ *  otherwise silently disable it — a confusing footgun). */
+function isGuided(cfg: IOpenAICompatibleConfig): boolean {
+  const value: unknown = cfg.guidedDecoding;
+
+  return value === true || value === "true";
 }
 
 /** Build the request body object (pure). Field order keeps the qwen default

--- a/packages/core/src/inference/request.ts
+++ b/packages/core/src/inference/request.ts
@@ -97,13 +97,11 @@ function tokenCapField(cfg: IOpenAICompatibleConfig): Record<string, number> {
     : { max_tokens: max };
 }
 
-/** The `tools` (+ `tool_choice`) request fields, with provider constraints
- *  applied: DeepSeek's CLOUD thinking API rejects an explicit `tool_choice`, so
- *  omit it there (the model still gets the tools and decides). A guided-decoding-
- *  capable endpoint (local vLLM serving e.g. DeepSeek-V4-Flash) accepts it and
- *  grammar-constrains the call — so `guidedDecoding` opts that endpoint back into
- *  sending `tool_choice`, which forces a well-formed call instead of free-form
- *  text the harness would otherwise have to salvage. */
+/** The `tools` (+ `tool_choice`) request fields. `tool_choice` is sent by default
+ *  — it grammar-constrains the call to a well-formed schema instead of free-form
+ *  text the harness would have to salvage — and is suppressed ONLY for the deepseek
+ *  style on DeepSeek's CLOUD host, whose thinking API 400s on it (see
+ *  `suppressesToolChoice`). No configuration needed for the common local case. */
 function toolsBlock(
   cfg: IOpenAICompatibleConfig,
   opts: ICompleteOptions
@@ -152,10 +150,17 @@ function guidedOverride(cfg: IOpenAICompatibleConfig): boolean | undefined {
 }
 
 /** True for the DeepSeek CLOUD API host (api.deepseek.com / *.deepseek.com) — the
- *  only endpoint known to reject an explicit `tool_choice`. */
+ *  only endpoint known to reject an explicit `tool_choice`. Tolerates a scheme-less
+ *  baseUrl (e.g. `api.deepseek.com/v1` from a hand-edited config): without a scheme
+ *  `new URL()` throws, which would miss the cloud host and wrongly SEND tool_choice
+ *  — the exact 400 this guards against — so prepend `https://` before parsing. */
 function isDeepSeekCloudHost(baseUrl: string): boolean {
+  const withScheme = /^[a-z][a-z0-9+.-]*:\/\//iu.test(baseUrl)
+    ? baseUrl
+    : `https://${baseUrl}`;
+
   try {
-    return /(^|\.)deepseek\.com$/iu.test(new URL(baseUrl).hostname);
+    return /(^|\.)deepseek\.com$/iu.test(new URL(withScheme).hostname);
   } catch {
     return false;
   }

--- a/packages/core/src/models-config.ts
+++ b/packages/core/src/models-config.ts
@@ -35,6 +35,11 @@ export interface IModelEntry {
   reasoning?: ReasoningStyle;
   /** Reasoning effort for `deepseek`/`openai` styles. */
   reasoningEffort?: "low" | "medium" | "high";
+  /** Endpoint supports OpenAI structured outputs (guided decoding). Set true for a
+   *  local vLLM/SGLang/llama.cpp server (it grammar-constrains tool calls); leave
+   *  false for the DeepSeek CLOUD API. Lets the `deepseek` style send `tool_choice`
+   *  to force well-formed calls instead of salvageable free-form text. */
+  guidedDecoding?: boolean;
   /** Arbitrary fields merged into the request body (override built-ins) — the
    *  escape hatch for any provider-specific param. */
   extraBody?: Record<string, unknown>;

--- a/packages/core/src/models-config.ts
+++ b/packages/core/src/models-config.ts
@@ -35,10 +35,9 @@ export interface IModelEntry {
   reasoning?: ReasoningStyle;
   /** Reasoning effort for `deepseek`/`openai` styles. */
   reasoningEffort?: "low" | "medium" | "high";
-  /** Endpoint supports OpenAI structured outputs (guided decoding). Set true for a
-   *  local vLLM/SGLang/llama.cpp server (it grammar-constrains tool calls); leave
-   *  false for the DeepSeek CLOUD API. Lets the `deepseek` style send `tool_choice`
-   *  to force well-formed calls instead of salvageable free-form text. */
+  /** OPTIONAL override for guided-decoding (structured tool-call) support.
+   *  Normally leave unset — it's auto-detected per endpoint (local on, DeepSeek
+   *  cloud off). Set true/false only to correct a misdetection. */
   guidedDecoding?: boolean;
   /** Arbitrary fields merged into the request body (override built-ins) — the
    *  escape hatch for any provider-specific param. */

--- a/packages/core/tests/cli.test.ts
+++ b/packages/core/tests/cli.test.ts
@@ -2,7 +2,13 @@ import { test, expect } from "bun:test";
 import { mkdtemp, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { parseArgs, isOneShot, applyRecipe, runNotify } from "../src/cli";
+import {
+  parseArgs,
+  isOneShot,
+  applyRecipe,
+  runNotify,
+  providerConfig,
+} from "../src/cli";
 import type { ITaskRecipe } from "../src/config/recipes";
 
 // Regression: runNotify used to spawn `sh -c cmd` with a bare `await proc.exited`
@@ -420,4 +426,36 @@ test("editor input submission while busy queues exactly one message to pending",
   expect(pending[0]).toBe("test message");
 
   handle.close();
+});
+
+test("providerConfig: TSFORGE_GUIDED_DECODING env enables guided decoding", () => {
+  const prev = process.env.TSFORGE_GUIDED_DECODING;
+
+  try {
+    process.env.TSFORGE_GUIDED_DECODING = "1";
+    expect(
+      providerConfig({ baseUrl: "http://x/v1", model: "m" }).guidedDecoding
+    ).toBe(true);
+
+    delete process.env.TSFORGE_GUIDED_DECODING;
+    expect(
+      providerConfig({ baseUrl: "http://x/v1", model: "m" }).guidedDecoding
+    ).toBeUndefined();
+
+    // A registry entry value wins over the env flag.
+    process.env.TSFORGE_GUIDED_DECODING = "1";
+    expect(
+      providerConfig({
+        baseUrl: "http://x/v1",
+        model: "m",
+        guidedDecoding: false,
+      }).guidedDecoding
+    ).toBe(false);
+  } finally {
+    if (prev === undefined) {
+      delete process.env.TSFORGE_GUIDED_DECODING;
+    } else {
+      process.env.TSFORGE_GUIDED_DECODING = prev;
+    }
+  }
 });

--- a/packages/core/tests/cli.test.ts
+++ b/packages/core/tests/cli.test.ts
@@ -2,13 +2,7 @@ import { test, expect } from "bun:test";
 import { mkdtemp, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import {
-  parseArgs,
-  isOneShot,
-  applyRecipe,
-  runNotify,
-  providerConfig,
-} from "../src/cli";
+import { parseArgs, isOneShot, applyRecipe, runNotify } from "../src/cli";
 import type { ITaskRecipe } from "../src/config/recipes";
 
 // Regression: runNotify used to spawn `sh -c cmd` with a bare `await proc.exited`
@@ -426,36 +420,4 @@ test("editor input submission while busy queues exactly one message to pending",
   expect(pending[0]).toBe("test message");
 
   handle.close();
-});
-
-test("providerConfig: TSFORGE_GUIDED_DECODING env enables guided decoding", () => {
-  const prev = process.env.TSFORGE_GUIDED_DECODING;
-
-  try {
-    process.env.TSFORGE_GUIDED_DECODING = "1";
-    expect(
-      providerConfig({ baseUrl: "http://x/v1", model: "m" }).guidedDecoding
-    ).toBe(true);
-
-    delete process.env.TSFORGE_GUIDED_DECODING;
-    expect(
-      providerConfig({ baseUrl: "http://x/v1", model: "m" }).guidedDecoding
-    ).toBeUndefined();
-
-    // A registry entry value wins over the env flag.
-    process.env.TSFORGE_GUIDED_DECODING = "1";
-    expect(
-      providerConfig({
-        baseUrl: "http://x/v1",
-        model: "m",
-        guidedDecoding: false,
-      }).guidedDecoding
-    ).toBe(false);
-  } finally {
-    if (prev === undefined) {
-      delete process.env.TSFORGE_GUIDED_DECODING;
-    } else {
-      process.env.TSFORGE_GUIDED_DECODING = prev;
-    }
-  }
 });

--- a/packages/core/tests/request-builder.test.ts
+++ b/packages/core/tests/request-builder.test.ts
@@ -82,6 +82,15 @@ describe("buildRequestBody: reasoning styles", () => {
     expect(b.tool_choice).toBe("auto");
   });
 
+  test("guidedDecoding tolerates a stringified 'true' (hand-edited models.json)", () => {
+    const b = body(
+      { reasoning: "deepseek", guidedDecoding: "true" as unknown as boolean },
+      { tools: [{}], toolChoice: "required" }
+    );
+
+    expect(b.tool_choice).toBe("required");
+  });
+
   test("openai uses max_completion_tokens, reasoning_effort, and omits temperature", () => {
     const b = body(
       { reasoning: "openai", reasoningEffort: "medium" },

--- a/packages/core/tests/request-builder.test.ts
+++ b/packages/core/tests/request-builder.test.ts
@@ -47,9 +47,19 @@ describe("buildRequestBody: reasoning styles", () => {
     expect(b.chat_template_kwargs).toBeUndefined();
   });
 
-  test("deepseek sends tools but omits tool_choice (thinking mode rejects it)", () => {
+  test("local deepseek auto-sends tool_choice (no config — vLLM accepts it)", () => {
     const b = body(
-      { reasoning: "deepseek" },
+      { reasoning: "deepseek", baseUrl: "http://192.168.20.108:8000/v1" },
+      { tools: [{}], toolChoice: "required" }
+    );
+
+    expect(b.tools).toBeDefined();
+    expect(b.tool_choice).toBe("required");
+  });
+
+  test("DeepSeek CLOUD host auto-omits tool_choice (its thinking API 400s on it)", () => {
+    const b = body(
+      { reasoning: "deepseek", baseUrl: "https://api.deepseek.com/v1" },
       { tools: [{}], toolChoice: "required" }
     );
 
@@ -63,28 +73,39 @@ describe("buildRequestBody: reasoning styles", () => {
     expect(b.tool_choice).toBe("required");
   });
 
-  test("deepseek WITH guidedDecoding sends tool_choice (local vLLM accepts it)", () => {
+  test("guidedDecoding:false forces omit even on a local endpoint", () => {
     const b = body(
-      { reasoning: "deepseek", guidedDecoding: true },
+      {
+        reasoning: "deepseek",
+        baseUrl: "http://192.168.20.108:8000/v1",
+        guidedDecoding: false,
+      },
       { tools: [{}], toolChoice: "required" }
     );
 
-    expect(b.tools).toBeDefined();
+    expect(b.tool_choice).toBeUndefined();
+  });
+
+  test("guidedDecoding:true forces send even on the cloud host (override)", () => {
+    const b = body(
+      {
+        reasoning: "deepseek",
+        baseUrl: "https://api.deepseek.com/v1",
+        guidedDecoding: true,
+      },
+      { tools: [{}], toolChoice: "required" }
+    );
+
     expect(b.tool_choice).toBe("required");
   });
 
-  test("guidedDecoding defaults tool_choice to auto when unset", () => {
+  test("override tolerates a stringified boolean (hand-edited models.json)", () => {
     const b = body(
-      { reasoning: "deepseek", guidedDecoding: true },
-      { tools: [{}] }
-    );
-
-    expect(b.tool_choice).toBe("auto");
-  });
-
-  test("guidedDecoding tolerates a stringified 'true' (hand-edited models.json)", () => {
-    const b = body(
-      { reasoning: "deepseek", guidedDecoding: "true" as unknown as boolean },
+      {
+        reasoning: "deepseek",
+        baseUrl: "https://api.deepseek.com/v1",
+        guidedDecoding: "true" as unknown as boolean,
+      },
       { tools: [{}], toolChoice: "required" }
     );
 
@@ -243,7 +264,9 @@ describe("reasoning_content round-trip", () => {
     );
   });
 
-  test("auto-detected deepseek also omits tool_choice (thinking mode rejects it)", () => {
+  test("auto-detected deepseek on a non-cloud host still sends tool_choice", () => {
+    // Style is auto-detected as deepseek from the model name (for reasoning
+    // replay), but the host isn't api.deepseek.com, so tool_choice is sent.
     const b = buildRequestBody(
       cfg({ model: "deepseek-pro-4" }),
       MSGS,
@@ -252,7 +275,7 @@ describe("reasoning_content round-trip", () => {
     );
 
     expect(b.tools).toBeDefined();
-    expect(b.tool_choice).toBeUndefined();
+    expect(b.tool_choice).toBe("auto");
   });
 });
 

--- a/packages/core/tests/request-builder.test.ts
+++ b/packages/core/tests/request-builder.test.ts
@@ -49,7 +49,7 @@ describe("buildRequestBody: reasoning styles", () => {
 
   test("local deepseek auto-sends tool_choice (no config — vLLM accepts it)", () => {
     const b = body(
-      { reasoning: "deepseek", baseUrl: "http://192.168.20.108:8000/v1" },
+      { reasoning: "deepseek", baseUrl: "http://localhost:8000/v1" },
       { tools: [{}], toolChoice: "required" }
     );
 
@@ -67,6 +67,15 @@ describe("buildRequestBody: reasoning styles", () => {
     expect(b.tool_choice).toBeUndefined();
   });
 
+  test("scheme-less DeepSeek cloud baseUrl is still detected (omits tool_choice)", () => {
+    const b = body(
+      { reasoning: "deepseek", baseUrl: "api.deepseek.com/v1" },
+      { tools: [{}], toolChoice: "required" }
+    );
+
+    expect(b.tool_choice).toBeUndefined();
+  });
+
   test("non-deepseek still sends tool_choice", () => {
     const b = body({}, { tools: [{}], toolChoice: "required" });
 
@@ -77,7 +86,7 @@ describe("buildRequestBody: reasoning styles", () => {
     const b = body(
       {
         reasoning: "deepseek",
-        baseUrl: "http://192.168.20.108:8000/v1",
+        baseUrl: "http://localhost:8000/v1",
         guidedDecoding: false,
       },
       { tools: [{}], toolChoice: "required" }
@@ -99,14 +108,17 @@ describe("buildRequestBody: reasoning styles", () => {
     expect(b.tool_choice).toBe("required");
   });
 
-  test("override tolerates a stringified boolean (hand-edited models.json)", () => {
-    const b = body(
-      {
-        reasoning: "deepseek",
-        baseUrl: "https://api.deepseek.com/v1",
-        guidedDecoding: "true" as unknown as boolean,
-      },
-      { tools: [{}], toolChoice: "required" }
+  test("override tolerates a stringified boolean from hand-edited JSON", () => {
+    // Mirror a hand-edited models.json where the override is a JSON string, not a
+    // boolean — parsed (not cast) so the test stays type-honest about runtime input.
+    const cfg: IOpenAICompatibleConfig = JSON.parse(
+      '{"baseUrl":"https://api.deepseek.com/v1","model":"m","reasoning":"deepseek","guidedDecoding":"true"}'
+    );
+    const b = buildRequestBody(
+      cfg,
+      MSGS,
+      { tools: [{}], toolChoice: "required" },
+      false
     );
 
     expect(b.tool_choice).toBe("required");

--- a/packages/core/tests/request-builder.test.ts
+++ b/packages/core/tests/request-builder.test.ts
@@ -63,6 +63,25 @@ describe("buildRequestBody: reasoning styles", () => {
     expect(b.tool_choice).toBe("required");
   });
 
+  test("deepseek WITH guidedDecoding sends tool_choice (local vLLM accepts it)", () => {
+    const b = body(
+      { reasoning: "deepseek", guidedDecoding: true },
+      { tools: [{}], toolChoice: "required" }
+    );
+
+    expect(b.tools).toBeDefined();
+    expect(b.tool_choice).toBe("required");
+  });
+
+  test("guidedDecoding defaults tool_choice to auto when unset", () => {
+    const b = body(
+      { reasoning: "deepseek", guidedDecoding: true },
+      { tools: [{}] }
+    );
+
+    expect(b.tool_choice).toBe("auto");
+  });
+
   test("openai uses max_completion_tokens, reasoning_effort, and omits temperature", () => {
     const b = body(
       { reasoning: "openai", reasoningEffort: "medium" },


### PR DESCRIPTION
First execution item from the **borrowed-ideas roadmap** (`docs/borrowed-ideas.md`): **#1 constrained decoding** — make local endpoints emit `tool_choice` so the model is grammar-constrained to a well-formed tool call instead of free-form text the harness must salvage.

## Behavior: auto-detected, zero config
`tool_choice` is **sent by default**. It is suppressed **only** for the deepseek reasoning style on DeepSeek's **cloud** host (`*.deepseek.com`), whose thinking API 400s on it. So:
- **Local / self-hosted endpoints (vLLM/SGLang/llama.cpp) → tool_choice sent automatically.** No flag, no env, nothing for a regular user to know.
- **DeepSeek cloud API → auto-suppressed** (unchanged, safe).

An optional `guidedDecoding` registry field exists **only** as an override to correct a misdetection (`true` = always send, `false` = always omit; tolerates a stringified boolean from hand-edited JSON). Normal users never set it.

## Why
Verified live against the local DeepSeek-V4-Flash cluster (`192.168.20.108:8000`): the endpoint honors `tool_choice` (incl. `required`) and `response_format: json_schema`, even with MTP speculative decoding. End-to-end through the real provider + `toolsFor` schemas, **zero config**, a local endpoint forces a structured `read(...)` call with `salvaged: 0` and no narration. Salvage remains the fallback for non-guided endpoints.

## Tests
- `request-builder`: local deepseek auto-sends; cloud host auto-omits; scheme-less cloud baseUrl still detected; overrides (true/false, stringified); non-deepseek unchanged.
- `bun run validate` green.

## Follow-up (not here)
`response_format: json_schema` passthrough as an `ICompleteOptions` field for any future raw-structured-JSON caller (tool calls cover the current need).