### PR TITLE
feat(agents): live agent tree renderer for fan-out (multiagent PR-B3)

### DIFF
--- a/apps/docs/src/content/docs/cli/review.mdx
+++ b/apps/docs/src/content/docs/cli/review.mdx
@@ -47,6 +47,18 @@ By default the per-file find pass and per-finding verify pass run one model call
 
 Review then fans out up to that many calls at once — each with a fresh provider — and prints a live `agents: 2 running, 5/16 done (…)` progress line. Results are identical in structure and order to a sequential run; only the wall-clock changes (≈2× measured at cap 8 on a batching endpoint). Keep the cap a couple below your server's `max_num_seqs` so an interactive session is never starved, and leave it at 1 for endpoints that serialize requests anyway.
 
+## The live agent tree
+
+Any fan-out — `tsforge review` above, or `tsforge agents <ids> "<task>"` — draws a live tree pinned to the bottom of the terminal while it runs, one row per subagent:
+
+```
+● agents · 1 running · 1/2 done
+├─ ✓ explore · 1.2s · 3 turns
+└─ ⠹ verify
+```
+
+Pending rows appear up-front, running rows animate, and each finishes with its wall-clock and turn count. The tree repaints in place (it never scrolls the transcript) and collapses to `… +N more` past a dozen rows. When output is piped or redirected — no TTY — it falls back to the one-line `agents: …` summary instead, so logs and CI stay plain-text.
+
 ## In CI
 
 `tsforge review` exits non-zero if any error-severity finding survives, so you can gate a PR on it. It uses `git` to find what changed, so run it inside a git repository.

--- a/apps/docs/src/content/docs/cli/review.mdx
+++ b/apps/docs/src/content/docs/cli/review.mdx
@@ -49,7 +49,7 @@ Review then fans out up to that many calls at once — each with a fresh provide
 
 ## The live agent tree
 
-Any fan-out — `tsforge review` above, or `tsforge agents <ids> "<task>"` — draws a live tree pinned to the bottom of the terminal while it runs, one row per subagent:
+`tsforge agents <ids> "<task>"` — a read-only fan-out over named agent specs — draws a live tree pinned to the bottom of the terminal while it runs, one row per subagent:
 
 ```
 ● agents · 1 running · 1/2 done
@@ -57,7 +57,7 @@ Any fan-out — `tsforge review` above, or `tsforge agents <ids> "<task>"` — d
 └─ ⠹ verify
 ```
 
