### PR TITLE
feat(agents): tsforge agents CLI + recipe agents field (multiagent PR-B2)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,7 +16,8 @@ evals/*
 !.claude/skills/
 evals/runs/
 evals/.web-cache-*/
-.tsforge/
+**/.tsforge/*
+!**/.tsforge/agents/
 models.json
 
 # Generated gate artifact + stray scaffold left at the repo root from running

--- a/.tsforge/agents/explore.json
+++ b/.tsforge/agents/explore.json
@@ -1,0 +1,5 @@
+{
+  "id": "explore",
+  "description": "Read-only codebase explorer — maps a subsystem and returns conclusions with file:line references",
+  "maxTurns": 10
+}

--- a/apps/docs/src/content/docs/cli/recipes.mdx
+++ b/apps/docs/src/content/docs/cli/recipes.mdx
@@ -55,6 +55,7 @@ A project recipe **overrides** a global one with the same id. `tsforge recipes` 
 | `mode` | `--greenfield` | `"greenfield"` selects the [feature-checklist build loop](/loop/greenfield/) |
 | `plannerModel`, `workModel`, `evaluatorModel` | greenfield roles | per-role model names; each falls back to `model`/active |
 | `profile` | `tsforge.config.json` `profile` | `recommended`, `strict`, `security`, `frontend`, `backend`, `opinionated` |
+| `agents` | `tsforge agents <ids>` | agent spec ids from `.tsforge/agents/` to fan out over the task |
 | `web`, `plan`, `log`, `strictFloorOnly` | the matching flags | booleans |
 
 A recipe is, in effect, a saved set of CLI options: `tsforge run <id>` applies them, and you can also combine `--recipe <id>` with other commands (e.g. `tsforge review --recipe …`). **An explicit CLI flag always wins** over the recipe, so `tsforge run api-endpoint --files lib/**` overrides just the scope.

--- a/apps/docs/src/content/docs/cli/recipes.mdx
+++ b/apps/docs/src/content/docs/cli/recipes.mdx
@@ -55,7 +55,7 @@ A project recipe **overrides** a global one with the same id. `tsforge recipes` 
 | `mode` | `--greenfield` | `"greenfield"` selects the [feature-checklist build loop](/loop/greenfield/) |
 | `plannerModel`, `workModel`, `evaluatorModel` | greenfield roles | per-role model names; each falls back to `model`/active |
 | `profile` | `tsforge.config.json` `profile` | `recommended`, `strict`, `security`, `frontend`, `backend`, `opinionated` |
-| `agents` | `tsforge agents <ids>` | agent spec ids from `.tsforge/agents/` to fan out over the task |
+| `agents` | `tsforge agents <ids>` | agent spec ids to fan out over the task — resolved from `.tsforge/agents/` (project) and `~/.tsforge/agents/` (global, project wins) |
 | `web`, `plan`, `log`, `strictFloorOnly` | the matching flags | booleans |
 
 A recipe is, in effect, a saved set of CLI options: `tsforge run <id>` applies them, and you can also combine `--recipe <id>` with other commands (e.g. `tsforge review --recipe …`). **An explicit CLI flag always wins** over the recipe, so `tsforge run api-endpoint --files lib/**` overrides just the scope.

--- a/packages/core/src/cli.ts
+++ b/packages/core/src/cli.ts
@@ -16,7 +16,10 @@ import {
   type IGreenfieldDeps,
   type Reporter,
 } from "./loop";
