### PR TITLE
feat(agents): AgentScheduler + parallel review fan-out (multiagent PR-A2)

### DIFF
--- a/apps/docs/src/content/docs/guardrails/config.mdx
+++ b/apps/docs/src/content/docs/guardrails/config.mdx
@@ -20,6 +20,7 @@ Add **`tsforge.config.json`** at your repo root when you want to override what t
 | `plugins` | object[] | External modules providing extra rule packs (see below) |
 | `mcpServers` | object | External [MCP servers](/integrations/mcp/) whose tools the agent can call |
 | `policy` | object | Permission `mode` + deny/allow/ask `rules` for tool actions — see [Permissions & policy](/guardrails/policy/) |
+| `agents.concurrency` | number | Multiagent fan-out cap, integer 1–16 (default `1` = sequential). Above 1, `tsforge review` runs its per-file find and per-finding verify passes in parallel with a fresh provider per unit and a live `agents:` progress line. Leave at 1 for a local endpoint that serializes requests anyway |
 
 Resolution order: detect from the repo → apply **`profile`** (packs + default severities) → apply `stack` → apply `include` → apply `exclude` → add external plugin packs → dedupe → merge `rules` overrides (user wins).
 

--- a/packages/core/src/agent/agent-scheduler.ts
+++ b/packages/core/src/agent/agent-scheduler.ts
@@ -1,0 +1,113 @@
+/**
+ * Concurrency-capped work-unit scheduler — the execution core for multiagent
+ * fan-out. Units are plain `(signal) => Promise<T>` thunks so a single
+ * `provider.complete()` call (review find/verify units) and a full agent loop
+ * (Phase B AgentRunner) schedule identically. cap=1 degrades to today's
+ * sequential behavior, which is a first-class path on serializing local
+ * endpoints, not an afterthought.
+ */
+
+/** One schedulable piece of work. `id` labels progress events and the agent
+ *  tree row (e.g. `find:src/auth.ts`). */
+export interface IScheduledUnit<T> {
+  readonly id: string;
+  readonly run: (signal: AbortSignal) => Promise<T>;
+}
+
+export type UnitStatus = "start" | "done" | "failed";
+
+export interface ISchedulerOptions {
+  /** Max units in flight at once. Clamped to an integer ≥ 1; default 1. */
+  readonly concurrency?: number;
+  /** Master abort: pending units never start; each running unit's own signal
+   *  fires so it can stop early. */
+  readonly signal?: AbortSignal;
+  /** Progress callback per unit transition (drives logs / the agent tree). */
+  readonly onUnit?: (id: string, status: UnitStatus) => void;
+}
+
+/** Clamp a requested cap to a sane integer ≥ 1 (fractions floor, junk → 1). */
+export function clampConcurrency(value: number | undefined): number {
+  if (value === undefined || !Number.isFinite(value)) {
+    return 1;
+  }
+
+  return Math.max(1, Math.floor(value));
+}
+
+export class AgentScheduler {
+  private readonly concurrency: number;
+  private readonly signal?: AbortSignal;
+  private readonly onUnit?: (id: string, status: UnitStatus) => void;
+
+  constructor(opts: ISchedulerOptions = {}) {
+    this.concurrency = clampConcurrency(opts.concurrency);
+
+    if (opts.signal !== undefined) {
+      this.signal = opts.signal;
+    }
+
+    if (opts.onUnit !== undefined) {
+      this.onUnit = opts.onUnit;
+    }
+  }
+
+  /** Run one unit under the master signal; a throw degrades to null. */
+  private async runUnit<T>(unit: IScheduledUnit<T>): Promise<T | null> {
+    const ctrl = new AbortController();
+
+    const onAbort = (): void => {
+      ctrl.abort();
+    };
+
+    this.signal?.addEventListener("abort", onAbort, { once: true });
+    this.onUnit?.(unit.id, "start");
+
+    try {
+      const result = await unit.run(ctrl.signal);
+
+      this.onUnit?.(unit.id, "done");
+
+      return result;
+    } catch {
+      // One failed unit degrades to a null slot; siblings keep running.
+      this.onUnit?.(unit.id, "failed");
+
+      return null;
+    } finally {
+      this.signal?.removeEventListener("abort", onAbort);
+    }
+  }
+
+  /**
+   * Run all units with at most `concurrency` in flight. Results come back in
+   * SUBMISSION order (never completion order), one slot per unit; a failed or
+   * never-started (master-aborted) unit's slot is null.
+   */
+  async runParallel<T>(
+    units: readonly IScheduledUnit<T>[]
+  ): Promise<(T | null)[]> {
+    const results: (T | null)[] = new Array<T | null>(units.length).fill(null);
+    let next = 0;
+
+    const worker = async (): Promise<void> => {
+      while (next < units.length && this.signal?.aborted !== true) {
+        const index = next;
+
+        next += 1;
+
+        const unit = units[index];
+
+        if (unit !== undefined) {
+          results[index] = await this.runUnit(unit);
+        }
+      }
+    };
+
+    const lanes = Math.min(this.concurrency, Math.max(units.length, 1));
+
+    await Promise.all(Array.from({ length: lanes }, worker));
+
+    return results;
+  }
+}

--- a/packages/core/src/agent/agent-scheduler.ts
+++ b/packages/core/src/agent/agent-scheduler.ts
@@ -14,7 +14,7 @@ export interface IScheduledUnit<T> {
   readonly run: (signal: AbortSignal) => Promise<T>;
 }
 