-Pending rows appear up-front, running rows animate, and each finishes with its wall-clock and turn count. The tree repaints in place (it never scrolls the transcript) and collapses to `… +N more` past a dozen rows. When output is piped or redirected — no TTY — it falls back to the one-line `agents: …` summary instead, so logs and CI stay plain-text.
+Pending rows appear up-front, running rows animate, and each finishes with its wall-clock and turn count. The tree repaints in place (it never scrolls the transcript) and collapses to `… +N more` past a dozen rows. When output is piped or redirected — no TTY — it falls back to the one-line `agents: …` summary instead, so logs and CI stay plain-text. (`tsforge review`'s fan-out uses that compact `agents: …` summary line described above, not the tree.)
 
 ## In CI
 

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "test": "bun test packages",
     "check:bun": "bun packages/core/scripts/check-bun-version.ts",
     "e2e": "python3 scripts/e2e-iterm-tui.py && python3 scripts/e2e-iterm-plan-mode.py",
-    "e2e:pty": "python3 scripts/e2e-pty.py && python3 scripts/e2e-wizard-pty.py && python3 scripts/e2e-config-repl-pty.py && python3 scripts/e2e-help-menu-pty.py && python3 scripts/e2e-editor-pty.py",
+    "e2e:pty": "python3 scripts/e2e-pty.py && python3 scripts/e2e-wizard-pty.py && python3 scripts/e2e-config-repl-pty.py && python3 scripts/e2e-help-menu-pty.py && python3 scripts/e2e-editor-pty.py && python3 scripts/e2e-agents-pty.py",
     "validate": "bun run check:bun && bun run typecheck && bun run lint && bun run format:check && bun run test && bun run e2e:pty",
     "rules:build": "bun packages/core/scripts/build-rules-md.ts",
     "rules:docs": "bun packages/core/scripts/build-rule-docs.ts",

--- a/packages/core/src/cli.ts
+++ b/packages/core/src/cli.ts
@@ -293,17 +293,20 @@ function summaryProgress(): IAgentProgress {
 function treeProgress(
   results: ReadonlyMap<string, IAgentResult>
 ): IAgentProgress {
-  const columns = process.stdout.columns > 0 ? process.stdout.columns : 80;
-  // Cap the tree to the viewport height so the pinned block never scrolls off
-  // the top — the relative-redraw (cursor-climb + erase) is only correct while
-  // the whole block stays on screen; a taller block would ghost on repaint.
-  const rows = process.stdout.rows > 0 ? process.stdout.rows : 24;
-  const maxRows = Math.max(3, rows - 3);
   const model = new AgentTreeModel();
   const live = new LiveRegion(process.stdout, true);
   let frame = 0;
 
   const repaint = (): void => {
+    // Read the live terminal size on every repaint so a mid-run resize adapts:
+    // a stale width would break line-clipping (wrapped rows → ghosting), and a
+    // stale height would let the block scroll off. Cap the tree to the viewport
+    // so the pinned block never scrolls — the cursor-climb redraw is only
+    // correct while the whole block stays on screen.
+    const columns = process.stdout.columns > 0 ? process.stdout.columns : 80;
+    const rows = process.stdout.rows > 0 ? process.stdout.rows : 24;
+    const maxRows = Math.max(3, rows - 3);
+
     live.render(
       renderAgentTree(model.rows(), { columns, maxRows, frame, color: true })
     );

--- a/packages/core/src/cli.ts
+++ b/packages/core/src/cli.ts
@@ -294,12 +294,19 @@ function treeProgress(
   results: ReadonlyMap<string, IAgentResult>
 ): IAgentProgress {
   const columns = process.stdout.columns > 0 ? process.stdout.columns : 80;
+  // Cap the tree to the viewport height so the pinned block never scrolls off
+  // the top — the relative-redraw (cursor-climb + erase) is only correct while
+  // the whole block stays on screen; a taller block would ghost on repaint.
+  const rows = process.stdout.rows > 0 ? process.stdout.rows : 24;
+  const maxRows = Math.max(3, rows - 3);
   const model = new AgentTreeModel();
   const live = new LiveRegion(process.stdout, true);
   let frame = 0;
 
   const repaint = (): void => {
-    live.render(renderAgentTree(model.rows(), { columns, frame, color: true }));
+    live.render(
+      renderAgentTree(model.rows(), { columns, maxRows, frame, color: true })
+    );
   };
 
   const ticker = setInterval(() => {

--- a/packages/core/src/cli.ts
+++ b/packages/core/src/cli.ts
@@ -46,7 +46,14 @@ import {
   loadTsforgeConfig,
   resolveAgentConcurrency,
 } from "./config/tsforge-config";
-import { makeAgentSummaryTracker } from "./render/agent-tree";
+import {
+  makeAgentSummaryTracker,
+  renderAgentTree,
+  AgentTreeModel,
+  type IRowMeta,
+} from "./render/agent-tree";
+import { LiveRegion } from "./render/live-region";
+import type { UnitStatus } from "./agent/agent-scheduler";
 
 /**
  * The tsforge CLI — the product surface over the same engine the eval harness
@@ -240,6 +247,91 @@ function printAgentResult(
   return result.status === "done";
 }
 
+/** Live progress for a fan-out — the TTY tree or the piped summary line. */
+interface IAgentProgress {
+  onUnit: (id: string, status: UnitStatus) => void;
+  /** Freeze the animation and clear the live region (TTY); no-op otherwise. */
+  stop: () => void;
+}
+
+/** Terminal-row metadata (wall-clock + turns) from a finished unit's result. */
+function metaFromResult(
+  result: IAgentResult | undefined
+): IRowMeta | undefined {
+  return result === undefined
+    ? undefined
+    : { durationMs: result.durationMs, turns: result.turns };
+}
+
+/** Non-TTY path: fold unit transitions into the one-line summary tracker. */
+function summaryProgress(): IAgentProgress {
+  const tracker = makeAgentSummaryTracker(
+    (line) => void process.stdout.write(`  ↳ ${line}\n`)
+  );
+
+  return {
+    onUnit: (id, status): void => {
+      if (status === "pending") {
+        tracker({ kind: "agent_spawned", task: "agents", message: id });
+      } else if (status === "start") {
+        tracker({ kind: "agent_started", task: "agents", message: id });
+      } else {
+        tracker({
+          kind: "agent_result",
+          task: "agents",
+          message: id,
+          passed: status === "done",
+        });
+      }
+    },
+    stop: (): void => undefined,
+  };
+}
+
+/** TTY path: a spinner-animated agent tree pinned to the bottom of the screen,
+ *  repainted on every transition and on a timer so running rows animate. */
+function treeProgress(
+  results: ReadonlyMap<string, IAgentResult>
+): IAgentProgress {
+  const columns = process.stdout.columns > 0 ? process.stdout.columns : 80;
+  const model = new AgentTreeModel();
+  const live = new LiveRegion(process.stdout, true);
+  let frame = 0;
+
+  const repaint = (): void => {
+    live.render(renderAgentTree(model.rows(), { columns, frame, color: true }));
+  };
+
+  const ticker = setInterval(() => {
+    frame += 1;
+    repaint();
+  }, 120);
+
+  return {
+    onUnit: (id, status): void => {
+      const meta =
+        status === "done" || status === "failed"
+          ? metaFromResult(results.get(id))
+          : undefined;
+
+      model.applyUnit(id, status, meta);
+      repaint();
+    },
+    stop: (): void => {
+      clearInterval(ticker);
+      live.clear();
+    },
+  };
+}
+
+/** Pick the live-progress surface for a fan-out: the tree on a real terminal,
+ *  the summary line when piped/redirected. */
+function makeAgentProgress(
+  results: ReadonlyMap<string, IAgentResult>
+): IAgentProgress {
+  return process.stdout.isTTY ? treeProgress(results) : summaryProgress();
+}
+
 /** `tsforge agents` — list discovered agent specs, or fan the named specs out
  *  over a task (read-only, concurrency-capped, project policy enforced). */
 async function agentsMode(args: ICliArgs): Promise<number> {
@@ -298,84 +390,73 @@ async function agentsMode(args: ICliArgs): Promise<number> {
     ? args.policyMode
     : (config.policy?.mode ?? "default");
   const policyRules = config.policy?.rules;
-  const tracker = makeAgentSummaryTracker((line) => {
-    write(`  ↳ ${line}`);
-  });
   const results = new Map<string, IAgentResult>();
+  const progress = makeAgentProgress(results);
   const scheduler = new AgentScheduler({
     concurrency,
-    onUnit: (id, status) => {
-      if (status === "pending") {
-        tracker({ kind: "agent_spawned", task: "agents", message: id });
-      } else if (status === "start") {
-        tracker({ kind: "agent_started", task: "agents", message: id });
-      } else {
-        tracker({
-          kind: "agent_result",
-          task: "agents",
-          message: id,
-          passed: status === "done",
-        });
-      }
-    },
+    onUnit: progress.onUnit,
   });
 
   write(`agents: running ${ids.join(", ")} (cap ${String(concurrency)})`);
 
-  await scheduler.runParallel(
-    ids.map((id) => ({
-      id,
-      run: async (signal: AbortSignal): Promise<IAgentResult | null> => {
-        const spec = findAgentSpec(specs, id);
+  const units = ids.map((id) => ({
+    id,
+    run: async (signal: AbortSignal): Promise<IAgentResult | null> => {
+      const spec = findAgentSpec(specs, id);
 
-        if (spec === undefined) {
-          return null; // unreachable: ids were validated above
+      if (spec === undefined) {
+        return null; // unreachable: ids were validated above
+      }
+
+      try {
+        // Model precedence: the spec's pin wins, else --model/recipe model,
+        // else the active model (resolveModelByName's own fallback).
+        const modelName =
+          spec.model ?? (args.model.length > 0 ? args.model : undefined);
+        const { entry } = await resolveModelByName(modelName);
+        const result = await new AgentRunner(spec).run({
+          provider: makeProvider(entry),
+          cwd: args.dir,
+          parentTaskId: "agents",
+          task: args.task,
+          signal,
+          policyMode,
+          ...(policyRules === undefined ? {} : { policyRules }),
+        });
+
+        results.set(id, result);
+
+        if (result.status !== "done") {
+          // max_turns/aborted/error are all failures: throw so the live
+          // summary marks the unit failed, matching the block + exit code.
+          throw new Error(`${result.status}: ${result.output}`);
         }
 
-        try {
-          // Model precedence: the spec's pin wins, else --model/recipe model,
-          // else the active model (resolveModelByName's own fallback).
-          const modelName =
-            spec.model ?? (args.model.length > 0 ? args.model : undefined);
-          const { entry } = await resolveModelByName(modelName);
-          const result = await new AgentRunner(spec).run({
-            provider: makeProvider(entry),
-            cwd: args.dir,
-            parentTaskId: "agents",
-            task: args.task,
-            signal,
-            policyMode,
-            ...(policyRules === undefined ? {} : { policyRules }),
+        return result;
+      } catch (err) {
+        // Setup failures (bad model, provider construction) would otherwise
+        // vanish into the scheduler's null slot as a bare "did not run" —
+        // record a synthetic error result so the block shows the reason.
+        if (!results.has(id)) {
+          results.set(id, {
+            status: "error",
+            output: err instanceof Error ? err.message : String(err),
+            turns: 0,
+            durationMs: 0,
+            events: [],
           });
-
-          results.set(id, result);
-
-          if (result.status !== "done") {
-            // max_turns/aborted/error are all failures: throw so the live
-            // summary marks the unit failed, matching the block + exit code.
-            throw new Error(`${result.status}: ${result.output}`);
-          }
-
-          return result;
-        } catch (err) {
-          // Setup failures (bad model, provider construction) would otherwise
-          // vanish into the scheduler's null slot as a bare "did not run" —
-          // record a synthetic error result so the block shows the reason.
-          if (!results.has(id)) {
-            results.set(id, {
-              status: "error",
-              output: err instanceof Error ? err.message : String(err),
-              turns: 0,
-              durationMs: 0,
-              events: [],
-            });
-          }
-
-          throw err;
         }
-      },
-    }))
-  );
+
+        throw err;
+      }
+    },
+  }));
+
+  try {
+    await scheduler.runParallel(units);
+  } finally {
+    progress.stop();
+  }
 
   let allDone = true;
 

--- a/packages/core/src/render/agent-tree.ts
+++ b/packages/core/src/render/agent-tree.ts
@@ -73,12 +73,17 @@ export function makeAgentSummaryTracker(
   const statuses = new Map<string, AgentItemStatus>();
 
   return (event: ILoopEvent): void => {
+    // Key by the subagent's identity (agentId) when present, else `message` —
+    // the scheduler's synthetic lifecycle events carry the id in `message`,
+    // while a real subagent's `agent_result` puts the payload there, not the id.
+    const id = event.agentId ?? event.message;
+
     if (event.kind === "agent_spawned") {
-      statuses.set(event.message, "pending");
+      statuses.set(id, "pending");
     } else if (event.kind === "agent_started") {
-      statuses.set(event.message, "running");
+      statuses.set(id, "running");
     } else if (event.kind === "agent_result") {
-      statuses.set(event.message, event.passed === true ? "done" : "failed");
+      statuses.set(id, event.passed === true ? "done" : "failed");
     } else {
       return;
     }
@@ -186,7 +191,10 @@ function fitLabel(label: string, avail: number): string {
   return `${sliceToWidth(label, avail - 1).text}…`;
 }
 
-/** Render one child row: connector + status glyph + clipped label + meta. */
+/** Render one child row: connector + status glyph + clipped label + meta. The
+ *  label and meta share the width budget; meta is dropped wholesale (never
+ *  half-printed) when it can't fit, so the assembled line never exceeds
+ *  `columns - 1` (which the terminal would self-wrap, breaking the repaint). */
 function rowLine(
   row: IAgentRow,
   isLast: boolean,
@@ -196,17 +204,19 @@ function rowLine(
 ): string {
   const connector = isLast ? CONNECT_END : CONNECT_MID;
   const glyph = statusGlyph(row.status, frame);
+  // connector + glyph + the single space before the label.
+  const prefixWidth = displayWidth(connector) + displayWidth(glyph.text) + 1;
+  const budget = Math.max(0, columns - 1 - prefixWidth);
   const meta = rowMeta(row);
-  const label = row.label ?? row.id;
-  const fixed =
-    displayWidth(connector) + displayWidth(glyph.text) + 1 + displayWidth(meta);
-  const avail = Math.max(0, columns - 1 - fixed);
+  const showMeta = meta.length > 0 && displayWidth(meta) <= budget;
+  const labelBudget = showMeta ? budget - displayWidth(meta) : budget;
+  const label = fitLabel(row.label ?? row.id, labelBudget);
 
   return (
     paint(connector, STYLE.dim, color) +
     paint(glyph.text, glyph.code, color) +
-    ` ${fitLabel(label, avail)}` +
-    paint(meta, STYLE.dim, color)
+    ` ${label}` +
+    (showMeta ? paint(meta, STYLE.dim, color) : "")
   );
 }
 
@@ -239,7 +249,9 @@ function headerLine(
 /**
  * Render the live agent tree as an ordered array of terminal lines (header +
  * one row per child, tail-collapsed past `maxRows`). Every line is kept
- * ≤ `columns - 1` so a terminal never self-wraps one. Empty input → `[]`.
+ * ≤ `columns - 1` so a terminal never self-wraps one (labels clip, meta drops).
+ * The real terminal width is honored — no upward clamp that could draw wider
+ * than the screen. A non-positive width falls back to 80. Empty input → `[]`.
  */
 export function renderAgentTree(
   rows: readonly IAgentRow[],
@@ -249,7 +261,7 @@ export function renderAgentTree(
     return [];
   }
 
-  const columns = Math.max(20, opts.columns);
+  const columns = opts.columns > 0 ? opts.columns : 80;
   const color = opts.color ?? true;
   const frame = opts.frame ?? 0;
   const maxRows = Math.max(1, opts.maxRows ?? DEFAULT_MAX_ROWS);
@@ -325,14 +337,24 @@ export class AgentTreeModel {
     this.set(id, unitToItem(status), meta);
   }
 
-  /** Fold an `agent_spawned`/`agent_started`/`agent_result` lifecycle event. */
+  /** Fold an `agent_spawned`/`agent_started`/`agent_result` lifecycle event.
+   *  Rows are keyed by `agentId` (the subagent's identity) when present, falling
+   *  back to `message` for the scheduler's synthetic events (which put the id in
+   *  `message`). Without this, an `agent_result` whose `message` carries the
+   *  final payload — not the id — would spawn a bogus row instead of completing
+   *  the running one. On spawn, `message` becomes the row label when `agentId`
+   *  already identifies the row. */
   applyEvent(event: ILoopEvent): void {
+    const id = event.agentId ?? event.message;
+
     if (event.kind === "agent_spawned") {
-      this.set(event.message, "pending");
+      const label = event.agentId === undefined ? undefined : event.message;
+
+      this.set(id, "pending", label === undefined ? undefined : { label });
     } else if (event.kind === "agent_started") {
-      this.set(event.message, "running");
+      this.set(id, "running");
     } else if (event.kind === "agent_result") {
-      this.set(event.message, event.passed === true ? "done" : "failed");
+      this.set(id, event.passed === true ? "done" : "failed");
     }
   }
 

--- a/packages/core/src/render/agent-tree.ts
+++ b/packages/core/src/render/agent-tree.ts
@@ -1,10 +1,14 @@
 /**
- * Agent-tree rendering, Phase A slice: a one-line textual summary of a
- * fan-out's progress (`agents: 2 running, 1 done (find:a.ts · find:b.ts)`).
- * The full live tree (per-child rows above the input row, Claude-Code style)
- * lands in Phase B and grows out of this module.
+ * Agent-tree rendering. Two surfaces grow from the same fold-the-lifecycle model:
+ *   - `formatAgentSummary` / `makeAgentSummaryTracker` — a one-line textual
+ *     summary (`agents: 2 running, 1/6 done (…)`) for non-TTY / piped output.
+ *   - `renderAgentTree` + `AgentTreeModel` — the live multi-row tree (per-child
+ *     rows, Claude-Code style) painted above the prompt on a real terminal.
  */
 import type { ILoopEvent, Reporter } from "../loop/loop.types";
+import type { UnitStatus } from "../agent/agent-scheduler";
+import { STYLE, paint } from "./style";
+import { displayWidth, sliceToWidth } from "./width";
 
 export type AgentItemStatus = "pending" | "running" | "done" | "failed";
 
@@ -86,4 +90,264 @@ export function makeAgentSummaryTracker(
 
     write(formatAgentSummary(items));
   };
+}
+
+// --- live multi-row tree -----------------------------------------------------
+
+/** One rendered child row: its label, current status, and (once terminal) the
+ *  wall-clock + turn count so a finished row reads `✓ explore · 1.2s · 3 turns`. */
+export interface IAgentRow {
+  readonly id: string;
+  /** Human label; falls back to `id` when absent. */
+  readonly label?: string;
+  readonly status: AgentItemStatus;
+  /** Wall-clock once the row is done/failed. */
+  readonly durationMs?: number;
+  /** Model turns once the row is done/failed. */
+  readonly turns?: number;
+}
+
+/** Braille spinner frames for running rows (shared visual language with the
+ *  turn spinner in render/spinner.ts). */
+const TREE_SPINNER_FRAMES = ["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"];
+
+const CONNECT_MID = "├─ ";
+const CONNECT_END = "└─ ";
+
+/** Default cap on rendered rows before the tail collapses to `… +N more`, so a
+ *  big fan-out can't push the prompt off a short terminal. */
+const DEFAULT_MAX_ROWS = 12;
+
+export interface IAgentTreeOptions {
+  /** Terminal width; lines are kept ≤ `columns - 1` so none self-wraps. */
+  readonly columns: number;
+  /** Spinner frame index (running rows animate as the caller ticks this). */
+  readonly frame?: number;
+  /** Max rows before overflow collapses; ≥1. */
+  readonly maxRows?: number;
+  readonly color?: boolean;
+}
+
+interface ISegment {
+  readonly text: string;
+  readonly code: string;
+}
+
+/** Glyph + color for a row's status; running rows animate through the spinner. */
+function statusGlyph(status: AgentItemStatus, frame: number): ISegment {
+  if (status === "running") {
+    const i =
+      ((frame % TREE_SPINNER_FRAMES.length) + TREE_SPINNER_FRAMES.length) %
+      TREE_SPINNER_FRAMES.length;
+
+    return { text: TREE_SPINNER_FRAMES[i] ?? "⠋", code: STYLE.brand };
+  }
+
+  if (status === "done") {
+    return { text: "✓", code: STYLE.green };
+  }
+
+  if (status === "failed") {
+    return { text: "✗", code: STYLE.red };
+  }
+
+  return { text: "○", code: STYLE.dim };
+}
+
+/** Trailing ` · 1.2s · 3 turns` for a terminal row; empty while pending/running. */
+function rowMeta(row: IAgentRow): string {
+  if (row.status !== "done" && row.status !== "failed") {
+    return "";
+  }
+
+  const parts: string[] = [];
+
+  if (row.durationMs !== undefined) {
+    parts.push(`${(row.durationMs / 1000).toFixed(1)}s`);
+  }
+
+  if (row.turns !== undefined) {
+    parts.push(`${String(row.turns)} turn${row.turns === 1 ? "" : "s"}`);
+  }
+
+  return parts.length > 0 ? ` · ${parts.join(" · ")}` : "";
+}
+
+/** Fit `label` into `avail` columns, appending `…` when it must be clipped. */
+function fitLabel(label: string, avail: number): string {
+  if (displayWidth(label) <= avail) {
+    return label;
+  }
+
+  if (avail <= 1) {
+    return sliceToWidth(label, avail).text;
+  }
+
+  return `${sliceToWidth(label, avail - 1).text}…`;
+}
+
+/** Render one child row: connector + status glyph + clipped label + meta. */
+function rowLine(
+  row: IAgentRow,
+  isLast: boolean,
+  frame: number,
+  columns: number,
+  color: boolean
+): string {
+  const connector = isLast ? CONNECT_END : CONNECT_MID;
+  const glyph = statusGlyph(row.status, frame);
+  const meta = rowMeta(row);
+  const label = row.label ?? row.id;
+  const fixed =
+    displayWidth(connector) + displayWidth(glyph.text) + 1 + displayWidth(meta);
+  const avail = Math.max(0, columns - 1 - fixed);
+
+  return (
+    paint(connector, STYLE.dim, color) +
+    paint(glyph.text, glyph.code, color) +
+    ` ${fitLabel(label, avail)}` +
+    paint(meta, STYLE.dim, color)
+  );
+}
+
+/** The header line: `● agents · 2 running · 1/3 done · 1 failed`. */
+function headerLine(
+  rows: readonly IAgentRow[],
+  columns: number,
+  color: boolean
+): string {
+  const running = rows.filter((r) => r.status === "running").length;
+  const done = rows.filter((r) => r.status === "done").length;
+  const failed = rows.filter((r) => r.status === "failed").length;
+  const parts = ["agents"];
+
+  if (running > 0) {
+    parts.push(`${String(running)} running`);
+  }
+
+  parts.push(`${String(done)}/${String(rows.length)} done`);
+
+  if (failed > 0) {
+    parts.push(`${String(failed)} failed`);
+  }
+
+  const text = fitLabel(parts.join(" · "), Math.max(0, columns - 3));
+
+  return `${paint("●", STYLE.brand, color)} ${paint(text, STYLE.dim, color)}`;
+}
+
+/**
+ * Render the live agent tree as an ordered array of terminal lines (header +
+ * one row per child, tail-collapsed past `maxRows`). Every line is kept
+ * ≤ `columns - 1` so a terminal never self-wraps one. Empty input → `[]`.
+ */
+export function renderAgentTree(
+  rows: readonly IAgentRow[],
+  opts: IAgentTreeOptions
+): string[] {
+  if (rows.length === 0) {
+    return [];
+  }
+
+  const columns = Math.max(20, opts.columns);
+  const color = opts.color ?? true;
+  const frame = opts.frame ?? 0;
+  const maxRows = Math.max(1, opts.maxRows ?? DEFAULT_MAX_ROWS);
+  const overflow = rows.length > maxRows;
+  const shown = overflow ? rows.slice(0, maxRows - 1) : rows;
+  const lines = [headerLine(rows, columns, color)];
+
+  shown.forEach((row, i) => {
+    const isLast = !overflow && i === shown.length - 1;
+
+    lines.push(rowLine(row, isLast, frame, columns, color));
+  });
+
+  if (overflow) {
+    const hidden = rows.length - shown.length;
+
+    lines.push(paint(`└─ … +${String(hidden)} more`, STYLE.dim, color));
+  }
+
+  return lines;
+}
+
+/** Map a scheduler unit status onto a tree item status (`start` → running). */
+function unitToItem(status: UnitStatus): AgentItemStatus {
+  if (status === "start") {
+    return "running";
+  }
+
+  if (status === "done" || status === "failed") {
+    return status;
+  }
+
+  return "pending";
+}
+
+/** Optional terminal-row metadata (wall-clock + turns), threaded from the
+ *  scheduled unit's IAgentResult on the done/failed transition. */
+export interface IRowMeta {
+  readonly label?: string;
+  readonly durationMs?: number;
+  readonly turns?: number;
+}
+
+/**
+ * Folds a fan-out's lifecycle into an ordered set of {@link IAgentRow}s for the
+ * live tree. Insertion order (spawn order) is preserved, so pending rows appear
+ * up-front and never reshuffle as they run/finish. Fed either from scheduler
+ * unit transitions (`applyUnit`, used by `tsforge agents`) or from lifecycle
+ * events (`applyEvent`, for the event-driven REPL path).
+ */
+export class AgentTreeModel {
+  private readonly order: string[] = [];
+  private readonly byId = new Map<string, IAgentRow>();
+
+  private set(id: string, status: AgentItemStatus, meta?: IRowMeta): void {
+    if (!this.byId.has(id)) {
+      this.order.push(id);
+    }
+
+    const prev = this.byId.get(id);
+
+    this.byId.set(id, {
+      id,
+      status,
+      label: meta?.label ?? prev?.label,
+      durationMs: meta?.durationMs ?? prev?.durationMs,
+      turns: meta?.turns ?? prev?.turns,
+    });
+  }
+
+  /** Fold a scheduler unit transition (pending/start/done/failed). */
+  applyUnit(id: string, status: UnitStatus, meta?: IRowMeta): void {
+    this.set(id, unitToItem(status), meta);
+  }
+
+  /** Fold an `agent_spawned`/`agent_started`/`agent_result` lifecycle event. */
+  applyEvent(event: ILoopEvent): void {
+    if (event.kind === "agent_spawned") {
+      this.set(event.message, "pending");
+    } else if (event.kind === "agent_started") {
+      this.set(event.message, "running");
+    } else if (event.kind === "agent_result") {
+      this.set(event.message, event.passed === true ? "done" : "failed");
+    }
+  }
+
+  /** The current rows, in spawn order. */
+  rows(): IAgentRow[] {
+    const out: IAgentRow[] = [];
+
+    for (const id of this.order) {
+      const row = this.byId.get(id);
+
+      if (row !== undefined) {
+        out.push(row);
+      }
+    }
+
+    return out;
+  }
 }

--- a/packages/core/src/render/index.ts
+++ b/packages/core/src/render/index.ts
@@ -24,3 +24,15 @@ export { renderMarkdown, formatTables, highlightCode } from "./markdown";
 export { StreamingMarkdown } from "./stream-markdown";
 export { STYLE, RESET, paint } from "./style";
 export { makeAgentRail, type IAgentRail } from "./agent-rail";
+export {
+  formatAgentSummary,
+  makeAgentSummaryTracker,
+  renderAgentTree,
+  AgentTreeModel,
+  type AgentItemStatus,
+  type IAgentSummaryItem,
+  type IAgentRow,
+  type IAgentTreeOptions,
+  type IRowMeta,
+} from "./agent-tree";
+export { LiveRegion, type ILiveRegionOut } from "./live-region";

--- a/packages/core/src/render/live-region.ts
+++ b/packages/core/src/render/live-region.ts
@@ -32,8 +32,14 @@ export class LiveRegion {
 
   /** Move the cursor from the bottom of the current block to its top and erase
    *  it. Assumes the cursor is parked at the end of the last drawn line (where
-   *  the previous render left it). No-op prefix when nothing is drawn yet. */
+   *  the previous render left it). When nothing is drawn yet (`rows === 0`) this
+   *  is empty: there is no block of ours to erase, and emitting `\r ESC[0J`
+   *  would clobber whatever the caller just printed on the current line. */
   private eraseCurrent(): string {
+    if (this.rows === 0) {
+      return "";
+    }
+
     if (this.rows > 1) {
       return `${ESC}[${String(this.rows - 1)}A\r${ESC}[0J`;
     }

--- a/packages/core/src/render/live-region.ts
+++ b/packages/core/src/render/live-region.ts
@@ -1,0 +1,71 @@
+/**
+ * A block of lines pinned to the bottom of the terminal and repainted in place
+ * (log-update style): each `render` climbs to the block's top, `ESC[0J`-erases
+ * to end of screen, and redraws. Scrollback above the block is never touched.
+ *
+ * Unlike {@link StatusBar} it owns no input/editor/bar state — just N status
+ * lines — so it is the minimal live surface for one-shot fan-out output (the
+ * `tsforge agents` tree). On a non-TTY sink every call is a no-op, so piped and
+ * `--log` runs fall back to the caller's plain-text path unchanged.
+ */
+const ESC = "\x1b";
+
+/** The minimal sink LiveRegion needs — matches `process.stdout` but injectable
+ *  so a VirtualScreen test can capture the exact byte stream. */
+export interface ILiveRegionOut {
+  write(data: string): boolean;
+  readonly isTTY?: boolean;
+}
+
+export class LiveRegion {
+  /** Terminal rows the block currently occupies (0 = nothing drawn yet). */
+  private rows = 0;
+
+  constructor(
+    private readonly out: ILiveRegionOut,
+    private readonly enabled = true
+  ) {}
+
+  private get active(): boolean {
+    return this.enabled && this.out.isTTY === true;
+  }
+
+  /** Move the cursor from the bottom of the current block to its top and erase
+   *  it. Assumes the cursor is parked at the end of the last drawn line (where
+   *  the previous render left it). No-op prefix when nothing is drawn yet. */
+  private eraseCurrent(): string {
+    if (this.rows > 1) {
+      return `${ESC}[${String(this.rows - 1)}A\r${ESC}[0J`;
+    }
+
+    return `\r${ESC}[0J`;
+  }
+
+  /** Repaint the block with `lines`. Empty `lines` clears it. */
+  render(lines: readonly string[]): void {
+    if (!this.active) {
+      return;
+    }
+
+    if (lines.length === 0) {
+      this.clear();
+
+      return;
+    }
+
+    // Raw-mode terminals are ONLCR-off; joining with CRLF renders correctly in
+    // both raw and cooked sinks (a cooked terminal collapses the extra CR).
+    this.out.write(this.eraseCurrent() + lines.join("\r\n"));
+    this.rows = lines.length;
+  }
+
+  /** Erase the block and leave the cursor at its former top line. Idempotent. */
+  clear(): void {
+    if (!this.active || this.rows === 0) {
+      return;
+    }
+
+    this.out.write(this.eraseCurrent());
+    this.rows = 0;
+  }
+}

--- a/packages/core/tests/agent-tree-render-e2e.test.ts
+++ b/packages/core/tests/agent-tree-render-e2e.test.ts
@@ -1,0 +1,122 @@
+import { test, expect, describe } from "bun:test";
+import { LiveRegion } from "../src/render/live-region";
+import { AgentTreeModel, renderAgentTree } from "../src/render/agent-tree";
+import { VirtualScreen } from "./helpers/virtual-screen";
+
+/** A capturing terminal double: records every byte written, reports as a TTY. */
+function captureTerm(): {
+  out: { write: (s: string) => boolean; isTTY: boolean };
+  bytes: () => string;
+} {
+  const chunks: string[] = [];
+
+  return {
+    out: {
+      isTTY: true,
+      write: (s: string): boolean => {
+        chunks.push(s);
+
+        return true;
+      },
+    },
+    bytes: (): string => chunks.join(""),
+  };
+}
+
+/** Replay a captured byte stream onto a grid and return trimmed rows. */
+function screenOf(bytes: string, rows = 10, cols = 60): VirtualScreen {
+  const screen = new VirtualScreen(rows, cols);
+
+  screen.feed(bytes);
+
+  return screen;
+}
+
+describe("LiveRegion + agent tree — the real rendered screen", () => {
+  test("repaints in place: the final frame shows, earlier frames leave no ghost", () => {
+    const term = captureTerm();
+    const live = new LiveRegion(term.out, true);
+    const model = new AgentTreeModel();
+
+    model.applyUnit("explore", "pending");
+    model.applyUnit("review", "pending");
+    live.render(
+      renderAgentTree(model.rows(), { columns: 60, frame: 0, color: false })
+    );
+
+    model.applyUnit("explore", "start");
+    live.render(
+      renderAgentTree(model.rows(), { columns: 60, frame: 1, color: false })
+    );
+
+    model.applyUnit("explore", "done", { durationMs: 1200, turns: 2 });
+    live.render(
+      renderAgentTree(model.rows(), { columns: 60, frame: 2, color: false })
+    );
+
+    const screen = screenOf(term.bytes());
+
+    // The single tree occupies exactly 3 rows (header + 2 children) — the two
+    // earlier frames were erased in place, not stacked.
+    expect(screen.row(1)).toBe("● agents · 1/2 done");
+    expect(screen.row(2)).toBe("├─ ✓ explore · 1.2s · 2 turns");
+    expect(screen.row(3)).toBe("└─ ○ review");
+    expect(screen.row(4)).toBe("");
+
+    // Each label appears on exactly one row (no duplication from repaints).
+    expect(screen.rowsContaining("explore")).toBe(1);
+    expect(screen.rowsContaining("review")).toBe(1);
+  });
+
+  test("the tree renders below prior scrollback and keeps it intact", () => {
+    const term = captureTerm();
+    const live = new LiveRegion(term.out, true);
+    const model = new AgentTreeModel();
+
+    // Scrollback (the `agents: running …` header) written straight to the sink.
+    term.out.write("agents: running explore (cap 1)\r\n");
+    model.applyUnit("explore", "start");
+    live.render(
+      renderAgentTree(model.rows(), { columns: 60, frame: 0, color: false })
+    );
+
+    const screen = screenOf(term.bytes());
+
+    expect(screen.row(1)).toBe("agents: running explore (cap 1)");
+    expect(screen.row(2)).toBe("● agents · 1 running · 0/1 done");
+    expect(screen.row(3)).toBe("└─ ⠋ explore");
+  });
+
+  test("clear() erases the region and frees the space for scrollback below", () => {
+    const term = captureTerm();
+    const live = new LiveRegion(term.out, true);
+    const model = new AgentTreeModel();
+
+    model.applyUnit("explore", "start");
+    live.render(
+      renderAgentTree(model.rows(), { columns: 60, frame: 0, color: false })
+    );
+    live.clear();
+
+    // After clear, the result block prints where the tree was.
+    term.out.write("=== explore: done ===\r\n");
+
+    const screen = screenOf(term.bytes());
+
+    expect(screen.rowsContaining("agents ·")).toBe(0); // tree gone
+    expect(screen.text()).toContain("=== explore: done ===");
+  });
+
+  test("non-TTY sink is a no-op (piped runs never emit escape sequences)", () => {
+    const chunks: string[] = [];
+    const live = new LiveRegion(
+      { write: (s) => (chunks.push(s), true), isTTY: false },
+      true
+    );
+
+    live.render(["● agents · 0/1 done", "└─ ○ x"]);
+    live.clear();
+
+    expect(chunks).toHaveLength(0);
+  });
+});

--- a/packages/core/tests/agent-tree-render-e2e.test.ts
+++ b/packages/core/tests/agent-tree-render-e2e.test.ts
@@ -107,6 +107,17 @@ describe("LiveRegion + agent tree — the real rendered screen", () => {
     expect(screen.text()).toContain("=== explore: done ===");
   });
 
+  test("first render (rows=0) emits no erase — it can't clobber prior output", () => {
+    const term = captureTerm();
+    const live = new LiveRegion(term.out, true);
+
+    live.render(["a", "b"]);
+
+    // No leading cursor-up / erase-display before the first line: the block has
+    // nothing of its own to erase yet, so it must not touch the current line.
+    expect(term.bytes().startsWith("a\r\nb")).toBe(true);
+  });
+
   test("non-TTY sink is a no-op (piped runs never emit escape sequences)", () => {
     const chunks: string[] = [];
     const live = new LiveRegion(

--- a/packages/core/tests/agent-tree.test.ts
+++ b/packages/core/tests/agent-tree.test.ts
@@ -2,7 +2,11 @@ import { test, expect, describe } from "bun:test";
 import {
   formatAgentSummary,
   makeAgentSummaryTracker,
+  renderAgentTree,
+  AgentTreeModel,
+  type IAgentRow,
 } from "../src/render/agent-tree";
+import { displayWidth } from "../src/render/width";
 
 describe("formatAgentSummary", () => {
   test("empty input renders nothing", () => {
@@ -92,5 +96,131 @@ describe("makeAgentSummaryTracker", () => {
     });
 
     expect(lines.at(-1)).toBe("agents: 0/1 done, 1 failed");
+  });
+});
+
+describe("renderAgentTree", () => {
+  const plain = { columns: 60, color: false };
+
+  test("empty input renders nothing", () => {
+    expect(renderAgentTree([], plain)).toEqual([]);
+  });
+
+  test("a single done row shows glyph, label, and meta", () => {
+    const lines = renderAgentTree(
+      [{ id: "explore", status: "done", durationMs: 1200, turns: 3 }],
+      plain
+    );
+
+    expect(lines[0]).toBe("● agents · 1/1 done");
+    expect(lines[1]).toBe("└─ ✓ explore · 1.2s · 3 turns");
+  });
+
+  test("status glyphs: pending ○, running spinner, done ✓, failed ✗", () => {
+    const rows: IAgentRow[] = [
+      { id: "a", status: "pending" },
+      { id: "b", status: "running" },
+      { id: "c", status: "done" },
+      { id: "d", status: "failed" },
+    ];
+    const lines = renderAgentTree(rows, { ...plain, frame: 0 });
+
+    expect(lines[0]).toBe("● agents · 1 running · 1/4 done · 1 failed");
+    expect(lines[1]).toBe("├─ ○ a");
+    expect(lines[2]).toBe("├─ ⠋ b"); // frame 0 spinner
+    expect(lines[3]).toBe("├─ ✓ c");
+    expect(lines[4]).toBe("└─ ✗ d"); // last row → end connector
+  });
+
+  test("running rows animate with the frame index", () => {
+    const row: IAgentRow[] = [{ id: "x", status: "running" }];
+
+    expect(renderAgentTree(row, { ...plain, frame: 1 })[1]).toBe("└─ ⠙ x");
+    expect(renderAgentTree(row, { ...plain, frame: 2 })[1]).toBe("└─ ⠹ x");
+  });
+
+  test("negative/large frame indices stay in range (no crash, valid glyph)", () => {
+    const row: IAgentRow[] = [{ id: "x", status: "running" }];
+
+    expect(renderAgentTree(row, { ...plain, frame: -1 })[1]).toBe("└─ ⠏ x");
+    expect(renderAgentTree(row, { ...plain, frame: 1000 })[1]).toBe("└─ ⠋ x");
+  });
+
+  test("overflow collapses the tail into a `… +N more` row", () => {
+    const rows: IAgentRow[] = Array.from({ length: 10 }, (_, i) => ({
+      id: `agent-${String(i)}`,
+      status: "pending" as const,
+    }));
+    const lines = renderAgentTree(rows, { ...plain, maxRows: 4 });
+
+    // header + (maxRows-1)=3 shown rows + 1 overflow line
+    expect(lines).toHaveLength(5);
+    expect(lines[0]).toBe("● agents · 0/10 done"); // denominator = full total
+    expect(lines.at(-1)).toBe("└─ … +7 more");
+  });
+
+  test("labels are clipped with … and no line exceeds columns-1", () => {
+    const rows: IAgentRow[] = [
+      {
+        id: "a-very-long-agent-identifier-that-will-not-fit",
+        status: "running",
+      },
+    ];
+    const lines = renderAgentTree(rows, {
+      columns: 20,
+      color: false,
+      frame: 0,
+    });
+
+    for (const line of lines) {
+      expect(displayWidth(line)).toBeLessThanOrEqual(19);
+    }
+
+    expect(lines[1]).toContain("…");
+  });
+});
+
+describe("AgentTreeModel", () => {
+  test("applyUnit maps start→running and preserves spawn order", () => {
+    const model = new AgentTreeModel();
+
+    model.applyUnit("b", "pending");
+    model.applyUnit("a", "pending");
+    model.applyUnit("a", "start");
+
+    const rows = model.rows();
+
+    expect(rows.map((r) => r.id)).toEqual(["b", "a"]); // insertion order, not status
+    expect(rows[0]?.status).toBe("pending");
+    expect(rows[1]?.status).toBe("running");
+  });
+
+  test("done meta (duration/turns) is retained across later reads", () => {
+    const model = new AgentTreeModel();
+
+    model.applyUnit("x", "pending");
+    model.applyUnit("x", "start");
+    model.applyUnit("x", "done", { durationMs: 900, turns: 2 });
+
+    const row = model.rows()[0];
+
+    expect(row?.status).toBe("done");
+    expect(row?.durationMs).toBe(900);
+    expect(row?.turns).toBe(2);
+  });
+
+  test("applyEvent folds lifecycle events (passed=false → failed)", () => {
+    const model = new AgentTreeModel();
+
+    model.applyEvent({ kind: "agent_spawned", task: "t", message: "one" });
+    model.applyEvent({ kind: "agent_started", task: "t", message: "one" });
+    model.applyEvent({
+      kind: "agent_result",
+      task: "t",
+      message: "one",
+      passed: false,
+    });
+
+    expect(model.rows()[0]?.status).toBe("failed");
   });
 });

--- a/packages/core/tests/agent-tree.test.ts
+++ b/packages/core/tests/agent-tree.test.ts
@@ -178,6 +178,29 @@ describe("renderAgentTree", () => {
 
     expect(lines[1]).toContain("…");
   });
+
+  test("a done row's meta drops (not half-prints) rather than overflow", () => {
+    const rows: IAgentRow[] = [
+      { id: "x", status: "done", durationMs: 1200, turns: 3 },
+    ];
+    const lines = renderAgentTree(rows, { columns: 12, color: false });
+
+    for (const line of lines) {
+      expect(displayWidth(line)).toBeLessThanOrEqual(11);
+    }
+
+    // The meta couldn't fit, so it's gone entirely — no ` · 1.2` fragment.
+    expect(lines[1]).not.toContain("1.2");
+  });
+
+  test("honors the real width — no upward clamp that draws wider than the screen", () => {
+    const rows: IAgentRow[] = [{ id: "explore", status: "pending" }];
+
+    // A 10-col terminal must not produce a 19-col line (the old 20-clamp bug).
+    for (const line of renderAgentTree(rows, { columns: 10, color: false })) {
+      expect(displayWidth(line)).toBeLessThanOrEqual(9);
+    }
+  });
 });
 
 describe("AgentTreeModel", () => {
@@ -222,5 +245,36 @@ describe("AgentTreeModel", () => {
     });
 
     expect(model.rows()[0]?.status).toBe("failed");
+  });
+
+  test("keys rows by agentId; agent_result payload in message doesn't spawn a row", () => {
+    const model = new AgentTreeModel();
+
+    model.applyEvent({
+      kind: "agent_spawned",
+      task: "t",
+      agentId: "run-1:explore",
+      message: "explore",
+    });
+    model.applyEvent({
+      kind: "agent_started",
+      task: "t",
+      agentId: "run-1:explore",
+      message: "explore",
+    });
+    // agent_result: message carries the final payload, NOT the id.
+    model.applyEvent({
+      kind: "agent_result",
+      task: "t",
+      agentId: "run-1:explore",
+      message: "3 findings",
+      passed: true,
+    });
+
+    const rows = model.rows();
+
+    expect(rows).toHaveLength(1); // completed the running row, no bogus "3 findings"
+    expect(rows[0]?.status).toBe("done");
+    expect(rows[0]?.label).toBe("explore"); // spawn message kept as the label
   });
 });

--- a/scripts/e2e-agents-pty.py
+++ b/scripts/e2e-agents-pty.py
@@ -1,0 +1,111 @@
+#!/usr/bin/env python3
+"""Real-PTY reality test for the live agent tree (`tsforge agents`).
+
+Drives the REAL tsforge CLI in a REAL pseudo-terminal against the deterministic
+stub model, fans out two read-only subagents over a task, and asserts on the
+REAL byte stream that the Claude-Code-style tree actually rendered: the `● agents`
+header, per-child rows with tree connectors, a running spinner frame, done ✓
+glyphs, and the final result blocks. Erased frames stay in the captured stream
+(the erase is an escape sequence, not a deletion), so we can assert a running
+frame was shown even though the stub answers near-instantly.
+
+Run: python3 scripts/e2e-agents-pty.py
+"""
+import json
+import os
+import re
+import sys
+import tempfile
+
+sys.path.insert(0, os.path.join(os.path.dirname(os.path.abspath(__file__)), "lib"))
+from ptyharness import (  # noqa: E402
+    Checker,
+    read_until,
+    reap,
+    spawn_tsforge,
+    start_stub_server,
+    toolcall_chunks,
+)
+
+ANSI = re.compile(r"\x1b\[[0-9;?]*[A-Za-z]")
+
+
+def strip(text):
+    """Remove ANSI escape sequences so tree glyphs assert as plain substrings."""
+    return ANSI.sub("", text)
+
+
+def _decide(_messages):
+    """Every agent turn: return the structured result tool call → 1-turn 'done'."""
+    return toolcall_chunks(
+        "agent_result", {"result": "Explored the workspace; nothing to report."}
+    )
+
+
+def _write_spec(agents_dir, spec_id, description):
+    with open(os.path.join(agents_dir, f"{spec_id}.json"), "w") as f:
+        json.dump({"id": spec_id, "description": description, "maxTurns": 5}, f)
+
+
+def spawn(port):
+    """Fork `tsforge agents explore,verify "<task>"` into a real pty."""
+    work = tempfile.mkdtemp(prefix="tsforge-agents-")
+    home = tempfile.mkdtemp(prefix="tsforge-home-")
+    agents_dir = os.path.join(work, ".tsforge", "agents")
+    os.makedirs(agents_dir)
+    _write_spec(agents_dir, "explore", "map the workspace")
+    _write_spec(agents_dir, "verify", "double-check the findings")
+
+    pid, master = spawn_tsforge(
+        port,
+        {},
+        cwd=work,
+        home=home,
+        args=("agents", "explore,verify", "Summarize this repo."),
+    )
+    return pid, master
+
+
+def scenario(port, chk):
+    print("\n# live agent tree (tsforge agents, real pty)")
+    pid, master = spawn(port)
+    try:
+        # Wait for both result blocks (plain text, printed after the tree clears).
+        got, buf = read_until(
+            master, lambda b: "=== verify:" in b and "=== explore:" in b, 60
+        )
+        clean = strip(buf)
+
+        chk.check("tree header rendered (● agents)", "● agents" in clean, clean[-400:])
+        chk.check(
+            "tree connectors rendered (├─ / └─)",
+            "├─" in clean or "└─" in clean,
+            clean[-400:],
+        )
+        chk.check(
+            "a running frame was shown (header said 'running')",
+            "running" in clean,
+        )
+        chk.check("explore finished done (✓)", "✓" in clean and "explore" in clean)
+        chk.check(
+            "both result blocks printed",
+            got and "=== explore: done" in buf and "=== verify: done" in buf,
+        )
+    finally:
+        # One-shot command: it exits on its own; reap without an /exit cmd.
+        reap(pid, master, exit_cmd=b"")
+
+
+def main():
+    srv, port = start_stub_server(_decide)
+    print(f"stub model @ 127.0.0.1:{port}")
+    chk = Checker()
+    try:
+        scenario(port, chk)
+    finally:
+        srv.shutdown()
+    sys.exit(chk.finish())
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## What

The screenshot north star: a live, Claude-Code-style agent tree while a fan-out runs. One row per subagent, pinned to the bottom of the terminal and repainted in place.

```
● agents · 1 running · 1/2 done
├─ ✓ explore · 1.2s · 3 turns
└─ ⠹ verify
```

Pending rows appear up-front, running rows animate a spinner, and each finishes with its wall-clock and turn count. The tree repaints in place (never scrolls the transcript) and collapses to `… +N more` past a dozen rows.

## How

- **`render/agent-tree.ts`** — `renderAgentTree` (status glyphs `○`/spinner/`✓`/`✗`, tree connectors, `· 1.2s · 3 turns` meta, Unicode-aware width clipping, overflow cap) + `AgentTreeModel`, which folds either **scheduler unit transitions** (`applyUnit`, used by `tsforge agents`) or **`agent_*` lifecycle events** (`applyEvent`, ready for the Phase-C in-REPL path) into ordered rows, spawn order preserved.
- **`render/live-region.ts`** — a minimal pinned-bottom repaint surface (cursor climb + `ESC[0J` erase + redraw). Non-TTY = no-op. Deliberately **separate from the load-bearing StatusBar** to keep the highest-risk render code untouched.
- **`cli.ts` `agentsMode`** — draws the live tree on a real TTY (spinner-animated on a 120ms tick), and falls back to the existing one-line `agents: …` summary when piped/redirected, so logs and CI stay plain-text.

## Tests

- 12 renderer/model unit tests (glyphs, connectors, meta, truncation, overflow, frame wrap-around, order/meta retention, lifecycle fold).
- 4 **VirtualScreen** "real rendered screen" e2e: repaint-in-place with no ghost rows, tree below scrollback, `clear()` frees the region, non-TTY no-op.
- A **real-PTY** e2e (`scripts/e2e-agents-pty.py`, added to `e2e:pty`) that boots `tsforge agents explore,verify "…"` against the stub server and asserts the tree header, connectors, a running frame, and `✓` glyphs render in a genuine terminal — 5/5 pass.

## Verification note

`typecheck`, `lint`, `format`, all new tests, and the new PTY e2e are green. The full `bun run validate` currently trips two **pre-existing, environmental** failures unrelated to this diff: one e2e test hangs on `model endpoint unreachable` (no local model server up), which starved the run and timed out `settle-steps.test.ts` — the latter passes in 1.45s in isolation. Neither failing test touches the files in this PR.

Part of the multiagent initiative (PR-A1 #73, A2 #74, B1 #75, B2 #76). This is the last Phase-B slice; Phase C is the model-invoked `spawn_agent` tool, which reuses `AgentTreeModel.applyEvent` for its in-REPL tree.