### PR TITLE
feat(agents): IAgentSpec + loader + read-only AgentRunner (multiagent PR-B1)

### DIFF
--- a/apps/docs/src/content/docs/cli/review.mdx
+++ b/apps/docs/src/content/docs/cli/review.mdx
@@ -37,6 +37,16 @@ The usual failure of AI review is confident nonsense. tsforge runs an adversaria
 
 When a `tsconfig.json` is present, it also feeds the reviewer the callers of each changed export, computed from the type graph, so the regression check looks at concrete call sites instead of guessing.
 
+## Parallel review
+
+By default the per-file find pass and per-finding verify pass run one model call at a time. If your endpoint genuinely batches concurrent requests (e.g. vllm with `max_num_seqs` headroom), set [`agents.concurrency`](/guardrails/config/) in `tsforge.config.json`:
+
+```json
+{ "agents": { "concurrency": 4 } }
+```
+
+Review then fans out up to that many calls at once — each with a fresh provider — and prints a live `agents: 2 running, 5/16 done (…)` progress line. Results are identical in structure and order to a sequential run; only the wall-clock changes (≈2× measured at cap 8 on a batching endpoint). Keep the cap a couple below your server's `max_num_seqs` so an interactive session is never starved, and leave it at 1 for endpoints that serialize requests anyway.
+
 ## In CI
 
 `tsforge review` exits non-zero if any error-severity finding survives, so you can gate a PR on it. It uses `git` to find what changed, so run it inside a git repository.

