### PR TITLE
feat: recipe-level rule profiles + procedure fix cards + skills reorg

### DIFF
--- a/.claude/skills/authoring/effective-tsforge-skills/SKILL.md
+++ b/.claude/skills/authoring/effective-tsforge-skills/SKILL.md
@@ -1,0 +1,83 @@
+---
+name: effective-tsforge-skills
+description: How to write and maintain tsforge agent skills — when to use a skill vs a rule vs a recipe vs docs, description routing, progressive disclosure, and the ship checklist. Use when creating, editing, or reviewing SKILL.md files under .claude/skills/, or when asked "should this be a skill?".
+---
+
+# Effective tsforge skills
+
+tsforge is **enforcement-first**: the gate, rule packs, and `rule-docs` bad/good cards are the runtime oracle. Skills are **maintainer and IDE affordances** — procedures the harness does not load. Write skills for repeatable human/agent workflows; write rules for anything that must hold whether or not the model remembers.
+
+## When to use what
+
+| Need                                          | Use                                                 | Lives in                                       |
+| --------------------------------------------- | --------------------------------------------------- | ---------------------------------------------- |
+| Must be true before "done"                    | ESLint rule, meta-rule, or gate check               | `packages/core/src/rule-packs/`, `meta-rules/` |
+| Fix guidance on gate failure                  | `IRuleDoc` (what + bad + good + optional procedure) | `packages/core/src/loop/feedback/rule-docs.ts` |
+| Named run setup (flags, gate, model)          | Recipe JSON                                         | `.tsforge/recipes/*.json`                      |
+| Maintainer procedure (release, harness audit) | Skill                                               | `.claude/skills/<category>/<name>/SKILL.md`    |
+| User-facing product docs                      | Starlight page                                      | `apps/docs/src/content/docs/`                  |
+
+**Do not** put enforceable invariants only in a skill. **Do not** duplicate `AGENTS.md` house rules in skills — they are already in prompts and ESLint.
+
+## Category taxonomy
+
+```
+.claude/skills/
+├── harness/     # adversarial subsystem review (harness-review)
+├── release/     # npm + GitHub release (tsforge-release)
+├── authoring/   # this skill, rules-build helpers
+└── workflow/    # eval sweep, spec loop (when committed)
+```
+
+Folder name must **exactly match** frontmatter `name`. File must be `SKILL.md`.
+
+## Description as routing contract
+
+The `description` is the only discovery surface. Include:
+
+1. **What** the skill does (one phrase)
+2. **When** / trigger phrases the user will say
+3. **Differentiator** vs sibling skills
+
+Describe _what_ and _when_, never _how_. A step-by-step summary in `description` makes agents skip the body.
+
+## Two patterns
+
+**Capability primitives** — bash/scripts, exact commands, failure modes. Example: `tsforge-release` → `scripts/release.sh`.
+
+**Process primitives** — methodology, checklists, output templates. Example: `harness-review` → repro-before-report.
+
+Use `disable-model-invocation: true` for manual-only skills (release, handoff-style) so they do not auto-fire mid-task.
+
+## Progressive disclosure
+
+Keep `SKILL.md` lean. Push install detail, format specs, and long references to `references/` and link with explicit "read when" pointers. One level deep only — no reference chains.
+
+Pack-level deep guidance belongs in rule pack `references/`, surfaced via `IRuleDoc.reference`, not in always-on prompts.
+
+## Composition map
+
+| Skill                      | Reads / invokes                                       |
+| -------------------------- | ----------------------------------------------------- |
+| `harness-review`           | `docs/harness-subsystems.md`                          |
+| `tsforge-release`          | `scripts/release.sh`, `.github/workflows/release.yml` |
+| `effective-tsforge-skills` | (this file)                                           |
+
+Recipes compose CLI knobs; skills compose procedures. Cross-reference by skill `name`, do not duplicate bodies.
+
+## Ship checklist
+
+- [ ] `name` matches parent folder name
+- [ ] Description: what + when + differentiator (no how-to summary)
+- [ ] Output format documented if the skill produces structured findings
+- [ ] Validation loop: what command proves success (`bun run validate` for code changes)
+- [ ] Repro required before reporting harness bugs (see `harness-review`)
+- [ ] No human-facing README inside the skill folder
+- [ ] Relative paths from repo root (`scripts/…`, not `../../../../scripts/…`)
+
+## Anti-patterns
+
+- Runtime skill loading in `packages/core` — conflicts with enforcement-first design
+- Monolithic mega-skills — split by concern; recipes + skills compose at use time
+- Re-teaching TypeScript or git basics the model already knows
+- Skills that only restate `AGENTS.md` without a procedure

--- a/.claude/skills/harness/harness-review/SKILL.md
+++ b/.claude/skills/harness/harness-review/SKILL.md
@@ -30,12 +30,7 @@ traced it to a concrete `file:line`.
 4. **Reproduce.** For any suspected break, write the smallest repro — a throwaway
    `bun` script or a focused test in a temp dir. A repro that fires is a P1/P2; one that
    doesn't clears the hunch (say so). Never report an unreproduced "could be".
-5. **Report.** Return a findings list, highest severity first. Per finding:
-   - **severity** P1/P2/P3 (definitions in the manifest header)
-   - **title** one line
-   - **location** `file:line`
-   - **evidence** the repro or the exact code path (quote the lines)
-   - **fix** a concrete sketch (and the regression test that would lock it)
+5. **Report.** Return a findings list using the output template below.
 
    If the subsystem is clean, say so explicitly and list which invariants you verified
    and how — "clean" with no evidence is not an acceptable result.
@@ -47,6 +42,26 @@ user opted into multi-agent orchestration), each running the single-subsystem
 procedure on its own slice, then collate into one severity-sorted list with a short
 per-subsystem "verified / findings" summary. This is opt-in per run (it spawns many
 agents); don't trigger it automatically.