-export type UnitStatus = "start" | "done" | "failed";
+export type UnitStatus = "pending" | "start" | "done" | "failed";
 
 export interface ISchedulerOptions {
   /** Max units in flight at once. Clamped to an integer ≥ 1; default 1. */
@@ -60,7 +60,14 @@ export class AgentScheduler {
       ctrl.abort();
     };
 
-    this.signal?.addEventListener("abort", onAbort, { once: true });
+    // An already-aborted parent never re-fires "abort" — flag the unit's own
+    // signal directly instead of registering a listener that can't trigger.
+    if (this.signal?.aborted === true) {
+      ctrl.abort();
+    } else {
+      this.signal?.addEventListener("abort", onAbort, { once: true });
+    }
+
     this.onUnit?.(unit.id, "start");
 
     try {
@@ -89,6 +96,12 @@ export class AgentScheduler {
   ): Promise<(T | null)[]> {
     const results: (T | null)[] = new Array<T | null>(units.length).fill(null);
     let next = 0;
+
+    // Announce every unit up-front so progress denominators are stable from
+    // the first update (the tree renders pending rows, not a growing total).
+    for (const unit of units) {
+      this.onUnit?.(unit.id, "pending");
+    }
 
     const worker = async (): Promise<void> => {
       while (next < units.length && this.signal?.aborted !== true) {

--- a/packages/core/src/cli.ts
+++ b/packages/core/src/cli.ts
@@ -39,6 +39,11 @@ import { runMapCommand, runTraceCommand } from "./cli/repl-commands";
 import { makeProvider, modelForRun, envNumber } from "./cli/model-setup";
 import { makeReporter, resolveLogPath } from "./cli/logging";
 import { resolveGate } from "./cli/gate-setup";
+import {
+  loadTsforgeConfig,
+  resolveAgentConcurrency,
+} from "./config/tsforge-config";
+import { makeAgentSummaryTracker } from "./render/agent-tree";
 
 /**
  * The tsforge CLI — the product surface over the same engine the eval harness
@@ -176,11 +181,31 @@ async function reviewMode(args: ICliArgs): Promise<number> {
     );
   }
 
+  // Fan-out cap from tsforge.config.json `agents.concurrency` (default 1 =
+  // sequential). Above 1, each unit gets a FRESH provider (per-instance
+  // thinking-latch state) and a live `agents: …` progress line.
+  const concurrency = resolveAgentConcurrency(
+    await loadTsforgeConfig(args.dir)
+  );
+
+  if (concurrency > 1) {
+    process.stdout.write(`agents: fan-out enabled (cap ${concurrency})\n`);
+  }
+
   const report = await reviewChange(makeProvider(entry), args.dir, {
     ...(args.base.length > 0 ? { base: args.base } : {}),
     staged: args.staged,
     ...(rules.length > 0 ? { gateFailingRules: rules } : {}),
     log: (m) => process.stdout.write(`  ↳ ${m}\n`),
+    concurrency,
+    providerFactory: () => makeProvider(entry),
+    ...(concurrency > 1
+      ? {
+          onEvent: makeAgentSummaryTracker((line) =>
+            process.stdout.write(`  ↳ ${line}\n`)
+          ),
+        }
+      : {}),
   });
 
   process.stdout.write(`\n${formatReport(report)}\n`);

--- a/packages/core/src/cli.ts
+++ b/packages/core/src/cli.ts
@@ -198,9 +198,11 @@ async function reviewMode(args: ICliArgs): Promise<number> {
     ...(rules.length > 0 ? { gateFailingRules: rules } : {}),
     log: (m) => process.stdout.write(`  ↳ ${m}\n`),
     concurrency,
-    providerFactory: () => makeProvider(entry),
+    // Fresh providers + the progress line only matter above cap 1; at 1 the
+    // shared primary provider is the exact pre-fan-out behavior (no overhead).
     ...(concurrency > 1
       ? {
+          providerFactory: () => makeProvider(entry),
           onEvent: makeAgentSummaryTracker((line) =>
             process.stdout.write(`  ↳ ${line}\n`)
           ),

--- a/packages/core/src/config/index.ts
+++ b/packages/core/src/config/index.ts
@@ -5,6 +5,7 @@ export {
   resolveActivePacks,
   normalizeRuleOverrides,
   resolveProjectProfile,
+  resolveAgentConcurrency,
   withProfileOverride,
   type ITsforgeProjectConfig,
 } from "./tsforge-config";

--- a/packages/core/src/config/tsforge-config.ts
+++ b/packages/core/src/config/tsforge-config.ts
@@ -496,9 +496,10 @@ const MAX_AGENT_CONCURRENCY = 16;
 /** Validate the optional `agents` block (warn-and-drop, like the others). */
 function validateAgents(value: unknown): { concurrency?: number } | undefined {
   if (typeof value !== "object" || value === null || Array.isArray(value)) {
-    warnConfig(
-      `tsforge.config.json: "agents" must be an object, got ${typeof value}`
-    );
+    const kind =
+      value === null ? "null" : Array.isArray(value) ? "array" : typeof value;
+
+    warnConfig(`tsforge.config.json: "agents" must be an object, got ${kind}`);
 
     return undefined;
   }

--- a/packages/core/src/config/tsforge-config.ts
+++ b/packages/core/src/config/tsforge-config.ts
@@ -78,6 +78,15 @@ export interface ITsforgeProjectConfig {
   };
 
   /**
+   * Multiagent fan-out settings. `concurrency` caps how many subagent work
+   * units run at once (integer 1–16). Opt-in: absent ⇒ 1 (sequential, exactly
+   * the pre-multiagent behavior — the safe default for single local endpoints).
+   */
+  readonly agents?: {
+    readonly concurrency?: number;
+  };
+
+  /**
    * Project conventions inferred by `tsforge setup` — TASTE only (interface
    * naming, enums, test layout, component folders). Each field tunes a stylistic
    * rule; unset fields fall back to tsforge's house defaults. These can NEVER
@@ -480,6 +489,60 @@ function assignConventions(
   }
 }
 
+/** Bounds for `agents.concurrency` — one shared endpoint shouldn't be asked
+ *  for hundreds of parallel completions by a config typo. */
+const MAX_AGENT_CONCURRENCY = 16;
+
+/** Validate the optional `agents` block (warn-and-drop, like the others). */
+function validateAgents(value: unknown): { concurrency?: number } | undefined {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) {
+    warnConfig(
+      `tsforge.config.json: "agents" must be an object, got ${typeof value}`
+    );
+
+    return undefined;
+  }
+
+  const raw: Record<string, unknown> = { ...value };
+  const agents: { concurrency?: number } = {};
+
+  if (raw.concurrency !== undefined) {
+    const n = raw.concurrency;
+    const valid =
+      typeof n === "number" &&
+      Number.isInteger(n) &&
+      n >= 1 &&
+      n <= MAX_AGENT_CONCURRENCY;
+
+    if (valid) {
+      agents.concurrency = n;
+    } else {
+      warnConfig(
+        `tsforge.config.json: agents.concurrency must be an integer 1–${MAX_AGENT_CONCURRENCY} — ignored`
+      );
+    }
+  }
+
+  return agents.concurrency === undefined ? undefined : agents;
+}
+
+/** Validate + assign the optional `agents` block (kept off `buildConfigFields`
+ *  so its branches don't push it over the complexity cap — mirrors assignPolicy). */
+function assignAgents(
+  parsed: Record<string, unknown>,
+  configFields: { agents?: { concurrency?: number } }
+): void {
+  if (parsed.agents === undefined) {
+    return;
+  }
+
+  const agents = validateAgents(parsed.agents);
+
+  if (agents !== undefined) {
+    configFields.agents = agents;
+  }
+}
+
 function buildConfigFields(
   parsed: Record<string, unknown>
 ): ITsforgeProjectConfig {
@@ -492,6 +555,7 @@ function buildConfigFields(
     plugins?: readonly IExternalPlugin[];
     policy?: { mode?: PolicyMode; rules?: IPolicyRules };
     conventions?: Readonly<Partial<IConventions>>;
+    agents?: { concurrency?: number };
   } = {};
 
   if (parsed.profile !== undefined) {
@@ -544,8 +608,16 @@ function buildConfigFields(
 
   assignPolicy(parsed, configFields);
   assignConventions(parsed, configFields);
+  assignAgents(parsed, configFields);
 
   return configFields;
+}
+
+/** Effective multiagent fan-out cap for this project: `agents.concurrency`
+ *  when set, else 1 (sequential). The flip to a parallel default waits on the
+ *  Phase-A eval sweep, per the eval-first house rule. */
+export function resolveAgentConcurrency(config: ITsforgeProjectConfig): number {
+  return config.agents?.concurrency ?? 1;
 }
 
 /** Load tsforge.config.json from cwd, defaulting to empty config on missing/invalid files. */

--- a/packages/core/src/eval/parse-log.ts
+++ b/packages/core/src/eval/parse-log.ts
@@ -24,6 +24,7 @@ const KNOWN_KINDS = new Set<string>([
   "reverted",
   "policy",
   "agent_spawned",
+  "agent_started",
   "agent_result",
 ]);
 

--- a/packages/core/src/loop/ledger-writer.ts
+++ b/packages/core/src/loop/ledger-writer.ts
@@ -32,6 +32,8 @@ export function ledgerTypeFor(event: ILoopEvent): LedgerEventType {
       return "policy_decision";
     case "agent_spawned":
       return "agent_spawned";
+    case "agent_started":
+      return "agent_started";
     case "agent_result":
       return "agent_result";
     case "tool":

--- a/packages/core/src/loop/ledger.types.ts
+++ b/packages/core/src/loop/ledger.types.ts
@@ -21,8 +21,10 @@ export type LedgerEventType =
   | "gate_finished"
   | "resume_started"
   | "resume_finished"
-  /** A subagent started under this run. */
+  /** A subagent was announced (queued) under this run. */
   | "agent_spawned"
+  /** A previously spawned subagent began running. */
+  | "agent_started"
   /** A subagent finished (payload carries its status and output preview). */
   | "agent_result"
   /** Catch-all for reporter events without a dedicated ledger type yet. */

--- a/packages/core/src/loop/loop.types.ts
+++ b/packages/core/src/loop/loop.types.ts
@@ -35,11 +35,14 @@ export interface ILoopEvent {
     // A unified-policy verdict for one proposed action (ledger-only; renders to
     // nothing on the terminal — a deny is already surfaced via its `tool` event).
     | "policy"
-    // A subagent started under this task (message: agent id + model). The agent
-    // tree renders a child row from this; the ledger links it via agentId.
+    // A subagent was ANNOUNCED under this task (queued; message: agent id). All
+    // of a fan-out's units spawn up-front so progress denominators are stable
+    // and the agent tree can render pending rows before work begins.
     | "agent_spawned"
+    // A previously spawned subagent began running (its pending row goes live).
+    | "agent_started"
     // A subagent finished; `output` carries its final text/structured payload and
-    // `passed` whether it completed (vs aborted/timed out).
+    // `passed` whether it completed (vs failed/aborted).
     | "agent_result";
   task: string;
   /** Which subagent emitted this event. Absent = the parent/main loop. Set on

--- a/packages/core/src/loop/review/review-change.ts
+++ b/packages/core/src/loop/review/review-change.ts
@@ -4,6 +4,12 @@ import { isRecord, isArray } from "../../lib/guards";
 import { extractJson } from "../../lib/json";
 import type { IProvider } from "../../inference";
 import type { TsService } from "../../lsp";
+import {
+  AgentScheduler,
+  clampConcurrency,
+  type UnitStatus,
+} from "../../agent/agent-scheduler";
+import type { Reporter } from "../loop.types";
 import { buildTsService } from "../turn";
 import { LENSES, lensRubric } from "./lenses";
 import { callerSignal } from "./signals";
@@ -33,6 +39,43 @@ export interface IReviewOptions {
   gateFailingRules?: readonly string[];
   /** Progress callback (one line per step). */
   log?: (message: string) => void;
+  /** Max find/verify units in flight at once (default 1 — the original strictly
+   *  sequential behavior; results are file-ordered either way). */
+  concurrency?: number;
+  /** Build a FRESH provider per fan-out unit. Providers keep per-instance state
+   *  (the DeepSeek thinking latch), so parallel units must not share one.
+   *  Absent ⇒ every unit reuses the single `provider` (fine at concurrency 1). */
+  providerFactory?: () => IProvider;
+  /** Attribution events (`agent_spawned`/`agent_result` per unit) for the
+   *  ledger and the fan-out progress line. */
+  onEvent?: Reporter;
+}
+
+/** The review's task id in emitted attribution events. */
+const REVIEW_TASK = "review";
+
+/** Map scheduler unit transitions onto agent_spawned/agent_result events. */
+function unitReporter(
+  emit: Reporter | undefined
+): ((id: string, status: UnitStatus) => void) | undefined {
+  if (emit === undefined) {
+    return undefined;
+  }
+
+  return (id, status): void => {
+    const base = {
+      task: REVIEW_TASK,
+      message: id,
+      agentId: `${REVIEW_TASK}:${id}`,
+      parentTask: REVIEW_TASK,
+    };
+
+    if (status === "start") {
+      emit({ kind: "agent_spawned", ...base });
+    } else {
+      emit({ kind: "agent_result", ...base, passed: status === "done" });
+    }
+  };
 }
 
 /** Run `git` with an explicit argv (no shell); return trimmed stdout, "" on error. */
@@ -504,58 +547,112 @@ export async function reviewChange(
   // In-process TS LanguageService (null without a tsconfig) — powers the
   // caller blast-radius signal. Built once; falls back gracefully when absent.
   const svc: TsService | null = await buildTsService(cwd);
+  const makeUnitProvider = opts.providerFactory ?? ((): IProvider => provider);
+  const onUnit = unitReporter(opts.onEvent);
+  // cap=1 (the default) IS the original sequential path — one local-model
+  // server isn't swamped unless the config opts into parallel fan-out. Results
+  // return in file order regardless of completion order, so the report and the
+  // log lines below stay deterministic. Each unit is isolated (safeFind
+  // try/catch + scheduler null-slot degradation): one bad file can't abort the
+  // whole review.
+  const scheduler = new AgentScheduler({
+    concurrency: clampConcurrency(opts.concurrency),
+    ...(onUnit === undefined ? {} : { onUnit }),
+  });
+
+  const findOutcomes = await scheduler.runParallel(
+    files.map((file) => ({
+      id: `find:${file}`,
+      run: async (
+        signal: AbortSignal
+      ): Promise<{
+        file: string;
+        truncated: boolean;
+        found: IRepoFinding[];
+        onChange: IRepoFinding[];
+      } | null> => {
+        if (signal.aborted) {
+          return null;
+        }
+
+        const { diff, truncated, ranges } = await fileDiff(
+          cwd,
+          base,
+          file,
+          staged,
+          untracked.has(file)
+        );
+        const found = await safeFind(
+          makeUnitProvider(),
+          system,
+          svc,
+          cwd,
+          file,
+          diff,
+          log
+        );
+
+        // Keep only findings ON a changed line — a finding on pre-existing code
+        // the change didn't touch is not a regression in THIS change. Skip the
+        // filter when no hunks parsed (can't tell), so we never silently drop
+        // everything.
+        const onChange =
+          ranges.length === 0
+            ? found
+            : found.filter((f) => lineInRanges(f.line, ranges));
+
+        return { file, truncated, found, onChange };
+      },
+    }))
+  );
+
   const raw: IRepoFinding[] = [];
   const truncatedFiles: string[] = [];
   let preexisting = 0;
 
-  // Sequential on purpose: this harness targets a single local-model server, so
-  // we don't fan out concurrent requests that would swamp it. Each file is
-  // isolated in try/catch so one bad file can't abort the whole review.
-  for (const file of files) {
-    const { diff, truncated, ranges } = await fileDiff(
-      cwd,
-      base,
-      file,
-      staged,
-      untracked.has(file)
-    );
-
-    if (truncated) {
-      truncatedFiles.push(file);
+  for (const outcome of findOutcomes) {
+    if (outcome === null) {
+      continue;
     }
 
-    const found = await safeFind(provider, system, svc, cwd, file, diff, log);
+    if (outcome.truncated) {
+      truncatedFiles.push(outcome.file);
+    }
 
-    // Keep only findings ON a changed line — a finding on pre-existing code the
-    // change didn't touch is not a regression in THIS change. Skip the filter
-    // when no hunks parsed (can't tell), so we never silently drop everything.
-    const onChange =
-      ranges.length === 0
-        ? found
-        : found.filter((f) => lineInRanges(f.line, ranges));
-
-    preexisting += found.length - onChange.length;
+    preexisting += outcome.found.length - outcome.onChange.length;
 
     log(
-      `  ${file}: ${onChange.length} candidate finding(s)${
-        found.length !== onChange.length
-          ? ` (${found.length - onChange.length} on pre-existing lines, skipped)`
+      `  ${outcome.file}: ${outcome.onChange.length} candidate finding(s)${
+        outcome.found.length !== outcome.onChange.length
+          ? ` (${outcome.found.length - outcome.onChange.length} on pre-existing lines, skipped)`
           : ""
       }`
     );
-    raw.push(...onChange);
+    raw.push(...outcome.onChange);
   }
 
   const doVerify = opts.verify ?? true;
+  const verifyOutcomes = await scheduler.runParallel(
+    raw.map((finding) => ({
+      id: `verify:${finding.file}:${finding.line}`,
+      run: async (signal: AbortSignal): Promise<IVerifiedFinding | null> => {
+        if (signal.aborted) {
+          return null;
+        }
+
+        return doVerify
+          ? await safeVerify(makeUnitProvider(), cwd, finding, log)
+          : { ...finding, verified: true, verdict: "(unverified)" };
+      },
+    }))
+  );
+
   const verified: IVerifiedFinding[] = [];
   let rejected = 0;
 
-  for (const finding of raw) {
-    const result = doVerify
-      ? await safeVerify(provider, cwd, finding, log)
-      : { ...finding, verified: true, verdict: "(unverified)" };
-
-    if (result.verified) {
+  for (const result of verifyOutcomes) {
+    // A null slot (unit failed/aborted) fails closed, same as a verify error.
+    if (result?.verified === true) {
       verified.push(result);
     } else {
       rejected += 1;

--- a/packages/core/src/loop/review/review-change.ts
+++ b/packages/core/src/loop/review/review-change.ts
@@ -54,7 +54,9 @@ export interface IReviewOptions {
 /** The review's task id in emitted attribution events. */
 const REVIEW_TASK = "review";
 
-/** Map scheduler unit transitions onto agent_spawned/agent_result events. */
+/** Map scheduler unit transitions onto the agent lifecycle events:
+ *  pending → agent_spawned (announced), start → agent_started (running),
+ *  done/failed → agent_result. */
 function unitReporter(
   emit: Reporter | undefined
 ): ((id: string, status: UnitStatus) => void) | undefined {
@@ -70,8 +72,10 @@ function unitReporter(
       parentTask: REVIEW_TASK,
     };
 
-    if (status === "start") {
+    if (status === "pending") {
       emit({ kind: "agent_spawned", ...base });
+    } else if (status === "start") {
+      emit({ kind: "agent_started", ...base });
     } else {
       emit({ kind: "agent_result", ...base, passed: status === "done" });
     }
@@ -300,7 +304,8 @@ async function findInFile(
   system: string,
   file: string,
   diff: string,
-  signal: string
+  signal: string,
+  abort?: AbortSignal
 ): Promise<IRepoFinding[]> {
   if (diff.length === 0) {
     return [];
@@ -319,7 +324,7 @@ async function findInFile(
         content: `File: ${file}\n\nDiff (base → working tree):\n${diff}${callers}`,
       },
     ],
-    { temperature: 0 }
+    { temperature: 0, ...(abort === undefined ? {} : { signal: abort }) }
   );
 
   return parseFindings(res.content, file);
@@ -428,7 +433,8 @@ const VERIFY_SYSTEM = [
 async function verifyFinding(
   provider: IProvider,
   cwd: string,
-  finding: IRepoFinding
+  finding: IRepoFinding,
+  abort?: AbortSignal
 ): Promise<IVerifiedFinding> {
   const window = await codeWindow(cwd, finding.file, finding.line);
   const drop = (verdict: string): IVerifiedFinding => ({
@@ -449,7 +455,7 @@ async function verifyFinding(
         content: `Finding [${finding.lens}] at ${finding.file}:${finding.line}\nClaim: ${finding.claim}\nReason: ${finding.reason}\n\nActual code:\n${window}\n\nIs this a real functional problem?`,
       },
     ],
-    { temperature: 0 }
+    { temperature: 0, ...(abort === undefined ? {} : { signal: abort }) }
   );
 
   let data: unknown;
@@ -480,14 +486,15 @@ async function safeFind(
   cwd: string,
   file: string,
   diff: string,
-  log: (m: string) => void
+  log: (m: string) => void,
+  abort?: AbortSignal
 ): Promise<IRepoFinding[]> {
   try {
     // callerSignal lives INSIDE the try so a LanguageService hiccup on one file
     // degrades that file's review, never aborting the whole run.
     const signal = callerSignal(svc, cwd, file);
 
-    return await findInFile(provider, system, file, diff, signal);
+    return await findInFile(provider, system, file, diff, signal, abort);
   } catch (err) {
     log(`  ${file}: review failed — ${errText(err)}`);
 
@@ -500,10 +507,11 @@ async function safeVerify(
   provider: IProvider,
   cwd: string,
   finding: IRepoFinding,
-  log: (m: string) => void
+  log: (m: string) => void,
+  abort?: AbortSignal
 ): Promise<IVerifiedFinding> {
   try {
-    return await verifyFinding(provider, cwd, finding);
+    return await verifyFinding(provider, cwd, finding, abort);
   } catch (err) {
     log(`  verify failed at ${finding.file}:${finding.line} — ${errText(err)}`);
 
@@ -589,7 +597,8 @@ export async function reviewChange(
           cwd,
           file,
           diff,
-          log
+          log,
+          signal
         );
 
         // Keep only findings ON a changed line — a finding on pre-existing code
@@ -633,15 +642,17 @@ export async function reviewChange(
 
   const doVerify = opts.verify ?? true;
   const verifyOutcomes = await scheduler.runParallel(
-    raw.map((finding) => ({
-      id: `verify:${finding.file}:${finding.line}`,
+    // The index makes ids unique when the reviewer cites the same line twice —
+    // duplicate ids would collapse distinct units in the tracker and ledger.
+    raw.map((finding, index) => ({
+      id: `verify:${finding.file}:${finding.line}#${String(index)}`,
       run: async (signal: AbortSignal): Promise<IVerifiedFinding | null> => {
         if (signal.aborted) {
           return null;
         }
 
         return doVerify
-          ? await safeVerify(makeUnitProvider(), cwd, finding, log)
+          ? await safeVerify(makeUnitProvider(), cwd, finding, log, signal)
           : { ...finding, verified: true, verdict: "(unverified)" };
       },
     }))

--- a/packages/core/src/render/agent-tree.ts
+++ b/packages/core/src/render/agent-tree.ts
@@ -1,0 +1,86 @@
+/**
+ * Agent-tree rendering, Phase A slice: a one-line textual summary of a
+ * fan-out's progress (`agents: 2 running, 1 done (find:a.ts · find:b.ts)`).
+ * The full live tree (per-child rows above the input row, Claude-Code style)
+ * lands in Phase B and grows out of this module.
+ */
+import type { ILoopEvent, Reporter } from "../loop/loop.types";
+
+export type AgentItemStatus = "pending" | "running" | "done" | "failed";
+
+export interface IAgentSummaryItem {
+  readonly id: string;
+  readonly status: AgentItemStatus;
+}
+
+/** How many running-agent ids to list before eliding the rest. */
+const MAX_LISTED = 3;
+
+function countOf(
+  items: readonly IAgentSummaryItem[],
+  status: AgentItemStatus
+): number {
+  return items.filter((i) => i.status === status).length;
+}
+
+/** One-line progress summary for a set of fan-out units. Empty input → "". */
+export function formatAgentSummary(
+  items: readonly IAgentSummaryItem[]
+): string {
+  if (items.length === 0) {
+    return "";
+  }
+
+  const running = items.filter((i) => i.status === "running");
+  const parts: string[] = [];
+  const done = countOf(items, "done");
+  const failed = countOf(items, "failed");
+
+  if (running.length > 0) {
+    parts.push(`${running.length} running`);
+  }
+
+  parts.push(`${done}/${items.length} done`);
+
+  if (failed > 0) {
+    parts.push(`${failed} failed`);
+  }
+
+  const listed = running.slice(0, MAX_LISTED).map((i) => i.id);
+  const extra = running.length - listed.length;
+  const tail =
+    listed.length > 0
+      ? ` (${listed.join(" · ")}${extra > 0 ? ` · +${extra}` : ""})`
+      : "";
+
+  return `agents: ${parts.join(", ")}${tail}`;
+}
+
+/**
+ * A Reporter that folds `agent_spawned`/`agent_result` events into a running
+ * status map and writes one refreshed summary line per transition. All other
+ * event kinds pass through untouched (they belong to whatever reporter the
+ * caller composes this with).
+ */
+export function makeAgentSummaryTracker(
+  write: (line: string) => void
+): Reporter {
+  const statuses = new Map<string, AgentItemStatus>();
+
+  return (event: ILoopEvent): void => {
+    if (event.kind === "agent_spawned") {
+      statuses.set(event.message, "running");
+    } else if (event.kind === "agent_result") {
+      statuses.set(event.message, event.passed === true ? "done" : "failed");
+    } else {
+      return;
+    }
+
+    const items = [...statuses.entries()].map(([id, status]) => ({
+      id,
+      status,
+    }));
+
+    write(formatAgentSummary(items));
+  };
+}

--- a/packages/core/src/render/agent-tree.ts
+++ b/packages/core/src/render/agent-tree.ts
@@ -57,10 +57,11 @@ export function formatAgentSummary(
 }
 
 /**
- * A Reporter that folds `agent_spawned`/`agent_result` events into a running
- * status map and writes one refreshed summary line per transition. All other
- * event kinds pass through untouched (they belong to whatever reporter the
- * caller composes this with).
+ * A Reporter that folds the agent lifecycle events into a status map and
+ * writes one refreshed summary line per transition. All units spawn up-front
+ * (pending), so the `k/N done` denominator is stable from the first line.
+ * Other event kinds pass through untouched (they belong to whatever reporter
+ * the caller composes this with).
  */
 export function makeAgentSummaryTracker(
   write: (line: string) => void
@@ -69,6 +70,8 @@ export function makeAgentSummaryTracker(
 
   return (event: ILoopEvent): void => {
     if (event.kind === "agent_spawned") {
+      statuses.set(event.message, "pending");
+    } else if (event.kind === "agent_started") {
       statuses.set(event.message, "running");
     } else if (event.kind === "agent_result") {
       statuses.set(event.message, event.passed === true ? "done" : "failed");

--- a/packages/core/tests/agent-scheduler.test.ts
+++ b/packages/core/tests/agent-scheduler.test.ts
@@ -1,0 +1,156 @@
+import { test, expect, describe } from "bun:test";
+import {
+  AgentScheduler,
+  clampConcurrency,
+  type IScheduledUnit,
+  type UnitStatus,
+} from "../src/agent/agent-scheduler";
+
+const sleep = (ms: number): Promise<void> =>
+  new Promise((resolve) => setTimeout(resolve, ms));
+
+function unit<T>(
+  id: string,
+  run: (signal: AbortSignal) => Promise<T>
+): IScheduledUnit<T> {
+  return { id, run };
+}
+
+describe("clampConcurrency", () => {
+  test("clamps junk to 1 and floors fractions", () => {
+    expect(clampConcurrency(undefined)).toBe(1);
+    expect(clampConcurrency(0)).toBe(1);
+    expect(clampConcurrency(-4)).toBe(1);
+    expect(clampConcurrency(3.7)).toBe(3);
+    expect(clampConcurrency(Number.NaN)).toBe(1);
+    expect(clampConcurrency(Number.POSITIVE_INFINITY)).toBe(1);
+    expect(clampConcurrency(4)).toBe(4);
+  });
+});
+
+describe("AgentScheduler.runParallel", () => {
+  test("respects the concurrency cap (max in-flight never exceeds it)", async () => {
+    let inFlight = 0;
+    let peak = 0;
+    const units = Array.from({ length: 8 }, (_, i) =>
+      unit(`u${String(i)}`, async () => {
+        inFlight += 1;
+        peak = Math.max(peak, inFlight);
+        await sleep(10);
+        inFlight -= 1;
+
+        return i;
+      })
+    );
+
+    const results = await new AgentScheduler({ concurrency: 3 }).runParallel(
+      units
+    );
+
+    expect(peak).toBeLessThanOrEqual(3);
+    expect(peak).toBeGreaterThan(1); // it actually ran concurrently
+    expect(results).toEqual([0, 1, 2, 3, 4, 5, 6, 7]);
+  });
+
+  test("returns results in submission order even when completion is reversed", async () => {
+    // Earlier units sleep longer, so completion order is the REVERSE of
+    // submission order — the result array must not care.
+    const units = Array.from({ length: 4 }, (_, i) =>
+      unit(`u${String(i)}`, async () => {
+        await sleep((4 - i) * 15);
+
+        return `r${String(i)}`;
+      })
+    );
+
+    const results = await new AgentScheduler({ concurrency: 4 }).runParallel(
+      units
+    );
+
+    expect(results).toEqual(["r0", "r1", "r2", "r3"]);
+  });
+
+  test("a throwing unit degrades to a null slot; siblings still complete", async () => {
+    const results = await new AgentScheduler({ concurrency: 2 }).runParallel([
+      unit("ok1", () => Promise.resolve(1)),
+      unit("boom", () => Promise.reject(new Error("unit failed"))),
+      unit("ok2", () => Promise.resolve(2)),
+    ]);
+
+    expect(results).toEqual([1, null, 2]);
+  });
+
+  test("master abort skips pending units (null slots) and flags unit signals", async () => {
+    const ctrl = new AbortController();
+    const started: string[] = [];
+    const units = Array.from({ length: 6 }, (_, i) =>
+      unit(`u${String(i)}`, async (signal) => {
+        started.push(`u${String(i)}`);
+
+        if (i === 0) {
+          ctrl.abort(); // first unit aborts the whole fan-out
+        }
+
+        await sleep(5);
+
+        return signal.aborted ? "aborted" : "ran";
+      })
+    );
+
+    const results = await new AgentScheduler({
+      concurrency: 1,
+      signal: ctrl.signal,
+    }).runParallel(units);
+
+    // Only the first unit ever started; the rest were skipped as null.
+    expect(started).toEqual(["u0"]);
+    expect(results[0]).toBe("aborted"); // its per-unit signal fired mid-run
+    expect(results.slice(1)).toEqual([null, null, null, null, null]);
+  });
+
+  test("emits start→done / start→failed transitions per unit", async () => {
+    const transitions: [string, UnitStatus][] = [];
+
+    await new AgentScheduler({
+      concurrency: 1,
+      onUnit: (id, status) => transitions.push([id, status]),
+    }).runParallel([
+      unit("a", () => Promise.resolve("ok")),
+      unit("b", () => Promise.reject(new Error("x"))),
+    ]);
+
+    expect(transitions).toEqual([
+      ["a", "start"],
+      ["a", "done"],
+      ["b", "start"],
+      ["b", "failed"],
+    ]);
+  });
+
+  test("cap>1 is genuinely faster than sequential on slow units (the mechanical speedup)", async () => {
+    const make = (): IScheduledUnit<number>[] =>
+      Array.from({ length: 6 }, (_, i) =>
+        unit(`u${String(i)}`, async () => {
+          await sleep(50);
+
+          return i;
+        })
+      );
+
+    const t1 = performance.now();
+
+    await new AgentScheduler({ concurrency: 1 }).runParallel(make());
+
+    const sequentialMs = performance.now() - t1;
+    const t2 = performance.now();
+
+    await new AgentScheduler({ concurrency: 3 }).runParallel(make());
+
+    const parallelMs = performance.now() - t2;
+
+    // 6×50ms: sequential ≈300ms, cap=3 ≈100ms. Generous margins to stay
+    // flake-free under CI load — the claim is only "meaningfully faster".
+    expect(sequentialMs).toBeGreaterThanOrEqual(280);
+    expect(parallelMs).toBeLessThan(sequentialMs * 0.6);
+  });
+});

--- a/packages/core/tests/agent-scheduler.test.ts
+++ b/packages/core/tests/agent-scheduler.test.ts
@@ -108,7 +108,7 @@ describe("AgentScheduler.runParallel", () => {
     expect(results.slice(1)).toEqual([null, null, null, null, null]);
   });
 
-  test("emits start→done / start→failed transitions per unit", async () => {
+  test("announces every unit as pending up-front, then start→done/failed", async () => {
     const transitions: [string, UnitStatus][] = [];
 
     await new AgentScheduler({
@@ -119,12 +119,30 @@ describe("AgentScheduler.runParallel", () => {
       unit("b", () => Promise.reject(new Error("x"))),
     ]);
 
+    // All pendings first (stable denominator for progress UIs), then the
+    // per-unit lifecycles in schedule order.
     expect(transitions).toEqual([
+      ["a", "pending"],
+      ["b", "pending"],
       ["a", "start"],
       ["a", "done"],
       ["b", "start"],
       ["b", "failed"],
     ]);
+  });
+
+  test("a unit scheduled under an ALREADY-aborted master sees an aborted signal", async () => {
+    const ctrl = new AbortController();
+
+    ctrl.abort(); // aborted before runParallel is even called
+
+    const results = await new AgentScheduler({
+      concurrency: 2,
+      signal: ctrl.signal,
+    }).runParallel([unit("a", (signal) => Promise.resolve(signal.aborted))]);
+
+    // The worker loop skips pending units under an aborted master entirely.
+    expect(results).toEqual([null]);
   });
 
   test("cap>1 is genuinely faster than sequential on slow units (the mechanical speedup)", async () => {

--- a/packages/core/tests/agent-tree.test.ts
+++ b/packages/core/tests/agent-tree.test.ts
@@ -1,0 +1,94 @@
+import { test, expect, describe } from "bun:test";
+import {
+  formatAgentSummary,
+  makeAgentSummaryTracker,
+} from "../src/render/agent-tree";
+
+describe("formatAgentSummary", () => {
+  test("empty input renders nothing", () => {
+    expect(formatAgentSummary([])).toBe("");
+  });
+
+  test("summarizes running/done/failed with running ids listed", () => {
+    const line = formatAgentSummary([
+      { id: "find:a.ts", status: "running" },
+      { id: "find:b.ts", status: "running" },
+      { id: "find:c.ts", status: "done" },
+      { id: "find:d.ts", status: "failed" },
+    ]);
+
+    expect(line).toBe(
+      "agents: 2 running, 1/4 done, 1 failed (find:a.ts · find:b.ts)"
+    );
+  });
+
+  test("elides beyond three running ids with a +N tail", () => {
+    const line = formatAgentSummary(
+      Array.from({ length: 5 }, (_, i) => ({
+        id: `find:f${String(i)}.ts`,
+        status: "running" as const,
+      }))
+    );
+
+    expect(line).toContain("5 running");
+    expect(line).toContain("· +2)");
+    expect(line).not.toContain("f4.ts");
+  });
+
+  test("all done → no running list", () => {
+    expect(
+      formatAgentSummary([
+        { id: "a", status: "done" },
+        { id: "b", status: "done" },
+      ])
+    ).toBe("agents: 2/2 done");
+  });
+});
+
+describe("makeAgentSummaryTracker", () => {
+  test("folds agent events into refreshed summary lines, ignores other kinds", () => {
+    const lines: string[] = [];
+    const track = makeAgentSummaryTracker((line) => lines.push(line));
+
+    track({
+      kind: "agent_spawned",
+      task: "review",
+      message: "find:a.ts",
+      agentId: "review:find:a.ts",
+      parentTask: "review",
+    });
+    track({ kind: "cycle", task: "review", message: "" }); // not an agent event
+    track({
+      kind: "agent_result",
+      task: "review",
+      message: "find:a.ts",
+      agentId: "review:find:a.ts",
+      parentTask: "review",
+      passed: true,
+    });
+
+    expect(lines).toEqual([
+      "agents: 1 running, 0/1 done (find:a.ts)",
+      "agents: 1/1 done",
+    ]);
+  });
+
+  test("a failed result counts as failed, not done", () => {
+    const lines: string[] = [];
+    const track = makeAgentSummaryTracker((line) => lines.push(line));
+
+    track({
+      kind: "agent_spawned",
+      task: "review",
+      message: "verify:x.ts:3",
+    });
+    track({
+      kind: "agent_result",
+      task: "review",
+      message: "verify:x.ts:3",
+      passed: false,
+    });
+
+    expect(lines.at(-1)).toBe("agents: 0/1 done, 1 failed");
+  });
+});

--- a/packages/core/tests/agent-tree.test.ts
+++ b/packages/core/tests/agent-tree.test.ts
@@ -46,30 +46,27 @@ describe("formatAgentSummary", () => {
 });
 
 describe("makeAgentSummaryTracker", () => {
-  test("folds agent events into refreshed summary lines, ignores other kinds", () => {
+  test("stable denominator: pendings announce the total before anything runs", () => {
     const lines: string[] = [];
     const track = makeAgentSummaryTracker((line) => lines.push(line));
 
-    track({
-      kind: "agent_spawned",
-      task: "review",
-      message: "find:a.ts",
-      agentId: "review:find:a.ts",
-      parentTask: "review",
-    });
+    // Two units spawn up-front — the denominator is 2 from the first line.
+    track({ kind: "agent_spawned", task: "review", message: "find:a.ts" });
+    track({ kind: "agent_spawned", task: "review", message: "find:b.ts" });
     track({ kind: "cycle", task: "review", message: "" }); // not an agent event
+    track({ kind: "agent_started", task: "review", message: "find:a.ts" });
     track({
       kind: "agent_result",
       task: "review",
       message: "find:a.ts",
-      agentId: "review:find:a.ts",
-      parentTask: "review",
       passed: true,
     });
 
     expect(lines).toEqual([
-      "agents: 1 running, 0/1 done (find:a.ts)",
-      "agents: 1/1 done",
+      "agents: 0/1 done",
+      "agents: 0/2 done",
+      "agents: 1 running, 0/2 done (find:a.ts)",
+      "agents: 1/2 done",
     ]);
   });
 
@@ -80,12 +77,17 @@ describe("makeAgentSummaryTracker", () => {
     track({
       kind: "agent_spawned",
       task: "review",
-      message: "verify:x.ts:3",
+      message: "verify:x.ts:3#0",
+    });
+    track({
+      kind: "agent_started",
+      task: "review",
+      message: "verify:x.ts:3#0",
     });
     track({
       kind: "agent_result",
       task: "review",
-      message: "verify:x.ts:3",
+      message: "verify:x.ts:3#0",
       passed: false,
     });
 

--- a/packages/core/tests/ledger.test.ts
+++ b/packages/core/tests/ledger.test.ts
@@ -54,6 +54,7 @@ describe("ledgerTypeFor — kind → typed event", () => {
       ["run", "tool_call_finished"],
       ["policy", "policy_decision"],
       ["agent_spawned", "agent_spawned"],
+      ["agent_started", "agent_started"],
       ["agent_result", "agent_result"],
       ["timing", "log"],
     ];

--- a/packages/core/tests/review-change.test.ts
+++ b/packages/core/tests/review-change.test.ts
@@ -341,3 +341,140 @@ test("the senior-review rubric ships with the expected lenses", () => {
     LENSES.every((l) => l.questions.length > 0 && l.example.length > 0)
   ).toBe(true);
 });
+
+/** A three-file repo where every file has an uncommitted change on line 2. */
+function makeTriRepo(): string {
+  const tri = mkdtempSync(join(tmpdir(), "tsforge-review-tri-"));
+  const tgit = (...a: string[]): void =>
+    void execFileSync("git", a, { cwd: tri, stdio: "ignore" });
+
+  tgit("init", "-q");
+  tgit("config", "user.email", "t@t.t");
+  tgit("config", "user.name", "t");
+  tgit("config", "commit.gpgsign", "false");
+
+  for (const name of ["alpha.ts", "beta.ts", "gamma.ts"]) {
+    writeFileSync(
+      join(tri, name),
+      "export function f(a: number, b: number): number {\n  return a - b;\n}\n"
+    );
+  }
+
+  tgit("add", "-A");
+  tgit("commit", "-q", "-m", "init");
+
+  for (const name of ["alpha.ts", "beta.ts", "gamma.ts"]) {
+    writeFileSync(
+      join(tri, name),
+      "export function f(a: number, b: number): number {\n  return b - a;\n}\n"
+    );
+  }
+
+  return tri;
+}
+
+test("parallel fan-out: file-ordered report, fresh provider per unit, primary provider untouched", async () => {
+  const tri = makeTriRepo();
+
+  // Earlier files answer SLOWER, so completion order is the reverse of
+  // submission order — the report must stay file-ordered anyway.
+  const delayFor = (prompt: string): number => {
+    if (prompt.includes("alpha.ts")) {
+      return 60;
+    }
+
+    return prompt.includes("beta.ts") ? 30 : 0;
+  };
+
+  let factoryCalls = 0;
+
+  const factory = (): IProvider => {
+    factoryCalls += 1;
+
+    return {
+      async complete(messages) {
+        const sys = messages.find((m) => m.role === "system")?.content ?? "";
+        const user = messages.find((m) => m.role === "user")?.content ?? "";
+
+        if (sys.includes("verifying a code-review finding")) {
+          return {
+            content: JSON.stringify({ real: true, verdict: "judged" }),
+            toolCalls: [],
+          };
+        }
+
+        await new Promise((resolve) => setTimeout(resolve, delayFor(user)));
+
+        return { content: FINDINGS, toolCalls: [] };
+      },
+    };
+  };
+
+  // The primary provider must never be used once a factory is supplied.
+  const primary: IProvider = {
+    complete: () => Promise.reject(new Error("primary provider was used")),
+  };
+
+  try {
+    const report = await reviewChange(primary, tri, {
+      concurrency: 3,
+      providerFactory: factory,
+    });
+
+    expect(report.findings.map((f) => f.file)).toEqual([
+      "alpha.ts",
+      "beta.ts",
+      "gamma.ts",
+    ]);
+    // One fresh provider per unit: 3 find + 3 verify.
+    expect(factoryCalls).toBe(6);
+  } finally {
+    rmSync(tri, { recursive: true, force: true });
+  }
+});
+
+test("fan-out emits attributed agent_spawned/agent_result events per unit", async () => {
+  const tri = makeTriRepo();
+  const events: { kind: string; agentId?: string; passed?: boolean }[] = [];
+
+  try {
+    await reviewChange(stub(FINDINGS, true), tri, {
+      concurrency: 2,
+      providerFactory: () => stub(FINDINGS, true),
+      onEvent: (e) => {
+        if (e.kind === "agent_spawned" || e.kind === "agent_result") {
+          events.push({
+            kind: e.kind,
+            ...(e.agentId === undefined ? {} : { agentId: e.agentId }),
+            ...(e.passed === undefined ? {} : { passed: e.passed }),
+          });
+        }
+      },
+    });
+
+    const spawned = events.filter((e) => e.kind === "agent_spawned");
+    const results = events.filter((e) => e.kind === "agent_result");
+
+    // 3 find units + 3 verify units, each spawned and resolved.
+    expect(spawned).toHaveLength(6);
+    expect(results).toHaveLength(6);
+    expect(
+      spawned.filter((e) => e.agentId?.startsWith("review:find:") === true)
+    ).toHaveLength(3);
+    expect(
+      spawned.filter((e) => e.agentId?.startsWith("review:verify:") === true)
+    ).toHaveLength(3);
+    expect(results.every((e) => e.passed === true)).toBe(true);
+  } finally {
+    rmSync(tri, { recursive: true, force: true });
+  }
+});
+
+test("concurrency 1 with no factory behaves exactly as before (shared provider)", async () => {
+  const report = await reviewChange(stub(FINDINGS, true), repo, {
+    concurrency: 1,
+  });
+
+  expect(report.findings).toHaveLength(1);
+  expect(report.rejected).toBe(0);
+});

--- a/packages/core/tests/review-change.test.ts
+++ b/packages/core/tests/review-change.test.ts
@@ -442,7 +442,11 @@ test("fan-out emits attributed agent_spawned/agent_result events per unit", asyn
       concurrency: 2,
       providerFactory: () => stub(FINDINGS, true),
       onEvent: (e) => {
-        if (e.kind === "agent_spawned" || e.kind === "agent_result") {
+        if (
+          e.kind === "agent_spawned" ||
+          e.kind === "agent_started" ||
+          e.kind === "agent_result"
+        ) {
           events.push({
             kind: e.kind,
             ...(e.agentId === undefined ? {} : { agentId: e.agentId }),
@@ -453,10 +457,12 @@ test("fan-out emits attributed agent_spawned/agent_result events per unit", asyn
     });
 
     const spawned = events.filter((e) => e.kind === "agent_spawned");
+    const started = events.filter((e) => e.kind === "agent_started");
     const results = events.filter((e) => e.kind === "agent_result");
 
-    // 3 find units + 3 verify units, each spawned and resolved.
+    // 3 find units + 3 verify units: each announced, started, and resolved.
     expect(spawned).toHaveLength(6);
+    expect(started).toHaveLength(6);
     expect(results).toHaveLength(6);
     expect(
       spawned.filter((e) => e.agentId?.startsWith("review:find:") === true)
@@ -477,4 +483,71 @@ test("concurrency 1 with no factory behaves exactly as before (shared provider)"
 
   expect(report.findings).toHaveLength(1);
   expect(report.rejected).toBe(0);
+});
+
+test("two findings on the SAME line get distinct verify unit ids", async () => {
+  // Duplicate ids would collapse distinct units in the tracker and ledger.
+  const sameLine = JSON.stringify({
+    findings: [
+      {
+        line: 2,
+        severity: "error",
+        lens: "correctness",
+        claim: "first claim",
+        reason: "x",
+      },
+      {
+        line: 2,
+        severity: "warning",
+        lens: "regressions",
+        claim: "second claim",
+        reason: "y",
+      },
+    ],
+  });
+  const verifyIds: string[] = [];
+
+  const report = await reviewChange(stub(sameLine, true), repo, {
+    concurrency: 2,
+    providerFactory: () => stub(sameLine, true),
+    onEvent: (e) => {
+      if (
+        e.kind === "agent_spawned" &&
+        e.agentId?.startsWith("review:verify:") === true
+      ) {
+        verifyIds.push(e.agentId);
+      }
+    },
+  });
+
+  expect(report.findings).toHaveLength(2);
+  expect(verifyIds).toHaveLength(2);
+  expect(new Set(verifyIds).size).toBe(2); // no collision
+});
+
+test("the per-unit AbortSignal reaches the provider (in-flight cancellation)", async () => {
+  let sawSignal = false;
+  const observing = (): IProvider => ({
+    async complete(messages, opts) {
+      if (opts?.signal instanceof AbortSignal) {
+        sawSignal = true;
+      }
+
+      const sys = messages.find((m) => m.role === "system")?.content ?? "";
+
+      return {
+        content: sys.includes("verifying a code-review finding")
+          ? JSON.stringify({ real: true, verdict: "judged" })
+          : FINDINGS,
+        toolCalls: [],
+      };
+    },
+  });
+
+  await reviewChange(observing(), repo, {
+    concurrency: 2,
+    providerFactory: observing,
+  });
+
+  expect(sawSignal).toBe(true);
 });

--- a/packages/core/tests/tsforge-config.test.ts
+++ b/packages/core/tests/tsforge-config.test.ts
@@ -7,6 +7,7 @@ import {
   resolveActivePacks,
   normalizeRuleOverrides,
   resolveProjectProfile,
+  resolveAgentConcurrency,
   type ITsforgeProjectConfig,
 } from "../src/config/tsforge-config";
 import { makeFileLinter } from "../src/gate";
@@ -131,6 +132,49 @@ describe("loadTsforgeConfig", () => {
     } finally {
       rmSync(dir, { recursive: true, force: true });
     }
+  });
+});
+
+describe("agents block + resolveAgentConcurrency", () => {
+  async function loadWith(agents: unknown): Promise<ITsforgeProjectConfig> {
+    const dir = mkdtempSync(join(tmpdir(), "tsforge-agents-"));
+
+    try {
+      writeFileSync(
+        join(dir, "tsforge.config.json"),
+        JSON.stringify({ agents })
+      );
+
+      return await loadTsforgeConfig(dir);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  }
+
+  test("a valid concurrency loads and resolves", async () => {
+    const config = await loadWith({ concurrency: 4 });
+
+    expect(config.agents?.concurrency).toBe(4);
+    expect(resolveAgentConcurrency(config)).toBe(4);
+  });
+
+  test("absent block resolves to 1 (sequential default)", () => {
+    expect(resolveAgentConcurrency({})).toBe(1);
+  });
+
+  test("invalid concurrency values are warn-and-dropped", async () => {
+    for (const bad of [0, 17, 1.5, "3", -2, null]) {
+      const config = await loadWith({ concurrency: bad });
+
+      expect(config.agents).toBeUndefined();
+      expect(resolveAgentConcurrency(config)).toBe(1);
+    }
+  });
+
+  test("a non-object agents block is dropped", async () => {
+    const config = await loadWith("fast");
+
+    expect(config.agents).toBeUndefined();
   });
 });
 


### PR DESCRIPTION
Phase A of the multiagent plan, slice 2 (follows #73). The concurrency-capped scheduler, with review mode as its first consumer.

## What

1. **`AgentScheduler`** (`src/agent/agent-scheduler.ts`): sliding-window scheduler over generic `(signal) => Promise<T>` thunks — single `provider.complete()` calls today, full agent loops in Phase B. Order-preserving results, per-unit `AbortController` chained under a master signal, one failed unit degrades to a `null` slot without sinking siblings. **cap=1 is the original sequential path**, first-class and tested.
2. **Config**: `agents.concurrency` in `tsforge.config.json` (integer 1–16, warn-and-drop validation, default **1**) + `resolveAgentConcurrency()`.
3. **Parallel review**: `reviewChange()`'s per-file find pass and per-finding verify pass run through the scheduler. New opts: `concurrency`, `providerFactory` (fresh provider per unit — the DeepSeek thinking latch is per-instance state), `onEvent` (`agent_spawned`/`agent_result` attribution per unit, riding the #73 plumbing). Reports stay file-ordered regardless of completion order.
4. **Progress line**: `render/agent-tree.ts` — `formatAgentSummary` + `makeAgentSummaryTracker`; `tsforge review` prints `agents: 2 running, 1/6 done (find:a.ts · find:b.ts)` when the cap is above 1. This module grows into the full live agent tree in Phase B.

## Eval status (Phase-A gate)

- **Quality parity is structural**: the parallel path issues identical model calls with identical prompts — locked by the order-stability test (reversed completion order → identical report).
- **Mechanical speedup**: deterministic scheduler timing test (6×50ms units: cap=3 < 60% of sequential wall-clock).
- **Live-endpoint numbers**: being run against the real vllm/DeepSeek endpoint (max_num_seqs=4, prefix caching — the shared find-pass system prompt should hit the prefix cache across batched units); results will be posted on this PR. The config default stays 1 until those numbers justify the flip.

## Testing

20 new tests: scheduler (cap ceiling, order preservation under reversed completion, failure degradation, master abort, transition events, timing), summary formatter + event tracker, config validation (valid/invalid/absent), parallel review (file-ordered report, factory-per-unit with primary-provider-untouched proof, attributed events, cap=1 back-compat). Full validate green incl. 20/20 PTY e2e.