### PR TITLE
fix(harness): post-0.28 harness-review — 4 P1 + 3 P2 + manifest sync

### DIFF
--- a/docs/harness-subsystems.md
+++ b/docs/harness-subsystems.md
@@ -16,11 +16,14 @@ a guard that doesn't guard); **P2** a partial fix, missing test, or hidden failu
 
 ---
 
-## loop / turn — `src/loop/turn.ts`, `src/loop/session.ts`, `src/loop/loop.types.ts`
+## loop / turn — `src/loop/turn.ts`, `src/loop/session.ts`, `src/loop/loop.types.ts`, `src/loop/run.ts`
 
-Drives a turn: dispatch tool calls, account for writes, re-gate, settle.
+Drives a turn: dispatch tool calls, account for writes, re-gate, settle. `run.ts` is the
+headless outer driver (max-turns gating, degeneration/TTSR handling, gate settling) that
+iterates `turn.ts`; `staged-build.ts` and `model-call.ts` (PR #66) compose out of Session.
 
 **Invariants**
+
 - Every workspace mutation re-gates. A tool that writes without the model
   hand-writing it must surface `event.mutated`; an `edit`/`create` surfaces `event.file`.
 - A write is counted ONLY when it actually wrote (no name-based pre-counting — a
@@ -41,6 +44,7 @@ agent edit → re-gate (and for quality, re-judge) → keep only on improvement,
 roll back. The revert is the load-bearing safety property.
 
 **Invariants**
+
 - Snapshot/restore is glob-aware: `task.files` is documented as GLOBS, so anything
   that walks the scope must expand them (`snapshotFiles`, `score`, `scopeCode` all
   go through the shared walker), never read a literal glob path.
@@ -65,6 +69,7 @@ Filesystem-state outer loop: a `features.json` checklist drives an implement→e
 →persist cycle per feature until all green or a feature exhausts its attempts.
 
 **Invariants**
+
 - Feature ids come from the model, so they're validated kebab (`isFeatureId`) at
   parse/load and unsafe ids are dropped (defence against `../` traversal). Greenfield
   writes only `features.json` / `spec.md` / `progress.md` (no per-feature contract files).
@@ -87,6 +92,7 @@ Tool handlers + dispatch. Handlers return a `string` (model feedback); mutations
 reported via `ctx.report(ILoopEvent)`, never the return value.
 
 **Invariants**
+
 - Mutating tool ⇒ reports a change (or is in `SPECIAL`: `run`, `script`).
 - Mutation events fire ONLY on a real change (empty/no-op ⇒ no event).
 - A failure returns a tool-error string — never throws into the loop.
@@ -100,9 +106,13 @@ optimistic success text; arg parsing that accepts a flag/path injection.
 guard); for each mutating tool confirm the `mutated`-only-on-success path; grep
 handlers for `throw` reaching the caller.
 
-## gate / detect-gate — `src/detect-gate.ts`, `src/validate.ts`
+## gate / detect-gate — `src/gate/*`, `src/validate/*`
 
 Composes the gate command (tsc strict + eslint + opt-in oracles) and the fix/auto-format.
+(PR #66 split the old single files: `src/gate/*` = `core-gate.ts`, `web-gate.ts`,
+`linter.ts`, `tsconfig.ts`, `shell.ts`, `test-discovery.ts`, `tool-paths.ts`,
+`types.ts`; `src/validate/*` = `validate.ts`, `accept.ts`, `parse.ts`, `run-tests.ts`,
+`errors.ts`.)
 
 **Invariants** the gate uses tsforge's OWN bundled toolchain (works on any target);
 opt-in oracles only join when their env var is set; a failing gate never reports green.
@@ -115,8 +125,14 @@ opt-in oracles only join when their env var is set; a failing gate never reports
 
 "Does it RUN / render / stay covered" — failure classes tsc/eslint miss.
 
-**Invariants** opt-in (boot/browser/proptest/coverage gated by env); ephemeral ports
-via the shared `serveEphemeral` retry; a browser absence skips, not fails.
+**Invariants** In the CORE gate, boot (`TSFORGE_BOOT`), proptest (`TSFORGE_PROPTEST`),
+and coverage (`TSFORGE_COVERAGE`) are opt-in via env (`appendOptInOracles`); the
+browser render-check is NOT env-gated — it's mandatory in the WEB gate (`web-gate.ts`),
+where only the a11y + screenshots features are env-opt-in. Ephemeral ports via the
+shared `serveEphemeral` retry apply to the port-binding oracles only (`boot-check`,
+`browser-check`); the non-serving oracles (`proptest-check`, `test-coverage-check`)
+spawn via `runArgvCommand`/`Bun.spawn` with a timeout-kill and bind no port. A browser
+absence skips, not fails.
 
 **Risk areas** raw `Bun.serve({port:0})` (EADDRINUSE on old Bun); a server left running.
 
@@ -176,7 +192,7 @@ the ghost-row / non-ASCII / cursor-clip bugs string assertions missed).
 **Checklist** spinner inline gate off in the interactive REPL; teardown on
 `process.on("exit")`; resize handler calls `statusBar.resize` AND `editorHandle.resize`.
 