+
+## Output template
+
+Return findings in this shape (highest severity first):
+
+```markdown
+## Harness review: <subsystem>
+
+### Findings
+
+#### P1 — <title>
+- **location:** `path/to/file.ts:42`
+- **evidence:** <repro steps or quoted code path>
+- **fix:** <concrete sketch + regression test name>
+
+#### P2 — …
+
+### Verified (if clean)
+- <invariant>: checked via <how>
+```
 
 ## Output discipline
 

--- a/.claude/skills/release/tsforge-release/SKILL.md
+++ b/.claude/skills/release/tsforge-release/SKILL.md
@@ -1,14 +1,12 @@
 ---
 name: tsforge-release
-description: >-
-  End-to-end tsforge release: validate, commit all pending work, bump version,
-  signed tag, push, watch npm publish. Use when the user asks to release,
-  publish, ship, tag, or cut a version. Does not require a clean git tree.
+description: End-to-end tsforge release — validate, commit pending work, bump version, signed tag, push, watch npm publish. Use when the user asks to release, publish, ship, tag, or cut a version. Does not require a clean git tree. Manual-only; do not auto-run during unrelated tasks.
+disable-model-invocation: true
 ---
 
 # tsforge release
 
-One command from dirty `main` to npm + GitHub Release. Pushing `v*.*.*` triggers [`.github/workflows/release.yml`](../../.github/workflows/release.yml).
+One command from dirty `main` to npm + GitHub Release. Pushing `v*.*.*` triggers [`.github/workflows/release.yml`](.github/workflows/release.yml).
 
 **The script commits everything for you.** Uncommitted work is included in the release commit. You do not need a clean tree first.
 
@@ -77,5 +75,5 @@ Do not manually `npm publish` unless the user explicitly asks to bypass CI.
 
 ## Related docs
 
-- [CONTRIBUTING.md](../../CONTRIBUTING.md)
-- [apps/docs/DEPLOY.md](../../apps/docs/DEPLOY.md)
+- [CONTRIBUTING.md](CONTRIBUTING.md)
+- [apps/docs/DEPLOY.md](apps/docs/DEPLOY.md)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,7 +14,7 @@ bun run rules:docs                            # regenerate rule-docs.generated.j
 bun run eval:sweep                            # A/B feature sweep (see tsforge.dev/eval/ab-testing/)
 bun run eval:benchmark                        # compare edit mechanisms across runs
 ./scripts/audit-repo-settings.sh             # diff GitHub repo settings vs .github/desired-repo-settings.json
-./scripts/release.sh patch                   # bump, tag, push → npm + GitHub Release (see .cursor/skills/tsforge-release/)
+./scripts/release.sh patch                   # bump, tag, push → npm + GitHub Release (see .claude/skills/release/tsforge-release/)
 ```
 
 ## Layout

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -109,7 +109,7 @@ Use the release script. It validates, commits all pending work, bumps version, t
 ./scripts/release.sh patch --yes        # later releases
 ```
 
-See [`.cursor/skills/tsforge-release/SKILL.md`](.cursor/skills/tsforge-release/SKILL.md). Requires `NPM_TOKEN` in GitHub repo secrets.
+See [`.claude/skills/release/tsforge-release/SKILL.md`](.claude/skills/release/tsforge-release/SKILL.md). Requires `NPM_TOKEN` in GitHub repo secrets.
 
 ### Docs deploy
 

