### PR TITLE
[codex] fix editor input regressions

### DIFF
--- a/packages/core/src/cli.ts
+++ b/packages/core/src/cli.ts
@@ -54,7 +54,11 @@ import {
 import { makeSpinner, spinnerPhase } from "./render/spinner";
 import { validate } from "./validate";
 import { isPolicyMode } from "./policy";
-import { startEditor, type IEditorHandle } from "./editor";
+import {
+  EDITOR_RESERVED_ROWS,
+  startEditor,
+  type IEditorHandle,
+} from "./editor";
 import { renderEditor } from "./editor/view";
 import { flags } from "./config/flags";
 import {
@@ -1605,6 +1609,21 @@ async function repl(args: ICliArgs): Promise<number> {
       }
     };
 
+    const closeLoop = (): void => {
+      closed = true;
+
+      if (rl !== null) {
+        rl.close();
+      }
+
+      if (editorHandle !== null) {
+        editorHandle.close();
+      }
+
+      statusBar.teardown();
+      maybeFinish();
+    };
+
     // Submit a line of input: check if busy/pending, echo it, handle /exit, or run it.
     const submitLine = (raw: string): void => {
       const line = raw.trim();
@@ -1627,14 +1646,7 @@ async function repl(args: ICliArgs): Promise<number> {
       if (busy) {
         if (line === "/exit" || line === "/quit") {
           active?.abort();
-
-          if (rl !== null) {
-            rl.close();
-          }
-
-          if (editorHandle !== null) {
-            editorHandle.close();
-          }
+          closeLoop();
         } else {
           pending.push(line);
           echo("  ↳ queued (steers the next turn)\n");
@@ -1653,9 +1665,7 @@ async function repl(args: ICliArgs): Promise<number> {
       try {
         if (line.startsWith("/")) {
           if (await command(line)) {
-            if (rl !== null) {
-              rl.close();
-            }
+            closeLoop();
 
             return;
           }
@@ -1702,19 +1712,28 @@ async function repl(args: ICliArgs): Promise<number> {
         },
         {
           columns: process.stdout.columns,
-          maxRows: process.stdout.rows,
+          maxRows: Math.max(1, process.stdout.rows - EDITOR_RESERVED_ROWS),
           color: true,
         }
       );
 
-      statusBar.writeStream(frame.frame);
+      statusBar.setEditor(
+        frame.frame.length > 0 ? frame.frame.split("\n") : [],
+        frame.cursorRow,
+        frame.cursorCol
+      );
     };
 
     // Open the interactive `/` command palette: pick a command from a navigable
     // list, then either run it (no-arg) or prefill the line so the user types the
     // argument. Cancel ⇒ back to a clean prompt. Only meaningful on a TTY.
     const openPalette = async (): Promise<void> => {
+      if (busy || paletteOpen) {
+        return;
+      }
+
       paletteOpen = true;
+      editorHandle?.suspendInput();
 
       try {
         const picked = await pickCommand(process.stdout.isTTY);
@@ -1722,15 +1741,15 @@ async function repl(args: ICliArgs): Promise<number> {
         if (picked !== null) {
           if (editorHandle !== null) {
             editorHandle.getBuffer().setText("");
-            editorHandle.getBuffer().insert(picked.name);
 
             if (takesArg(picked)) {
+              editorHandle.getBuffer().insert(picked.name);
               editorHandle.getBuffer().insert(" ");
+              repaintEditor(editorHandle);
             } else {
+              repaintEditor(editorHandle);
               void runLine(picked.name);
             }
-
-            repaintEditor(editorHandle);
           } else if (rl !== null) {
             rl.write(null, { ctrl: true, name: "u" }); // clear the typed "/"
 
@@ -1742,6 +1761,7 @@ async function repl(args: ICliArgs): Promise<number> {
           }
         }
       } finally {
+        editorHandle?.resumeInput();
         paletteOpen = false;
 
         if (useInputRow) {
@@ -1761,7 +1781,12 @@ async function repl(args: ICliArgs): Promise<number> {
     // buffer — the picker owns input). On select, the full path is appended after
     // the `@`; at send time `@path` expands to the file's contents (see runSend).
     const openFilePicker = async (): Promise<void> => {
+      if (busy || paletteOpen) {
+        return;
+      }
+
       paletteOpen = true;
+      editorHandle?.suspendInput();
 
       const base =
         editorHandle !== null
@@ -1800,6 +1825,7 @@ async function repl(args: ICliArgs): Promise<number> {
           }
         }
       } finally {
+        editorHandle?.resumeInput();
         paletteOpen = false;
 
         if (useInputRow) {
@@ -1901,17 +1927,13 @@ async function repl(args: ICliArgs): Promise<number> {
       editorHandle.onSubmit(submitLine);
       editorHandle.onInterrupt(() => {
         if (active === null) {
-          closed = true;
-          editorHandle?.close();
-          maybeFinish();
+          closeLoop();
         } else {
           active.abort();
         }
       });
       editorHandle.onExit(() => {
-        closed = true;
-        editorHandle?.close();
-        maybeFinish();
+        closeLoop();
       });
     } else if (rl !== null) {
       rl.on("line", submitLine);

--- a/packages/core/src/editor/buffer.ts
+++ b/packages/core/src/editor/buffer.ts
@@ -413,7 +413,7 @@ export class EditorBuffer {
   }
 
   redo(): void {
-    const snapshot = this.undoStack.redo();
+    const snapshot = this.undoStack.redo(this.snapshot());
 
     if (snapshot) {
       this.lines = snapshot.lines;

--- a/packages/core/src/editor/controller.ts
+++ b/packages/core/src/editor/controller.ts
@@ -4,6 +4,7 @@ import { decodeKeys } from "./keys";
 import { createPasteScanner } from "./paste";
 import { renderEditor } from "./view";
 import { graphemes } from "./segments";
+import { shouldOpenAtPicker } from "../render/file-menu";
 
 export interface IEditorHandle {
   onSubmit(cb: (message: string) => void): void;
@@ -11,6 +12,8 @@ export interface IEditorHandle {
   onInterrupt(cb: () => void): void;
   onExit(cb: () => void): void;
   getBuffer(): EditorBuffer;
+  suspendInput(): void;
+  resumeInput(): void;
   /** Update the terminal dimensions and repaint. The CLI calls this on a
    *  terminal resize; without it the editor keeps wrapping/windowing at the
    *  dimensions captured when it was created, so after a resize the current
@@ -48,7 +51,7 @@ type KeyAction = (buffer: EditorBuffer) => void;
  *  can actually paint (rows - this), or the cursor line gets clipped off the
  *  bottom when the buffer is taller than the visible area. Mirrors
  *  RESERVED_ROWS (2) + 1 in status-bar.ts. */
-const EDITOR_RESERVED_ROWS = 3;
+export const EDITOR_RESERVED_ROWS = 3;
 
 /** Debug logging helper: append to TSFORGE_EDITOR_DEBUG if set. */
 function debugLog(msg: string): void {
@@ -160,6 +163,7 @@ export function startEditor(deps: IStartEditorDeps): IEditorHandle {
   const keyDispatchTable = buildKeyDispatchTable();
 
   let isOpen = true;
+  let inputSuspended = false;
   const submitCallbacks: ((message: string) => void)[] = [];
   const changeCallbacks: (() => void)[] = [];
   const interruptCallbacks: (() => void)[] = [];
@@ -368,8 +372,11 @@ export function startEditor(deps: IStartEditorDeps): IEditorHandle {
       });
     }
 
+    const { line, col } = buffer.getCursor();
+    const currentLine = currentText.split("\n")[line] ?? "";
+
     if (
-      currentText === "@" &&
+      shouldOpenAtPicker(currentLine, col) &&
       openFilePicker !== undefined &&
       typeof openFilePicker === "function"
     ) {
@@ -396,6 +403,7 @@ export function startEditor(deps: IStartEditorDeps): IEditorHandle {
 
     if (name === "char") {
       handleCharKey(text, ctrl, alt, shift);
+      triggerPaletteOrPicker();
 
       return;
     }
@@ -459,12 +467,10 @@ export function startEditor(deps: IStartEditorDeps): IEditorHandle {
       repaint();
       notifyChange();
     }
-
-    triggerPaletteOrPicker();
   }
 
   function onDataChunk(raw: string | Buffer): void {
-    if (!isOpen) {
+    if (!isOpen || inputSuspended) {
       return;
     }
 
@@ -553,6 +559,14 @@ export function startEditor(deps: IStartEditorDeps): IEditorHandle {
 
     getBuffer(): EditorBuffer {
       return buffer;
+    },
+
+    suspendInput(): void {
+      inputSuspended = true;
+    },
+
+    resumeInput(): void {
+      inputSuspended = false;
     },
 
     resize(nextColumns: number, nextRows: number): void {

--- a/packages/core/src/editor/index.ts
+++ b/packages/core/src/editor/index.ts
@@ -12,6 +12,7 @@ export {
   type IEditorFrame,
 } from "./view";
 export {
+  EDITOR_RESERVED_ROWS,
   startEditor,
   type IEditorHandle,
   type IStartEditorDeps,

--- a/packages/core/src/editor/segments.ts
+++ b/packages/core/src/editor/segments.ts
@@ -13,3 +13,66 @@ export function graphemes(s: string): string[] {
 export function graphemeCount(s: string): number {
   return graphemes(s).length;
 }
+
+function isCombiningMark(cp: number): boolean {
+  return (
+    (cp >= 0x0300 && cp <= 0x036f) ||
+    (cp >= 0x1ab0 && cp <= 0x1aff) ||
+    (cp >= 0x1dc0 && cp <= 0x1dff) ||
+    (cp >= 0x20d0 && cp <= 0x20ff) ||
+    (cp >= 0xfe20 && cp <= 0xfe2f)
+  );
+}
+
+function isWideCodePoint(cp: number): boolean {
+  return (
+    cp >= 0x1100 &&
+    (cp <= 0x115f ||
+      cp === 0x2329 ||
+      cp === 0x232a ||
+      (cp >= 0x2e80 && cp <= 0xa4cf && cp !== 0x303f) ||
+      (cp >= 0xac00 && cp <= 0xd7a3) ||
+      (cp >= 0xf900 && cp <= 0xfaff) ||
+      (cp >= 0xfe10 && cp <= 0xfe19) ||
+      (cp >= 0xfe30 && cp <= 0xfe6f) ||
+      (cp >= 0xff00 && cp <= 0xff60) ||
+      (cp >= 0xffe0 && cp <= 0xffe6))
+  );
+}
+
+function isEmojiCodePoint(cp: number): boolean {
+  return (cp >= 0x1f000 && cp <= 0x1faff) || (cp >= 0x2600 && cp <= 0x27bf);
+}
+
+export function graphemeWidth(segment: string): number {
+  if (segment.length === 0) {
+    return 0;
+  }
+
+  if (segment.includes("\u200d")) {
+    return 2;
+  }
+
+  let width = 0;
+  let sawEmoji = false;
+
+  for (const ch of segment) {
+    const cp = ch.codePointAt(0);
+
+    if (cp === undefined || cp === 0xfe0f || isCombiningMark(cp)) {
+      continue;
+    }
+
+    if (isEmojiCodePoint(cp)) {
+      sawEmoji = true;
+    }
+
+    width += isWideCodePoint(cp) ? 2 : 1;
+  }
+
+  return sawEmoji ? Math.max(2, width) : width;
+}
+
+export function displayWidth(s: string): number {
+  return graphemes(s).reduce((sum, segment) => sum + graphemeWidth(segment), 0);
+}

--- a/packages/core/src/editor/undo-stack.ts
+++ b/packages/core/src/editor/undo-stack.ts
@@ -24,11 +24,12 @@ export class UndoStack {
     return snapshot ?? null;
   }
 
-  redo(): ISnapshot | null {
+  redo(cur: ISnapshot): ISnapshot | null {
     if (this.redoStack.length === 0) {
       return null;
     }
 
+    this.undoStack.push(structuredClone(cur));
     const snapshot = this.redoStack.pop();
 
     return snapshot ?? null;

--- a/packages/core/src/editor/view.ts
+++ b/packages/core/src/editor/view.ts
@@ -1,4 +1,4 @@
-import { graphemes } from "./segments";
+import { graphemes, graphemeWidth } from "./segments";
 import { paint, STYLE } from "../render/style";
 
 export interface IEditorInput {
@@ -50,38 +50,43 @@ function wrapLine(
   const graphemeList = graphemes(line);
   const rows: IWrappedRow[] = [];
   let row = "";
-  let rowGraphemeCount = 0;
+  let rowWidth = 0;
   let rowCursorCol: number | undefined;
   let visualRow = 0;
 
+  const pushRow = (): void => {
+    rows.push({
+      text: row,
+      cursorRow: rowCursorCol !== undefined ? visualRow : undefined,
+      cursorCol: rowCursorCol,
+    });
+    row = "";
+    rowWidth = 0;
+    rowCursorCol = undefined;
+    visualRow += 1;
+  };
+
   for (let i = 0; i < graphemeList.length; i += 1) {
     const g = graphemeList[i];
+    const width = Math.max(0, Math.min(columns, graphemeWidth(g ?? "")));
 
-    if (rowGraphemeCount >= columns) {
-      rows.push({
-        text: row,
-        cursorRow: rowCursorCol !== undefined ? visualRow : undefined,
-        cursorCol: rowCursorCol,
-      });
-      row = "";
-      rowGraphemeCount = 0;
-      rowCursorCol = undefined;
-      visualRow += 1;
+    if (rowWidth > 0 && rowWidth + width > columns) {
+      pushRow();
     }
 
     if (i === cursorCol) {
-      rowCursorCol = rowGraphemeCount;
+      rowCursorCol = rowWidth;
     }
 
     if (g !== undefined) {
       row += g;
-      rowGraphemeCount += 1;
+      rowWidth += width;
     }
   }
 
   // Handle cursor at end of line
   if (graphemeList.length === cursorCol) {
-    rowCursorCol = rowGraphemeCount;
+    rowCursorCol = rowWidth;
   }
 
   // Push final row
@@ -92,6 +97,72 @@ function wrapLine(
   });
 
   return rows;
+}
+
+function visualRowsOf(frame: string): string[] {
+  return frame.length === 0 ? [] : frame.split("\n");
+}
+
+function clipFrameToMaxRows(
+  frame: string,
+  cursorRow: number,
+  cursorCol: number,
+  maxRows: number,
+  color: boolean
+): IEditorFrame {
+  const rows = visualRowsOf(frame);
+
+  if (rows.length <= maxRows) {
+    return { frame, rows: rows.length, cursorRow, cursorCol };
+  }
+
+  if (maxRows <= 0) {
+    return { frame: "", rows: 0, cursorRow: 0, cursorCol: 0 };
+  }
+
+  const safeCursorRow = Math.max(0, Math.min(cursorRow, rows.length - 1));
+
+  if (maxRows <= 2) {
+    const start = Math.max(0, Math.min(safeCursorRow, rows.length - maxRows));
+    const clippedRows = rows.slice(start, start + maxRows);
+
+    return {
+      frame: clippedRows.join("\n"),
+      rows: clippedRows.length,
+      cursorRow: safeCursorRow - start,
+      cursorCol,
+    };
+  }
+
+  let clippedAbove = false;
+  let clippedBelow = false;
+  let start = 0;
+  let end = rows.length;
+
+  for (let i = 0; i < 2; i += 1) {
+    const indicatorRows = (clippedAbove ? 1 : 0) + (clippedBelow ? 1 : 0);
+    const bodyRows = Math.max(1, maxRows - indicatorRows);
+
+    start = Math.max(0, Math.min(safeCursorRow, rows.length - bodyRows));
+    end = Math.min(rows.length, start + bodyRows);
+    clippedAbove = start > 0;
+    clippedBelow = end < rows.length;
+  }
+
+  const clippedRows = [
+    ...(clippedAbove ? [paint(`↑ ${start} more`, STYLE.dim, color)] : []),
+    ...rows.slice(start, end),
+    ...(clippedBelow
+      ? [paint(`↓ ${rows.length - end} more`, STYLE.dim, color)]
+      : []),
+  ];
+
+  return {
+    frame: clippedRows.join("\n"),
+    rows: clippedRows.length,
+    cursorRow: (clippedAbove ? 1 : 0) + safeCursorRow - start,
+    cursorCol,
+  };
 }
 
 /**
@@ -361,9 +432,19 @@ export function renderEditor(
     totalRows,
   } = buildFrameString(lines, window, cursorLine, cursorCol, columns, color);
 
+  if (totalRows > maxRows) {
+    return clipFrameToMaxRows(
+      frame,
+      cursorRow,
+      cursorColResult,
+      maxRows,
+      color
+    );
+  }
+
   return {
     frame,
-    rows: Math.min(totalRows, maxRows),
+    rows: totalRows,
     cursorRow,
     cursorCol: cursorColResult,
   };

--- a/packages/core/tests/editor-buffer.test.ts
+++ b/packages/core/tests/editor-buffer.test.ts
@@ -108,6 +108,18 @@ test("undo reverts a word as one unit, redo restores it", () => {
   expect(b.getText()).toBe("hi");
 });
 
+test("redo can be undone again", () => {
+  const b = new EditorBuffer();
+
+  b.insert("hi");
+  b.undo();
+  b.redo();
+  expect(b.getText()).toBe("hi");
+
+  b.undo();
+  expect(b.getText()).toBe("");
+});
+
 test("space then word are separate undo units", () => {
   const b = new EditorBuffer();
 

--- a/packages/core/tests/editor-controller.test.ts
+++ b/packages/core/tests/editor-controller.test.ts
@@ -218,6 +218,18 @@ describe("EditorController", () => {
     expect(h.getBuffer().getText()).toBe("a");
   });
 
+  test("suspendInput pauses raw editor mutations while an overlay owns input", () => {
+    const { stdin, handle } = makeHarness();
+
+    handle.suspendInput();
+    stdin.feed("x");
+    expect(handle.getBuffer().getText()).toBe("");
+
+    handle.resumeInput();
+    stdin.feed("x");
+    expect(handle.getBuffer().getText()).toBe("x");
+  });
+
   test("multiple chars typed in one feed", () => {
     const { stdin, handle } = makeHarness();
 
@@ -402,5 +414,49 @@ describe("EditorController", () => {
     stdin.feed("more");
     stdin.feed("\r");
     expect(submits).toEqual(["test\nmore"]);
+  });
+
+  test("typing slash on an empty buffer opens the command palette", () => {
+    const stdin = new FakeStdin();
+    let opens = 0;
+
+    const handle = startEditor({
+      stdin,
+      out: () => {},
+      columns: 80,
+      rows: 10,
+      openPalette: async () => {
+        opens += 1;
+      },
+    });
+
+    stdin.feed("/");
+
+    expect(opens).toBe(1);
+    handle.close();
+  });
+
+  test("@ picker opens only for a fresh mention boundary", () => {
+    const stdin = new FakeStdin();
+    let opens = 0;
+
+    const handle = startEditor({
+      stdin,
+      out: () => {},
+      columns: 80,
+      rows: 10,
+      openFilePicker: async () => {
+        opens += 1;
+      },
+    });
+
+    stdin.feed("ag@host");
+    expect(opens).toBe(0);
+
+    handle.getBuffer().setText("");
+    stdin.feed("please @");
+    expect(opens).toBe(1);
+
+    handle.close();
   });
 });

--- a/packages/core/tests/editor-view.test.ts
+++ b/packages/core/tests/editor-view.test.ts
@@ -74,13 +74,11 @@ test("single line renders one row", () => {
 // region: Gemini PR #52 regression tests
 
 test("emoji wrap and cursor positioning is grapheme-correct", () => {
-  // Emoji 👍 is 1 grapheme but multiple UTF-16 units
-  // Line: "hello 👍" (7 graphemes) + "world" (5 graphemes)
-  // Wrap at 8 columns: "hello 👍" = 8 graphemes → fits exactly
-  // "world" on next row
+  // Emoji 👍 is 1 grapheme, multiple UTF-16 units, and 2 terminal cells.
+  // "hello 👍" fills 8 cells, so "world" starts on the next row.
   const line = "hello 👍world";
   const r = renderEditor(
-    { lines: [line], cursorLine: 0, cursorCol: 8 }, // cursor at start of "world" (grapheme 8)
+    { lines: [line], cursorLine: 0, cursorCol: 7 }, // cursor at start of "world"
     { columns: 8, maxRows: 6, color: false }
   );
 
@@ -88,4 +86,39 @@ test("emoji wrap and cursor positioning is grapheme-correct", () => {
   expect(r.rows).toBe(2);
   expect(r.cursorRow).toBe(1); // cursor is on second visual row
   expect(r.cursorCol).toBe(0); // at column 0 of the second row
+});
+
+test("CJK wide characters wrap by terminal cells, not grapheme count", () => {
+  const r = renderEditor(
+    { lines: ["abc日本d"], cursorLine: 0, cursorCol: 5 },
+    { columns: 6, maxRows: 6, color: false }
+  );
+
+  expect(r.rows).toBe(2);
+  expect(r.frame.split("\n")[0]).toBe("abc日");
+  expect(r.cursorRow).toBe(1);
+  expect(r.cursorCol).toBe(2);
+});
+
+test("one wrapped logical line taller than the editor is visually clipped", () => {
+  const r = renderEditor(
+    { lines: ["x".repeat(200)], cursorLine: 0, cursorCol: 200 },
+    { columns: 20, maxRows: 7, color: false }
+  );
+
+  expect(r.rows).toBeLessThanOrEqual(7);
+  expect(r.frame.split("\n")).toHaveLength(r.rows);
+  expect(r.cursorRow).toBeGreaterThanOrEqual(0);
+  expect(r.cursorRow).toBeLessThan(r.rows);
+  expect(r.frame).toContain("more");
+});
+
+test("over-tall wrapped line keeps a top cursor in range when clipped below", () => {
+  const r = renderEditor(
+    { lines: ["x".repeat(200)], cursorLine: 0, cursorCol: 0 },
+    { columns: 20, maxRows: 7, color: false }
+  );
+
+  expect(r.cursorRow).toBe(0);
+  expect(r.frame).toContain("more");
 });


### PR DESCRIPTION
## Summary

- fix editor-backed `/exit` and `/quit` shutdown plus overlay input ownership
- restore `/` palette and `@` picker triggers in default editor mode
- make editor wrapping/clipping terminal-cell aware and fix redo undoability

## Root cause

The multiline editor became the default TTY input owner, but parts of the REPL still assumed readline-owned input. Some editor rendering code also reported clamped row counts while returning unclipped frames.

## Validation

- `bun run validate`