-## editor — `src/editor/*` (`buffer.ts`, `keys.ts`, `paste.ts`, `view.ts`, `controller.ts`, `segments.ts`)
+## editor — `src/editor/*` (`buffer.ts`, `completion.ts`, `controller.ts`, `index.ts`, `keys.ts`, `kill-ring.ts`, `paste.ts`, `segments.ts`, `undo-stack.ts`, `view.ts`)
 
 The multi-line input editor that replaced readline: a grapheme-correct buffer, a key
 decoder (Kitty CSI-u + modifyOtherKeys + legacy), a bracketed-paste scanner, a
@@ -194,6 +210,35 @@ multi-line insert + undo is atomic; the view windows to the editor's visible cap
 on shrink (top- vs bottom-anchored block); stale dims after resize; a paste path that
 auto-submits. **Tested via the `VirtualScreen` e2e harness** (`tests/editor-e2e.test.ts`)
 — assert the rendered grid, not emitted escape strings.
+
+## policy — `src/policy/*` (`policy.ts`, `classify.ts`, `patterns.ts`, `policy.types.ts`)
+
+The deny-first unified action policy (PR #23): classify every tool call into an action
+kind, then evaluate it against the mode's rules BEFORE any handler runs. The critical
+denials (`isDestructiveShell`, `pipesToShell`, `commandReadsPrivateKey`,
+`isPrivateKeyPath`) win in EVERY mode, `bypassPermissions` included.
+
+**Invariants**
+
+- Deny-first ordering: `executeTool` evaluates the policy before dispatch, so no tool
+  path (forced, salvaged, MCP, `script`/PTC, plan-mode) reaches a handler unpoliced.
+- The critical-deny set holds in every mode, and its shell detectors see through the
+  disguises a naive head-check misses — substitution, subshell, `find -exec`,
+  interpreter `-c`, quote-wrapping, AND shell function / brace-group bodies
+  (`f() { rm -rf /; }`). New shell syntax that hides a destructive head is the standing
+  risk (each escape is a P1: a guard that doesn't guard).
+- Private-key material is denied to BOTH `read` and the `run` shell (the `run` tool must
+  not be a side door around the `read` deny); `.env` is deliberately allowed.
+- MCP/unknown actions are policed (deny-by-default for unclassified), and a malformed
+  policy-rule config drops the bad rule rather than opening a hole.
+
+**Risk areas** a new evasion syntax past `patterns.ts`; deny-first ordering broken by a
+refactor that moves `executeTool`; a tool kind that classifies to an unpoliced action.
+
+**Checklist** `tests/policy-evaluation.test.ts` (destructive-shell + pipe + private-key
+detectors, incl. function/brace-group bodies), `tests/policy-config.test.ts` (rule
+parse/drop), `tests/policy-integration.test.ts` (deny-first at `executeTool`),
+`tests/write-policy-p1.test.ts`.
 
 ## mcp — `src/mcp/*`
 
@@ -222,6 +267,7 @@ conventions are **taste only** and a single source drives BOTH enforcement and
 guidance, so the gate and the prompts can never disagree.
 
 **Invariants**
+
 - The safety floor (no `any`/`as`/`!`, complexity cap, `eqeqeq`, `no-var`,
   `prefer-const`) can NEVER be relaxed through `conventions` OR `TSFORGE_RULE_OVERRIDES`,
   on either bundled surface — enforced by `PROTECTED_BUNDLED_RULES` +
@@ -276,8 +322,9 @@ shell form; an uncapped read; a NEW spawn site that bypasses the runner and so s
 the kill-timeout (the fixed `runNotify` hang).
 
 **Checklist** `tests/process.test.ts` group-kill + bounded drain + missing-binary 127
-+ custom env; `tests/cli.test.ts` `runNotify` is timeout-bounded; content-built
-commands use `runArgvCommand`.
+
+- custom env; `tests/cli.test.ts` `runNotify` is timeout-bounded; content-built
+  commands use `runArgvCommand`.
 
 ---
 

--- a/packages/core/src/editor/paste.ts
+++ b/packages/core/src/editor/paste.ts
@@ -38,10 +38,17 @@ function normalizeNewlines(s: string): string {
 }
 
 function finalizePasteContent(s: string): string {
-  // Decode tmux CSI-u control sequences: ESC[codepoint;modu → String.fromCharCode(codepoint)
+  // Decode tmux CSI-u control sequences: ESC[codepoint;modu → the Unicode char.
+  // Use fromCodePoint (not fromCharCode) so astral codepoints — emoji, high CJK,
+  // U+1xxxx — round-trip whole; fromCharCode truncates to the low 16 bits (👋
+  // U+1F44B → U+F44B, an unprintable that the control-strip below then drops).
+  // Guard the range: fromCodePoint throws RangeError outside [0, 0x10FFFF], so an
+  // out-of-range capture is dropped rather than crashing the paste path.
   const csiURegex = String.raw`\x1b\[(\d+);\d+u`;
   let decoded = s.replace(new RegExp(csiURegex, "g"), (_match, codepoint) => {
-    return String.fromCharCode(Number(codepoint));
+    const cp = Number(codepoint);
+
+    return cp >= 0 && cp <= 0x10ffff ? String.fromCodePoint(cp) : "";
   });
 
   // Normalize newlines first (CR/CRLF → LF)

--- a/packages/core/src/inference/openai-compatible.ts
+++ b/packages/core/src/inference/openai-compatible.ts
@@ -18,6 +18,18 @@ import {
 
 export { salvageToolCalls, salvageFusedToolName } from "./wire";
 
+/** A finite, non-negative number, or the fallback — for timing knobs that flow
+ *  into AbortSignal.timeout() (throws a RangeError outside [0, MAX_SAFE_INTEGER]).
+ *  Undefined/NaN/Infinity/negative all degrade to the fallback. */
+function finiteNonNegative(
+  value: number | undefined,
+  fallback: number
+): number {
+  return typeof value === "number" && Number.isFinite(value) && value >= 0
+    ? value
+    : fallback;
+}
+
 /**
  * Talks to any OpenAI-compatible `/chat/completions` endpoint — which Ollama,
  * vLLM, and llama.cpp all expose for a local Qwen3.6. Supports streaming: pass
@@ -86,9 +98,12 @@ export class OpenAICompatibleProvider implements IProvider {
       chatCompletionsUrl(this.cfg.baseUrl),
       headers,
       body,
-      this.cfg.timeoutMs ?? PROVIDER_LIMITS.requestTimeoutMs,
+      // Guard the timing knobs the same way request.ts guards its numeric params:
+      // a NaN/Infinity/negative value reaches AbortSignal.timeout() downstream and
+      // throws a RangeError, killing the request. Fall back to the default instead.
+      finiteNonNegative(this.cfg.timeoutMs, PROVIDER_LIMITS.requestTimeoutMs),
       effectiveOpts.signal,
-      this.cfg.connectRetryMs ?? PROVIDER_LIMITS.connectRetryMs
+      finiteNonNegative(this.cfg.connectRetryMs, PROVIDER_LIMITS.connectRetryMs)
     );
 
     if (!res.ok) {

--- a/packages/core/src/loop/greenfield/run.ts
+++ b/packages/core/src/loop/greenfield/run.ts
@@ -112,21 +112,25 @@ async function attemptFeature(
   feature.attempts += 1;
   say(`feature '${feature.id}': attempt ${feature.attempts} — ${feature.desc}`);
 
-  await deps.implement(feature, state);
+  // Persist in `finally` so an implement/evaluate THROW still records the bumped
+  // attempt count before it propagates — otherwise a crash on attempt N replays
+  // as attempt N-1 on resume, and a repeatedly-crashing feature never reaches
+  // `stuck`. The persisted state is the source of truth for resume-from-crash.
+  try {
+    await deps.implement(feature, state);
 
-  const verdict = await deps.evaluate(feature, state);
+    const verdict = await deps.evaluate(feature, state);
 
-  if (verdict.passed) {
-    feature.passes = true;
-    say(`feature '${feature.id}': verified ✓`);
-  } else {
-    say(
-      `feature '${feature.id}': failed at ${verdict.stage ?? "?"} — ${verdict.notes}`
-    );
+    if (verdict.passed) {
+      feature.passes = true;
+      say(`feature '${feature.id}': verified ✓`);
+    } else {
+      say(
+        `feature '${feature.id}': failed at ${verdict.stage ?? "?"} — ${verdict.notes}`
+      );
+    }
+  } finally {
+    await saveState(cwd, state);
+    await writeProgress(cwd, state);
   }
-
-  // Persist after every attempt so an interrupted run resumes from the last
-  // verified feature, not from scratch.
-  await saveState(cwd, state);
-  await writeProgress(cwd, state);
 }

--- a/packages/core/src/loop/greenfield/state.ts
+++ b/packages/core/src/loop/greenfield/state.ts
@@ -17,7 +17,9 @@ export function greenfieldDir(cwd: string): string {
  * trusted as a path component.
  */
 export function isFeatureId(id: string): boolean {
-  return /^[a-z0-9][a-z0-9-]*$/u.test(id);
+  // Alphanumeric at BOTH ends (or a single char) with internal hyphens only:
+  // true kebab-case, so `a`/`a-b` pass but `a-`/`-a`/`a--`-with-trailing don't.
+  return /^[a-z0-9](?:[a-z0-9-]*[a-z0-9])?$/u.test(id);
 }
 
 function featuresPath(cwd: string): string {

--- a/packages/core/src/loop/quality.ts
+++ b/packages/core/src/loop/quality.ts
@@ -100,24 +100,36 @@ export async function qualityRepair(
       report(event);
     };
 
-    await agent.implement({
-      cwd,
-      task,
-      errors: [
-        {
-          key: "quality",
-          message: `The code is green but a senior reviewer scored it ${best.quality}/5: "${best.notes}". Improve the code to address that critique.${guidance} Do NOT break the tests or the gate.`,
-        },
-      ],
-      cycle: attempts,
-      report: countingReport,
-    });
+    // A throw mid-attempt (agent error, fix-command crash, gate runner failure)
+    // must still roll the workspace back — otherwise a half-applied edit batch is
+    // left on disk over the green baseline. Restore, then rethrow so the caller
+    // still sees the failure (mirrors review-repair.ts).
+    let gate;
 
-    if (task.fix !== undefined && task.fix.length > 0) {
-      await runAccept({ ...task, accept: task.fix }, cwd);
+    try {
+      await agent.implement({
+        cwd,
+        task,
+        errors: [
+          {
+            key: "quality",
+            message: `The code is green but a senior reviewer scored it ${best.quality}/5: "${best.notes}". Improve the code to address that critique.${guidance} Do NOT break the tests or the gate.`,
+          },
+        ],
+        cycle: attempts,
+        report: countingReport,
+      });
+
+      if (task.fix !== undefined && task.fix.length > 0) {
+        await runAccept({ ...task, accept: task.fix }, cwd);
+      }
+
+      gate = await validate(task, cwd, opts.parse);
+    } catch (error) {
+      await restoreFiles(snapshot);
+
+      throw error;
     }
-
-    const gate = await validate(task, cwd, opts.parse);
 
     if (!gate.passed) {
       await restoreFiles(snapshot);

--- a/packages/core/src/loop/tools/script-tool.ts
+++ b/packages/core/src/loop/tools/script-tool.ts
@@ -3,6 +3,7 @@ import { join } from "node:path";
 import { randomUUID } from "node:crypto";
 import type { IToolCall } from "../../inference";
 import { isRecord } from "../../lib/guards";
+import { runArgvCommand } from "../../lib/fs";
 import { SCRIPT_EXPOSABLE_TOOLS, TOOL_NAME } from "../../agent";
 import { LOOP_LIMITS } from "../loop.constants";
 import { condenseToolOutput } from "./condense";
@@ -236,51 +237,30 @@ async function runScript(
   budgetMs: number,
   signal: AbortSignal | undefined
 ): Promise<IRunResult> {
-  const proc = Bun.spawn(["bun", "run", scriptPath], {
-    cwd,
+  // Route through the ONE shared runner instead of a bespoke Bun.spawn: it spawns
+  // `detached` and kills the whole process GROUP on timeout/abort, so a
+  // `(sleep …; touch x) &` backgrounded inside the script can't outlive the kill
+  // and mutate the workspace after the tool returns — and its final output drain
+  // is always FLUSH_GRACE_MS-bounded, so an orphan holding the pipe open can't
+  // stall the tool. A bespoke spawn here did neither.
+  const run = await runArgvCommand(cwd, ["bun", "run", scriptPath], {
     env,
-    stdout: "pipe",
-    stderr: "pipe",
+    timeoutMs: budgetMs,
+    ...(signal === undefined ? {} : { signal }),
   });
-  // Holder (not a bare `let`) so the union type survives — a plain variable
-  // assigned only inside the timer/abort closures gets narrowed to `null` by
-  // control-flow analysis, which would dead-flag the `note` comparisons below.
-  const kill: { reason: "timeout" | "abort" | null } = { reason: null };
-  const timer = setTimeout(() => {
-    kill.reason = "timeout";
-    proc.kill("SIGKILL");
-  }, budgetMs);
 
-  const onAbort = (): void => {
-    kill.reason = "abort";
-    proc.kill("SIGKILL");
+  // runArgvCommand only reports `timedOut` for the kill-timeout; an abort kills
+  // without that flag, so distinguish the two from the signal state for the note.
+  const note = run.timedOut
+    ? `\n[script killed: exceeded ${String(budgetMs)}ms timeout]`
+    : signal?.aborted === true
+      ? "\n[script aborted]"
+      : "";
+
+  return {
+    exitCode: run.exitCode,
+    output: `${run.stdout}${run.stderr}${note}`,
   };
-
-  signal?.addEventListener("abort", onAbort, { once: true });
-
-  try {
-    const [stdout, stderr] = await Promise.all([
-      new Response(proc.stdout).text(),
-      new Response(proc.stderr).text(),
-    ]);
-
-    await proc.exited;
-
-    const note =
-      kill.reason === "timeout"
-        ? `\n[script killed: exceeded ${String(budgetMs)}ms timeout]`
-        : kill.reason === "abort"
-          ? "\n[script aborted]"
-          : "";
-
-    return {
-      exitCode: proc.exitCode ?? 1,
-      output: `${stdout}${stderr}${note}`,
-    };
-  } finally {
-    clearTimeout(timer);
-    signal?.removeEventListener("abort", onAbort);
-  }
 }
 
 /**

--- a/packages/core/src/policy/patterns.ts
+++ b/packages/core/src/policy/patterns.ts
@@ -57,8 +57,16 @@ function commandHead(segment: string): string {
   while (i < tokens.length) {
     const token = tokens[i] ?? "";
 
-    if (/^[A-Za-z_][A-Za-z0-9_]*=/.test(token) || COMMAND_WRAPPERS.has(token)) {
-      i += 1; // env-assignment or a wrapper command
+    if (
+      /^[A-Za-z_][A-Za-z0-9_]*=/.test(token) ||
+      COMMAND_WRAPPERS.has(token) ||
+      token === "{"
+    ) {
+      // env-assignment, a wrapper command, or a `{` group/function-body opener.
+      // The `{` skip matters: `f() { rm -rf /; }` splits to a ` { rm -rf /`
+      // segment whose head would read as `{` (harmless) and hide the `rm` —
+      // stepping past the brace surfaces the real destructive head.
+      i += 1;
     } else if (token.startsWith("-")) {
       i += WRAPPER_VALUE_FLAGS.has(token) ? 2 : 1; // a wrapper flag (+ its value)
     } else {

--- a/packages/core/tests/detect-gate.test.ts
+++ b/packages/core/tests/detect-gate.test.ts
@@ -500,9 +500,19 @@ test("opt-in oracles join the gate ONLY when their env var is set", async () => 
     expect((await buildGate(dir)).label).toContain("property tests");
     delete process.env.TSFORGE_PROPTEST;
 
-    // An empty value does NOT count as set (guards against `export X=`).
+    // An empty value does NOT count as set (guards against `export X=`) — for
+    // EVERY opt-in oracle, not just coverage.
     process.env.TSFORGE_COVERAGE = "";
     expect((await buildGate(dir)).label).not.toContain("test coverage");
+    delete process.env.TSFORGE_COVERAGE;
+
+    process.env.TSFORGE_BOOT = "";
+    expect((await buildGate(dir)).label).not.toContain("boot smoke");
+    delete process.env.TSFORGE_BOOT;
+
+    process.env.TSFORGE_PROPTEST = "";
+    expect((await buildGate(dir)).label).not.toContain("property tests");
+    delete process.env.TSFORGE_PROPTEST;
   } finally {
     for (const [k, v] of saved) {
       if (v === undefined) {

--- a/packages/core/tests/editor-paste.test.ts
+++ b/packages/core/tests/editor-paste.test.ts
@@ -38,6 +38,33 @@ describe("PasteScanner", () => {
     expect(s.isActive()).toBe(false);
   });
 
+  test("decodes astral CSI-u codepoints (emoji) whole, not truncated", () => {
+    const s = createPasteScanner();
+    // 👋 = U+1F44B (128075), 👌 = U+1F44C (128076) re-emitted as tmux CSI-u.
+    // fromCharCode would truncate to U+F44B/U+F44C (unprintable, then stripped);
+    // fromCodePoint round-trips the astral chars.
+    const chunk = "\x1b[200~hi\x1b[128075;0u\x1b[128076;0u\x1b[201~";
+    const r = s.feed(chunk);
+
+    expect(r.content).toBe("hi👋👌");
+    expect(Array.from(r.content ?? "", (c) => c.codePointAt(0))).toEqual([
+      0x68, 0x69, 0x1f44b, 0x1f44c,
+    ]);
+  });
+
+  test("an out-of-range CSI-u codepoint is dropped, not thrown", () => {
+    const s = createPasteScanner();
+    // 0x110000 is one past the max valid codepoint — fromCodePoint would throw
+    // RangeError; the range guard drops it instead of crashing the paste.
+    const chunk = "\x1b[200~a\x1b[1114112;0ub\x1b[201~";
+
+    expect(() => s.feed(chunk)).not.toThrow();
+    // re-feed on a fresh scanner (the throwing feed above consumed state)
+    const s2 = createPasteScanner();
+
+    expect(s2.feed(chunk).content).toBe("ab");
+  });
+
   test("strips non-printable control chars except newline", () => {
     const s = createPasteScanner();
     // Include some control chars: \x00, \x01, \x1f (unit sep), \x7f (DEL)

--- a/packages/core/tests/greenfield-planner.test.ts
+++ b/packages/core/tests/greenfield-planner.test.ts
@@ -58,12 +58,15 @@ describe("planner: parsePlan / planFeatures", () => {
           { id: "../../../README", desc: "path traversal" },
           { id: "has/slash", desc: "slash" },
           { id: "Has Space", desc: "space" },
+          { id: "trailing-", desc: "trailing hyphen — not kebab" },
+          { id: "-leading", desc: "leading hyphen — not kebab" },
           { id: "good-feature", desc: "fine" },
+          { id: "a", desc: "single char is valid kebab" },
         ],
       })
     );
 
-    expect(plan?.features.map((f) => f.id)).toEqual(["good-feature"]);
+    expect(plan?.features.map((f) => f.id)).toEqual(["good-feature", "a"]);
   });
 
   test("planFeatures tolerates a fenced JSON block", async () => {

--- a/packages/core/tests/greenfield.test.ts
+++ b/packages/core/tests/greenfield.test.ts
@@ -236,6 +236,54 @@ describe("runGreenfield: outer loop", () => {
     expect(implemented).toEqual(["b"]); // 'a' skipped
   });
 
+  test("persists the bumped attempt count even when implement throws", async () => {
+    const s = state("a");
+    const deps: IGreenfieldDeps = {
+      implement: async () => {
+        throw new Error("model died mid-attempt");
+      },
+      evaluate: async () => ({ passed: true, notes: "" }),
+    };
+
+    // The throw propagates (crash), but the incremented counter must be on disk
+    // so a resume doesn't replay attempt 0 forever.
+    await expect(runGreenfield(dir, s, deps)).rejects.toThrow(
+      "model died mid-attempt"
+    );
+
+    const onDisk = await loadState(dir);
+
+    expect(onDisk?.features[0]?.attempts).toBe(1);
+    expect(onDisk?.features[0]?.passes).toBe(false);
+  });
+
+  test("a repeatedly-crashing feature still reaches `stuck` across resumes", async () => {
+    const deps: IGreenfieldDeps = {
+      implement: async () => {
+        throw new Error("boom");
+      },
+      evaluate: async () => ({ passed: true, notes: "" }),
+    };
+
+    // Each run crashes on its single attempt but persists the bump; resuming from
+    // disk three times exhausts maxAttempts instead of looping on attempt 0.
+    for (let i = 0; i < 3; i += 1) {
+      const resumed = (await loadState(dir)) ?? state("a");
+
+      await expect(
+        runGreenfield(dir, resumed, deps, { maxAttemptsPerFeature: 3 })
+      ).rejects.toThrow("boom");
+    }
+
+    const final = (await loadState(dir)) ?? state("a");
+    const res = await runGreenfield(dir, final, deps, {
+      maxAttemptsPerFeature: 3,
+    });
+
+    expect(res.status).toBe("stuck");
+    expect(res.stuckFeature).toBe("a");
+  });
+
   test("writes progress.md as it goes", async () => {
     const s = state("a");
     const deps: IGreenfieldDeps = {

--- a/packages/core/tests/inference.test.ts
+++ b/packages/core/tests/inference.test.ts
@@ -34,6 +34,32 @@ test("retries a transient connection blip, then succeeds", async () => {
   expect(r.content).toBe("ok");
 });
 
+test("a non-finite/negative timeoutMs falls back to the default, not a crash", async () => {
+  // A NaN/Infinity/negative timeout reaches AbortSignal.timeout() in transport.ts
+  // and throws a RangeError before the request even starts. The provider must
+  // guard it and use the default instead.
+  let calls = 0;
+  const countingFetch = (async () => {
+    calls += 1;
+
+    return okResponse();
+  }) as unknown as typeof fetch;
+
+  for (const timeoutMs of [Number.NaN, Number.POSITIVE_INFINITY, -1]) {
+    const p = new OpenAICompatibleProvider({
+      baseUrl: "http://x/v1",
+      model: "m",
+      timeoutMs,
+      fetch: countingFetch,
+    });
+    const r = await p.complete([{ role: "user", content: "hi" }], {});
+
+    expect(r.content).toBe("ok");
+  }
+
+  expect(calls).toBe(3); // all three reached the (mocked) wire, none crashed
+});
+
 test("captures token usage from a non-streaming response", async () => {
   const fetchWithUsage = (async () =>
     new Response(

--- a/packages/core/tests/policy-evaluation.test.ts
+++ b/packages/core/tests/policy-evaluation.test.ts
@@ -185,6 +185,19 @@ describe("destructive-shell detection", () => {
     expect(isDestructiveShell('"echo" rm')).toBe(false);
     expect(isDestructiveShell("bash -c 'npm run build' --silent")).toBe(false);
   });
+
+  test("sees through shell function / brace-group bodies", () => {
+    // A destructive command as the FIRST token inside `{ … }` (a function body or
+    // a bare group) must not hide behind the `{` reading as the segment head.
+    expect(isDestructiveShell("f() { rm -rf /; }; f")).toBe(true);
+    expect(isDestructiveShell("function f() { rm -rf /; }; f")).toBe(true);
+    expect(isDestructiveShell("g() { dd if=/dev/zero of=/dev/sda; }; g")).toBe(
+      true
+    );
+    expect(isDestructiveShell("{ rm -rf /; }")).toBe(true);
+    // a benign function body stays clean
+    expect(isDestructiveShell("build() { npm run build; }; build")).toBe(false);
+  });
 });
 
 describe("pipe-to-shell detection", () => {

--- a/packages/core/tests/quality.test.ts
+++ b/packages/core/tests/quality.test.ts
@@ -181,6 +181,42 @@ test("reverts an attempt that breaks the gate", async () => {
   }
 });
 
+// Regression: a THROW mid-attempt (agent error, fix crash, gate runner failure)
+// must roll the workspace back to the green baseline before propagating —
+// otherwise a half-applied edit batch is left on disk over green code. Mirrors
+// review-repair.ts's try/catch-restore-rethrow.
+test("a throw mid-attempt restores the snapshot before rethrowing", async () => {
+  const dir = await mkdtemp(join(tmpdir(), "tsforge-quality-throw-"));
+
+  try {
+    await Bun.write(join(dir, "a.ts"), "baseline");
+
+    const agent: IAgent = {
+      async implement(ctx) {
+        await Bun.write(join(ctx.cwd, "a.ts"), "// HALF-APPLIED");
+
+        throw new Error("agent exploded mid-repair");
+      },
+    };
+
+    await expect(
+      qualityRepair(
+        { id: "1", accept: "true", files: ["a.ts"] },
+        dir,
+        agent,
+        risingJudge([3]), // parseable 3/5 → enters the improvement loop
+        { goal: "g", criteria: "c" },
+        { target: 5, maxAttempts: 1 }
+      )
+    ).rejects.toThrow("agent exploded mid-repair");
+
+    // The half-applied edit must be rolled back, not left on disk.
+    expect(await Bun.file(join(dir, "a.ts")).text()).toBe("baseline");
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
 // Regression: an UNPARSEABLE judge response (judge infra failure, not a real 0/5)
 // must NOT enter the improvement loop. Feeding the generator "a reviewer scored you
 // 0/5: 'unparseable judge response'" is a nonsense critique it can't act on — live,

--- a/packages/core/tests/script-tool.test.ts
+++ b/packages/core/tests/script-tool.test.ts
@@ -355,6 +355,66 @@ test("a runaway script is killed at the wall-clock timeout", async () => {
   expect(out).not.toContain("script exit 0");
 });
 
+test("a child backgrounded inside a script does not survive the timeout kill", async () => {
+  const dir = await mkdtemp(join(tmpdir(), "tsforge-script-"));
+
+  try {
+    const marker = join(dir, "leaked-marker");
+    // The script backgrounds a grandchild that would touch a marker AFTER the
+    // timeout fires. Killing only the `bun` process (the old bug) leaves the
+    // grandchild alive to touch it; a process-GROUP kill takes it down too.
+    const code = [
+      `Bun.spawn(["sh", "-c", ${JSON.stringify(`sleep 1.5 && touch ${marker}`)}]);`,
+      "while (true) {}",
+    ].join("\n");
+    const events: ILoopEvent[] = [];
+
+    const out = await doScript(
+      { code, timeoutMs: 400 },
+      makeCtx({ cwd: dir }, events),
+      { execute: recordingExecute([]) }
+    );
+
+    expect(out).toContain("killed: exceeded");
+
+    // Wait past when the leaked child WOULD have touched the marker.
+    await new Promise((r) => setTimeout(r, 2000));
+
+    expect(await Bun.file(marker).exists()).toBe(false);
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+}, 15_000);
+
+test("the output drain is bounded when a backgrounded child holds the pipe open", async () => {
+  const dir = await mkdtemp(join(tmpdir(), "tsforge-script-"));
+
+  try {
+    // `sh` backgrounds `sleep 5` (which inherits — and holds open — the script's
+    // stdout pipe) then exits immediately, so `bun` exits fast while the orphan
+    // keeps the pipe open. An unbounded drain (`Response(stdout).text()`) would
+    // block the whole 5s waiting for EOF; the shared runner bounds it.
+    const code = [
+      `Bun.spawnSync(["sh", "-c", "sleep 5 &"], { stdout: "inherit" });`,
+      'console.log("SCRIPT_DONE");',
+    ].join("\n");
+    const events: ILoopEvent[] = [];
+
+    const started = Date.now();
+    const out = await doScript(
+      { code, timeoutMs: 30_000 },
+      makeCtx({ cwd: dir }, events),
+      { execute: recordingExecute([]) }
+    );
+    const elapsed = Date.now() - started;
+
+    expect(out).toContain("SCRIPT_DONE");
+    expect(elapsed).toBeLessThan(3000); // bounded ~500ms, not the child's 5s
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+}, 15_000);
+
 test("the RPC server rejects a request with a wrong token", async () => {
   const events: ILoopEvent[] = [];
   const code = [


### PR DESCRIPTION
Full 16-subsystem adversarial `/harness-review all` sweep after 0.28.0 (one reviewer per contract + independent refuters per finding; 47 agents). 22 raw findings → **17 survived verification, 5 refuted**. Every fix carries a failing-then-passing regression test; full `bun run validate` is green (1927 tests pass, e2e:pty 20/20).

## P1 — correctness/safety
- **greenfield loses the attempt counter on crash** (`loop/greenfield/run.ts`): an `implement`/`evaluate` throw skipped `saveState`/`writeProgress`, so a repeatedly-crashing feature replayed attempt 0 forever and never reached `stuck`. Persist in `try/finally`.
- **paste truncates emoji** (`editor/paste.ts`): tmux CSI-u decode used `String.fromCharCode` → 👋 U+1F44B collapsed to U+F44B and got stripped. Switched to `String.fromCodePoint` with a `[0, 0x10FFFF]` range guard.
- **script-tool leaks backgrounded children** (`loop/tools/script-tool.ts`): the bespoke `Bun.spawn` had no `detached` and killed only the direct pid, so a `(sleep; touch) &` child survived the timeout kill. Rerouted through the shared `runArgvCommand` (process-group kill + `FLUSH_GRACE_MS`-bounded drain) — fixes the P1 leak **and** the P2 unbounded-drain in one change, and restores the lib/fs "one runner" invariant.
- **policy destructive-shell bypass** (`policy/patterns.ts`): `f() { rm -rf /; }; f` read `{` as the segment head and hid the `rm` — a critical-deny that didn't deny in any mode. Skip a leading `{` group/function-body opener.

## P2
- **quality repair** (`loop/quality.ts`): no `try/catch` around the mutating attempt (unlike `review-repair.ts`) → a throw left a half-applied edit over green code. Added restore-then-rethrow.
- **detect-gate test gap**: the empty-oracle-value guard was only tested for `TSFORGE_COVERAGE`; added `TSFORGE_BOOT` + `TSFORGE_PROPTEST` (code was already correct).

## P3 / manifest (the manifest is part of the contract)
- **inference** (`openai-compatible.ts`): guard NaN/Infinity/negative `timeoutMs`/`connectRetryMs` before they hit `AbortSignal.timeout` (a `RangeError`); matches `request.ts`'s `Number.isFinite` pattern.
- **greenfield `isFeatureId`**: reject leading/trailing hyphens (true kebab-case).
- **docs/harness-subsystems.md**: gate paths → `src/gate/*`+`src/validate/*`; add the missing **policy** subsystem entry; name `run.ts`/`staged-build`/`model-call` in loop/turn; complete the editor file list; correct the oracle opt-in claim (browser is mandatory in the web gate, not env-gated) and the `serveEphemeral` scope.

## Deliberately not landed
greenfield `evaluate.ts` "malformed browser result" hardening (SPLIT verdict) — `IRenderResult.errors` is compiler-required, so the defensive branch is dead code that can't be covered by a house-rules-compliant test (no `as`/`@ts-expect-error`). The refuter was right.