--- a/packages/core/src/agent/agent-runner.ts
+++ b/packages/core/src/agent/agent-runner.ts
@@ -1,0 +1,286 @@
+/**
+ * AgentRunner — the read-only subagent loop. Composes the turn primitives
+ * directly (provider.complete + runToolCalls), NOT runTask: runTask is an
+ * edit-to-green loop (RED precheck, gate-driving, full toolset) and a
+ * read-only explorer has nothing to gate. Read-only is STRUCTURAL here:
+ * (1) advertised tools are the spec subset ∩ TOOL_SPECS read-only set,
+ * (2) ctx.tool.readOnly=true makes executeTool hard-reject any mutation,
+ * (3) the policy layer still evaluates first, as for every tool call.
+ * Lifecycle events (agent_spawned/started/result) belong to the ORCHESTRATOR
+ * (scheduler unitReporter); the runner only tags its inner events with
+ * agentId/parentTask so interleaved streams stay attributable.
+ */
+import type { IProvider } from "../inference";
+import type { ILoopEvent, Reporter } from "../loop/loop.types";
+import {
+  buildTsService,
+  runToolCalls,
+  toolsFor,
+  type ILoopCtx,
+  type ILoopState,
+} from "../loop/turn";
+import { TOOL_SPECS } from "./agent.constants";
+import type { IAgentSpec } from "./agent-spec";
+
+export const AGENT_LIMITS = {
+  /** Default turn cap for a subagent — exploration, not an open-ended session. */
+  maxTurns: 12,
+} as const;
+
+const DEFAULT_SYSTEM = [
+  "You are a focused read-only investigator inside a coding harness.",
+  "Explore the workspace with the provided tools, then answer the task in ONE",
+  "final message: state conclusions with file:line references, not raw dumps.",
+  "You cannot edit files — do not propose tool calls that write.",
+].join(" ");
+
+/** The structured-output control tool: intercepted by the runner itself (never
+ *  dispatched to executeTool), so the parent gets a parseable final payload. */
+const AGENT_RESULT_TOOL = {
+  type: "function",
+  function: {
+    name: "agent_result",
+    description:
+      "Return your final result and finish. Call exactly once, when done.",
+    parameters: {
+      type: "object",
+      properties: {
+        result: {
+          type: "string",
+          description: "Your complete findings/answer.",
+        },
+      },
+      required: ["result"],
+    },
+  },
+} as const;
+
+/** Cast-free read-only check against the TOOL_SPECS registry. */
+function isReadOnlyTool(name: string): boolean {
+  return Object.entries(TOOL_SPECS).some(
+    ([tool, spec]) => tool === name && spec.readOnly
+  );
+}
+
+/** The agent's advertised tools: read-only set ∩ optional spec subset. */
+function agentTools(subset: readonly string[] | undefined): unknown[] {
+  return toolsFor(true).filter((tool) => {
+    const name = tool.function.name;
+
+    return (
+      isReadOnlyTool(name) && (subset === undefined || subset.includes(name))
+    );
+  });
+}
+
+export interface IAgentResult {
+  status: "done" | "max_turns" | "aborted" | "error";
+  /** Final text (or the structured `result` payload). */
+  output: string;
+  turns: number;
+  durationMs: number;
+  /** Every event the agent emitted, agentId-tagged (for replay/tests). */
+  events: ILoopEvent[];
+}
+
+export interface IAgentRunOptions {
+  provider: IProvider;
+  cwd: string;
+  /** The spawning task's id — the agent's id becomes `${parentTaskId}:${spec.id}`. */
+  parentTaskId: string;
+  /** The task text; falls back to spec.task. */
+  task?: string;
+  report?: Reporter;
+  signal?: AbortSignal;
+  temperature?: number;
+}
+
+/** Pull the structured payload out of an intercepted agent_result call. */
+function resultPayload(args: Record<string, unknown>): string {
+  return typeof args.result === "string" ? args.result : JSON.stringify(args);
+}
+
+export class AgentRunner {
+  constructor(private readonly spec: IAgentSpec) {}
+
+  async run(opts: IAgentRunOptions): Promise<IAgentResult> {
+    const spec = this.spec;
+
+    if (spec.kind === "generate") {
+      return {
+        status: "error",
+        output: `agent '${spec.id}': kind "generate" is not implemented yet`,
+        turns: 0,
+        durationMs: 0,
+        events: [],
+      };
+    }
+
+    const agentId = `${opts.parentTaskId}:${spec.id}`;
+    const events: ILoopEvent[] = [];
+
+    const report: Reporter = (event) => {
+      const tagged: ILoopEvent = {
+        ...event,
+        agentId,
+        parentTask: opts.parentTaskId,
+      };
+
+      events.push(tagged);
+      opts.report?.(tagged);
+    };
+
+    const taskText = opts.task ?? spec.task ?? "";
+    const structured = spec.outputMode === "structured";
+    const tools = structured
+      ? [...agentTools(spec.tools), AGENT_RESULT_TOOL]
+      : agentTools(spec.tools);
+    const ctx: ILoopCtx = {
+      // No gate for a read-only agent: accept is empty (never run), and the
+      // whole-repo "scope" only matters to write paths executeTool rejects.
+      task: { id: agentId, accept: "", files: ["**/*"] },
+      cwd: opts.cwd,
+      tsService: await buildTsService(opts.cwd),
+      report,
+      messages: [
+        { role: "system", content: spec.systemPrompt ?? DEFAULT_SYSTEM },
+        { role: "user", content: taskText },
+      ],
+      // readOnly is NOT taken from the spec — Phase B/C agents cannot mutate,
+      // full stop; the write path arrives with Phase D worktree writers.
+      tool: {
+        touched: new Set<string>(),
+        readOnly: true,
+        ...(opts.signal === undefined ? {} : { signal: opts.signal }),
+      },
+      gate: { parse: undefined },
+    };
+    const state: ILoopState = {
+      prevGateErrors: [],
+      gateNoProgress: 0,
+      bestErrorCount: Number.POSITIVE_INFINITY,
+      noNewLow: 0,
+      errorAge: new Map(),
+      lastGateCount: -1,
+      edits: 0,
+      regressions: 0,
+      ttsrInterrupts: 0,
+    };
+    const maxTurns = spec.maxTurns ?? AGENT_LIMITS.maxTurns;
+    const start = performance.now();
+    const finish = (
+      status: IAgentResult["status"],
+      output: string,
+      turns: number
+    ): IAgentResult => ({
+      status,
+      output,
+      turns,
+      durationMs: performance.now() - start,
+      events,
+    });
+
+    try {
+      return await this.turnLoop(opts, ctx, state, {
+        agentId,
+        structured,
+        tools,
+        maxTurns,
+        report,
+        finish,
+      });
+    } catch (err) {
+      report({
+        kind: "tool",
+        task: agentId,
+        message: `agent ${spec.id} failed: ${err instanceof Error ? err.message : String(err)}`,
+      });
+
+      return finish("error", "", maxTurns);
+    }
+  }
+
+  /** The model↔tools turn loop, split from run() to keep complexity in check. */
+  private async turnLoop(
+    opts: IAgentRunOptions,
+    ctx: ILoopCtx,
+    state: ILoopState,
+    loop: {
+      agentId: string;
+      structured: boolean;
+      tools: unknown[];
+      maxTurns: number;
+      report: Reporter;
+      finish: (
+        status: IAgentResult["status"],
+        output: string,
+        turns: number
+      ) => IAgentResult;
+    }
+  ): Promise<IAgentResult> {
+    const { agentId, structured, tools, maxTurns, report, finish } = loop;
+    let lastText = "";
+
+    {
+      for (let turn = 1; turn <= maxTurns; turn += 1) {
+        if (opts.signal?.aborted === true) {
+          return finish("aborted", lastText, turn - 1);
+        }
+
+        report({
+          kind: "cycle",
+          task: agentId,
+          cycle: turn,
+          message: `agent ${this.spec.id} · turn ${turn}`,
+        });
+
+        const res = await opts.provider.complete(ctx.messages, {
+          tools,
+          toolChoice: "auto",
+          temperature: opts.temperature ?? 0,
+          ...(opts.signal === undefined ? {} : { signal: opts.signal }),
+          onToken: (text) => {
+            report({ kind: "token", task: agentId, message: text });
+          },
+        });
+
+        ctx.messages.push({
+          role: "assistant",
+          content: res.content,
+          toolCalls: res.toolCalls,
+          ...(res.reasoning === undefined
+            ? {}
+            : { reasoningContent: res.reasoning }),
+        });
+        lastText = res.content.length > 0 ? res.content : lastText;
+
+        const resultCall = res.toolCalls.find(
+          (c) => c.name === AGENT_RESULT_TOOL.function.name
+        );
+
+        if (resultCall !== undefined) {
+          return finish("done", resultPayload(resultCall.arguments), turn);
+        }
+
+        if (res.toolCalls.length === 0) {
+          // A structured agent that just stops talking has NOT delivered its
+          // payload — nudge once per remaining turn rather than accept prose.
+          if (structured) {
+            ctx.messages.push({
+              role: "user",
+              content:
+                "Call the agent_result tool with your final result to finish.",
+            });
+            continue;
+          }
+
+          return finish("done", res.content, turn);
+        }
+
+        await runToolCalls(res.toolCalls, ctx, state);
+      }
+
+      return finish("max_turns", lastText, maxTurns);
+    }
+  }
+}

