### PR TITLE
feat(agents): event/ledger agent attribution + scoped output routing (multiagent PR-A1)

### DIFF
--- a/packages/core/src/cli/logging.ts
+++ b/packages/core/src/cli/logging.ts
@@ -1,8 +1,9 @@
 /**
  * CLI-side reporting plumbing: the shared spinner, the terminal Reporter, the
- * `--log` JSONL ledger reporter, and run-log path helpers. The REPL routes
- * streamed output through the StatusBar via setInteractiveStream(); everywhere
- * else the reporter writes straight to stdout.
+ * `--log` JSONL ledger reporter, and run-log path helpers. Rendered output is
+ * routed through the OutputRouter: the REPL installs a StatusBar-aware parent
+ * sink (so text scrolls above the pinned input row); subagents get their own
+ * sinks from Phase B on; everywhere else writes go straight to stdout.
  */
 import { join, isAbsolute } from "node:path";
 import { mkdirSync } from "node:fs";
@@ -12,20 +13,13 @@ import { renderEvent } from "../render";
 import { LedgerWriter, ledgerTypeFor, type Reporter } from "../loop";
 import { logsDir } from "../session-store";
 import { trace } from "../lib/trace";
+import { OutputRouter } from "./output-router";
 
 export const spinner = makeSpinner();
 
