### PR TITLE
fix(edit): kill the auto-format edit-rejection round-trip

### DIFF
--- a/docs/borrowed-ideas.md
+++ b/docs/borrowed-ideas.md
@@ -82,6 +82,14 @@ decoding — returning schema-conformant output. See memory
   existing `files-edit` / `salvage-toolcall` tests). **ROI:** high.
 - **Done when:** near-miss edits (whitespace/indent drift) apply instead of
   failing, and malformed-but-recoverable tool calls parse without a retry.
+- **Status (PR #57):** the **edit-on-autoformat** friction (the local model's #1
+  reported pain — the write-guard reformats after a write, so the next edit's
+  oldString no longer matches) is addressed: (1) `fuzzyLineReplace` now also
+  tolerates prettier trailing commas + semicolon drift, so more near-miss edits
+  just land; (2) a not-found rejection now **inlines the file's current content**
+  (numbered, ≤400 lines) so the model repairs the stale anchor in the SAME turn
+  instead of spending one on a re-`read`. BAML-style lenient tool-call parsing and
+  the create-side ACI echo (#2) remain follow-ups.
 
 ---
 

--- a/packages/core/src/files/edit.ts
+++ b/packages/core/src/files/edit.ts
@@ -176,7 +176,11 @@ function fuzzyLineReplace(
       .trim()
       .replace(/['"`]/gu, '"') // unify quote style (straight + the folded curly)
       .replace(/\s+/gu, " ") // collapse internal whitespace runs
-      .replace(/\s*([^\w\s])\s*/gu, "$1"); // drop whitespace AROUND punctuation
+      .replace(/\s*([^\w\s])\s*/gu, "$1") // drop whitespace AROUND punctuation
+      .replace(/[;,]+$/u, ""); // drop a line-trailing `,`/`;` (prettier adds trailing
+  //   commas in multiline literals/args and normalizes semicolons — the model
+  //   writes `b` where the formatted file has `b,`, or `foo()` vs `foo();`). The
+  //   unique-window guard still blocks any ambiguous match this might widen into.
   // ^ `foo( a, b )`, `foo(a,b)`, and `foo(a, b)` all normalize equal, but two
   //   identifiers keep their separating space (`const x` never becomes `constx`),
   //   so the match stays meaningful. Unique-window guard still blocks ambiguity.

--- a/packages/core/src/loop/tools/file-ops.ts
+++ b/packages/core/src/loop/tools/file-ops.ts
@@ -669,10 +669,11 @@ export async function doEdit(
  *  advising a `read` so a huge file can't flood the model's context. */
 const EDIT_REJECT_MAX_LINES = 400;
 
-/** The file's current content as numbered lines (same shape as `read`), or null
- *  if it's missing, too large to inline, or unreadable. Used to repair a stale-
- *  anchor edit in the SAME turn — the model copies its oldString from the post-
- *  format text. Returns null on any I/O error (race, permissions): the edit has
+/** The file's current content as numbered rows (line number + `HL_LINE_SEP` + text)
+ *  — like `read`'s body but WITHOUT its hashline header (this repairs a `str_replace`
+ *  edit, which anchors on verbatim text, not a line hash). Null if the file is
+ *  missing, too large to inline, or unreadable. Used to repair a stale-anchor edit in
+ *  the SAME turn — the model copies its oldString from the post-format text. Returns null on any I/O error (race, permissions): the edit has
  *  already failed, so enriching its message must never crash the tool — the caller
  *  then falls back to advising a `read`. */
 async function currentFileView(

--- a/packages/core/src/loop/tools/file-ops.ts
+++ b/packages/core/src/loop/tools/file-ops.ts
@@ -670,25 +670,32 @@ export async function doEdit(
 const EDIT_REJECT_MAX_LINES = 400;
 
 /** The file's current content as numbered lines (same shape as `read`), or null
- *  if it's missing or too large to inline. Used to repair a stale-anchor edit in
- *  the SAME turn — the model copies its oldString from the post-format text. */
+ *  if it's missing, too large to inline, or unreadable. Used to repair a stale-
+ *  anchor edit in the SAME turn — the model copies its oldString from the post-
+ *  format text. Returns null on any I/O error (race, permissions): the edit has
+ *  already failed, so enriching its message must never crash the tool — the caller
+ *  then falls back to advising a `read`. */
 async function currentFileView(
   cwd: string,
   file: string
 ): Promise<string | null> {
-  const handle = Bun.file(join(cwd, file));
+  try {
+    const handle = Bun.file(join(cwd, file));
 
-  if (!(await handle.exists())) {
+    if (!(await handle.exists())) {
+      return null;
+    }
+
+    const lines = (await handle.text()).split("\n");
+
+    if (lines.length > EDIT_REJECT_MAX_LINES) {
+      return null;
+    }
+
+    return lines.map((line, i) => `${i + 1}${HL_LINE_SEP}${line}`).join("\n");
+  } catch {
     return null;
   }
-
-  const lines = (await handle.text()).split("\n");
-
-  if (lines.length > EDIT_REJECT_MAX_LINES) {
-    return null;
-  }
-
-  return lines.map((line, i) => `${i + 1}${HL_LINE_SEP}${line}`).join("\n");
 }
 
 /**

--- a/packages/core/src/loop/tools/file-ops.ts
+++ b/packages/core/src/loop/tools/file-ops.ts
@@ -643,12 +643,52 @@ export async function doEdit(
     edit.edits.length > 1 ? ` (replacement #${result.index + 1})` : "";
 
   const authored = ctx.touched?.has(edit.file.replaceAll("\\", "/")) ?? false;
+  let help = editFailHelp(edit.file, result, authored);
+
+  // A not-found edit is almost always a STALE ANCHOR — the auto-formatter rewrote
+  // the file after the model's last write, so its oldString no longer matches. The
+  // harness already has the current bytes, so inline them rather than make the
+  // model spend a turn re-`read`ing (its #1 reported friction).
+  if (result.reason === EDIT_FAIL_REASON.notFound) {
+    const view = await currentFileView(ctx.cwd, edit.file);
+
+    help +=
+      view === null
+        ? ` \`read\` ${edit.file} to see its exact current content, then edit with text copied verbatim.`
+        : ` Its CURRENT content is below — copy oldString verbatim from it and retry (no need to \`read\`):\n\n${view}`;
+  }
 
   return reject(
     ctx,
     `edit:${result.reason}`,
-    `edit ${edit.file} REJECTED${where}: ${editFailHelp(edit.file, result, authored)}`
+    `edit ${edit.file} REJECTED${where}: ${help}`
   );
+}
+
+/** Cap on lines inlined into a not-found edit rejection; above this, fall back to
+ *  advising a `read` so a huge file can't flood the model's context. */
+const EDIT_REJECT_MAX_LINES = 400;
+
+/** The file's current content as numbered lines (same shape as `read`), or null
+ *  if it's missing or too large to inline. Used to repair a stale-anchor edit in
+ *  the SAME turn — the model copies its oldString from the post-format text. */
+async function currentFileView(
+  cwd: string,
+  file: string
+): Promise<string | null> {
+  const handle = Bun.file(join(cwd, file));
+
+  if (!(await handle.exists())) {
+    return null;
+  }
+
+  const lines = (await handle.text()).split("\n");
+
+  if (lines.length > EDIT_REJECT_MAX_LINES) {
+    return null;
+  }
+
+  return lines.map((line, i) => `${i + 1}${HL_LINE_SEP}${line}`).join("\n");
 }
 
 /**
@@ -681,7 +721,7 @@ function editFailHelp(
       ? ` Since you created ${file} this session, you may also \`create\` it again to fully rewrite it.`
       : " Do NOT use `create` (it already exists).";
 
-    return `the file ${file} EXISTS, but your oldString text was not found in it.${rewrite} \`read\` the file to see its exact current contents, then edit with text copied verbatim from it.`;
+    return `the file ${file} EXISTS, but your oldString text was not found in it (it was likely auto-reformatted after your last write — imports reordered, quotes/commas normalized).${rewrite}`;
   }
 
   return result.reason;

--- a/packages/core/tests/edit-autoformat.e2e.test.ts
+++ b/packages/core/tests/edit-autoformat.e2e.test.ts
@@ -1,0 +1,42 @@
+import { test, expect } from "bun:test";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { formatFile } from "../src/detect-gate";
+import { applyEdits } from "../src/files/edit";
+
+// e2e: the write-guard auto-formats a file (real eslint --fix + prettier) right
+// after a write, so the model's next edit anchor no longer matches disk. This
+// drives the REAL formatter (not a hand-built "formatted" string) and proves a
+// pre-format anchor still lands via the widened fuzzy matcher — the local model's
+// #1 reported friction. (A structural rewrite the fuzzy can't bridge falls back to
+// the inlined-content rejection, covered in files-edit.test.ts.)
+test("a pre-format edit anchor survives the real write-guard auto-format", async () => {
+  const dir = await mkdtemp(join(tmpdir(), "tsforge-fmt-e2e-"));
+  const file = "demo.ts";
+  // No trailing comma, no semicolons — the formatter will add both.
+  const before = "const o = {\n  a: 1,\n  b: 2\n}\n";
+
+  await Bun.write(join(dir, file), before);
+
+  try {
+    await formatFile(dir, file);
+    const after = await Bun.file(join(dir, file)).text();
+
+    // Sanity: the formatter actually reformatted (else the test proves nothing).
+    expect(after).not.toBe(before);
+    expect(after).toContain("b: 2,"); // prettier added the trailing comma
+
+    // The model's pre-format anchor (`b: 2\n}`, no trailing comma) exact-misses the
+    // formatted file (`b: 2,\n};`) — it must still apply via the fuzzy fallback,
+    // NOT reject and force a re-read.
+    const r = await applyEdits(dir, file, [
+      { oldString: "  a: 1,\n  b: 2\n}", newString: "  a: 1,\n  b: 999\n}" },
+    ]);
+
+    expect(r.ok).toBe(true);
+    expect(await Bun.file(join(dir, file)).text()).toContain("b: 999");
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});

--- a/packages/core/tests/files-edit.test.ts
+++ b/packages/core/tests/files-edit.test.ts
@@ -3,6 +3,8 @@ import { mkdtemp, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { applyEdit, applyEdits } from "../src/files/edit";
+import { doEdit } from "../src/loop/tools/file-ops";
+import type { IToolContext } from "../src/loop/tools/tool-context";
 
 async function tmp(files: Record<string, string>): Promise<string> {
   const dir = await mkdtemp(join(tmpdir(), "tsforge-edit-"));
@@ -134,6 +136,44 @@ test("fuzzy edit preserves CRLF line endings (no mixed endings) — issue #24", 
     expect(out).toContain("INDENTED2");
     // After stripping every proper CRLF pair, no lone \n may remain.
     expect(out.replace(/\r\n/g, "").includes("\n")).toBe(false);
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test("fuzzy edit tolerates a prettier trailing comma (multiline literal)", async () => {
+  // Prettier added a trailing comma after `b: 2`. The model's oldString ends the
+  // window at `b: 2` (no comma), so the EXACT match misses (`b: 2\n}` ≠ `b: 2,\n}`);
+  // only the comma-tolerant fuzzy path can match.
+  const dir = await tmp({ "a.ts": "const o = {\n  a: 1,\n  b: 2,\n};\n" });
+
+  try {
+    const r = await applyEdits(dir, "a.ts", [
+      { oldString: "  a: 1,\n  b: 2\n}", newString: "  a: 1,\n  b: 3\n}" },
+    ]);
+
+    expect(r.ok).toBe(true);
+    expect(await Bun.file(join(dir, "a.ts")).text()).toContain("b: 3");
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test("fuzzy edit tolerates semicolon-style drift", async () => {
+  // File has trailing semicolons (prettier); the model's multi-line oldString
+  // omits them, so the exact match misses and the semicolon-tolerant fuzzy fires.
+  const dir = await tmp({ "a.ts": "const a = 1;\nconst b = 2;\n" });
+
+  try {
+    const r = await applyEdits(dir, "a.ts", [
+      {
+        oldString: "const a = 1\nconst b = 2",
+        newString: "const a = 1\nconst b = 99",
+      },
+    ]);
+
+    expect(r.ok).toBe(true);
+    expect(await Bun.file(join(dir, "a.ts")).text()).toContain("const b = 99");
   } finally {
     await rm(dir, { recursive: true, force: true });
   }
@@ -341,6 +381,36 @@ test("applyEdits sees the result of earlier replacements (sequential)", async ()
 
     expect(r).toMatchObject({ ok: true, count: 2 });
     expect(await Bun.file(join(dir, "a.ts")).text()).toBe("z");
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+// A not-found edit (stale anchor after auto-format) inlines the file's CURRENT
+// content into the rejection, so the model repairs it in the SAME turn instead
+// of spending one on a re-`read` — the model's #1 reported friction.
+test("not-found edit rejection carries the file's current content", async () => {
+  const dir = await tmp({ "a.ts": "const x = 1;\nconst y = 2;\n" });
+  const ctx: IToolContext = {
+    cwd: dir,
+    files: ["**/*.ts"],
+    task: "t",
+    report: () => undefined,
+  };
+
+  try {
+    const msg = await doEdit(
+      { file: "a.ts", oldString: "const z = 99;", newString: "const z = 0;" },
+      ctx
+    );
+
+    expect(msg).toContain("REJECTED");
+    expect(msg).toContain("CURRENT content is below");
+    // The actual current lines are present so the model can copy oldString verbatim.
+    expect(msg).toContain("const x = 1;");
+    expect(msg).toContain("const y = 2;");
+    // And it does NOT tell the model to go `read` the file (content is inline).
+    expect(msg).not.toContain("`read` a.ts to see");
   } finally {
     await rm(dir, { recursive: true, force: true });
   }


### PR DESCRIPTION
From the local DeepSeek model's own UX feedback: its **#1 friction** is that the write-guard auto-formats a file right after `create`/`edit` (eslint --fix + prettier — the fast feedback it otherwise loves), so the model's next `edit` `oldString` no longer matches disk → `not-found` → a wasted turn spent re-`read`ing the file. Confirmed by the user ("the edit tool fails because the pointer is no longer correct"). Borrowed-ideas **#3 (+#2)**.

## Two fixes
1. **Widen the fuzzy matcher.** `fuzzyLineReplace` already folds quotes/whitespace/punctuation/Unicode; it now also tolerates a **line-trailing comma or semicolon** — the classic prettier drift (trailing commas in multiline literals/args; semicolon normalization). More near-miss edits just land. The unique-window guard still blocks any ambiguous match.
2. **Inline the current content on a not-found rejection.** The harness already has the post-format bytes, so instead of telling the model to go `read` the file, the rejection now includes its **current content** (numbered, ≤400 lines) — the model fixes the stale anchor in the *same* turn. Falls back to advising `read` for huge files.

Also refreshed the `not-found` message to name the likely cause (auto-reformat: reordered imports, normalized quotes/commas).

## Tests
- Genuine multi-line fuzzy cases that miss on exact and only pass via the new comma/semicolon tolerance.
- A `doEdit` test asserting a not-found rejection carries the file's current content and drops the "go read it" instruction.
- `bun run validate` green (1826 tests).

## Follow-ups (not here)
- Create-side **ACI echo** (#2): return post-format content after `create` so anchors stay fresh preventively.
- **BAML-style** lenient tool-call parsing to upgrade `salvageToolCalls` (#3b).
- Gate false-positives the model flagged: `test-sibling-required` on pure-renderer modules; `package-exact-deps` noise on throwaway projects.