--- a/packages/core/src/agent/agent-runner.ts
+++ b/packages/core/src/agent/agent-runner.ts
@@ -11,6 +11,8 @@
  * agentId/parentTask so interleaved streams stay attributable.
  */
 import type { IProvider } from "../inference";
+import type { TsService } from "../lsp";
+import type { PolicyMode, IPolicyRules } from "../policy";
 import type { ILoopEvent, Reporter } from "../loop/loop.types";
 import {
   buildTsService,
@@ -55,11 +57,16 @@ const AGENT_RESULT_TOOL = {
   },
 } as const;
 
-/** Cast-free read-only check against the TOOL_SPECS registry. */
+/** Read-only tool names, computed once from the registry (O(1) lookups,
+ *  no casts). */
+const READ_ONLY_TOOL_NAMES: ReadonlySet<string> = new Set(
+  Object.entries(TOOL_SPECS)
+    .filter(([, spec]) => spec.readOnly)
+    .map(([name]) => name)
+);
+
 function isReadOnlyTool(name: string): boolean {
-  return Object.entries(TOOL_SPECS).some(
-    ([tool, spec]) => tool === name && spec.readOnly
-  );
+  return READ_ONLY_TOOL_NAMES.has(name);
 }
 
 /** The agent's advertised tools: read-only set ∩ optional spec subset. */
@@ -93,6 +100,13 @@ export interface IAgentRunOptions {
   report?: Reporter;
   signal?: AbortSignal;
   temperature?: number;
+  /** Project policy — subagents obey the SAME deny/allow/ask rules as the
+   *  parent session; omitting these must be a caller decision, not a leak. */
+  policyMode?: PolicyMode;
+  policyRules?: IPolicyRules;
+  /** Reuse the parent's TsService — building one per concurrent agent is
+   *  heavy. `null` = workspace has none; undefined = build our own. */
+  tsService?: TsService | null;
 }
 
 /** Pull the structured payload out of an intercepted agent_result call. */
@@ -127,7 +141,12 @@ export class AgentRunner {
       };
 
       events.push(tagged);
-      opts.report?.(tagged);
+
+      try {
+        opts.report?.(tagged);
+      } catch {
+        // A caller's reporter throwing must never kill the agent run.
+      }
     };
 
     const taskText = opts.task ?? spec.task ?? "";
