### PR TITLE
loop: silence noisy TTSR rules per-rule instead of disabling the manager

### DIFF
--- a/packages/core/src/loop/session.ts
+++ b/packages/core/src/loop/session.ts
@@ -875,6 +875,14 @@ export class Session {
     this.activeThinking = opts.enableThinking;
     this.repairing = false; // fresh send starts in (fast, thinking-off) creation mode
 
+    // The TtsrManager persists for the whole session, so per-rule silencing and
+    // the global interrupt cap must reset per user message — otherwise a rule
+    // silenced (or the manager disabled) during one prompt stays off for every
+    // later, unrelated prompt. The headless run.ts path builds a fresh manager
+    // per run and needs neither reset.
+    this.ttsrManager?.resetInterrupts();
+    this.state.ttsrInterrupts = 0;
+
     try {
       // Auto-compact BEFORE adding the new message (so it stays a fresh turn
       // after the summary) when the held context is near the window.

--- a/packages/core/src/loop/ttsr-init.ts
+++ b/packages/core/src/loop/ttsr-init.ts
@@ -6,7 +6,12 @@ import type { IChatMessage } from "../inference";
 import { TtsrManager, parseProjectRules, type ITtsrRule } from "./ttsr";
 import { DEFAULT_TTSR_RULES } from "./ttsr-defaults";
 
-const TTSR_INTERRUPT_CAP = 3;
+/** Global backstop across ALL rules. Individual noisy rules are silenced
+ *  per-rule (TtsrManager.recordInterrupt, cap 2) well before this trips; the
+ *  global cap only guards against pathological runs where many DIFFERENT
+ *  rules keep interrupting — that signals a model that can't hold the
+ *  constraints, and more aborts just burn its generation budget. */
+const TTSR_INTERRUPT_CAP = 6;
 
 /**
  * Load a project's TTSR rules: hand-authored `.tsforge/rules.json` AND the
@@ -69,9 +74,11 @@ export async function initTtsrManager(
 
 /**
  * Apply a TTSR interrupt: count it, report it, inject the corrective guidance as
- * a user message, and disable the manager once the per-run cap is hit (so a
- * stubborn pattern can't loop forever). Shared by both loops; the caller decides
- * what to do next (retry the turn). Timing emission stays with the caller.
+ * a user message, and silence the offending RULE once its per-rule cap is hit —
+ * one stubborn pattern must not blind the other rules for the rest of the task.
+ * A raised global cap remains as a backstop so interrupts can't loop forever.
+ * Shared by both loops; the caller decides what to do next (retry the turn).
+ * Timing emission stays with the caller.
  */
 export function applyTtsrInterrupt(
   ttsrFired: { ruleName: string; guidance: string },
@@ -89,11 +96,22 @@ export function applyTtsrInterrupt(
     message: `⚠ TTSR interrupted: ${ttsrFired.ruleName}`,
   });
 
+  const ruleSilenced =
+    ttsrManager?.recordInterrupt(ttsrFired.ruleName) ?? false;
+
+  if (ruleSilenced) {
+    report({
+      kind: "tool",
+      task: taskId,
+      message: `TTSR rule ${ttsrFired.ruleName} silenced after repeated interrupts (other rules stay active)`,
+    });
+  }
+
   if (state.ttsrInterrupts >= TTSR_INTERRUPT_CAP) {
     report({
       kind: "tool",
       task: taskId,
-      message: `TTSR disabled after ${state.ttsrInterrupts} interrupts (hit cap)`,
+      message: `TTSR disabled after ${state.ttsrInterrupts} interrupts (hit global cap)`,
     });
 
     ttsrManager?.disable();

--- a/packages/core/src/loop/ttsr.ts
+++ b/packages/core/src/loop/ttsr.ts
@@ -45,6 +45,11 @@ export class TtsrManager {
     string,
     RegExp[]
   >();
+  private readonly interruptCounts: Map<string, number> = new Map<
+    string,
+    number
+  >();
+  private readonly silencedRules: Set<string> = new Set<string>();
   private buffers: Record<"content" | "tool-args", string> = {
     content: "",
     "tool-args": "",
@@ -96,6 +101,30 @@ export class TtsrManager {
     this.disabled = true;
   }
 
+  /** Per-rule interrupt cap: a rule still firing after this many corrective
+   *  retries isn't teaching the model anything — silence IT, not the manager,
+   *  so the other rules keep watching the stream. */
+  private readonly RULE_INTERRUPT_CAP = 2;
+
+  /**
+   * Record an interrupt attributed to `ruleName`. Once the same rule has
+   * interrupted RULE_INTERRUPT_CAP times it is silenced for the rest of the
+   * task. Returns true when this call silenced the rule.
+   */
+  recordInterrupt(ruleName: string): boolean {
+    const count = (this.interruptCounts.get(ruleName) ?? 0) + 1;
+
+    this.interruptCounts.set(ruleName, count);
+
+    if (count >= this.RULE_INTERRUPT_CAP && !this.silencedRules.has(ruleName)) {
+      this.silencedRules.add(ruleName);
+
+      return true;
+    }
+
+    return false;
+  }
+
   checkDelta(text: string, context: IMatchContext): ITtsrRule | null {
     if (this.disabled) {
       return null;
@@ -116,6 +145,10 @@ export class TtsrManager {
 
     // Check all rules; return first match that passes repeat policy and scope gates.
     for (const [ruleName, rule] of this.rules) {
+      if (this.silencedRules.has(ruleName)) {
+        continue;
+      }
+
       if (!this.isScopeActive(rule, context)) {
         continue;
       }

--- a/packages/core/src/loop/ttsr.ts
+++ b/packages/core/src/loop/ttsr.ts
@@ -125,6 +125,20 @@ export class TtsrManager {
     return false;
   }
 
+  /**
+   * Clear all interrupt counters and silenced rules, and re-enable the manager.
+   * The manager instance is retained for the whole interactive session
+   * (session.ts), so without a per-send reset a rule silenced — or the manager
+   * globally disabled — during one user message would stay off for every later,
+   * unrelated prompt. The headless loop (run.ts) builds a fresh manager per run
+   * and never needs this.
+   */
+  resetInterrupts(): void {
+    this.interruptCounts.clear();
+    this.silencedRules.clear();
+    this.disabled = false;
+  }
+
   checkDelta(text: string, context: IMatchContext): ITtsrRule | null {
     if (this.disabled) {
       return null;

--- a/packages/core/tests/ttsr-silencing.test.ts
+++ b/packages/core/tests/ttsr-silencing.test.ts
@@ -1,0 +1,72 @@
+import { test, expect } from "bun:test";
+import { TtsrManager, type ITtsrRule } from "../src/loop/ttsr";
+
+const RULE_A: ITtsrRule = {
+  name: "no-as-any",
+  condition: [/\bas\s+any\b/],
+  scope: "tool-args",
+  guidance: "Type the value properly instead of casting to any.",
+  repeatMode: "cooldown",
+  repeatGap: 0,
+};
+
+const RULE_B: ITtsrRule = {
+  name: "no-ts-ignore",
+  condition: [/@ts-ignore/],
+  scope: "tool-args",
+  guidance: "Fix the type error instead of suppressing it.",
+  repeatMode: "cooldown",
+  repeatGap: 0,
+};
+
+function manager(): TtsrManager {
+  const m = new TtsrManager();
+
+  m.addRule(RULE_A);
+  m.addRule(RULE_B);
+
+  return m;
+}
+
+test("recordInterrupt silences a rule only at its per-rule cap", () => {
+  const m = manager();
+
+  expect(m.recordInterrupt("no-as-any")).toBe(false); // 1st interrupt: warn only
+  expect(m.recordInterrupt("no-as-any")).toBe(true); // 2nd: silenced
+  expect(m.recordInterrupt("no-as-any")).toBe(false); // already silenced: no re-report
+});
+
+test("a silenced rule stops matching while OTHER rules keep watching", () => {
+  const m = manager();
+
+  expect(
+    m.checkDelta("const x = y as any;", { source: "tool-args" })?.name
+  ).toBe("no-as-any");
+
+  m.recordInterrupt("no-as-any");
+  m.recordInterrupt("no-as-any");
+  m.resetBuffer();
+
+  // The noisy rule no longer fires…
+  expect(
+    m.checkDelta("const z = w as any;", { source: "tool-args" })
+  ).toBeNull();
+
+  m.resetBuffer();
+
+  // …but the previous behavior (manager-wide disable) would have missed this:
+  expect(m.checkDelta("// @ts-ignore", { source: "tool-args" })?.name).toBe(
+    "no-ts-ignore"
+  );
+});
+
+test("manager-wide disable still silences everything (global backstop)", () => {
+  const m = manager();
+
+  m.disable();
+
+  expect(
+    m.checkDelta("const x = y as any;", { source: "tool-args" })
+  ).toBeNull();
+  expect(m.checkDelta("// @ts-ignore", { source: "tool-args" })).toBeNull();
+});

--- a/packages/core/tests/ttsr-silencing.test.ts
+++ b/packages/core/tests/ttsr-silencing.test.ts
@@ -70,3 +70,39 @@ test("manager-wide disable still silences everything (global backstop)", () => {
   ).toBeNull();
   expect(m.checkDelta("// @ts-ignore", { source: "tool-args" })).toBeNull();
 });
+
+test("resetInterrupts re-arms a silenced rule (per-send reset in a persistent session)", () => {
+  const m = manager();
+
+  m.recordInterrupt("no-as-any");
+  m.recordInterrupt("no-as-any");
+  m.resetBuffer();
+
+  // Silenced within the drive…
+  expect(
+    m.checkDelta("const z = w as any;", { source: "tool-args" })
+  ).toBeNull();
+
+  // …but a new user message resets it, so the rule fires again.
+  m.resetInterrupts();
+  m.resetBuffer();
+
+  expect(
+    m.checkDelta("const q = r as any;", { source: "tool-args" })?.name
+  ).toBe("no-as-any");
+
+  // The silencing counter also resets: it takes the full cap again to re-silence.
+  expect(m.recordInterrupt("no-as-any")).toBe(false);
+  expect(m.recordInterrupt("no-as-any")).toBe(true);
+});
+
+test("resetInterrupts re-enables a globally disabled manager", () => {
+  const m = manager();
+
+  m.disable();
+  m.resetInterrupts();
+
+  expect(
+    m.checkDelta("const x = y as any;", { source: "tool-args" })?.name
+  ).toBe("no-as-any");
+});


### PR DESCRIPTION
## Summary

One noisy TTSR rule currently blinds all of them: `TTSR_INTERRUPT_CAP = 3` counts interrupts across **all** rules and calls `ttsrManager.disable()` when hit, so a single pattern the model keeps tripping (or a regex false positive, e.g. `no-as-any` matching inside a string literal) turns off every stream rule — including 18 that never fired — for the rest of the task.

This PR makes silencing per-rule: after 2 interrupts attributed to the same rule, only that rule stops matching (`TtsrManager.recordInterrupt`); the others keep watching the stream. The manager-wide disable stays as a backstop, raised to 6, and now only guards the pathological case where many *different* rules keep interrupting — which signals a model that can't hold the constraints, where more aborts just burn generation budget.

## Changes

- `TtsrManager`: per-rule interrupt counter + silenced-rule set, checked in `checkDelta`; `recordInterrupt(ruleName)` returns true exactly once, when it silences the rule
- `applyTtsrInterrupt`: attributes each interrupt to the firing rule and reports rule-level silencing distinctly from the global cap
- Global backstop documented and raised 3 → 6 (per-rule silencing at 2 now does the targeted work the global cap was doing bluntly)

## Testing

- New behavioral tests in `packages/core/tests/ttsr-silencing.test.ts`: per-rule cap semantics, a silenced rule stops matching while other rules still fire, and the manager-wide disable backstop
- `bun run typecheck` / `bun run lint` / `bun run format:check` all pass; `bun test packages` — 1936 pass, 0 fail

🤖 Generated with [Claude Code](https://claude.com/claude-code)