### PR TITLE
fix(scope): allow the co-located test sibling of an in-scope source

### DIFF
--- a/packages/core/src/lib/scope/scope.ts
+++ b/packages/core/src/lib/scope/scope.ts
@@ -45,23 +45,32 @@ export function writable(file: string, patterns: string[]): boolean {
   // writable too — otherwise the rule demands a file the scope forbids, the task is
   // unsatisfiable, and the model thrashes to the cycle cap (observed: multi-file
   // specs whose scope lists only sources, e.g. `lexer.ts`, deadlocking on
-  // `lexer.test.ts`). Only the test of an IN-SCOPE source is allowed.
-  const source = testSibling(file);
+  // `lexer.test.ts`). Match on the STEM across source extensions, since a `.tsx`
+  // source is commonly tested by a plain `.test.ts`. Only an IN-SCOPE source counts.
+  const stem = testStem(file);
 
-  return source !== null && isInScope(source, patterns);
+  return (
+    stem !== null &&
+    SOURCE_EXTENSIONS.some((ext) => isInScope(`${stem}.${ext}`, patterns))
+  );
 }
 
-/** The source path a `*.test.*` / `*.spec.*` file tests (strip the test/spec
- *  segment), or null when `file` isn't a test file. `lexer.test.ts` → `lexer.ts`,
- *  `src/a.spec.tsx` → `src/a.tsx`. */
-function testSibling(file: string): string | null {
-  const m = /^(.*)\.(?:test|spec)(\.[cm]?[jt]sx?)$/u.exec(file);
+/** Source extensions a co-located test may belong to — checked against the test's
+ *  stem so `Component.test.ts` is allowed when `Component.tsx` is in scope. */
+const SOURCE_EXTENSIONS = [
+  "ts",
+  "tsx",
+  "mts",
+  "cts",
+  "js",
+  "jsx",
+  "mjs",
+  "cjs",
+];
 
-  if (m === null) {
-    return null;
-  }
-
-  const [, base, ext] = m;
-
-  return base === undefined || ext === undefined ? null : `${base}${ext}`;
+/** The stem of a `*.test.*` / `*.spec.*` path (everything before `.test`/`.spec`),
+ *  or null when `file` isn't a test file. `lexer.test.ts` → `lexer`,
+ *  `src/Component.spec.tsx` → `src/Component`. */
+function testStem(file: string): string | null {
+  return /^(.*)\.(?:test|spec)\.(?:[cm]?[jt]sx?)$/u.exec(file)?.[1] ?? null;
 }

--- a/packages/core/src/lib/scope/scope.ts
+++ b/packages/core/src/lib/scope/scope.ts
@@ -36,5 +36,32 @@ export function writable(file: string, patterns: string[]): boolean {
     return false;
   }
 
-  return isInScope(file, patterns) || file.startsWith(SCRATCH_PREFIX);
+  if (isInScope(file, patterns) || file.startsWith(SCRATCH_PREFIX)) {
+    return true;
+  }
+
+  // The gate's `test-sibling-required` rule makes the model add a CO-LOCATED test
+  // for any source file it changes. So a test sibling of an in-scope source must be
+  // writable too — otherwise the rule demands a file the scope forbids, the task is
+  // unsatisfiable, and the model thrashes to the cycle cap (observed: multi-file
+  // specs whose scope lists only sources, e.g. `lexer.ts`, deadlocking on
+  // `lexer.test.ts`). Only the test of an IN-SCOPE source is allowed.
+  const source = testSibling(file);
+
+  return source !== null && isInScope(source, patterns);
+}
+
+/** The source path a `*.test.*` / `*.spec.*` file tests (strip the test/spec
+ *  segment), or null when `file` isn't a test file. `lexer.test.ts` → `lexer.ts`,
+ *  `src/a.spec.tsx` → `src/a.tsx`. */
+function testSibling(file: string): string | null {
+  const m = /^(.*)\.(?:test|spec)(\.[cm]?[jt]sx?)$/u.exec(file);
+
+  if (m === null) {
+    return null;
+  }
+
+  const [, base, ext] = m;
+
+  return base === undefined || ext === undefined ? null : `${base}${ext}`;
 }

