### PR TITLE
fix(loop): never feed a no-signal judge result to the generator as a critique

### DIFF
--- a/packages/core/src/eval/eval.types.ts
+++ b/packages/core/src/eval/eval.types.ts
@@ -13,6 +13,10 @@ export interface IJudgeScore {
   design: number;
   readability: number;
   notes: string;
+  /** False when the judge produced NO usable score (unparseable / errored). The
+   *  caller must treat this as "no signal" — never as a real 0/5 critique to act
+   *  on, or it feeds the generator a nonsense "improve this" instruction. */
+  scored: boolean;
 }
 
 export interface IRunRecord {

--- a/packages/core/src/eval/judge.ts
+++ b/packages/core/src/eval/judge.ts
@@ -37,6 +37,7 @@ const UNPARSEABLE: IJudgeScore = {
   design: 0,
   readability: 0,
   notes: "unparseable judge response",
+  scored: false,
 };
 
 export async function judge(
@@ -72,6 +73,7 @@ export async function judge(
     design: clampScore(data.design),
     readability: clampScore(data.readability),
     notes: typeof data.notes === "string" ? data.notes : "",
+    scored: true,
   };
 }
 

--- a/packages/core/src/eval/judge.ts
+++ b/packages/core/src/eval/judge.ts
@@ -67,13 +67,18 @@ export async function judge(
     return UNPARSEABLE;
   }
 
+  const overall = clampScore(data.overall);
+
   return {
-    overall: clampScore(data.overall),
+    overall,
     correctness: clampScore(data.correctness),
     design: clampScore(data.design),
     readability: clampScore(data.readability),
     notes: typeof data.notes === "string" ? data.notes : "",
-    scored: true,
+    // Parseable but lacking a valid 1–5 `overall` (missing/out-of-range → clamped
+    // to 0) is still no usable signal — flag it unscored so the caller skips the
+    // loop instead of acting on a fake 0/5.
+    scored: overall > 0,
   };
 }
 