-/** When the interactive REPL pins an editable input row, streamed output must be
- *  written THROUGH the StatusBar (so it scrolls in the region above the row and
- *  the cursor stays parked on the row). Null elsewhere ⇒ a plain stdout write. */
-let interactiveStream: ((text: string) => void) | null = null;
-
-/** Install (or clear, with null) the REPL's streamed-output sink. */
-export function setInteractiveStream(
-  sink: ((text: string) => void) | null
-): void {
-  interactiveStream = sink;
-}
+/** The process-wide router for the one terminal. The REPL installs its parent
+ *  sink at boot and clears it on exit; agent sinks come and go per subagent. */
+export const outputRouter = new OutputRouter();
 
 const render: Reporter = (event) => {
   const phase = spinnerPhase(event);
@@ -38,12 +32,7 @@ const render: Reporter = (event) => {
 
   if (out.length > 0) {
     spinner.clear();
-
-    if (interactiveStream !== null) {
-      interactiveStream(out);
-    } else {
-      process.stdout.write(out);
-    }
+    outputRouter.route(out, event.agentId);
   }
 };
 
@@ -67,9 +56,9 @@ export function makeReporter(
   return (event) => {
     render(event);
 
-    const { kind, ...rest } = event;
+    const { kind, agentId, ...rest } = event;
 
-    ledger.record(ledgerTypeFor(event), { kind, ...rest });
+    ledger.record(ledgerTypeFor(event), { kind, ...rest }, agentId);
   };
 }
 

--- a/packages/core/src/cli/output-router.ts
+++ b/packages/core/src/cli/output-router.ts
@@ -1,0 +1,52 @@
+/**
+ * Scoped terminal-output routing. The terminal is one resource, but N event
+ * streams may write to it (the parent loop today; subagents from Phase B on).
+ * Instead of a single undifferentiated text sink, every write is routed by the
+ * emitting agent's id: a registered agent sink wins, else the parent sink
+ * (the REPL's StatusBar region), else plain stdout. Replaces the old
+ * module-level `interactiveStream` latch in cli/logging.ts.
+ */
+
+export type OutputSink = (text: string) => void;
+
+export class OutputRouter {
+  private parentSink: OutputSink | null = null;
+  private readonly agentSinks = new Map<string, OutputSink>();
+
+  /** Install (or clear, with null) the parent stream sink — the REPL's
+   *  StatusBar-aware writer. Headless/one-shot runs leave it null (stdout). */
+  setParentSink(sink: OutputSink | null): void {
+    this.parentSink = sink;
+  }
+
+  /** Register a dedicated sink for one subagent's rendered output. */
+  setAgentSink(agentId: string, sink: OutputSink): void {
+    this.agentSinks.set(agentId, sink);
+  }
+
+  /** Remove a subagent's sink (its writes fall back to the parent sink). */
+  clearAgentSink(agentId: string): void {
+    this.agentSinks.delete(agentId);
+  }
+
+  /** Route one rendered chunk: agent sink → parent sink → stdout. */
+  route(text: string, agentId?: string): void {
+    if (agentId !== undefined) {
+      const sink = this.agentSinks.get(agentId);
+
+      if (sink !== undefined) {
+        sink(text);
+
+        return;
+      }
+    }
+
+    if (this.parentSink !== null) {
+      this.parentSink(text);
+
+      return;
+    }
+
+    process.stdout.write(text);
+  }
+}

--- a/packages/core/src/cli/repl.ts
+++ b/packages/core/src/cli/repl.ts
@@ -76,12 +76,7 @@ import {
   getUpdateNotice,
   refreshUpdateCacheInBackground,
 } from "../update-check";
-import {
-  spinner,
-  setInteractiveStream,
-  makeReporter,
-  resolveLogPath,
-} from "./logging";
+import { spinner, outputRouter, makeReporter, resolveLogPath } from "./logging";
 import {
   modelInfo,
   detectContextWindow,
@@ -1012,7 +1007,7 @@ export async function repl(args: ICliArgs): Promise<number> {
   // Route streamed agent output through the bar so it scrolls above the pinned
   // input row; cleared on loop exit so later/headless writes go straight to stdout.
   if (useInputRow) {
-    setInteractiveStream((text): void => {
+    outputRouter.setParentSink((text): void => {
       if (!agentTurnOpen) {
         agentTurnOpen = true;
         agentRail = makeAgentRail(agentBar(true), railInnerWidth); // fresh per turn
@@ -1689,7 +1684,7 @@ export async function repl(args: ICliArgs): Promise<number> {
 
   statusBar.teardown(); // belt-and-suspenders: restore the terminal on loop exit
   process.stdout.off("resize", handleResize); // don't pin the REPL closure
-  setInteractiveStream(null); // later/headless writes go straight to stdout again
+  outputRouter.setParentSink(null); // later/headless writes go straight to stdout again
 
   return 0;
 }

--- a/packages/core/src/eval/parse-log.ts
+++ b/packages/core/src/eval/parse-log.ts
@@ -23,6 +23,8 @@ const KNOWN_KINDS = new Set<string>([
   "ttsr",
   "reverted",
   "policy",
+  "agent_spawned",
+  "agent_result",
 ]);
 
 function isKind(value: string): value is ILoopEvent["kind"] {
@@ -162,6 +164,28 @@ function assignVerdict(event: ILoopEvent, src: Record<string, unknown>): void {
   }
 }
 
+/** Re-attach agent attribution. `parentTask` rides inside the payload, but the
+ *  ledger writer lifts `agentId` OUT of the payload into a top-level column —
+ *  so read it from the source first (flat/legacy shape) and fall back to the
+ *  outer record (wrapped ledger shape). */
+function assignAgent(
+  event: ILoopEvent,
+  src: Record<string, unknown>,
+  record: unknown
+): void {
+  const outer = isRecord(record) ? optionalString(record.agentId) : undefined;
+  const agentId = optionalString(src.agentId) ?? outer;
+  const parentTask = optionalString(src.parentTask);
+
+  if (agentId !== undefined) {
+    event.agentId = agentId;
+  }
+
+  if (parentTask !== undefined) {
+    event.parentTask = parentTask;
+  }
+}
+
 /** Coerce one parsed JSONL record into an ILoopEvent, or null when it isn't one.
  *  Carries the fields the failure classifier, the metrics, and the trace summary
  *  consume — enough to reconstruct a typed event stream from a `--log` file. */
@@ -187,6 +211,7 @@ function coerceEvent(record: unknown): ILoopEvent | null {
   assignText(event, src);
   assignNumbers(event, src);
   assignVerdict(event, src);
+  assignAgent(event, src, record);
 
   return event;
 }

--- a/packages/core/src/loop/ledger-writer.ts
+++ b/packages/core/src/loop/ledger-writer.ts
@@ -30,6 +30,10 @@ export function ledgerTypeFor(event: ILoopEvent): LedgerEventType {
       return "edit_reverted";
     case "policy":
       return "policy_decision";
+    case "agent_spawned":
+      return "agent_spawned";
+    case "agent_result":
+      return "agent_result";
     case "tool":
       return event.message.startsWith("tool_rejected")
         ? "tool_call_failed"
@@ -103,7 +107,11 @@ export class LedgerWriter {
     private readonly sessionId?: string
   ) {}
 
-  record(type: LedgerEventType, payload: Record<string, unknown>): void {
+  record(
+    type: LedgerEventType,
+    payload: Record<string, unknown>,
+    agentId?: string
+  ): void {
     if (this.file.length === 0) {
       return;
     }
@@ -112,6 +120,7 @@ export class LedgerWriter {
       eventId: newEventId(),
       runId: this.runId,
       ...(this.sessionId === undefined ? {} : { sessionId: this.sessionId }),
+      ...(agentId === undefined ? {} : { agentId }),
       timestamp: new Date().toISOString(),
       type,
       payload: capPayload(payload),

--- a/packages/core/src/loop/ledger.types.ts
+++ b/packages/core/src/loop/ledger.types.ts
@@ -21,6 +21,10 @@ export type LedgerEventType =
   | "gate_finished"
   | "resume_started"
   | "resume_finished"
+  /** A subagent started under this run. */
+  | "agent_spawned"
+  /** A subagent finished (payload carries its status and output preview). */
+  | "agent_result"
   /** Catch-all for reporter events without a dedicated ledger type yet. */
   | "log";
 
@@ -31,6 +35,8 @@ export interface IBaseLedgerEvent {
   runId: string;
   /** The interactive session id, when applicable. */
   sessionId?: string;
+  /** The subagent that emitted this event; absent = the parent/main loop. */
+  agentId?: string;
   /** ISO-8601 timestamp. */
   timestamp: string;
   type: LedgerEventType;

--- a/packages/core/src/loop/loop.types.ts
+++ b/packages/core/src/loop/loop.types.ts
@@ -34,8 +34,21 @@ export interface ILoopEvent {
     | "reverted"
     // A unified-policy verdict for one proposed action (ledger-only; renders to
     // nothing on the terminal — a deny is already surfaced via its `tool` event).
-    | "policy";
+    | "policy"
+    // A subagent started under this task (message: agent id + model). The agent
+    // tree renders a child row from this; the ledger links it via agentId.
+    | "agent_spawned"
+    // A subagent finished; `output` carries its final text/structured payload and
+    // `passed` whether it completed (vs aborted/timed out).
+    | "agent_result";
   task: string;
+  /** Which subagent emitted this event. Absent = the parent/main loop. Set on
+   *  every event a subagent emits (not just agent_* kinds), so interleaved
+   *  parallel streams stay attributable in the ledger and the agent tree. */
+  agentId?: string;
+  /** The spawning task's id for agent_* events, so a renderer can build the
+   *  parent→children tree without parsing hierarchical id strings. */
+  parentTask?: string;
   message: string;
   cycle?: number;
   cycles?: number;

--- a/packages/core/tests/ledger.test.ts
+++ b/packages/core/tests/ledger.test.ts
@@ -1,4 +1,4 @@
-import { test, expect, describe } from "bun:test";
+import { test, expect, describe, spyOn } from "bun:test";
 import { mkdtemp, rm, readFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
@@ -9,6 +9,8 @@ import {
   type ILoopEvent,
   type LedgerEventType,
 } from "../src/loop";
+import { makeReporter } from "../src/cli/logging";
+import { parseEventLog } from "../src/eval";
 
 async function withLog<T>(
   fn: (file: string, read: () => Promise<IBaseLedgerEvent[]>) => Promise<T>
@@ -165,5 +167,61 @@ describe("LedgerWriter", () => {
     expect(() =>
       new LedgerWriter("", "r").record("run_started", {})
     ).not.toThrow();
+  });
+});
+
+describe("agent attribution write→read round-trip", () => {
+  test("makeReporter --log lines parse back with agentId/parentTask intact", async () => {
+    await withLog(async (file) => {
+      const report = makeReporter(file, "run-1", "sess-1");
+      // Silence terminal rendering; the ledger file is what we assert on.
+      const spy = spyOn(process.stdout, "write").mockImplementation(() => true);
+
+      try {
+        report({
+          kind: "agent_spawned",
+          task: "run-1",
+          message: "explore (qwen3-coder)",
+          agentId: "run-1:explore",
+          parentTask: "run-1",
+        });
+        report({
+          kind: "usage",
+          task: "run-1:explore",
+          message: "",
+          totalTokens: 42,
+          agentId: "run-1:explore",
+        });
+        report({ kind: "usage", task: "run-1", message: "" }); // parent event
+        report({
+          kind: "agent_result",
+          task: "run-1",
+          message: "3 findings",
+          agentId: "run-1:explore",
+          parentTask: "run-1",
+          passed: true,
+        });
+      } finally {
+        spy.mockRestore();
+      }
+
+      const events = parseEventLog(await readFile(file, "utf8"));
+      const spawned = events.find((e) => e.kind === "agent_spawned");
+      const result = events.find((e) => e.kind === "agent_result");
+      const child = events.find(
+        (e) => e.kind === "usage" && e.agentId !== undefined
+      );
+      const parent = events.find(
+        (e) => e.kind === "usage" && e.agentId === undefined
+      );
+
+      expect(spawned?.agentId).toBe("run-1:explore");
+      expect(spawned?.parentTask).toBe("run-1");
+      expect(result?.agentId).toBe("run-1:explore");
+      expect(result?.passed).toBe(true);
+      expect(child?.agentId).toBe("run-1:explore");
+      expect(child?.totalTokens).toBe(42);
+      expect(parent).toBeDefined();
+    });
   });
 });

--- a/packages/core/tests/ledger.test.ts
+++ b/packages/core/tests/ledger.test.ts
@@ -51,6 +51,8 @@ describe("ledgerTypeFor — kind → typed event", () => {
       ["create", "tool_call_finished"],
       ["run", "tool_call_finished"],
       ["policy", "policy_decision"],
+      ["agent_spawned", "agent_spawned"],
+      ["agent_result", "agent_result"],
       ["timing", "log"],
     ];
 
@@ -135,6 +137,20 @@ describe("LedgerWriter", () => {
 
       expect(output.length).toBeLessThan(10_000);
       expect(output).toContain("chars]");
+    });
+  });
+
+  test("records agentId when given and omits it otherwise (round-trip)", async () => {
+    await withLog(async (file, read) => {
+      const w = new LedgerWriter(file, "run-1", "sess-1");
+
+      w.record("agent_spawned", { spec: "explore" }, "run-1:explore");
+      w.record("model_call_started", {}); // parent event — no agentId
+
+      const [spawned, parent] = await read();
+
+      expect(spawned?.agentId).toBe("run-1:explore");
+      expect(parent?.agentId).toBeUndefined();
     });
   });
 

--- a/packages/core/tests/output-router.test.ts
+++ b/packages/core/tests/output-router.test.ts
@@ -1,0 +1,93 @@
+import { test, expect, describe } from "bun:test";
+import { OutputRouter } from "../src/cli/output-router";
+
+/** Capture stdout writes made during fn, restoring the real writer after. */
+function captureStdout(fn: () => void): string {
+  const chunks: string[] = [];
+  const original = process.stdout.write.bind(process.stdout);
+
+  process.stdout.write = (chunk: string | Uint8Array): boolean => {
+    chunks.push(String(chunk));
+
+    return true;
+  };
+
+  try {
+    fn();
+  } finally {
+    process.stdout.write = original;
+  }
+
+  return chunks.join("");
+}
+
+describe("OutputRouter", () => {
+  test("routes to stdout when no sinks are installed", () => {
+    const router = new OutputRouter();
+
+    const out = captureStdout(() => {
+      router.route("plain\n");
+    });
+
+    expect(out).toBe("plain\n");
+  });
+
+  test("parent sink wins over stdout once installed, and clears back", () => {
+    const router = new OutputRouter();
+    const parent: string[] = [];
+
+    router.setParentSink((text) => parent.push(text));
+    router.route("to-parent");
+    expect(parent).toEqual(["to-parent"]);
+
+    router.setParentSink(null);
+
+    const out = captureStdout(() => {
+      router.route("back-to-stdout");
+    });
+
+    expect(out).toBe("back-to-stdout");
+    expect(parent).toEqual(["to-parent"]); // untouched after clear
+  });
+
+  test("an agent's writes go to its own sink, not the parent's", () => {
+    const router = new OutputRouter();
+    const parent: string[] = [];
+    const agent: string[] = [];
+
+    router.setParentSink((text) => parent.push(text));
+    router.setAgentSink("run:explore", (text) => agent.push(text));
+
+    router.route("child-text", "run:explore");
+    router.route("parent-text");
+
+    expect(agent).toEqual(["child-text"]);
+    expect(parent).toEqual(["parent-text"]);
+  });
+
+  test("an agentId with no registered sink falls back to the parent sink", () => {
+    const router = new OutputRouter();
+    const parent: string[] = [];
+
+    router.setParentSink((text) => parent.push(text));
+    router.route("orphan-child", "run:unknown");
+
+    expect(parent).toEqual(["orphan-child"]);
+  });
+
+  test("clearAgentSink removes the route; later writes fall back", () => {
+    const router = new OutputRouter();
+    const parent: string[] = [];
+    const agent: string[] = [];
+
+    router.setParentSink((text) => parent.push(text));
+    router.setAgentSink("run:a", (text) => agent.push(text));
+
+    router.route("first", "run:a");
+    router.clearAgentSink("run:a");
+    router.route("second", "run:a");
+
+    expect(agent).toEqual(["first"]);
+    expect(parent).toEqual(["second"]);
+  });
+});

--- a/packages/core/tests/output-router.test.ts
+++ b/packages/core/tests/output-router.test.ts
@@ -1,21 +1,22 @@
-import { test, expect, describe } from "bun:test";
+import { test, expect, describe, spyOn } from "bun:test";
 import { OutputRouter } from "../src/cli/output-router";
 
-/** Capture stdout writes made during fn, restoring the real writer after. */
+/** Capture stdout writes made during fn. spyOn + mockRestore puts back the
+ *  ORIGINAL method (identity and all) so later tests see an untouched stream. */
 function captureStdout(fn: () => void): string {
   const chunks: string[] = [];
-  const original = process.stdout.write.bind(process.stdout);
+  const spy = spyOn(process.stdout, "write").mockImplementation(
+    (chunk: string | Uint8Array): boolean => {
+      chunks.push(String(chunk));
 
-  process.stdout.write = (chunk: string | Uint8Array): boolean => {
-    chunks.push(String(chunk));
-
-    return true;
-  };
+      return true;
+    }
+  );
 
   try {
     fn();
   } finally {
-    process.stdout.write = original;
+    spy.mockRestore();
   }
 
   return chunks.join("");


### PR DESCRIPTION
First slice of the approved multiagent plan (Phase A / PR-A1). Pure groundwork — **no behavior change**.

## What

1. **Event attribution**: `ILoopEvent` gains `agentId?` (which subagent emitted the event; absent = parent loop) and `parentTask?`, plus two new kinds — `agent_spawned` / `agent_result` — that the agent tree and ledger will consume.
2. **Ledger attribution**: `LedgerWriter.record()` takes an optional `agentId` recorded as a first-class column; `agent_spawned`/`agent_result` get typed ledger event types. Old ledgers remain valid (field simply absent).
3. **Scoped output routing**: the module-level `interactiveStream` latch in `cli/logging.ts` is replaced by `OutputRouter` (`cli/output-router.ts`): each rendered chunk routes agent sink → parent sink → stdout keyed by the emitting event's `agentId`. The REPL installs its StatusBar-aware writer as the parent sink (same two call sites as before). Today only the parent writes; per-agent sinks arrive with the live agent tree (Phase B).

## Why

Interleaved parallel event streams need attribution end-to-end (terminal routing + ledger replay) before any scheduler or fan-out lands. This is the piece every later phase depends on, extracted so it can merge as a no-op.

## Testing

- 5 new OutputRouter unit tests (stdout default, parent install/clear, agent sink isolation, unknown-agent fallback, clearAgentSink fallback)
- Ledger: agentId round-trip test + new kind mappings added to the existing table test
- Full `bun run validate` green — typecheck, eslint, prettier, whole suite, **20/20 real-PTY e2e** (proves REPL streaming through the router is pixel-identical)