--- a/packages/core/src/lib/scope/scope.ts
+++ b/packages/core/src/lib/scope/scope.ts
@@ -72,5 +72,11 @@ const SOURCE_EXTENSIONS = [
  *  or null when `file` isn't a test file. `lexer.test.ts` → `lexer`,
  *  `src/Component.spec.tsx` → `src/Component`. */
 function testStem(file: string): string | null {
-  return /^(.*)\.(?:test|spec)\.(?:[cm]?[jt]sx?)$/u.exec(file)?.[1] ?? null;
+  // Restrict to REAL test-file extensions (ts/tsx/js/jsx/mts/cts/mjs/cjs) — a loose
+  // `[cm]?[jt]sx?` would also match non-existent ones like `.mjsx`/`.mtsx` and widen
+  // the writable set. No `*tsx`/`*jsx` with a c/m prefix exists.
+  return (
+    /^(.*)\.(?:test|spec)\.(?:tsx?|jsx?|[cm]ts|[cm]js)$/u.exec(file)?.[1] ??
+    null
+  );
 }

--- a/packages/core/tests/scope.test.ts
+++ b/packages/core/tests/scope.test.ts
@@ -45,3 +45,26 @@ test("a path escaping the workspace is not writable (no traversal)", () => {
   expect(writable(out, ["**/*"])).toBe(false);
   expect(writable("/etc/passwd", ["**/*"])).toBe(false);
 });
+
+// Regression: the gate's `test-sibling-required` rule makes the model add a
+// co-located test for any source it changes — so the editable scope must implicitly
+// allow that test sibling, or the rule demands a file the scope forbids and the
+// model stalls to the cycle cap (observed live on multi-file specs: `lexer.ts` in
+// scope, but `lexer.test.ts` rejected → deadlock).
+test("writable allows the co-located test sibling of an in-scope source", () => {
+  // Multi-file spec scope: only the sources are listed.
+  const scope = ["lexer.ts", "parser.ts", "executor.ts", "query.ts"];
+
+  expect(writable("lexer.test.ts", scope)).toBe(true);
+  expect(writable("parser.test.ts", scope)).toBe(true);
+  expect(writable("src/a.spec.tsx", ["src/a.tsx"])).toBe(true);
+
+  // But NOT a test whose source is out of scope — no arbitrary test writes.
+  expect(writable("pricing.test.ts", scope)).toBe(false);
+  expect(writable("evil.test.ts", scope)).toBe(false);
+
+  // The source file itself is still writable; isInScope stays literal (sibling
+  // allowance lives in writable, not isInScope).
+  expect(writable("lexer.ts", scope)).toBe(true);
+  expect(isInScope("lexer.test.ts", scope)).toBe(false);
+});

--- a/packages/core/tests/scope.test.ts
+++ b/packages/core/tests/scope.test.ts
@@ -68,6 +68,14 @@ test("writable allows the co-located test sibling of an in-scope source", () => 
   expect(writable("pricing.test.ts", scope)).toBe(false);
   expect(writable("evil.test.ts", scope)).toBe(false);
 
+  // Only REAL test-file extensions count — a bogus `.mjsx`/`.mtsx` must not be
+  // treated as a test of `lexer` and slip into the writable set.
+  expect(writable("lexer.test.mjsx", scope)).toBe(false);
+  expect(writable("lexer.test.mtsx", scope)).toBe(false);
+  // …but the valid module variants do.
+  expect(writable("lexer.test.mts", scope)).toBe(true);
+  expect(writable("lexer.spec.js", scope)).toBe(true);
+
   // The source file itself is still writable; isInScope stays literal (sibling
   // allowance lives in writable, not isInScope).
   expect(writable("lexer.ts", scope)).toBe(true);

--- a/packages/core/tests/scope.test.ts
+++ b/packages/core/tests/scope.test.ts
@@ -59,6 +59,11 @@ test("writable allows the co-located test sibling of an in-scope source", () => 
   expect(writable("parser.test.ts", scope)).toBe(true);
   expect(writable("src/a.spec.tsx", ["src/a.tsx"])).toBe(true);
 
+  // A `.tsx`/`.jsx` source is commonly tested by a plain `.test.ts` — match on the
+  // stem across source extensions, not the test file's own extension.
+  expect(writable("src/Component.test.ts", ["src/Component.tsx"])).toBe(true);
+  expect(writable("Widget.test.ts", ["Widget.jsx"])).toBe(true);
+
   // But NOT a test whose source is out of scope — no arbitrary test writes.
   expect(writable("pricing.test.ts", scope)).toBe(false);
   expect(writable("evil.test.ts", scope)).toBe(false);


### PR DESCRIPTION
**Found by a discovery eval sweep** (running evals to surface real friction, per the established loop). A 4-seed edit-heavy sweep against the local cluster blocked **2 of 4** (`query`, `checkout`) — both dead-stalled to the cycle cap on `test-sibling-required`.

## Root cause: an unsatisfiable harness contradiction
- The gate's `test-sibling-required` **demands** the model add a co-located test (e.g. `lexer.test.ts`) for any logic file it changed.
- But the task's editable scope lists only the **sources** (`files: lexer.ts, parser.ts, executor.ts, query.ts`), and `writable()` does literal/glob matching — so `writable("lexer.test.ts", scope)` returned **`false`**.
- → The rule requires a file the scope forbids. **Unsatisfiable → the model thrashes to the cycle cap.** Any model stalls here.

Confirmed directly:
```
writable("lexer.test.ts", ["lexer.ts","parser.ts","executor.ts","query.ts"]) === false
```
`checkout` hit the identical wall on `pricing.test.ts`. Single-file seeds (`slugify`) escaped it because their one acceptance test is *provided*, satisfying the sibling.

## Fix
`writable()` now also allows a `*.test.*` / `*.spec.*` sibling **whose underlying source is in scope** (co-located): `lexer.test.ts` is writable iff `lexer.ts` is. 
- `isInScope` stays literal (unchanged) — the allowance lives only in `writable()`.
- Can't write a test for an out-of-scope source (`pricing.test.ts`, `evil.test.ts` still rejected).
- Traversal/absolute paths still rejected first.

## Tests
- `scope`: co-located siblings of in-scope sources are writable; out-of-scope-source tests are not; the source itself stays writable; `isInScope` stays literal.
- `bun run validate` green (1832 tests).

## Note
The model *also* thrashed sub-optimally (kept editing `lexer.ts` instead of creating the test), but the scope contradiction is the root enabling condition — with it fixed, the gate's instruction ("Add `lexer.test.ts`") is now actually followable. Mirrored `tests/` paths (the rule's secondary option) are a possible follow-up; co-located is what the rule suggests first and what unblocks the observed stalls.