-import { modelAgent } from "./agent";
+import { modelAgent, AgentRunner, type IAgentResult } from "./agent";
+import { AgentScheduler } from "./agent/agent-scheduler";
+import { loadAgentSpecs, findAgentSpec } from "./config/agent-specs";
+import { isPolicyMode } from "./policy";
 import { loadRecipes, findRecipe } from "./config/recipes";
 import {
   parseArgs,
@@ -214,6 +217,153 @@ async function reviewMode(args: ICliArgs): Promise<number> {
 
   // Exit non-zero when there are error-severity findings, so it's CI-usable.
   return report.findings.some((f) => f.severity === "error") ? 1 : 0;
+}
+
+/** Print one agent's outcome block to the transcript. */
+function printAgentResult(
+  id: string,
+  result: IAgentResult | undefined,
+  write: (m: string) => void
+): boolean {
+  if (result === undefined) {
+    write(`\n=== ${id}: did not run ===`);
+
+    return false;
+  }
+
+  const seconds = (result.durationMs / 1000).toFixed(1);
+  const turns = `${String(result.turns)} turn${result.turns === 1 ? "" : "s"}`;
+
+  write(`\n=== ${id}: ${result.status} (${seconds}s, ${turns}) ===`);
+  write(result.output);
+
+  return result.status === "done";
+}
+
+/** `tsforge agents` — list discovered agent specs, or fan the named specs out
+ *  over a task (read-only, concurrency-capped, project policy enforced). */
+async function agentsMode(args: ICliArgs): Promise<number> {
+  const write = (m: string): void => void process.stdout.write(`${m}\n`);
+  const specs = await loadAgentSpecs(args.dir, (m) => {
+    write(`  ↳ ${m}`);
+  });
+
+  if (args.agentIds.length === 0) {
+    if (specs.length === 0) {
+      write(
+        "No agent specs found. Add .tsforge/agents/<id>.json to define one."
+      );
+    } else {
+      write("Available agents:");
+
+      for (const s of specs) {
+        write(
+          `  ${s.id}${s.description === undefined ? "" : ` — ${s.description}`}`
+        );
+      }
+
+      write('\nRun them: tsforge agents <id,id> "task"');
+    }
+
+    return 0;
+  }
+
+  if (args.task.length === 0) {
+    write('agents: a task is required — tsforge agents <ids> "task"');
+
+    return 1;
+  }
+
+  const ids = args.agentIds
+    .split(",")
+    .map((s) => s.trim())
+    .filter((s) => s.length > 0);
+  const missing = ids.filter((id) => findAgentSpec(specs, id) === undefined);
+
+  if (missing.length > 0) {
+    const available = specs.map((s) => s.id).join(", ");
+
+    write(
+      `agents: unknown spec(s): ${missing.join(", ")} (available: ${available.length > 0 ? available : "none"})`
+    );
+
+    return 1;
+  }
+
+  const config = await loadTsforgeConfig(args.dir);
+  const concurrency = resolveAgentConcurrency(config);
+  // Subagents obey the SAME policy as a session would: --policy-mode wins,
+  // else the config file's policy.mode, else default (PR #75 P1 lesson).
+  const policyMode = isPolicyMode(args.policyMode)
+    ? args.policyMode
+    : (config.policy?.mode ?? "default");
+  const policyRules = config.policy?.rules;
+  const tracker = makeAgentSummaryTracker((line) => {
+    write(`  ↳ ${line}`);
+  });
+  const results = new Map<string, IAgentResult>();
+  const scheduler = new AgentScheduler({
+    concurrency,
+    onUnit: (id, status) => {
+      if (status === "pending") {
+        tracker({ kind: "agent_spawned", task: "agents", message: id });
+      } else if (status === "start") {
+        tracker({ kind: "agent_started", task: "agents", message: id });
+      } else {
+        tracker({
+          kind: "agent_result",
+          task: "agents",
+          message: id,
+          passed: status === "done",
+        });
+      }
+    },
+  });
+
+  write(`agents: running ${ids.join(", ")} (cap ${String(concurrency)})`);
+
+  await scheduler.runParallel(
+    ids.map((id) => ({
+      id,
+      run: async (signal: AbortSignal): Promise<IAgentResult | null> => {
+        const spec = findAgentSpec(specs, id);
+
+        if (spec === undefined) {
+          return null; // unreachable: ids were validated above
+        }
+
+        const { entry } = await resolveModelByName(spec.model);
+        const result = await new AgentRunner(spec).run({
+          provider: makeProvider(entry),
+          cwd: args.dir,
+          parentTaskId: "agents",
+          task: args.task,
+          signal,
+          policyMode,
+          ...(policyRules === undefined ? {} : { policyRules }),
+        });
+
+        results.set(id, result);
+
+        if (result.status === "error") {
+          // Let the scheduler mark the unit failed; the block still prints.
+          throw new Error(result.output);
+        }
+
+        return result;
+      },
+    }))
+  );
+
+  let allDone = true;
+
+  for (const id of ids) {
+    if (!printAgentResult(id, results.get(id), write)) {
+      allDone = false;
+    }
+  }
+
+  return allDone ? 0 : 1;
 }
 
 async function mapMode(args: ICliArgs): Promise<number> {
@@ -559,6 +709,10 @@ export async function main(): Promise<number> {
 
   if (args.review) {
     return reviewMode(args);
+  }
+
+  if (args.agents) {
+    return agentsMode(args);
   }
 
   if (args.map) {

--- a/packages/core/src/cli.ts
+++ b/packages/core/src/cli.ts
@@ -332,25 +332,47 @@ async function agentsMode(args: ICliArgs): Promise<number> {
           return null; // unreachable: ids were validated above
         }
 
-        const { entry } = await resolveModelByName(spec.model);
-        const result = await new AgentRunner(spec).run({
-          provider: makeProvider(entry),
-          cwd: args.dir,
-          parentTaskId: "agents",
-          task: args.task,
-          signal,
-          policyMode,
-          ...(policyRules === undefined ? {} : { policyRules }),
-        });
+        try {
+          // Model precedence: the spec's pin wins, else --model/recipe model,
+          // else the active model (resolveModelByName's own fallback).
+          const modelName =
+            spec.model ?? (args.model.length > 0 ? args.model : undefined);
+          const { entry } = await resolveModelByName(modelName);
+          const result = await new AgentRunner(spec).run({
+            provider: makeProvider(entry),
+            cwd: args.dir,
+            parentTaskId: "agents",
+            task: args.task,
+            signal,
+            policyMode,
+            ...(policyRules === undefined ? {} : { policyRules }),
+          });
 
-        results.set(id, result);
+          results.set(id, result);
 
-        if (result.status === "error") {
-          // Let the scheduler mark the unit failed; the block still prints.
-          throw new Error(result.output);
+          if (result.status !== "done") {
+            // max_turns/aborted/error are all failures: throw so the live
+            // summary marks the unit failed, matching the block + exit code.
+            throw new Error(`${result.status}: ${result.output}`);
+          }
+
+          return result;
+        } catch (err) {
+          // Setup failures (bad model, provider construction) would otherwise
+          // vanish into the scheduler's null slot as a bare "did not run" —
+          // record a synthetic error result so the block shows the reason.
+          if (!results.has(id)) {
+            results.set(id, {
+              status: "error",
+              output: err instanceof Error ? err.message : String(err),
+              turns: 0,
+              durationMs: 0,
+              events: [],
+            });
+          }
+
+          throw err;
         }
-
-        return result;
       },
     }))
   );

