### PR TITLE
chore: release 0.27.0

### DIFF
--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -2,7 +2,7 @@
   "name": "@tsforge/docs",
   "type": "module",
   "private": true,
-  "version": "0.26.1",
+  "version": "0.27.0",
   "description": "tsforge docs — Astro Starlight product site.",
   "scripts": {
     "sync:rules": "bun scripts/sync-rules-catalog.ts",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "tsforge",
   "type": "module",
-  "version": "0.26.1",
+  "version": "0.27.0",
   "license": "MIT",
   "description": "TypeScript coding harness with a deterministic gate, stack-aware guardrails, and stream-level correction.",
   "scripts": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@agjs/tsforge",
   "type": "module",
-  "version": "0.26.1",
+  "version": "0.27.0",
   "license": "MIT",
   "description": "TypeScript coding harness with a deterministic gate, stack-aware guardrails, and stream-level correction.",
   "repository": {


### PR DESCRIPTION
Release 0.27.0 — bumps version in root, packages/core, and apps/docs.

Ships the interactive-editor fixes merged in #61 (cursor/stream rendering, native @ completion, conversation UI, Esc-to-clear) + the overnight harness improvements. Tagging v0.27.0 after merge triggers the npm publish + GitHub Release workflow.