### PR TITLE
fix(feedback): stop emitting IRuleDoc.reference into runtime cards

### DIFF
--- a/packages/core/src/loop/feedback/rule-docs.ts
+++ b/packages/core/src/loop/feedback/rule-docs.ts
@@ -10,10 +10,10 @@ export interface IRuleDoc {
   good: string;
   /** Optional multi-step fix workflow for architecture or meta-rules. */
   procedure?: string;
-  /** Optional tsforge-repo-relative pointer to deeper guidance (a rule pack
-   *  dir or markdown). Only resolvable when tsforge runs on its own repo — in
-   *  user projects the path dangles, so keep the actionable steps in
-   *  `procedure`, which is inlined into the feedback everywhere. */
+  /** Maintainer-only pointer to the rule's implementation or deeper guidance
+   *  (tsforge-repo-relative). NEVER emitted into runtime feedback — the model
+   *  runs in the user's project where the path dangles. Anything the model
+   *  needs at repair time belongs in `procedure`, which is always inlined. */
   reference?: string;
 }
 
@@ -501,9 +501,9 @@ export function ruleHelp(errors: ErrorSet): string {
       block += `\n  procedure: ${doc.procedure}`;
     }
 
-    if (doc.reference !== undefined && doc.reference.length > 0) {
-      block += `\n  see: ${doc.reference}`;
-    }
+    // `reference` is deliberately NOT emitted: its paths are tsforge-repo-relative,
+    // and the model runs in the USER'S project where they dangle. Everything the
+    // model needs must be inline (what/bad/good/procedure).
 
     blocks.push(block);
   }

--- a/packages/core/tests/rule-docs.test.ts
+++ b/packages/core/tests/rule-docs.test.ts
@@ -160,6 +160,18 @@ test("ruleHelp: architecture rule with procedure surfaces fix steps", () => {
   expect(h).toContain("Component.hooks.ts");
 });
 
+test("ruleHelp: never emits a `see:` reference line (paths dangle in user projects)", () => {
+  // component-folder-structure carries a `reference` — it's a maintainer note,
+  // not model feedback: the tsforge-repo-relative path doesn't exist in the
+  // user's project, so pointing the model at it wastes a repair turn.
+  const h = ruleHelp([
+    { key: "k", rule: "tsforge/component-folder-structure", message: "" },
+  ]);
+
+  expect(h).not.toContain("see:");
+  expect(h).not.toContain("packages/core/src/rule-packs/");
+});
+
 test("ruleHelp: every multi-step architecture rule carries a fix procedure", () => {
   // The opinionated-profile rules whose fix is structural (move files, split
   // modules) — a bad/good pair alone can't teach the choreography.


### PR DESCRIPTION
## What

Option A from the PR #71 follow-up: `IRuleDoc.reference` becomes a **maintainer-only** pointer and is no longer rendered into the model's gate-feedback cards.

## Why

The reference paths are tsforge-repo-relative (`packages/core/src/rule-packs/...`). At runtime the model repairs code in the **user's** project, where that path doesn't exist — so the `see:` line either gets ignored or invites a wasted turn trying to read a nonexistent file. It only ever resolved when tsforge ran on its own repo.

The feedback design principle stands: everything the model needs at repair time is inline (`what`/`bad`/`good`/`procedure`). The field itself stays, documented as maintainer-only, for pointing rule-doc authors at the implementing pack.

## Changes

- `ruleHelp()` no longer appends `see: <path>` (with an in-code comment explaining why, so it doesn't get re-added)
- `IRuleDoc.reference` JSDoc rewritten to state the contract explicitly
- Regression test: the card for `component-folder-structure` (which carries a `reference`) must not contain `see:` or the pack path

## Testing

Full `bun run validate` green — typecheck, eslint, prettier, whole suite, 20/20 PTY e2e.