--- a/packages/core/src/cli/args.ts
+++ b/packages/core/src/cli/args.ts
@@ -67,6 +67,12 @@ export interface ICliArgs {
   recipe: string;
   /** List discovered recipes (`tsforge recipes`). */
   recipes: boolean;
+  /** The `agents` subcommand (`tsforge agents [ids] "task"`): run named agent
+   *  specs against a task, or list discovered specs when no ids are given. */
+  agents: boolean;
+  /** Comma-separated agent spec ids to fan out (subcommand arg or a recipe's
+   *  `agents` field); "" = list mode. */
+  agentIds: string;
   /** The `run` subcommand was used (`tsforge run <id>`) — tracked so a missing id
    *  is an explicit error, not a silent fall-through to the interactive REPL. */
   run: boolean;
@@ -206,6 +212,8 @@ export function parseArgs(argv: readonly string[]): ICliArgs {
     trace: false,
     recipe: "",
     recipes: false,
+    agents: false,
+    agentIds: "",
     run: false,
     model: "",
     plannerModel: "",
@@ -253,6 +261,12 @@ export function parseArgs(argv: readonly string[]): ICliArgs {
     out.task = positional.slice(1).join(" ").trim();
   } else if (positional[0] === "recipes") {
     out.recipes = true;
+  } else if (positional[0] === "agents") {
+    // `tsforge agents` lists specs; `tsforge agents explore,verify "task"`
+    // fans the named specs out over the task.
+    out.agents = true;
+    out.agentIds = positional[1] ?? "";
+    out.task = positional.slice(2).join(" ").trim();
   } else if (positional[0] === "setup") {
     out.setup = true;
   } else if (positional[0] === "run") {
@@ -333,6 +347,13 @@ export function applyRecipe(args: ICliArgs, recipe: ITaskRecipe): void {
 
   if (args.profile.length === 0 && recipe.profile !== undefined) {
     args.profile = recipe.profile;
+  }
+
+  // A recipe with `agents` IS a fan-out run: pre-fill the ids and select the
+  // agents mode (an explicit `tsforge agents <ids>` still wins on ids).
+  if (args.agentIds.length === 0 && recipe.agents !== undefined) {
+    args.agentIds = recipe.agents.join(",");
+    args.agents = true;
   }
 
   applyRecipeFlags(args, recipe);

--- a/packages/core/src/config/recipes.ts
+++ b/packages/core/src/config/recipes.ts
@@ -65,6 +65,9 @@ export interface ITaskRecipe {
   readonly mode?: "greenfield";
   /** Rule profile preset (→ `tsforge.config.json` `profile` for this run). */
   readonly profile?: ProfileId;
+  /** Agent spec ids to fan out over the task (→ `tsforge agents <ids>`).
+   *  Ids resolve against `.tsforge/agents/*.json` at run time. */
+  readonly agents?: readonly string[];
 }
 
 function optString(value: unknown): string | undefined {
@@ -113,6 +116,7 @@ function assignScalars(recipe: Mutable, raw: Record<string, unknown>): void {
   recipe.files = stringArray(raw.files);
   recipe.maxTurns = optPositive(raw.maxTurns);
   recipe.thinkingBudget = optPositive(raw.thinkingBudget);
+  recipe.agents = stringArray(raw.agents);
 
   if (isPolicyMode(raw.policyMode)) {
     recipe.policyMode = raw.policyMode;
@@ -168,6 +172,7 @@ const KNOWN_KEYS = new Set<string>([
   "scout",
   "mode",
   "profile",
+  "agents",
 ]);
 
 /** A string `profile` value that isn't a known ProfileId, or undefined.

--- a/packages/core/src/config/recipes.ts
+++ b/packages/core/src/config/recipes.ts
@@ -66,7 +66,8 @@ export interface ITaskRecipe {
   /** Rule profile preset (→ `tsforge.config.json` `profile` for this run). */
   readonly profile?: ProfileId;
   /** Agent spec ids to fan out over the task (→ `tsforge agents <ids>`).
-   *  Ids resolve against `.tsforge/agents/*.json` at run time. */
+   *  Ids resolve at run time against `.tsforge/agents/*.json` (project) and
+   *  `~/.tsforge/agents/*.json` (global); project overrides global. */
   readonly agents?: readonly string[];
 }
 

--- a/packages/core/tests/cli.test.ts
+++ b/packages/core/tests/cli.test.ts
@@ -493,3 +493,29 @@ test("cliUsage documents the print-and-exit flags it is reached by", () => {
   expect(usage).toContain("--accept");
   expect(usage).toContain("tsforge review");
 });
+
+test("agents subcommand: list mode, ids+task mode, recipe fill", () => {
+  const list = parseArgs(["agents"]);
+
+  expect(list.agents).toBe(true);
+  expect(list.agentIds).toBe("");
+
+  const run = parseArgs(["agents", "explore,verify", "map", "the", "loop"]);
+
+  expect(run.agents).toBe(true);
+  expect(run.agentIds).toBe("explore,verify");
+  expect(run.task).toBe("map the loop");
+
+  // A recipe with `agents` selects fan-out mode and pre-fills ids…
+  const fromRecipe = parseArgs([]);
+
+  applyRecipe(fromRecipe, { id: "sweep", agents: ["explore", "verify"] });
+  expect(fromRecipe.agents).toBe(true);
+  expect(fromRecipe.agentIds).toBe("explore,verify");
+
+  // …but explicit CLI ids always win.
+  const explicit = parseArgs(["agents", "explore", "t"]);
+
+  applyRecipe(explicit, { id: "sweep", agents: ["verify"] });
+  expect(explicit.agentIds).toBe("explore");
+});

--- a/packages/core/tests/recipes.test.ts
+++ b/packages/core/tests/recipes.test.ts
@@ -223,3 +223,10 @@ describe("loadRecipes", () => {
     }
   });
 });
+
+test("parses the agents field and does not flag it as unrecognized", () => {
+  expect(parseRecipe({ id: "x", agents: ["explore", " ", 7] })?.agents).toEqual(
+    ["explore"]
+  );
+  expect(unrecognizedKeys({ id: "x", agents: ["a"] })).toEqual([]);
+});


### PR DESCRIPTION
Phase B, slice 2 (follows #75): **the user-facing surface for subagents.**

## What

1. **`tsforge agents`** — list discovered specs from `.tsforge/agents/` (project + `~/.tsforge/agents/` global). **`tsforge agents <id,id> "task"`** — fan the named specs out over the task via `AgentScheduler` + `AgentRunner`: live `agents: 1 running, 0/2 done (…)` progress line (stable denominator via the pending lifecycle from #74), per-agent result blocks with status/duration/turns, exit 0 only when every agent completes.
2. **Recipe `agents` field**: a recipe naming agent specs IS a fan-out run — `tsforge run <recipe>` pre-fills the ids and selects the mode; explicit CLI ids win (same precedence as every recipe field).
3. **Policy**: every agent gets project policy — `--policy-mode` wins, else the config file's `policy.mode`, else default. This is the #75 P1 lesson applied proactively at the new surface.
4. **Models**: fresh provider per agent, per-spec model resolution (`resolveModelByName` falls back to the active model) — a spec can pin its own models.json entry.
5. Dogfood: `.tsforge/agents/explore.json` committed for this repo.

## Live verification (real DeepSeek endpoint)

```
$ tsforge agents
Available agents:
  explore — Read-only codebase explorer — …

$ tsforge agents explore "What does the AgentScheduler class do? Two sentences max."
agents: running explore (cap 4)
  ↳ agents: 0/1 done
  ↳ agents: 1 running, 0/1 done (explore)
  ↳ agents: 1/1 done

=== explore: done (9.6s, 1 turn) ===
The AgentScheduler class manages the lifecycle and execution of agents…
```

Honest note: that run answered in 1 turn — the model replied from priors without calling `read`. The harness pipeline is proven end-to-end; **tool adoption** by local models is the open question Phase C's eval gate exists for.

## Testing

Subcommand parsing (list/ids+task), recipe fill + CLI-wins precedence, recipe field parse + KNOWN_KEYS. Full validate green incl. 20/20 PTY e2e.

## Next (PR-B3)

The live agent tree renderer — per-child rows above the input row, VirtualScreen + real-PTY tested.