--- a/apps/docs/astro.config.mjs
+++ b/apps/docs/astro.config.mjs
@@ -215,6 +215,7 @@ export default defineConfig({
           collapsed: true,
           items: [
             { label: "Model agent", link: "/agent/model-agent/" },
+            { label: "Skills and the harness", link: "/agent/skills-and-harness/" },
             { label: "File ops", link: "/edit/engine/" },
             { label: "TypeScript language server", link: "/lsp/typescript-server/" },
             { label: "Write diagnostics", link: "/uplift/write-diagnostics/" },

--- a/apps/docs/src/content/docs/agent/skills-and-harness.mdx
+++ b/apps/docs/src/content/docs/agent/skills-and-harness.mdx
@@ -1,0 +1,61 @@
+---
+title: Skills and the harness
+description: How IDE agent skills relate to tsforge enforcement — skills guide maintainers; the gate is the runtime oracle.
+---
+
+tsforge is **enforcement-first**. During a run, the harness does not load `SKILL.md` files. Instead it uses deterministic gates, [rule packs](/guardrails/rule-packs/), and [bad/good feedback cards](/loop/validation/) to tell the model what failed and how to fix it.
+
+**Agent skills** are a separate layer for maintainers and IDE workflows — release, harness audits, skill authoring. They live in the repo under `.claude/skills/` and are discovered by Claude Code / compatible agents at session start.
+
+## Two layers
+
+| Layer | What it does | Where it lives |
+| --- | --- | --- |
+| **Harness** | Enforces invariants; work is not done until the gate passes | `packages/core/` — rule packs, meta-rules, gate, `rule-docs` |
+| **Skills** | Repeatable procedures for humans/agents outside the run loop | `.claude/skills/<category>/<name>/SKILL.md` |
+
+```mermaid
+flowchart LR
+  Skills[IDE skills] -->|"inform authoring"| RuleDocs[rule-docs cards]
+  Recipe[JSON recipes] -->|"compose CLI knobs"| Run[tsforge run]
+  Run --> Gate[Gate oracle]
+  Gate --> Feedback[Structured errors + bad/good]
+  Feedback --> Learned[.tsforge/learned-rules.json]
+```
+
+Skills **inform** how you write rules and docs. They do **not** replace the gate.
+
+## Skill categories in this repo
+
+```
+.claude/skills/
+├── harness/     harness-review — adversarial subsystem audit
+├── release/     tsforge-release — npm + GitHub release
+└── authoring/   effective-tsforge-skills — how to write skills here
+```
+
+Each skill folder name must match its frontmatter `name`. See `effective-tsforge-skills` for the ship checklist.
+
+## When to use what
+
+| Need | Use |
+| --- | --- |
+| Must hold before "done" | ESLint rule, meta-rule, or gate check |
+| Fix guidance on failure | `IRuleDoc` in `rule-docs.ts` (what + bad + good + optional procedure) |
+| Named run setup | [Recipe](/cli/recipes/) JSON (gate, files, model, `profile`, flags) |
+| Maintainer workflow | Skill under `.claude/skills/` |
+| User-facing product behavior | [Docs site](/) page |
+
+Do not put enforceable invariants only in a skill. If the model must not ship without it, encode it in the gate.
+
+## Recipes vs skills
+
+[Recipes](/cli/recipes/) compose **existing CLI options** — gate, scope, models, `profile`, plan mode, greenfield. They are data (`*.json`), not procedures.
+
+Skills compose **methodology** — repro-before-report harness reviews, release scripts with failure modes. A recipe might set `profile: "strict"`; a skill teaches how to run `bun run validate` before tagging.
+
+## Learned rules
+
+tsforge mines gate failure→fix pairs into [`.tsforge/learned-rules.json`](/uplift/memory/) and promotes recurring patterns to TTSR triggers. These are repo-local "micro-skills" — machine triggers, not markdown runbooks. High-confidence patterns can later be promoted to committed `IRuleDoc` entries or maintainer skills.
+
+→ [Recipes](/cli/recipes/) · [Rule packs](/guardrails/rule-packs/) · [When the gate fails](/loop/validation/) · [Contributing](https://github.com/agjs/tsforge/blob/main/CONTRIBUTING.md)

--- a/apps/docs/src/content/docs/cli/recipes.mdx
+++ b/apps/docs/src/content/docs/cli/recipes.mdx
@@ -54,10 +54,11 @@ A project recipe **overrides** a global one with the same id. `tsforge recipes` 
 | `withReview` | `--with-review` | after green, run the review and feed verified findings into one repair cycle |
 | `mode` | `--greenfield` | `"greenfield"` selects the [feature-checklist build loop](/loop/greenfield/) |
 | `plannerModel`, `workModel`, `evaluatorModel` | greenfield roles | per-role model names; each falls back to `model`/active |
+| `profile` | `tsforge.config.json` `profile` | `recommended`, `strict`, `security`, `frontend`, `backend`, `opinionated` |
 | `web`, `plan`, `log`, `strictFloorOnly` | the matching flags | booleans |
 
 A recipe is, in effect, a saved set of CLI options: `tsforge run <id>` applies them, and you can also combine `--recipe <id>` with other commands (e.g. `tsforge review --recipe …`). **An explicit CLI flag always wins** over the recipe, so `tsforge run api-endpoint --files lib/**` overrides just the scope.
 
-Fields this version doesn't recognize (a typo, or a not-yet-supported field like `profile`/`tools`) are **reported, not silently ignored** — so a recipe never quietly does less than it says.
+Fields this version doesn't recognize (a typo, or a not-yet-supported field like `tools`) are **reported, not silently ignored** — so a recipe never quietly does less than it says.
 
 → [Commands](/reference/commands/) · [tsforge.config.json](/guardrails/config/) · [Models](/inference/models-json/)

--- a/packages/core/src/cli.ts
+++ b/packages/core/src/cli.ts
@@ -24,6 +24,7 @@ import {
   isOneShot,
   scopeOf,
   cliUsage,
+  resolveCliProfile,
   type ICliArgs,
 } from "./cli/args";
 import { validate } from "./validate";
@@ -62,7 +63,13 @@ import { resolveGate } from "./cli/gate-setup";
  * Slash commands (/help, /clear, /exit) follow the standard harness UX. Provider
  * via TSFORGE_* env.
  */
-export { parseArgs, applyRecipe, isOneShot, type ICliArgs } from "./cli/args";
+export {
+  parseArgs,
+  applyRecipe,
+  isOneShot,
+  resolveCliProfile,
+  type ICliArgs,
+} from "./cli/args";
 
 export { makeSpinner, spinnerPhase, type ISpinnerOut } from "./render/spinner";
 export { providerConfig } from "./cli/model-setup";
@@ -91,11 +98,13 @@ async function runOnce(args: ICliArgs): Promise<number> {
   const { entry } = await modelForRun(args);
   const provider = makeProvider(entry);
   const report = makeReporter(logFile, "cli");
+  const profile = resolveCliProfile(args.profile);
   const result = await runTask(task, args.dir, provider, {
     onEvent: report,
     ...(thinkingTokenBudget === undefined ? {} : { thinkingTokenBudget }),
     ...(args.maxTurns > 0 ? { maxTurns: args.maxTurns } : {}),
     ...(args.scout ? { scout: true } : {}),
+    ...(profile === undefined ? {} : { profile }),
   });
   const ok = result.status === RUN_STATUS.done;
 

--- a/packages/core/src/cli/args.ts
+++ b/packages/core/src/cli/args.ts
@@ -1,5 +1,6 @@
 import { join, isAbsolute } from "node:path";
 import type { ITaskRecipe } from "../config/recipes";
+import { isProfileId, type ProfileId } from "../config/profiles";
 
 /**
  * CLI argument parsing + recipe overlay — pure, no I/O, no module state. Extracted
@@ -79,6 +80,8 @@ export interface ICliArgs {
   maxTurns: number;
   /** Reasoning-token cap (from a recipe); 0 = the env/default. */
   thinkingBudget: number;
+  /** Rule profile override (from a recipe); "" = use tsforge.config.json. */
+  profile: string;
   /** Base policy mode (`--policy-mode <plan|default|acceptEdits|ci|dontAsk|
    *  bypassPermissions>`); overrides the config file's policy.mode. */
   policyMode: string;
@@ -210,6 +213,7 @@ export function parseArgs(argv: readonly string[]): ICliArgs {
     evaluatorModel: "",
     maxTurns: 0,
     thinkingBudget: 0,
+    profile: "",
     policyMode: "",
     setup: false,
     setupYes: false,
@@ -327,7 +331,18 @@ export function applyRecipe(args: ICliArgs, recipe: ITaskRecipe): void {
     args.thinkingBudget = recipe.thinkingBudget;
   }
 
+  if (args.profile.length === 0 && recipe.profile !== undefined) {
+    args.profile = recipe.profile;
+  }
+
   applyRecipeFlags(args, recipe);
+}
+
+/** Resolve a recipe/CLI profile string to a ProfileId, or undefined when unset. */
+export function resolveCliProfile(profile: string): ProfileId | undefined {
+  const trimmed = profile.trim();
+
+  return trimmed.length > 0 && isProfileId(trimmed) ? trimmed : undefined;
 }
 
 /** Recipe greenfield role models (split out to keep applyRecipe's complexity in

--- a/packages/core/src/cli/gate-setup.ts
+++ b/packages/core/src/cli/gate-setup.ts
@@ -87,11 +87,16 @@ async function baseGate(
     resolveActivePacks,
     normalizeRuleOverrides,
     resolveProjectProfile,
+    withProfileOverride,
   } = await import("../config/tsforge-config");
   const { resolveConventions } = await import("../infer-rules/conventions");
+  const { resolveCliProfile } = await import("./args");
 
   const stackProfile = await detectStack(args.dir);
-  const config = await loadTsforgeConfig(args.dir);
+  const config = withProfileOverride(
+    await loadTsforgeConfig(args.dir),
+    resolveCliProfile(args.profile)
+  );
   const activePacks = resolveActivePacks(stackProfile.packs, config);
   const ruleOverrides = normalizeRuleOverrides(config);
   const profile = resolveProjectProfile(config);

--- a/packages/core/src/cli/repl.ts
+++ b/packages/core/src/cli/repl.ts
@@ -31,7 +31,7 @@ import {
   type SetupWebFn,
 } from "../loop";
 import { loadRecipes } from "../config/recipes";
-import { scopeOf, WHOLE_REPO, type ICliArgs } from "./args";
+import { scopeOf, WHOLE_REPO, resolveCliProfile, type ICliArgs } from "./args";
 import { isPolicyMode } from "../policy";
 import { startEditor, type IEditorHandle } from "../editor";
 import { renderEditor } from "../editor/view";
@@ -203,6 +203,7 @@ async function initReplSession(args: ICliArgs): Promise<{
     (await detectContextWindow(provider.config)) ??
     32_768;
   const report = makeReporter(logFile, id, id);
+  const profile = resolveCliProfile(args.profile);
   const config = {
     provider,
     cwd: args.dir,
@@ -235,6 +236,7 @@ async function initReplSession(args: ICliArgs): Promise<{
     ...(autoCompactAt === undefined ? {} : { autoCompactAt }),
     // `--policy-mode` (validated) overrides the config file's policy.mode.
     ...(isPolicyMode(args.policyMode) ? { policyMode: args.policyMode } : {}),
+    ...(profile === undefined ? {} : { profile }),
     // Thinking OFF for interactive replies so they STREAM immediately instead of
     // stalling on a long hidden chain-of-thought (qwen-local defaults thinking on).
     // The session still flips thinking ON automatically while repairing gate errors.
@@ -662,9 +664,12 @@ export async function repl(args: ICliArgs): Promise<number> {
       case "help":
         await handleHelp();
         break;
-      case "clear":
+
+      case "clear": {
         // Rebuild the session with the current state (config is not reused;
         // repl's /clear creates a fresh Session.create call)
+        const profile = resolveCliProfile(args.profile);
+
         session = await Session.create({
           provider,
           cwd: args.dir,
@@ -673,6 +678,7 @@ export async function repl(args: ICliArgs): Promise<number> {
           contextWindow,
           report: makeReporter(logFile, id, id),
           enableThinking: false,
+          ...(profile === undefined ? {} : { profile }),
         });
         session.setSetupWeb(setupWeb);
         session.setPlanMode(planMode); // a /clear must not silently drop the mode
@@ -681,6 +687,7 @@ export async function repl(args: ICliArgs): Promise<number> {
         clearScreen(); // wipe the visible terminal + scrollback, not just the state
         process.stdout.write("conversation cleared\n");
         break;
+      }
 
       case "compact": {
         // Compaction is a full model round-trip (can take many seconds). Drive the

--- a/packages/core/src/config/index.ts
+++ b/packages/core/src/config/index.ts
@@ -5,6 +5,7 @@ export {
   resolveActivePacks,
   normalizeRuleOverrides,
   resolveProjectProfile,
+  withProfileOverride,
   type ITsforgeProjectConfig,
 } from "./tsforge-config";
 export {

--- a/packages/core/src/config/recipes.ts
+++ b/packages/core/src/config/recipes.ts
@@ -3,6 +3,7 @@ import { homedir } from "node:os";
 import { join } from "node:path";
 import { isRecord } from "../lib/guards";
 import { isPolicyMode, type PolicyMode } from "../policy";
+import { isProfileId, PROFILE_DEFINITIONS, type ProfileId } from "./profiles";
 
 /**
  * A declarative task recipe — tsforge's adaptation of Codebuff's `AgentDefinition`
@@ -62,6 +63,8 @@ export interface ITaskRecipe {
    *  (`runGreenfield`) instead of the default single-task loop. Omitted ⇒ the
    *  normal brownfield/one-shot run. */
   readonly mode?: "greenfield";
+  /** Rule profile preset (→ `tsforge.config.json` `profile` for this run). */
+  readonly profile?: ProfileId;
 }
 
 function optString(value: unknown): string | undefined {
@@ -118,6 +121,10 @@ function assignScalars(recipe: Mutable, raw: Record<string, unknown>): void {
   if (raw.mode === "greenfield") {
     recipe.mode = raw.mode;
   }
+
+  if (typeof raw.profile === "string" && isProfileId(raw.profile)) {
+    recipe.profile = raw.profile;
+  }
 }
 
 /** Assign the optional boolean flags onto a recipe under construction. */
@@ -135,8 +142,8 @@ function assignFlags(recipe: Mutable, raw: Record<string, unknown>): void {
 type Mutable = { -readonly [K in keyof ITaskRecipe]: ITaskRecipe[K] };
 
 /** Every field a v1 recipe applies. A key outside this set is reported (not
- *  silently dropped) so a typo or not-yet-supported field (e.g. `profile`,
- *  `tools`) is visible rather than mysteriously ignored. */
+ *  silently dropped) so a typo or not-yet-supported field (e.g. `tools`) is
+ *  visible rather than mysteriously ignored. */
 const KNOWN_KEYS = new Set<string>([
   "id",
   "description",
@@ -160,7 +167,18 @@ const KNOWN_KEYS = new Set<string>([
   "withReview",
   "scout",
   "mode",
+  "profile",
 ]);
+
+/** A string `profile` value that isn't a known ProfileId, or undefined.
+ *  Surfaced at load so a typo (`"strictt"`) can't silently run a looser gate. */
+export function invalidProfileValue(value: unknown): string | undefined {
+  if (!isRecord(value) || typeof value.profile !== "string") {
+    return undefined;
+  }
+
+  return isProfileId(value.profile) ? undefined : value.profile;
+}
 
 /** Keys present in the raw recipe that this version doesn't recognize. */
 export function unrecognizedKeys(value: unknown): string[] {
@@ -252,6 +270,14 @@ async function loadDir(
     if (unknown.length > 0) {
       report(
         `recipe '${name}': ignoring unrecognized field(s): ${unknown.join(", ")}`
+      );
+    }
+
+    const badProfile = invalidProfileValue(parsed);
+
+    if (badProfile !== undefined) {
+      report(
+        `recipe '${name}': invalid profile '${badProfile}' — ignored (valid: ${Object.keys(PROFILE_DEFINITIONS).join(", ")})`
       );
     }
 

--- a/packages/core/src/config/tsforge-config.ts
+++ b/packages/core/src/config/tsforge-config.ts
@@ -673,3 +673,15 @@ export function resolveProjectProfile(
 ): ProfileId {
   return config.profile ?? DEFAULT_PROFILE;
 }
+
+/** Overlay a recipe/CLI profile onto a loaded config without mutating the file. */
+export function withProfileOverride(
+  config: ITsforgeProjectConfig,
+  profile: ProfileId | undefined
+): ITsforgeProjectConfig {
+  if (profile === undefined) {
+    return config;
+  }
+
+  return { ...config, profile };
+}

--- a/packages/core/src/loop/feedback/rule-docs.ts
+++ b/packages/core/src/loop/feedback/rule-docs.ts
@@ -10,7 +10,10 @@ export interface IRuleDoc {
   good: string;
   /** Optional multi-step fix workflow for architecture or meta-rules. */
   procedure?: string;
-  /** Optional path to deeper guidance (repo-relative markdown). */
+  /** Optional tsforge-repo-relative pointer to deeper guidance (a rule pack
+   *  dir or markdown). Only resolvable when tsforge runs on its own repo — in
+   *  user projects the path dangles, so keep the actionable steps in
+   *  `procedure`, which is inlined into the feedback everywhere. */
   reference?: string;
 }
 

--- a/packages/core/src/loop/feedback/rule-docs.ts
+++ b/packages/core/src/loop/feedback/rule-docs.ts
@@ -8,6 +8,10 @@ export interface IRuleDoc {
   bad: string;
   /** The corrected version that satisfies it. */
   good: string;
+  /** Optional multi-step fix workflow for architecture or meta-rules. */
+  procedure?: string;
+  /** Optional path to deeper guidance (repo-relative markdown). */
+  reference?: string;
 }
 
 /**
@@ -186,11 +190,37 @@ const RULE_DOCS: Record<string, IRuleDoc> = {
     what: "State hooks (`useState`, `useEffect`, `useMemo`, …) belong in `Component.hooks.ts`, not in the `.tsx` component body.",
     bad: "export function Button() { const [open, setOpen] = useState(false); return <button />; }",
     good: "export function useButton() { const [open, setOpen] = useState(false); return { open }; }",
+    procedure:
+      "1) Create/open `Component.hooks.ts` next to the component. 2) Move the state/effect hooks into a `useComponent()` custom hook that returns the values and handlers the JSX needs. 3) Call the hook once at the top of the component and destructure. (`useId`/`useTransition`/`useDeferredValue` may stay inline.)",
   },
   "tsforge/no-inline-jsx-functions": {
     what: "No inline arrow/function expressions in JSX attributes — bind handlers in the hook and pass a reference.",
     bad: "<button onClick={() => doThing(id)} />",
     good: "const onClickRow = useCallback(() => doThing(id), [id]); <button onClick={onClickRow} />",
+    procedure:
+      "1) Define the handler in the component's hook file, wrapped in `useCallback` with its dependencies. 2) Return it from the hook and destructure it in the component. 3) Pass the reference (`onClick={onClickRow}`). For per-item handlers in a list, extract a row component that receives the item and binds internally.",
+  },
+  "tsforge/index-must-reexport-default": {
+    what: "A component folder's `index.ts` may only re-export: the component's default plus optional type re-exports — no logic.",
+    bad: "import Button from './Button'; export default Button;  // logic in Button/index.ts",
+    good: "export { default as Button } from './Button'; export * from './Button.types';",
+    procedure:
+      "1) Open the folder's `index.ts`. 2) Replace its body with `export { default as Component } from './Component'`. 3) Keep only type re-exports alongside (`export * from './Component.types'`); move any other code into its own module.",
+  },
+  "tsforge/max-hooks-per-file": {
+    what: "A `*.hooks.ts`/`*.queries.ts`/`*.mutations.ts` module may export at most 4 hooks — split god files by concern before they grow.",
+    bad: "users.queries.ts exporting 7 use* hooks",
+    good: "users.list.queries.ts + users.detail.queries.ts + users.mutations.ts, each ≤ 4 hooks",
+    procedure:
+      "1) Group the file's exported hooks by concern (list vs detail vs mutations). 2) Create one module per group (e.g. `users.list.queries.ts`, `users.mutations.ts`), each ≤ 4 hooks. 3) Move each hook with the imports it needs and update the import sites. 4) Delete the original file once it is empty.",
+  },
+  "tsforge/component-folder-structure": {
+    what: "Each component lives in its own folder with `Component.tsx`, `Component.hooks.ts`, and `index.ts` that re-exports the default.",
+    bad: "src/components/Button.tsx  // lone file, hooks inline",
+    good: "src/components/Button/Button.tsx + Button.hooks.ts + index.ts",
+    procedure:
+      "1) Create `Component/` folder. 2) Move hooks to `Component.hooks.ts`. 3) Add `index.ts` with `export { default } from './Component'`. 4) Update imports to the folder path.",
+    reference: "packages/core/src/rule-packs/react-component-architecture/",
   },
   "tsforge/no-throw-literal": {
     what: "Throw `Error` instances, not string or number literals.",
@@ -460,11 +490,19 @@ export function ruleHelp(errors: ErrorSet): string {
     // "// Example that violates the rule" placeholder is worse than nothing.
     const hasExample = doc.bad.length > 0 && doc.good.length > 0;
 
-    blocks.push(
-      hasExample
-        ? `${e.rule}: ${doc.what}\n  ✗ ${doc.bad}\n  ✓ ${doc.good}`
-        : `${e.rule}: ${doc.what}`
-    );
+    let block = hasExample
+      ? `${e.rule}: ${doc.what}\n  ✗ ${doc.bad}\n  ✓ ${doc.good}`
+      : `${e.rule}: ${doc.what}`;
+
+    if (doc.procedure !== undefined && doc.procedure.length > 0) {
+      block += `\n  procedure: ${doc.procedure}`;
+    }
+
+    if (doc.reference !== undefined && doc.reference.length > 0) {
+      block += `\n  see: ${doc.reference}`;
+    }
+
+    blocks.push(block);
   }
 
   return blocks.join("\n");

--- a/packages/core/src/loop/loop.types.ts
+++ b/packages/core/src/loop/loop.types.ts
@@ -1,4 +1,5 @@
 import type { ErrorParser } from "../validate";
+import type { ProfileId } from "../config/profiles";
 import {
   type RUN_STATUS,
   type STUCK_REASON,
@@ -136,6 +137,8 @@ export interface IRunOptions {
    *  the model must still implement the feature, and the per-feature browser/judge
    *  layers decide whether it's done. */
   requireRed?: boolean;
+  /** Rule profile override (from a recipe); defaults to tsforge.config.json. */
+  profile?: ProfileId;
 }
 
 export interface ISpecResult {

--- a/packages/core/src/loop/run.ts
+++ b/packages/core/src/loop/run.ts
@@ -17,6 +17,7 @@ import type {
 } from "./loop.types";
 import { mineLessons, consolidate as consolidateMemory } from "./memory";
 import type { ITsforgeProjectConfig } from "../config";
+import type { ProfileId } from "../config/profiles";
 import type { IConventions } from "../infer-rules/conventions.types";
 import type { PolicyMode, IPolicyRules } from "../policy";
 import { buildSystemPrompt, seedPrompt } from "./prompt";
@@ -184,7 +185,8 @@ function policyCtxFields(policy: ITsforgeProjectConfig["policy"]): {
 
 async function resolveStackForRun(
   cwd: string,
-  report: (message: string) => void
+  report: (message: string) => void,
+  profile?: ProfileId
 ): Promise<{
   stackProfile: Awaited<ReturnType<typeof detectStack>>;
   ruleOverrides: Readonly<Record<string, "error" | "warn" | "off">>;
@@ -192,11 +194,15 @@ async function resolveStackForRun(
   conventions: IConventions;
 }> {
   const detectedProfile = await detectStack(cwd);
-  const { loadTsforgeConfig, resolveActivePacks, normalizeRuleOverrides } =
-    await import("../config/tsforge-config");
+  const {
+    loadTsforgeConfig,
+    resolveActivePacks,
+    normalizeRuleOverrides,
+    withProfileOverride,
+  } = await import("../config/tsforge-config");
   const { resolveConventions } = await import("../infer-rules/conventions");
   const { loadAndRegisterPlugins } = await import("../config/external-plugins");
-  const cfg = await loadTsforgeConfig(cwd);
+  const cfg = withProfileOverride(await loadTsforgeConfig(cwd), profile);
   const activePacks = resolveActivePacks(detectedProfile.packs, cfg);
   const externalIds =
     cfg.plugins === undefined
@@ -343,9 +349,13 @@ export async function runTask(
 
   // Detect stack once per run, early; tsforge.config.json may adjust it
   const { stackProfile, ruleOverrides, policy, conventions } =
-    await resolveStackForRun(cwd, (message) => {
-      report({ kind: "tool", task: task.id, message });
-    });
+    await resolveStackForRun(
+      cwd,
+      (message) => {
+        report({ kind: "tool", task: task.id, message });
+      },
+      opts.profile
+    );
 
   report({
     kind: "tool",

--- a/packages/core/src/loop/session.ts
+++ b/packages/core/src/loop/session.ts
@@ -16,6 +16,7 @@ import {
 } from "../agent";
 import type { SetupWebFn } from "./tools";
 import type { PolicyMode } from "../policy";
+import type { ProfileId } from "../config/profiles";
 import { flags } from "../config";
 import { trace } from "../lib/trace";
 import { validate, isEslintJsonLine, type ErrorParser } from "../validate";
@@ -23,6 +24,7 @@ import { detectStack } from "../stack-detection";
 import { recallMapBlock } from "../codebase";
 import {
   loadTsforgeConfig,
+  withProfileOverride,
   normalizeRuleOverrides,
   resolveActivePacks,
 } from "../config/tsforge-config";
@@ -110,6 +112,8 @@ export interface ISessionConfig {
    *  the write-guard reports lint violations — the moat rules tsc can't see (`as`,
    *  `I`-prefix) — inline, so they're fixed in-context not piled up at the gate. */
   lintFile?: FileLinter;
+  /** Rule profile override for this session (from a recipe); defaults to config file. */
+  profile?: ProfileId;
   /** Offer the `scaffold_ui` tool (themed UI primitives). Web builds only — keeps
    *  it off the pure-TS/scratch tool list where it's meaningless noise. */
   scaffoldUi?: boolean;
@@ -556,7 +560,10 @@ export class Session {
     // (resolveStackForRun in run.ts) — interactive users get identical
     // pack selection and rule-severity overrides.
     const detected = await detectStack(cfg.cwd);
-    const projectConfig = await loadTsforgeConfig(cfg.cwd);
+    const projectConfig = withProfileOverride(
+      await loadTsforgeConfig(cfg.cwd),
+      cfg.profile
+    );
     // Base policy mode + rules: CLI (`--policy-mode` via cfg) wins over the
     // config file's `policy.mode`, else `"default"`. Plan mode overrides this
     // base at runtime (setPlanMode).

--- a/packages/core/src/stack-detection/packs.ts
+++ b/packages/core/src/stack-detection/packs.ts
@@ -12,7 +12,8 @@ export const PACK_REGISTRY = {
       "Core TypeScript safety rules for all projects (strict mode, index safety, no casts)",
     category: "language",
     appliesWhen: { always: true },
-    guidance: "Enforce strict TypeScript rules on all projects.",
+    guidance:
+      "Strict TypeScript on every file: narrow with guards (no `as`), prefix interfaces with `I`, keep cognitive complexity ≤ 20. When a type error repeats, fix the boundary (parse/validate at the edge) instead of sprinkling optional chaining.",
   } as const satisfies IRulePackDescriptor,
 
   react: {
@@ -21,7 +22,8 @@ export const PACK_REGISTRY = {
     description: "React component patterns and hooks usage",
     category: "framework",
     appliesWhen: { allDeps: ["react", "react-dom"] },
-    guidance: "Follow React best practices for component composition.",
+    guidance:
+      "React components: stable keys (not array index), hooks only at top level, no state updates during render. Prefer composition over prop drilling; colocate hooks with the component that owns the state they read.",
   } as const satisfies IRulePackDescriptor,
 
   "react-component-architecture": {
@@ -49,7 +51,8 @@ export const PACK_REGISTRY = {
     description: "Database access patterns using Drizzle ORM",
     category: "library",
     appliesWhen: { anyDeps: ["drizzle-orm"] },
-    guidance: "Use Drizzle ORM type-safely for database queries.",
+    guidance:
+      "Drizzle: schema-first queries via the typed `db` client — no raw SQL strings unless wrapped in `sql` tagged templates. Keep table definitions in schema modules; let inferred types flow to callers instead of hand-written row interfaces.",
   } as const satisfies IRulePackDescriptor,
 
   elysia: {

--- a/packages/core/tests/cli.test.ts
+++ b/packages/core/tests/cli.test.ts
@@ -193,6 +193,11 @@ test("applyRecipe fills defaults but an explicit CLI value always wins", () => {
   expect(filled.policyMode).toBe("default");
   expect(filled.web).toBe(true);
 
+  const profiled = parseArgs([]);
+
+  applyRecipe(profiled, { id: "strict", profile: "strict" });
+  expect(profiled.profile).toBe("strict");
+
   // An explicit --files overrides the recipe's scope; the rest still fill.
   const overridden = parseArgs(["--files", "lib/**"]);
 

--- a/packages/core/tests/recipes.test.ts
+++ b/packages/core/tests/recipes.test.ts
@@ -7,6 +7,7 @@ import {
   loadRecipes,
   findRecipe,
   unrecognizedKeys,
+  invalidProfileValue,
 } from "../src/config/recipes";
 
 describe("parseRecipe", () => {
@@ -101,11 +102,27 @@ describe("parseRecipe", () => {
   });
 
   test("flags fields it doesn't yet apply (so they don't silently vanish)", () => {
-    // `profile`/`tools` aren't applied in v1 — surface them rather than ignore.
-    expect(
-      unrecognizedKeys({ id: "x", profile: "strict", tools: ["read"] })
-    ).toEqual(["profile", "tools"]);
+    // `tools` isn't applied in v1 — surface it rather than ignore.
+    expect(unrecognizedKeys({ id: "x", tools: ["read"] })).toEqual(["tools"]);
+    expect(unrecognizedKeys({ id: "x", profile: "strict" })).toEqual([]);
     expect(unrecognizedKeys({ id: "x", gate: "g" })).toEqual([]);
+  });
+
+  test("parses a valid profile and drops an invalid one", () => {
+    expect(parseRecipe({ id: "strict-run", profile: "strict" })?.profile).toBe(
+      "strict"
+    );
+    expect(parseRecipe({ id: "x", profile: "yolo" })?.profile).toBeUndefined();
+  });
+
+  test("an invalid profile value is surfaced, a valid or absent one is not", () => {
+    expect(invalidProfileValue({ id: "x", profile: "strictt" })).toBe(
+      "strictt"
+    );
+    expect(invalidProfileValue({ id: "x", profile: "strict" })).toBeUndefined();
+    expect(invalidProfileValue({ id: "x" })).toBeUndefined();
+    // a non-string profile is a shape problem, not a typo'd id — not surfaced here
+    expect(invalidProfileValue({ id: "x", profile: 3 })).toBeUndefined();
   });
 });
 
@@ -144,6 +161,11 @@ describe("loadRecipes", () => {
         JSON.stringify({ id: "not-mismatch", gate: "g" })
       );
       await writeFile(join(cwd, ".tsforge/recipes/broken.json"), "{ not json");
+      // typo'd profile: loads, but must warn instead of silently downgrading
+      await writeFile(
+        join(cwd, ".tsforge/recipes/typo-profile.json"),
+        JSON.stringify({ id: "typo-profile", profile: "strictt" })
+      );
 
       const reports: string[] = [];
       const recipes = await loadRecipes(cwd, (m) => reports.push(m));
@@ -153,6 +175,7 @@ describe("loadRecipes", () => {
         "not-mismatch",
         "proj-only",
         "shared",
+        "typo-profile",
       ]);
       expect(findRecipe(recipes, "shared")?.gate).toBe("project-gate"); // project wins
       expect(reports.some((m) => m.includes("broken.json"))).toBe(true);
@@ -161,6 +184,15 @@ describe("loadRecipes", () => {
           (m) => m.includes("mismatch.json") && m.includes("not-mismatch")
         )
       ).toBe(true);
+      expect(
+        reports.some(
+          (m) => m.includes("invalid profile 'strictt'") && m.includes("valid:")
+        )
+      ).toBe(true);
+      // the valid-profile recipes above must not trigger the warning
+      expect(reports.filter((m) => m.includes("invalid profile")).length).toBe(
+        1
+      );
     } finally {
       if (prev === undefined) {
         delete process.env.TSFORGE_HOME;

--- a/packages/core/tests/rule-docs.test.ts
+++ b/packages/core/tests/rule-docs.test.ts
@@ -150,16 +150,44 @@ test("ruleHelp: implicit-any no-unsafe rule shows the validate-the-boundary fix"
   expect(h).toContain("✓");
 });
 
-test("ruleHelp: a pack rule with no worked example shows only its description (no fake ✗/✓)", () => {
-  // component-folder-structure has a generated (empty bad/good) entry, no curated one.
+test("ruleHelp: architecture rule with procedure surfaces fix steps", () => {
   const h = ruleHelp([
     { key: "k", rule: "tsforge/component-folder-structure", message: "" },
   ]);
 
-  if (h.length > 0) {
-    expect(h).not.toContain("// Example that violates the rule");
-    expect(h).not.toContain("✗ \n");
+  expect(h).toContain("tsforge/component-folder-structure");
+  expect(h).toContain("procedure:");
+  expect(h).toContain("Component.hooks.ts");
+});
+
+test("ruleHelp: every multi-step architecture rule carries a fix procedure", () => {
+  // The opinionated-profile rules whose fix is structural (move files, split
+  // modules) — a bad/good pair alone can't teach the choreography.
+  const rules = [
+    "tsforge/component-folder-structure",
+    "tsforge/no-state-in-component-body",
+    "tsforge/no-inline-jsx-functions",
+    "tsforge/index-must-reexport-default",
+    "tsforge/max-hooks-per-file",
+  ];
+
+  for (const rule of rules) {
+    const h = ruleHelp([{ key: "k", rule, message: "" }]);
+
+    expect(h).toContain(rule);
+    expect(h).toContain("procedure:");
   }
+});
+
+test("ruleHelp: a pack rule with no worked example shows only its description (no fake ✗/✓)", () => {
+  // job-name-must-be-constant has a generated (empty bad/good) entry, no curated one.
+  const h = ruleHelp([
+    { key: "k", rule: "tsforge/job-name-must-be-constant", message: "" },
+  ]);
+
+  expect(h).toContain("tsforge/job-name-must-be-constant");
+  expect(h).not.toContain("✗");
+  expect(h).not.toContain("✓");
 });
 
 test("generated docs the reader imports include the tsforge pack rules (guards the write→read path)", () => {


### PR DESCRIPTION
## What

Three related improvements (Cursor-authored base, reviewed + hardened in this PR):

### 1. Recipes can set the gate rule profile per run
A recipe JSON can now include `"profile": "strict"` (any of the six presets) and just that run gets that gate strictness — no `tsforge.config.json` edit. Applied via a pure `withProfileOverride` overlay, wired through one-shot runs, the REPL (including `/clear` re-init), gate setup, and session creation. An explicit config file is never mutated.

**Hardening:** an invalid profile value (`"strictt"`) is now *reported* at recipe load instead of silently running the config-default gate:
```
recipe 'x': invalid profile 'strictt' — ignored (valid: recommended, strict, security, frontend, backend, opinionated)
```

### 2. Gate feedback cards teach multi-step fixes
`IRuleDoc` gains optional `procedure`/`reference` fields rendered into the repair-loop feedback. All five multi-step architecture rules now carry step-by-step procedures (folder-structure, state-in-body, inline-JSX-functions, index-reexport, max-hooks), locked in by a regression test. Placeholder pack guidance strings ("follow best practices") replaced with rule-specific, actionable ones.

### 3. Skills reorg
Maintainer skills moved to `.claude/skills/{harness,release,authoring}/`; the release skill left `.cursor/` (stale duplicate deleted); new `effective-tsforge-skills` authoring skill + a docs page on the skills-vs-enforcement split.

## Known caveat
`IRuleDoc.reference` paths are tsforge-repo-relative, so the `see:` line only resolves when tsforge runs on itself — in user projects it dangles. Procedures are inline for exactly this reason. Worth deciding the field's future before more rules adopt it.

## Testing
- Full `bun run validate` green: typecheck, eslint, prettier, entire test suite, 20/20 PTY e2e
- New tests: recipe profile parse/apply, invalid-profile warning (unit + e2e through `loadRecipes`), procedure rendering for all five rules, restored no-fake-✗/✓ rendering test
- Invalid-profile warning verified live against a scratch recipe