@@ -140,7 +159,10 @@ export class AgentRunner {
       // whole-repo "scope" only matters to write paths executeTool rejects.
       task: { id: agentId, accept: "", files: ["**/*"] },
       cwd: opts.cwd,
-      tsService: await buildTsService(opts.cwd),
+      tsService:
+        opts.tsService !== undefined
+          ? opts.tsService
+          : await buildTsService(opts.cwd),
       report,
       messages: [
         { role: "system", content: spec.systemPrompt ?? DEFAULT_SYSTEM },
@@ -151,6 +173,12 @@ export class AgentRunner {
       tool: {
         touched: new Set<string>(),
         readOnly: true,
+        ...(opts.policyMode === undefined
+          ? {}
+          : { policyMode: opts.policyMode }),
+        ...(opts.policyRules === undefined
+          ? {}
+          : { policyRules: opts.policyRules }),
         ...(opts.signal === undefined ? {} : { signal: opts.signal }),
       },
       gate: { parse: undefined },
@@ -180,6 +208,10 @@ export class AgentRunner {
       events,
     });
 
+    // Shared progress so an abort/error mid-run reports the TRUE turn count
+    // and any partial output, not maxTurns + "".
+    const progress = { turns: 0, lastText: "" };
+
     try {
       return await this.turnLoop(opts, ctx, state, {
         agentId,
@@ -188,15 +220,22 @@ export class AgentRunner {
         maxTurns,
         report,
         finish,
+        progress,
       });
     } catch (err) {
+      // A provider AbortError from a mid-request cancellation is an ABORT,
+      // not an agent failure.
+      if (opts.signal?.aborted === true) {
+        return finish("aborted", progress.lastText, progress.turns);
+      }
+
       report({
         kind: "tool",
         task: agentId,
         message: `agent ${spec.id} failed: ${err instanceof Error ? err.message : String(err)}`,
       });
 
-      return finish("error", "", maxTurns);
+      return finish("error", progress.lastText, progress.turns);
     }
   }
 
@@ -216,9 +255,11 @@ export class AgentRunner {
         output: string,
         turns: number
       ) => IAgentResult;
+      progress: { turns: number; lastText: string };
     }
   ): Promise<IAgentResult> {
-    const { agentId, structured, tools, maxTurns, report, finish } = loop;
+    const { agentId, structured, tools, maxTurns, report, finish, progress } =
+      loop;
     let lastText = "";
 
     {
@@ -226,6 +267,8 @@ export class AgentRunner {
         if (opts.signal?.aborted === true) {
           return finish("aborted", lastText, turn - 1);
         }
+
+        progress.turns = turn;
 
         report({
           kind: "cycle",
@@ -253,6 +296,7 @@ export class AgentRunner {
             : { reasoningContent: res.reasoning }),
         });
         lastText = res.content.length > 0 ? res.content : lastText;
+        progress.lastText = lastText;
 
         const resultCall = res.toolCalls.find(
           (c) => c.name === AGENT_RESULT_TOOL.function.name

--- a/packages/core/src/agent/agent-spec.ts
+++ b/packages/core/src/agent/agent-spec.ts
@@ -1,0 +1,32 @@
+/**
+ * A declarative subagent definition — data-only, like recipes. Describes WHAT
+ * an agent is (model, persona, tool subset, caps); the AgentRunner decides how
+ * it executes. Loaded from `.tsforge/agents/*.json` (see config/agent-specs).
+ */
+
+export type AgentKind = "chat" | "generate";
+export type AgentOutputMode = "text" | "structured";
+
+export interface IAgentSpec {
+  /** Stable kebab-case id (`explore`, `verify-claim`). */
+  readonly id: string;
+  /** One-line summary shown by listings. */
+  readonly description?: string;
+  /** Model name from `~/.tsforge/models.json`; absent ⇒ the session's model. */
+  readonly model?: string;
+  /** `"chat"` (tool-loop agent, default). `"generate"` is the reserved seam for
+   *  non-chat specialists (image gen) — Phase D; the runner rejects it today. */
+  readonly kind?: AgentKind;
+  /** System-prompt override; absent ⇒ the runner's read-only explorer prompt. */
+  readonly systemPrompt?: string;
+  /** Tool subset the agent may use (names from TOOL_NAME). Always intersected
+   *  with the read-only tool set — a spec cannot grant mutation. */
+  readonly tools?: readonly string[];
+  /** Default task/prompt when the caller doesn't supply one. */
+  readonly task?: string;
+  /** Hard cap on model turns (default AGENT_LIMITS.maxTurns). */
+  readonly maxTurns?: number;
+  /** `"structured"` forces a final `agent_result` tool call so the parent gets
+   *  a parseable payload; `"text"` (default) returns the final message. */
+  readonly outputMode?: AgentOutputMode;
+}

--- a/packages/core/src/agent/index.ts
+++ b/packages/core/src/agent/index.ts
@@ -2,3 +2,10 @@ export * from "./agent.types";
 export * from "./agent.constants";
 export * from "./tools";
 export { modelAgent } from "./model-agent";
+export {
+  AgentRunner,
+  AGENT_LIMITS,
+  type IAgentResult,
+  type IAgentRunOptions,
+} from "./agent-runner";
+export type { IAgentSpec, AgentKind, AgentOutputMode } from "./agent-spec";

--- a/packages/core/src/config/agent-specs.ts
+++ b/packages/core/src/config/agent-specs.ts
@@ -1,0 +1,173 @@
+/**
+ * Loader for declarative agent specs — `.tsforge/agents/*.json` (project) and
+ * `~/.tsforge/agents/*.json` (global); a project spec overrides a global one
+ * with the same id. Mirrors config/recipes.ts: data-only, warn-and-drop
+ * validation, unrecognized keys reported so a typo never silently does less.
+ */
+import { readdir, readFile } from "node:fs/promises";
+import { homedir } from "node:os";
+import { join } from "node:path";
+import { isRecord } from "../lib/guards";
+import type {
+  AgentKind,
+  AgentOutputMode,
+  IAgentSpec,
+} from "../agent/agent-spec";
+
+type Mutable = { -readonly [K in keyof IAgentSpec]: IAgentSpec[K] };
+
+function optString(value: unknown): string | undefined {
+  if (typeof value !== "string") {
+    return undefined;
+  }
+
+  const trimmed = value.trim();
+
+  return trimmed.length > 0 ? trimmed : undefined;
+}
+
+function optKind(value: unknown): AgentKind | undefined {
+  return value === "chat" || value === "generate" ? value : undefined;
+}
+
+function optOutputMode(value: unknown): AgentOutputMode | undefined {
+  return value === "text" || value === "structured" ? value : undefined;
+}
+
+function optPositive(value: unknown): number | undefined {
+  return typeof value === "number" && Number.isInteger(value) && value > 0
+    ? value
+    : undefined;
+}
+
+function stringArray(value: unknown): readonly string[] | undefined {
+  if (!Array.isArray(value)) {
+    return undefined;
+  }
+
+  const strings = value
+    .filter((v): v is string => typeof v === "string")
+    .map((v) => v.trim())
+    .filter((v) => v.length > 0);
+
+  return strings.length > 0 ? strings : undefined;
+}
+
+const KNOWN_KEYS = new Set<string>([
+  "id",
+  "description",
+  "model",
+  "kind",
+  "systemPrompt",
+  "tools",
+  "task",
+  "maxTurns",
+  "outputMode",
+]);
+
+/** Keys present in the raw spec that this version doesn't recognize. */
+export function unrecognizedAgentKeys(value: unknown): string[] {
+  if (!isRecord(value)) {
+    return [];
+  }
+
+  return Object.keys(value).filter((key) => !KNOWN_KEYS.has(key));
+}
+
+/** Validate one parsed JSON value into an IAgentSpec, or null when it isn't
+ *  one. Wrong-typed fields drop (warn-and-drop happens at load); a malformed
+ *  spec degrades to "ignored", never a crash. */
+export function parseAgentSpec(value: unknown): IAgentSpec | null {
+  if (!isRecord(value)) {
+    return null;
+  }
+
+  const id = optString(value.id);
+
+  if (id === undefined || !/^[a-z0-9][a-z0-9-]*$/u.test(id)) {
+    return null;
+  }
+
+  const spec: Mutable = { id };
+
+  spec.description = optString(value.description);
+  spec.model = optString(value.model);
+  spec.kind = optKind(value.kind);
+  spec.systemPrompt = optString(value.systemPrompt);
+  spec.tools = stringArray(value.tools);
+  spec.task = optString(value.task);
+  spec.maxTurns = optPositive(value.maxTurns);
+  spec.outputMode = optOutputMode(value.outputMode);
+
+  return spec;
+}
+
+async function loadDir(
+  dir: string,
+  into: Map<string, IAgentSpec>,
+  report: (message: string) => void
+): Promise<void> {
+  let names: string[];
+
+  try {
+    names = (await readdir(dir)).filter((n) => n.endsWith(".json")).sort();
+  } catch {
+    return; // no directory = no specs, not an error
+  }
+
+  for (const name of names) {
+    let parsed: unknown;
+
+    try {
+      parsed = JSON.parse(await readFile(join(dir, name), "utf8"));
+    } catch {
+      report(`agent '${name}': not valid JSON — skipped`);
+      continue;
+    }
+
+    const spec = parseAgentSpec(parsed);
+
+    if (spec === null) {
+      report(
+        `agent '${name}': not a valid spec (needs a kebab-case id) — skipped`
+      );
+      continue;
+    }
+
+    const unknown = unrecognizedAgentKeys(parsed);
+
+    if (unknown.length > 0) {
+      report(
+        `agent '${name}': ignoring unrecognized field(s): ${unknown.join(", ")}`
+      );
+    }
+
+    into.set(spec.id, spec); // later dir (project) wins on id collision
+  }
+}
+
+function homeBase(): string {
+  return process.env.TSFORGE_HOME ?? homedir();
+}
+
+/** Discover all agent specs for a repo, project overriding global on id
+ *  collision. Never throws — a broken spec can't take down a run. */
+export async function loadAgentSpecs(
+  cwd: string,
+  report: (message: string) => void = () => undefined
+): Promise<IAgentSpec[]> {
+  const byId = new Map<string, IAgentSpec>();
+
+  await loadDir(join(homeBase(), ".tsforge", "agents"), byId, report);
+  await loadDir(join(cwd, ".tsforge", "agents"), byId, report);
+
+  return [...byId.values()].sort((a, b) => a.id.localeCompare(b.id));
+}
+
+/** Find one spec by id. */
+export function findAgentSpec(
+  specs: readonly IAgentSpec[],
+  id: string
+): IAgentSpec | undefined {
+  return specs.find((s) => s.id === id);
+}

--- a/packages/core/src/config/agent-specs.ts
+++ b/packages/core/src/config/agent-specs.ts
@@ -94,7 +94,11 @@ export function parseAgentSpec(value: unknown): IAgentSpec | null {
   spec.model = optString(value.model);
   spec.kind = optKind(value.kind);
   spec.systemPrompt = optString(value.systemPrompt);
-  spec.tools = stringArray(value.tools);
+  // `tools: []` is an explicit "no tools" — preserved, NOT collapsed to
+  // undefined (which would fall back to the full read-only set).
+  spec.tools = Array.isArray(value.tools)
+    ? (stringArray(value.tools) ?? [])
+    : undefined;
   spec.task = optString(value.task);
   spec.maxTurns = optPositive(value.maxTurns);
   spec.outputMode = optOutputMode(value.outputMode);
@@ -116,10 +120,19 @@ async function loadDir(
   }
 
   for (const name of names) {
+    let content: string;
+
+    try {
+      content = await readFile(join(dir, name), "utf8");
+    } catch {
+      report(`agent '${name}': could not be read — skipped`);
+      continue;
+    }
+
     let parsed: unknown;
 
     try {
-      parsed = JSON.parse(await readFile(join(dir, name), "utf8"));
+      parsed = JSON.parse(content);
     } catch {
       report(`agent '${name}': not valid JSON — skipped`);
       continue;
@@ -132,6 +145,12 @@ async function loadDir(
         `agent '${name}': not a valid spec (needs a kebab-case id) — skipped`
       );
       continue;
+    }
+
+    if (spec.id !== name.slice(0, -".json".length)) {
+      report(
+        `agent '${name}': id '${spec.id}' does not match the filename — invoke it as '${spec.id}'`
+      );
     }
 
     const unknown = unrecognizedAgentKeys(parsed);

--- a/packages/core/src/config/index.ts
+++ b/packages/core/src/config/index.ts
@@ -22,3 +22,9 @@ export {
   findRecipe,
   type ITaskRecipe,
 } from "./recipes";
+export {
+  parseAgentSpec,
+  loadAgentSpecs,
+  findAgentSpec,
+  unrecognizedAgentKeys,
+} from "./agent-specs";

--- a/packages/core/tests/agent-runner.test.ts
+++ b/packages/core/tests/agent-runner.test.ts
@@ -1,0 +1,259 @@
+import { test, expect, describe } from "bun:test";
+import { existsSync } from "node:fs";
+import { join } from "node:path";
+import type { IProvider, IModelResponse } from "../src/inference";
+import { AgentRunner, AGENT_LIMITS } from "../src/agent/agent-runner";
+import {
+  parseAgentSpec,
+  unrecognizedAgentKeys,
+} from "../src/config/agent-specs";
+
+/** A provider that replays a fixed queue of responses (repeats the last one). */
+function scripted(queue: IModelResponse[]): {
+  provider: IProvider;
+  seenTools: () => string[];
+} {
+  let toolNames: string[] = [];
+  let i = 0;
+
+  return {
+    provider: {
+      complete(_messages, opts) {
+        const raw = opts?.tools ?? [];
+
+        toolNames = raw.flatMap((t) =>
+          typeof t === "object" &&
+          t !== null &&
+          "function" in t &&
+          typeof t.function === "object" &&
+          t.function !== null &&
+          "name" in t.function &&
+          typeof t.function.name === "string"
+            ? [t.function.name]
+            : []
+        );
+
+        const res = queue[Math.min(i, queue.length - 1)];
+
+        i += 1;
+
+        if (res === undefined) {
+          throw new Error("scripted queue is empty");
+        }
+
+        return Promise.resolve(res);
+      },
+    },
+    seenTools: () => toolNames,
+  };
+}
+
+// The tsforge repo itself is the read-only workspace under test.
+const REPO = join(import.meta.dir, "..", "..", "..");
+
+describe("parseAgentSpec", () => {
+  test("accepts a well-formed spec and keeps only valid fields", () => {
+    const spec = parseAgentSpec({
+      id: "explore",
+      description: "map a subsystem",
+      model: "qwen3-coder",
+      kind: "chat",
+      tools: ["read", "search", 42],
+      maxTurns: 6,
+      outputMode: "structured",
+      bogus: true,
+    });
+
+    expect(spec?.id).toBe("explore");
+    expect(spec?.tools).toEqual(["read", "search"]);
+    expect(spec?.maxTurns).toBe(6);
+    expect(spec?.outputMode).toBe("structured");
+    expect(unrecognizedAgentKeys({ id: "x", bogus: true })).toEqual(["bogus"]);
+  });
+
+  test("rejects a missing/non-kebab id and drops invalid enums", () => {
+    expect(parseAgentSpec({ model: "m" })).toBeNull();
+    expect(parseAgentSpec({ id: "Has Space" })).toBeNull();
+    expect(parseAgentSpec({ id: "x", kind: "psychic" })?.kind).toBeUndefined();
+    expect(
+      parseAgentSpec({ id: "x", outputMode: "yaml" })?.outputMode
+    ).toBeUndefined();
+  });
+});
+
+describe("AgentRunner (read-only loop against this repo)", () => {
+  test("tool turn then final text; events are agentId-tagged", async () => {
+    const { provider } = scripted([
+      {
+        content: "",
+        toolCalls: [
+          { id: "1", name: "read", arguments: { file: "package.json" } },
+        ],
+      },
+      { content: "The package is @agjs/tsforge.", toolCalls: [] },
+    ]);
+    const runner = new AgentRunner({ id: "explore" });
+    const result = await runner.run({
+      provider,
+      cwd: REPO,
+      parentTaskId: "run-1",
+      task: "What package is this?",
+    });
+
+    expect(result.status).toBe("done");
+    expect(result.output).toContain("@agjs/tsforge");
+    expect(result.turns).toBe(2);
+    expect(result.events.length).toBeGreaterThan(0);
+    expect(result.events.every((e) => e.agentId === "run-1:explore")).toBe(
+      true
+    );
+    expect(result.events.every((e) => e.parentTask === "run-1")).toBe(true);
+  });
+
+  test("mutating tools are neither advertised nor executable", async () => {
+    const target = join(REPO, "SHOULD_NEVER_EXIST.ts");
+    const { provider, seenTools } = scripted([
+      {
+        content: "",
+        toolCalls: [
+          {
+            id: "1",
+            name: "create",
+            arguments: { file: "SHOULD_NEVER_EXIST.ts", content: "x" },
+          },
+        ],
+      },
+      { content: "done", toolCalls: [] },
+    ]);
+    const result = await new AgentRunner({ id: "explore" }).run({
+      provider,
+      cwd: REPO,
+      parentTaskId: "run-1",
+      task: "try to write",
+    });
+
+    // Layer 1: create/edit/run never advertised.
+    expect(seenTools()).not.toContain("create");
+    expect(seenTools()).not.toContain("edit_lines");
+    expect(seenTools()).toContain("read");
+    // Layer 2: the forced call was rejected at dispatch — nothing on disk.
+    expect(existsSync(target)).toBe(false);
+    expect(result.status).toBe("done");
+  });
+
+  test("spec.tools narrows the advertised read-only set", async () => {
+    const { provider, seenTools } = scripted([
+      { content: "ok", toolCalls: [] },
+    ]);
+
+    await new AgentRunner({ id: "narrow", tools: ["read"] }).run({
+      provider,
+      cwd: REPO,
+      parentTaskId: "r",
+      task: "t",
+    });
+
+    expect(seenTools()).toEqual(["read"]);
+  });
+
+  test("maxTurns caps a tool-looping agent", async () => {
+    const { provider } = scripted([
+      {
+        content: "",
+        toolCalls: [
+          { id: "1", name: "read", arguments: { file: "package.json" } },
+        ],
+      },
+    ]);
+    const result = await new AgentRunner({ id: "loopy", maxTurns: 3 }).run({
+      provider,
+      cwd: REPO,
+      parentTaskId: "r",
+      task: "loop forever",
+    });
+
+    expect(result.status).toBe("max_turns");
+    expect(result.turns).toBe(3);
+    expect(AGENT_LIMITS.maxTurns).toBeGreaterThan(0);
+  });
+
+  test("structured mode: prose gets nudged, agent_result delivers the payload", async () => {
+    const { provider, seenTools } = scripted([
+      { content: "here is my answer in prose", toolCalls: [] },
+      {
+        content: "",
+        toolCalls: [
+          {
+            id: "1",
+            name: "agent_result",
+            arguments: { result: "structured-answer" },
+          },
+        ],
+      },
+    ]);
+    const result = await new AgentRunner({
+      id: "structured",
+      outputMode: "structured",
+    }).run({ provider, cwd: REPO, parentTaskId: "r", task: "t" });
+
+    expect(seenTools()).toContain("agent_result");
+    expect(result.status).toBe("done");
+    expect(result.output).toBe("structured-answer");
+    expect(result.turns).toBe(2);
+  });
+
+  test("generate kind is rejected until Phase D", async () => {
+    const { provider } = scripted([{ content: "", toolCalls: [] }]);
+    const result = await new AgentRunner({ id: "img", kind: "generate" }).run({
+      provider,
+      cwd: REPO,
+      parentTaskId: "r",
+    });
+
+    expect(result.status).toBe("error");
+    expect(result.output).toContain("generate");
+  });
+});
+
+describe("loadAgentSpecs", () => {
+  test("project spec overrides global on id collision", async () => {
+    const { mkdtemp, mkdir, writeFile, rm } = await import("node:fs/promises");
+    const { tmpdir } = await import("node:os");
+    const { loadAgentSpecs } = await import("../src/config/agent-specs");
+    const home = await mkdtemp(join(tmpdir(), "tsforge-agents-home-"));
+    const cwd = await mkdtemp(join(tmpdir(), "tsforge-agents-proj-"));
+    const prev = process.env.TSFORGE_HOME;
+
+    try {
+      process.env.TSFORGE_HOME = home;
+      await mkdir(join(home, ".tsforge", "agents"), { recursive: true });
+      await mkdir(join(cwd, ".tsforge", "agents"), { recursive: true });
+      await writeFile(
+        join(home, ".tsforge/agents/explore.json"),
+        JSON.stringify({ id: "explore", model: "global-model" })
+      );
+      await writeFile(
+        join(cwd, ".tsforge/agents/explore.json"),
+        JSON.stringify({ id: "explore", model: "project-model", bogus: 1 })
+      );
+      await writeFile(join(cwd, ".tsforge/agents/broken.json"), "{ nope");
+
+      const reports: string[] = [];
+      const specs = await loadAgentSpecs(cwd, (m) => reports.push(m));
+
+      expect(specs.map((s) => s.id)).toEqual(["explore"]);
+      expect(specs[0]?.model).toBe("project-model");
+      expect(reports.some((m) => m.includes("broken.json"))).toBe(true);
+      expect(reports.some((m) => m.includes("bogus"))).toBe(true);
+    } finally {
+      if (prev === undefined) {
+        delete process.env.TSFORGE_HOME;
+      } else {
+        process.env.TSFORGE_HOME = prev;
+      }
+
+      await rm(home, { recursive: true, force: true });
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+});

--- a/packages/core/tests/agent-runner.test.ts
+++ b/packages/core/tests/agent-runner.test.ts
@@ -257,3 +257,91 @@ describe("loadAgentSpecs", () => {
     }
   });
 });
+
+describe("review-round regressions", () => {
+  test("project policy rules apply inside the agent (deny read)", async () => {
+    const { provider } = scripted([
+      {
+        content: "",
+        toolCalls: [
+          { id: "1", name: "read", arguments: { file: "package.json" } },
+        ],
+      },
+      { content: "blocked, giving up", toolCalls: [] },
+    ]);
+    const result = await new AgentRunner({ id: "explore" }).run({
+      provider,
+      cwd: REPO,
+      parentTaskId: "r",
+      task: "read the manifest",
+      policyMode: "default",
+      policyRules: { deny: [{ toolName: "read" }] },
+    });
+
+    // The deny rule fired at dispatch: a rejection event, no file content.
+    expect(
+      result.events.some((e) => e.message.startsWith("tool_rejected"))
+    ).toBe(true);
+    expect(result.status).toBe("done");
+  });
+
+  test("mid-request abort reports aborted + the true turn count", async () => {
+    const ctrl = new AbortController();
+    const aborting: IProvider = {
+      complete() {
+        ctrl.abort();
+
+        const err = new Error("The operation was aborted.");
+
+        err.name = "AbortError";
+
+        return Promise.reject(err);
+      },
+    };
+    const result = await new AgentRunner({ id: "explore" }).run({
+      provider: aborting,
+      cwd: REPO,
+      parentTaskId: "r",
+      task: "t",
+      signal: ctrl.signal,
+    });
+
+    expect(result.status).toBe("aborted");
+    expect(result.turns).toBe(1); // not maxTurns
+  });
+
+  test("tools: [] means NO tools, not the full read-only set", async () => {
+    const { parseAgentSpec: parse } = await import("../src/config/agent-specs");
+
+    expect(parse({ id: "x", tools: [] })?.tools).toEqual([]);
+
+    const { provider, seenTools } = scripted([
+      { content: "ok", toolCalls: [] },
+    ]);
+
+    await new AgentRunner({ id: "bare", tools: [] }).run({
+      provider,
+      cwd: REPO,
+      parentTaskId: "r",
+      task: "t",
+    });
+
+    expect(seenTools()).toEqual([]);
+  });
+
+  test("a throwing caller reporter cannot kill the run", async () => {
+    const { provider } = scripted([{ content: "fine", toolCalls: [] }]);
+    const result = await new AgentRunner({ id: "x" }).run({
+      provider,
+      cwd: REPO,
+      parentTaskId: "r",
+      task: "t",
+      report: () => {
+        throw new Error("consumer bug");
+      },
+    });
+
+    expect(result.status).toBe("done");
+    expect(result.output).toBe("fine");
+  });
+});

--- a/tsforge.config.json
+++ b/tsforge.config.json
@@ -1,0 +1,5 @@
+{
+  "agents": {
+    "concurrency": 4
+  }
+}


### PR DESCRIPTION
Phase B, slice 1 of the multiagent plan (follows #73/#74): **subagents become definable and runnable.**

## What

1. **`IAgentSpec`** (`src/agent/agent-spec.ts`): declarative agent definitions — id, model (models.json name), persona (`systemPrompt`), tool subset, `maxTurns`, `outputMode`. `kind: "generate"` is the reserved Phase-D seam for non-chat specialists (FLUX image gen) — the runner rejects it cleanly today.
2. **`AgentRunner`** (`src/agent/agent-runner.ts`): the read-only turn loop. Composes `provider.complete` + `runToolCalls` directly — NOT `runTask`, which is an edit-to-green loop (RED precheck, gate-driving) and the wrong primitive for explorers (per the external design review). **Read-only is structural, three layers**: mutating tools are never advertised (spec subset ∩ TOOL_SPECS read-only set), `ctx.tool.readOnly` makes `executeTool` hard-reject anything forced anyway, and the policy layer still evaluates first. `outputMode: "structured"` forces a runner-intercepted `agent_result` tool (prose answers get one nudge per remaining turn). Every inner event is agentId/parentTask-tagged; lifecycle events (`agent_spawned/started/result`) belong to the orchestrating scheduler, not the runner — no duplicates.
3. **Spec loader** (`src/config/agent-specs.ts`): `.tsforge/agents/*.json` + `~/.tsforge/agents/*.json`, project overrides global, warn-and-drop validation with unrecognized-key reporting — `config/recipes.ts` patterns exactly.
4. **Riding along** (as agreed): repo `tsforge.config.json` enabling `agents.concurrency: 4` (A/B-proven ~2× on the retuned DGX endpoint, 5-run evidence chain on #74) + a parallel-review docs section.

## Testing

9 new tests, including a **real consumer**: a scripted-provider agent runs against the tsforge repo itself and executes the actual `read` tool through the full `executeTool` path; the mutation-attempt test asserts `create` is neither advertised nor executable and nothing lands on disk. Plus spec parse/validation, subset narrowing, maxTurns cap, structured round-trip with nudge, generate-kind rejection, loader project-over-global. Full validate green incl. 20/20 PTY e2e.

## Next (PR-B2/B3)

Recipe `agents` field + `tsforge agents` CLI (the runner's user-facing surface), then the live agent tree renderer.