--- a/packages/core/src/eval/judge.ts
+++ b/packages/core/src/eval/judge.ts
@@ -44,16 +44,25 @@ export async function judge(
   provider: IProvider,
   input: IJudgeInput
 ): Promise<IJudgeScore> {
-  const res = await provider.complete(
-    [
-      { role: "system", content: SYSTEM },
-      {
-        role: "user",
-        content: `Goal: ${input.goal}\n\nAcceptance criteria:\n${input.criteria}\n\nSolution:\n${input.code}`,
-      },
-    ],
-    { temperature: 0 }
-  );
+  let res;
+
+  try {
+    res = await provider.complete(
+      [
+        { role: "system", content: SYSTEM },
+        {
+          role: "user",
+          content: `Goal: ${input.goal}\n\nAcceptance criteria:\n${input.criteria}\n\nSolution:\n${input.code}`,
+        },
+      ],
+      { temperature: 0 }
+    );
+  } catch {
+    // A judge call that errors (non-2xx, timeout, connection) is no signal — not a
+    // crash of the (best-effort) quality pass, and not a real 0/5. Treat it like an
+    // unparseable response so the caller skips the loop.
+    return { ...UNPARSEABLE, notes: "judge call failed" };
+  }
 
   let data: unknown;
 

--- a/packages/core/src/loop/quality.ts
+++ b/packages/core/src/loop/quality.ts
@@ -47,7 +47,24 @@ export async function qualityRepair(
   const maxAttempts = opts.maxAttempts ?? 2;
   const report: Reporter = opts.onEvent ?? (() => undefined);
 
-  let best = await score(task, cwd, judgeProvider, meta);
+  const initial = await score(task, cwd, judgeProvider, meta);
+
+  // No usable judge signal (unparseable/errored response, or nothing in scope to
+  // assess): do NOT enter the improvement loop. Feeding the generator "a reviewer
+  // scored you 0/5: <error>" is a nonsense critique it can't act on — observed
+  // live, the model spirals on it and burns attempts for zero gain. Keep the green
+  // baseline and move on.
+  if (!initial.scored) {
+    report({
+      kind: "fix",
+      task: task.id,
+      message: `quality not scored (${initial.notes}) — skipping quality pass`,
+    });
+
+    return { quality: initial.quality, notes: initial.notes, attempts: 0 };
+  }
+
+  let best = initial;
 
   report({
     kind: "fix",
@@ -149,6 +166,9 @@ export async function qualityRepair(
 interface IScore {
   quality: number;
   notes: string;
+  /** False when there was no real judge signal (unparseable, or nothing in scope)
+   *  — the caller must not treat it as an actionable 0/5 critique. */
+  scored: boolean;
 }
 
 async function score(
@@ -168,7 +188,7 @@ async function score(
   // code window scores unpredictably and burns an LLM call. Degrade, never throw:
   // quality repair is a best-effort post-green pass, not a gate.
   if (views.length === 0) {
-    return { quality: 0, notes: "no files in scope to judge" };
+    return { quality: 0, notes: "no files in scope to judge", scored: false };
   }
 
   const code = views.map((v) => `// ${v.path}\n${v.content}\n`).join("\n");
@@ -179,5 +199,9 @@ async function score(
     code,
   });
 
-  return { quality: result.overall, notes: result.notes };
+  return {
+    quality: result.overall,
+    notes: result.notes,
+    scored: result.scored,
+  };
 }

--- a/packages/core/tests/judge.test.ts
+++ b/packages/core/tests/judge.test.ts
@@ -80,6 +80,21 @@ test("parseable JSON lacking a valid overall is also flagged scored:false", asyn
   expect(outOfRange.scored).toBe(false);
 });
 
+test("a judge provider that throws is no-signal, not a crash", async () => {
+  // Non-2xx / timeout / connection error from the judge endpoint must not bubble
+  // out of the best-effort quality pass — it's treated as no usable signal.
+  const throwing: IProvider = {
+    async complete() {
+      throw new Error("503 from judge endpoint");
+    },
+  };
+
+  const s = await judge(throwing, { goal: "g", criteria: "c", code: "x" });
+
+  expect(s.scored).toBe(false);
+  expect(s.overall).toBe(0);
+});
+
 test("tolerates a fenced JSON block", async () => {
   const provider = providerSaying(
     'Here is my review:\n```json\n{"overall":2,"correctness":2,"design":2,"readability":2,"notes":"weak"}\n```\n'

--- a/packages/core/tests/judge.test.ts
+++ b/packages/core/tests/judge.test.ts
@@ -60,6 +60,26 @@ test("an unparseable response is flagged scored:false (no usable signal)", async
   expect(s.notes).toContain("unparseable");
 });
 
+test("parseable JSON lacking a valid overall is also flagged scored:false", async () => {
+  // Parses fine, but no usable 1–5 overall (missing / out of range → clamped to 0).
+  // That's still no signal — must not be treated as a real 0/5.
+  const missing = await judge(
+    providerSaying('{"design":4,"readability":4,"notes":"ok"}'),
+    { goal: "g", criteria: "c", code: "x" }
+  );
+
+  expect(missing.scored).toBe(false);
+  expect(missing.overall).toBe(0);
+
+  const outOfRange = await judge(providerSaying('{"overall":9,"notes":"ok"}'), {
+    goal: "g",
+    criteria: "c",
+    code: "x",
+  });
+
+  expect(outOfRange.scored).toBe(false);
+});
+
 test("tolerates a fenced JSON block", async () => {
   const provider = providerSaying(
     'Here is my review:\n```json\n{"overall":2,"correctness":2,"design":2,"readability":2,"notes":"weak"}\n```\n'

--- a/packages/core/tests/judge.test.ts
+++ b/packages/core/tests/judge.test.ts
@@ -43,6 +43,21 @@ test("parses a JSON quality score from the reviewer", async () => {
   expect(s.correctness).toBe(5);
   expect(s.readability).toBe(3);
   expect(s.notes).toContain("solid");
+  expect(s.scored).toBe(true); // a real, usable score
+});
+
+test("an unparseable response is flagged scored:false (no usable signal)", async () => {
+  const s = await judge(providerSaying("hmm, looks alright I guess"), {
+    goal: "g",
+    criteria: "c",
+    code: "x",
+  });
+
+  // Must be marked unscored so the caller skips the quality loop rather than
+  // feeding the generator a nonsense "0/5" critique.
+  expect(s.scored).toBe(false);
+  expect(s.overall).toBe(0);
+  expect(s.notes).toContain("unparseable");
 });
 
 test("tolerates a fenced JSON block", async () => {

--- a/packages/core/tests/quality.test.ts
+++ b/packages/core/tests/quality.test.ts
@@ -180,3 +180,44 @@ test("reverts an attempt that breaks the gate", async () => {
     await rm(dir, { recursive: true, force: true });
   }
 });
+
+// Regression: an UNPARSEABLE judge response (judge infra failure, not a real 0/5)
+// must NOT enter the improvement loop. Feeding the generator "a reviewer scored you
+// 0/5: 'unparseable judge response'" is a nonsense critique it can't act on — live,
+// the model spiraled on it and burned attempts. Treat it as no-signal: keep the
+// green baseline, run no improvement attempt.
+test("an unparseable judge response is no-signal — no improvement attempt", async () => {
+  const dir = await mkdtemp(join(tmpdir(), "tsforge-quality-unparse-"));
+
+  try {
+    await Bun.write(join(dir, "a.ts"), "export const a = 1;");
+
+    let implementCalls = 0;
+    const agent: IAgent = {
+      async implement() {
+        implementCalls += 1;
+      },
+    };
+    // Judge returns prose, not the required JSON → unparseable → scored:false.
+    const judgeProvider: IProvider = {
+      async complete() {
+        return { content: "Looks fine to me, honestly.", toolCalls: [] };
+      },
+    };
+
+    const result = await qualityRepair(
+      { id: "1", accept: "true", files: ["a.ts"] },
+      dir,
+      agent,
+      judgeProvider,
+      { goal: "g", criteria: "c" },
+      { target: 5, maxAttempts: 2 }
+    );
+
+    expect(implementCalls).toBe(0); // never fed the model a nonsense "0/5" critique
+    expect(result.attempts).toBe(0);
+    expect(result.notes).toContain("unparseable");
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
**Found by running real evals** (you asked me to — and it paid off). A 3-seed sweep against the local DeepSeek-V4-Flash cluster passed the gate on all three, but `fix-regression` came back **Q0/5**. The cause wasn't the solution — it was a harness bug.

## The bug
The quality loop judged the (green, correct) solution; the judge returned an **unparseable** response — a judge *infrastructure* failure, not a real score. The loop then handed the generator:

> "The code is green but a senior reviewer scored it 0/5: **\"unparseable judge response\"**. Improve the code to address that critique."

The model can't act on a non-critique. In the run.log it **spiraled** — pages of "the reviewer says it's broken but the code looks correct… maybe it's a system glitch… I'll make no changes" — and burned **both** quality attempts for zero gain. A pure friction sink, squarely against the lift-local-models north star.

## The fix
- `IJudgeScore` gains a **`scored`** flag — `false` when the judge produced no usable score (unparseable / errored).
- `qualityRepair` returns early when the initial score is unscored: **keep the green baseline, run no improvement attempt, never fabricate a critique.** The pre-existing "no files in scope to judge" path is now `scored:false` too (it had the same latent bug).

## Tests
- `judge`: a parseable response → `scored:true`; an unparseable one → `scored:false`, `overall:0`, notes "unparseable".
- `quality`: an unparseable judge → **`agent.implement` is never called**, `attempts:0` (the regression this fixes).
- `bun run validate` green (1825 tests).

## Note
This is independent of the edit-on-autoformat work (#57) — different files (`eval/judge.ts`, `loop/quality.ts`). Separately, the judge being unparseable for that one seed at temp 0 is a robustness gap worth a follow-up (lenient judge-output parsing — the BAML idea from the roadmap), but the critical fix is to stop poisoning the loop.