### PR TITLE
loop: cap gate feedback per rule so one noisy rule can't wall the budget

### DIFF
--- a/packages/core/src/loop/feedback/feedback.ts
+++ b/packages/core/src/loop/feedback/feedback.ts
@@ -13,6 +13,12 @@ import {
 /** Cap rendered source lines so a large error set can't wall the model. */
 const FEEDBACK_MAX_LINES = 20;
 
+/** Cap rendered instances PER RULE. The 4th repeat of the same rule teaches
+ *  the model nothing the first 3 didn't; without this, one project-wide rule
+ *  sweep (e.g. 30× no-explicit-any) walls the entire feedback budget and the
+ *  model never hears about the OTHER rules it also violated. */
+const FEEDBACK_MAX_PER_RULE = 3;
+
 /**
  * Gate failures the model can act on (its editable files), each rendered WITH
  * its location and the offending source line — so the model fixes the exact
@@ -44,14 +50,12 @@ export async function gateFeedback(
   });
   const readOnly = errors.length - own.length;
 
+  const { shown, skipped } = selectRepresentative(own);
   const list =
     own.length > 0
-      ? await renderErrors(own.slice(0, FEEDBACK_MAX_LINES), cwd)
+      ? await renderErrors(shown, cwd)
       : "(no failures in your editable files)";
-  const capped =
-    own.length > FEEDBACK_MAX_LINES
-      ? `\n… and ${own.length - FEEDBACK_MAX_LINES} more — fix the above first.`
-      : "";
+  const capped = overflowSummary(skipped);
 
   const note =
     readOnly > 0
@@ -94,6 +98,79 @@ export async function gateFeedback(
       : "";
 
   return `The acceptance command still fails:\n${list}${capped}${note}${helpBlock}${idiomBlock}${metaBlock}${metaHelpBlock}${missingBlock}\n\nFix your editable files and run it again.`;
+}
+
+/**
+ * Pick the errors worth rendering in full: keep parser emission order (tsc
+ * first — type errors gate everything else), but cap instances per rule so a
+ * single noisy rule can't spend the whole FEEDBACK_MAX_LINES budget. Errors
+ * without a rule id (generic/oracle output) are never capped per-rule — each
+ * one is distinct signal.
+ */
+function selectRepresentative(errors: ErrorSet): {
+  shown: ErrorSet;
+  skipped: ErrorSet;
+} {
+  const shown: ErrorSet = [];
+  const skipped: ErrorSet = [];
+  const perRule = new Map<string, number>();
+
+  for (const e of errors) {
+    const count = e.rule === undefined ? 0 : (perRule.get(e.rule) ?? 0);
+    const ruleCapped = e.rule !== undefined && count >= FEEDBACK_MAX_PER_RULE;
+
+    if (shown.length < FEEDBACK_MAX_LINES && !ruleCapped) {
+      shown.push(e);
+
+      if (e.rule !== undefined) {
+        perRule.set(e.rule, count + 1);
+      }
+    } else {
+      skipped.push(e);
+    }
+  }
+
+  return { shown, skipped };
+}
+
+/**
+ * Summarize the errors we did NOT render, grouped by rule with counts and the
+ * affected files — "12 more [no-explicit-any] in a.ts, b.ts" tells the model
+ * the shown fix applies elsewhere too, at a fraction of the token cost of
+ * rendering every instance.
+ */
+function overflowSummary(skipped: ErrorSet): string {
+  if (skipped.length === 0) {
+    return "";
+  }
+
+  const byRule = new Map<string, { count: number; files: Set<string> }>();
+
+  for (const e of skipped) {
+    const key = e.rule ?? "other";
+    const entry = byRule.get(key) ?? { count: 0, files: new Set<string>() };
+
+    entry.count += 1;
+
+    if (e.file !== undefined) {
+      entry.files.add(basename(e.file));
+    }
+
+    byRule.set(key, entry);
+  }
+
+  const lines = [...byRule.entries()]
+    .sort((a, b) => b[1].count - a[1].count)
+    .map(([rule, { count, files }]) => {
+      const names = [...files];
+      const shownFiles = names.slice(0, 3).join(", ");
+      const extra = names.length > 3 ? ` (+${names.length - 3} files)` : "";
+      const where = names.length > 0 ? ` in ${shownFiles}${extra}` : "";
+
+      return `  - ${count} more [${rule}]${where}`;
+    });
+
+  return `\n… plus ${skipped.length} more not shown — same rules, same fixes apply:\n${lines.join("\n")}`;
 }
 
 /**

--- a/packages/core/src/loop/feedback/feedback.ts
+++ b/packages/core/src/loop/feedback/feedback.ts
@@ -166,8 +166,11 @@ function overflowSummary(skipped: ErrorSet): string {
       const shownFiles = names.slice(0, 3).join(", ");
       const extra = names.length > 3 ? ` (+${names.length - 3} files)` : "";
       const where = names.length > 0 ? ` in ${shownFiles}${extra}` : "";
+      // "other" is the bucket for errors with no rule id (generic/oracle output);
+      // render it as prose so the model doesn't read it as a rule named `other`.
+      const label = rule === "other" ? "unclassified errors" : `[${rule}]`;
 
-      return `  - ${count} more [${rule}]${where}`;
+      return `  - ${count} more ${label}${where}`;
     });
 
   return `\n… plus ${skipped.length} more not shown — same rules, same fixes apply:\n${lines.join("\n")}`;

--- a/packages/core/tests/gate-feedback.test.ts
+++ b/packages/core/tests/gate-feedback.test.ts
@@ -67,3 +67,57 @@ test("gateFeedback degrades gracefully when an error has no location", async () 
     expect(fb).toContain("command exited non-zero");
   });
 });
+
+test("gateFeedback caps repeats of one rule so other rules still surface", async () => {
+  await withDir(async (dir) => {
+    await Bun.write(join(dir, "money.ts"), "export const x = 1;\n");
+
+    // 25× the same rule would previously wall the whole 20-line budget and
+    // the single OTHER error (a different rule, emitted last) was truncated.
+    const noisy: ErrorSet = Array.from({ length: 25 }, (_, i) => ({
+      key: `money.ts:${i + 1}:no-explicit-any`,
+      file: "money.ts",
+      line: 1,
+      rule: "no-explicit-any",
+      message: "Unexpected any.",
+    }));
+    const errors: ErrorSet = [
+      ...noisy,
+      {
+        key: "money.ts:1:TS2304",
+        file: "money.ts",
+        line: 1,
+        rule: "TS2304",
+        message: "Cannot find name 'foo'.",
+      },
+    ];
+
+    const fb = await gateFeedback(errors, TASK, dir);
+
+    // The distinct rule must be rendered in full, not truncated away.
+    expect(fb).toContain("[TS2304]");
+    expect(fb).toContain("Cannot find name 'foo'.");
+    // The noisy rule is summarized, not repeated 25 times.
+    expect(fb).toContain("22 more [no-explicit-any]");
+    expect((fb.match(/Unexpected any\./g) ?? []).length).toBeLessThanOrEqual(3);
+  });
+});
+
+test("gateFeedback summarizes overflow by rule with affected files", async () => {
+  await withDir(async (dir) => {
+    await Bun.write(join(dir, "money.ts"), "export const x = 1;\n");
+
+    const errors: ErrorSet = Array.from({ length: 30 }, (_, i) => ({
+      key: `money.ts:${i + 1}:TS2532`,
+      file: "money.ts",
+      line: 1,
+      rule: "TS2532",
+      message: "Object is possibly 'undefined'.",
+    }));
+
+    const fb = await gateFeedback(errors, TASK, dir);
+
+    expect(fb).toContain("same rules, same fixes apply");
+    expect(fb).toContain("27 more [TS2532] in money.ts");
+  });
+});

--- a/packages/core/tests/gate-feedback.test.ts
+++ b/packages/core/tests/gate-feedback.test.ts
@@ -121,3 +121,23 @@ test("gateFeedback summarizes overflow by rule with affected files", async () =>
     expect(fb).toContain("27 more [TS2532] in money.ts");
   });
 });
+
+test("gateFeedback labels rule-less overflow as 'unclassified errors', not [other]", async () => {
+  await withDir(async (dir) => {
+    await Bun.write(join(dir, "money.ts"), "export const x = 1;\n");
+
+    // 22 errors with NO rule id (generic/oracle output): 20 render, 2 overflow
+    // into the summary and must read as prose, not a fictitious rule `[other]`.
+    const errors: ErrorSet = Array.from({ length: 22 }, (_, i) => ({
+      key: `money.ts:${i + 1}:generic`,
+      file: "money.ts",
+      line: 1,
+      message: "command exited non-zero",
+    }));
+
+    const fb = await gateFeedback(errors, TASK, dir);
+
+    expect(fb).toContain("more unclassified errors");
+    expect(fb).not.toContain("[other]");
+  });
+});


### PR DESCRIPTION
## Summary

`gateFeedback` renders the first `FEEDBACK_MAX_LINES = 20` errors in raw parser-emission order. When one rule fails project-wide (e.g. 30× `no-explicit-any` after a sweep), those repeats consume the entire budget and the model **never hears about the other rules it also violated** — it fixes 20 instances, re-runs the gate, and only then discovers the next failure class. Each hidden failure class costs a full repair cycle to even become visible.

This PR keeps the budget and the ordering (tsc errors still lead, since the parser emits them first) but caps full renders at 3 instances per rule. Everything skipped is summarized by rule with counts and affected files:

```
… plus 22 more not shown — same rules, same fixes apply:
  - 22 more [no-explicit-any] in a.ts, b.ts (+2 files)
```

The model gets every distinct lesson once, plus explicit pointers that the shown fix applies elsewhere — far more signal per token than 20 renders of the same rule.

Errors without a rule id (generic parser output, oracle stages) are never capped per-rule: each one is distinct signal.

## Changes

- `selectRepresentative`: order-preserving selection with a per-rule cap of 3 within the existing 20-line budget
- `overflowSummary`: replaces the bare `… and N more — fix the above first.` line with a per-rule breakdown (count + up to 3 file names), sorted by frequency

## Testing

- New behavioral tests in `gate-feedback.test.ts`: a distinct rule emitted after a 25-error flood of another rule now survives into the rendered feedback; overflow summary format
- Existing feedback tests unchanged and passing
- `bun run typecheck` / `bun run lint` / `bun run format:check` all pass; `bun test packages` — 1935 pass, 0 fail

🤖 Generated with [Claude Code](https://claude.com/claude-code)