### PR TITLE
feat(agents): model-driven delegation — spawn_agent + built-in specialists + live navigable tree (Phase C)

### DIFF
--- a/.tsforge/agents/explore.json
+++ b/.tsforge/agents/explore.json
@@ -1,5 +1,0 @@
-{
-  "id": "explore",
-  "description": "Read-only codebase explorer — maps a subsystem and returns conclusions with file:line references",
-  "maxTurns": 10
-}

--- a/apps/docs/astro.config.mjs
+++ b/apps/docs/astro.config.mjs
@@ -173,6 +173,7 @@ export default defineConfig({
             { label: "Drive a change to green", link: "/workflows/fix-to-green/" },
             { label: "Build a whole app", link: "/loop/greenfield/" },
             { label: "Review your changes", link: "/cli/review/" },
+            { label: "Delegate to subagents", link: "/agent/delegation/" },
             { label: "Recipes", link: "/cli/recipes/" },
             { label: "Pre-edit scout", link: "/loop/scout/" },
             { label: "Map the repo", link: "/cli/map/" },

--- a/apps/docs/src/content/docs/agent/delegation.mdx
+++ b/apps/docs/src/content/docs/agent/delegation.mdx
@@ -1,0 +1,74 @@
+---
+title: Delegate to subagents
+description: "tsforge's orchestrator delegates focused, read-only investigation to specialist subagents on its own — you describe a task, it decides what to explore, research, or verify — and renders them as a live tree while they work."
+---
+
+You think in tasks, bugs, and features — never in subagents. So delegation in tsforge is **orchestrator-driven**: the model you're talking to decides, on its own, when a task needs focused investigation, hands it to a specialist subagent, and folds the findings back into its answer. You never name an agent, pass ids, or run a command for it.
+
+Ask it to "figure out how the gate decides a run is done and check there's no race in the scheduler," and it may spawn an `explore` agent for the first and a `verify` agent for the second — in parallel — while it keeps working.
+
+## Why delegate
+
+A subagent runs in its **own context window** and returns only a concise, cited summary. That keeps the orchestrator's context small on exploration-heavy work (it doesn't have to read twenty files itself), and — when several run at once — shortens wall-clock. Subagents are **read-only**: they explore, research, and verify; only the orchestrator edits files.
+
+## Built-in specialists
+
+These ship in the binary — delegation works with zero configuration:
+
+| Specialist | What it does |
+| ---------- | ------------ |
+| `explore` | Maps a subsystem or traces how something works; reports conclusions with `file:line` references. |
+| `research` | Researches external docs, package APIs, and the web; reports with source URLs. |
+| `verify` | Adversarially checks a specific claim or finding against the real code; returns a verdict. |
+| `review-lens` | Reviews a change for correctness / regressions from a senior-engineer lens. |
+
+Each is a read-only agent with a prompt that mandates real investigation and cited findings — it must read before it answers.
+
+### Add or override a specialist
+
+Drop a JSON file in `.tsforge/agents/<id>.json` (project) or `~/.tsforge/agents/<id>.json` (global). Precedence is **built-in < global < project**, so a file with the same id as a built-in overrides it.
+
+```json
+{
+  "id": "security",
+  "description": "Audits a change for security issues (authz, injection, secrets).",
+  "tools": ["read", "search", "git_context"],
+  "maxTurns": 12
+}
+```
+
+`tools` is intersected with the read-only tool set — a spec can never grant a subagent the ability to write.
+
+## The live agent tree
+
+While subagents run, they render as a live tree pinned above the input row — so a delegated run is never a black box:
+
+```
+● agents · 1 running · 1/2 done
+├─ ✓ explore · 1.2s · 3 turns
+└─ ⠹ verify
+```
+
+Rows appear the moment they're spawned, animate a spinner while running, and finish with their wall-clock and turn count. Beneath the tree, a detail pane streams the **focused** agent's live output (the files it reads, what it finds) — it follows the active agent automatically. The tree repaints in place (it never scrolls your transcript) and collapses to `… +N more` past a dozen rows. Ctrl-C cancels the turn and all its subagents.
+
+## Concurrency
+
+How many subagents run at once is capped by [`agents.concurrency`](/guardrails/config/) in `tsforge.config.json` (integer 1–16, default 1):
+
+```json
+{ "agents": { "concurrency": 4 } }
+```
+
+When the orchestrator spawns several agents in one turn, up to this many run in parallel; the rest queue (shown as pending `○` rows) until a slot frees. At `concurrency: 1` they run one at a time — you still get the context-isolation win, just no wall-clock overlap. The config is discovered by walking up from the working directory, so it applies even when tsforge runs from a subdirectory. The REPL prints the resolved setup at startup:
+
+```
+↳ delegation: 4 specialists (explore, research, review-lens, verify) · cap 4
+```
+
+If you set `concurrency` above 1 but agents still run serially, either the cap is resolving to 1 (check that startup line) or the model chose to spawn them one per turn rather than together.
+
+## Guarantees
+
+- **Read-only.** A subagent's tools are the read-only set ∩ its spec; the executor hard-rejects any mutation, and the policy layer evaluates every call.
+- **No recursion.** A subagent is never offered `spawn_agent`, so delegation depth is capped at one.
+- **Policy-aware.** Delegation is its own policy action class — a repo can `deny`/`ask` it via [permissions](/guardrails/policy/), and each subagent inherits the session's policy mode.

--- a/apps/docs/src/content/docs/cli/review.mdx
+++ b/apps/docs/src/content/docs/cli/review.mdx
@@ -47,18 +47,6 @@ By default the per-file find pass and per-finding verify pass run one model call
 
 Review then fans out up to that many calls at once — each with a fresh provider — and prints a live `agents: 2 running, 5/16 done (…)` progress line. Results are identical in structure and order to a sequential run; only the wall-clock changes (≈2× measured at cap 8 on a batching endpoint). Keep the cap a couple below your server's `max_num_seqs` so an interactive session is never starved, and leave it at 1 for endpoints that serialize requests anyway.
 
-## The live agent tree
-
-`tsforge agents <ids> "<task>"` — a read-only fan-out over named agent specs — draws a live tree pinned to the bottom of the terminal while it runs, one row per subagent:
-
-```
-● agents · 1 running · 1/2 done
-├─ ✓ explore · 1.2s · 3 turns
-└─ ⠹ verify
-```
-
-Pending rows appear up-front, running rows animate, and each finishes with its wall-clock and turn count. The tree repaints in place (it never scrolls the transcript) and collapses to `… +N more` past a dozen rows. When output is piped or redirected — no TTY — it falls back to the one-line `agents: …` summary instead, so logs and CI stay plain-text. (`tsforge review`'s fan-out uses that compact `agents: …` summary line described above, not the tree.)
-
 ## In CI
 
 `tsforge review` exits non-zero if any error-severity finding survives, so you can gate a PR on it. It uses `git` to find what changed, so run it inside a git repository.

--- a/apps/docs/src/content/docs/guardrails/config.mdx
+++ b/apps/docs/src/content/docs/guardrails/config.mdx
@@ -20,7 +20,7 @@ Add **`tsforge.config.json`** at your repo root when you want to override what t
 | `plugins` | object[] | External modules providing extra rule packs (see below) |
 | `mcpServers` | object | External [MCP servers](/integrations/mcp/) whose tools the agent can call |
 | `policy` | object | Permission `mode` + deny/allow/ask `rules` for tool actions — see [Permissions & policy](/guardrails/policy/) |
-| `agents.concurrency` | number | Multiagent fan-out cap, integer 1–16 (default `1` = sequential). Above 1, `tsforge review` runs its per-file find and per-finding verify passes in parallel with a fresh provider per unit and a live `agents:` progress line. Leave at 1 for a local endpoint that serializes requests anyway |
+| `agents.concurrency` | number | Multiagent cap, integer 1–16 (default `1` = sequential). Bounds how many subagents run at once — both [delegated `spawn_agent` calls](/agent/delegation/) and `tsforge review`'s parallel find/verify passes (fresh provider per unit, live `agents:` progress). Leave at 1 for a local endpoint that serializes requests anyway |
 
 Resolution order: detect from the repo → apply **`profile`** (packs + default severities) → apply `stack` → apply `include` → apply `exclude` → add external plugin packs → dedupe → merge `rules` overrides (user wins).
 

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "test": "bun test packages",
     "check:bun": "bun packages/core/scripts/check-bun-version.ts",
     "e2e": "python3 scripts/e2e-iterm-tui.py && python3 scripts/e2e-iterm-plan-mode.py",
-    "e2e:pty": "python3 scripts/e2e-pty.py && python3 scripts/e2e-wizard-pty.py && python3 scripts/e2e-config-repl-pty.py && python3 scripts/e2e-help-menu-pty.py && python3 scripts/e2e-editor-pty.py && python3 scripts/e2e-agents-pty.py",
+    "e2e:pty": "python3 scripts/e2e-pty.py && python3 scripts/e2e-wizard-pty.py && python3 scripts/e2e-config-repl-pty.py && python3 scripts/e2e-help-menu-pty.py && python3 scripts/e2e-editor-pty.py && python3 scripts/e2e-agents-pty.py && python3 scripts/e2e-spawn-agent-pty.py",
     "validate": "bun run check:bun && bun run typecheck && bun run lint && bun run format:check && bun run test && bun run e2e:pty",
     "rules:build": "bun packages/core/scripts/build-rules-md.ts",
     "rules:docs": "bun packages/core/scripts/build-rule-docs.ts",

--- a/packages/core/src/agent/agent-runner.ts
+++ b/packages/core/src/agent/agent-runner.ts
@@ -10,7 +10,7 @@
  * (scheduler unitReporter); the runner only tags its inner events with
  * agentId/parentTask so interleaved streams stay attributable.
  */
-import type { IProvider } from "../inference";
+import type { IProvider, IModelResponse } from "../inference";
 import type { TsService } from "../lsp";
 import type { PolicyMode, IPolicyRules } from "../policy";
 import type { ILoopEvent, Reporter } from "../loop/loop.types";
@@ -21,6 +21,7 @@ import {
   type ILoopCtx,
   type ILoopState,
 } from "../loop/turn";
+import { DEFAULT_TEMPERATURE } from "../loop/loop.constants";
 import { TOOL_SPECS } from "./agent.constants";
 import type { IAgentSpec } from "./agent-spec";
 
@@ -31,8 +32,12 @@ export const AGENT_LIMITS = {
 
 const DEFAULT_SYSTEM = [
   "You are a focused read-only investigator inside a coding harness.",
-  "Explore the workspace with the provided tools, then answer the task in ONE",
-  "final message: state conclusions with file:line references, not raw dumps.",
+  "You do NOT know the codebase — you MUST investigate before answering.",
+  "Use the tools (search/read/symbol_search/…) to open the actual files the",
+  "task is about; NEVER answer from memory or guess. Read real code first,",
+  "then answer in ONE final message: concrete conclusions, each backed by a",
+  "`file:line` reference you actually saw. An answer with no file:line",
+  "citations means you did not investigate and is wrong.",
   "You cannot edit files — do not propose tool calls that write.",
 ].join(" ");
 
@@ -112,6 +117,32 @@ export interface IAgentRunOptions {
 /** Pull the structured payload out of an intercepted agent_result call. */
 function resultPayload(args: Record<string, unknown>): string {
   return typeof args.result === "string" ? args.result : JSON.stringify(args);
+}
+
+/** Force the first move (`"required"`) while real tools exist and nothing has
+ *  been investigated yet — this is what stops a local model from answering from
+ *  memory in one turn. Once it has read something, or on the last turn (where a
+ *  forced call it can't act on is useless), fall back to `"auto"`. */
+function nextToolChoice(
+  hasRealTools: boolean,
+  hasInvestigated: boolean,
+  turn: number,
+  maxTurns: number
+): "required" | "auto" {
+  const mustInvestigate = hasRealTools && !hasInvestigated && turn < maxTurns;
+
+  return mustInvestigate ? "required" : "auto";
+}
+
+/** Append the model's turn (content + tool calls, replaying reasoning for the
+ *  deepseek style) to the conversation. */
+function pushAssistant(ctx: ILoopCtx, res: IModelResponse): void {
+  ctx.messages.push({
+    role: "assistant",
+    content: res.content,
+    toolCalls: res.toolCalls,
+    ...(res.reasoning === undefined ? {} : { reasoningContent: res.reasoning }),
+  });
 }
 
 export class AgentRunner {
@@ -261,6 +292,13 @@ export class AgentRunner {
     const { agentId, structured, tools, maxTurns, report, finish, progress } =
       loop;
     let lastText = "";
+    // Whether the agent has called ANY investigative tool yet. Until it has, we
+    // force a tool call (toolChoice "required") instead of letting the model
+    // answer from memory in one turn — the adoption failure that made read-only
+    // agents return uncited, empty prose. Once it has actually read something,
+    // switch to "auto" so it can produce its final answer.
+    let hasInvestigated = false;
+    const hasRealTools = tools.length > (structured ? 1 : 0);
 
     {
       for (let turn = 1; turn <= maxTurns; turn += 1) {
@@ -279,22 +317,23 @@ export class AgentRunner {
 
         const res = await opts.provider.complete(ctx.messages, {
           tools,
-          toolChoice: "auto",
-          temperature: opts.temperature ?? 0,
+          toolChoice: nextToolChoice(
+            hasRealTools,
+            hasInvestigated,
+            turn,
+            maxTurns
+          ),
+          // Match the main loop's default (0.2), NOT greedy: temperature 0 makes
+          // this model early-stop into empty/one-line answers on a long
+          // tool-result context. A caller can still override.
+          temperature: opts.temperature ?? DEFAULT_TEMPERATURE,
           ...(opts.signal === undefined ? {} : { signal: opts.signal }),
           onToken: (text) => {
             report({ kind: "token", task: agentId, message: text });
           },
         });
 
-        ctx.messages.push({
-          role: "assistant",
-          content: res.content,
-          toolCalls: res.toolCalls,
-          ...(res.reasoning === undefined
-            ? {}
-            : { reasoningContent: res.reasoning }),
-        });
+        pushAssistant(ctx, res);
         lastText = res.content.length > 0 ? res.content : lastText;
         progress.lastText = lastText;
 
@@ -306,19 +345,28 @@ export class AgentRunner {
           return finish("done", resultPayload(resultCall.arguments), turn);
         }
 
+        const investigativeCalls = res.toolCalls.filter(
+          (c) => c.name !== AGENT_RESULT_TOOL.function.name
+        );
+
+        if (investigativeCalls.length > 0) {
+          hasInvestigated = true;
+        }
+
         if (res.toolCalls.length === 0) {
-          // A structured agent that just stops talking has NOT delivered its
-          // payload — nudge once per remaining turn rather than accept prose.
-          if (structured) {
-            ctx.messages.push({
-              role: "user",
-              content:
-                "Call the agent_result tool with your final result to finish.",
-            });
-            continue;
+          const done = this.finalizeOrNudge(
+            res.content,
+            structured,
+            hasInvestigated,
+            ctx,
+            () => finish("done", res.content, turn)
+          );
+
+          if (done !== null) {
+            return done;
           }
 
-          return finish("done", res.content, turn);
+          continue;
         }
 
         await runToolCalls(res.toolCalls, ctx, state);
@@ -326,5 +374,38 @@ export class AgentRunner {
 
       return finish("max_turns", lastText, maxTurns);
     }
+  }
+
+  /** Decide what to do with a no-tool-call response: return a `done` result, or
+   *  `null` after pushing a follow-up nudge so the loop takes another turn. A
+   *  structured agent must still call `agent_result`; an empty answer with no
+   *  investigation is not accepted. */
+  private finalizeOrNudge(
+    content: string,
+    structured: boolean,
+    hasInvestigated: boolean,
+    ctx: ILoopCtx,
+    done: () => IAgentResult
+  ): IAgentResult | null {
+    if (structured) {
+      ctx.messages.push({
+        role: "user",
+        content: "Call the agent_result tool with your final result to finish.",
+      });
+
+      return null;
+    }
+
+    if (content.trim().length === 0 && !hasInvestigated) {
+      ctx.messages.push({
+        role: "user",
+        content:
+          "You haven't investigated yet. Use the tools to read the relevant files, then answer with file:line citations.",
+      });
+
+      return null;
+    }
+
+    return done();
   }
 }

--- a/packages/core/src/agent/agent-runner.ts
+++ b/packages/core/src/agent/agent-runner.ts
@@ -343,17 +343,37 @@ export class AgentRunner {
         const resultCall = res.toolCalls.find(
           (c) => c.name === AGENT_RESULT_TOOL.function.name
         );
-
-        if (resultCall !== undefined) {
-          return finish("done", resultPayload(resultCall.arguments), turn);
-        }
-
         const investigativeCalls = res.toolCalls.filter(
           (c) => c.name !== AGENT_RESULT_TOOL.function.name
         );
 
+        // Run any REAL tool calls first — that is what counts as investigation,
+        // and it must happen before we'd accept a result emitted in the same turn.
         if (investigativeCalls.length > 0) {
           hasInvestigated = true;
+          await runToolCalls(investigativeCalls, ctx, state);
+        }
+
+        // Accept a structured result ONLY after real investigation (or when the
+        // agent has no real tools to investigate with, e.g. `tools: []`).
+        // Otherwise `agent_result` on its own satisfies toolChoice:"required",
+        // letting a structured agent answer from memory on turn 1 — reject it and
+        // force a real tool call next.
+        if (resultCall !== undefined) {
+          if (hasInvestigated || !hasRealTools) {
+            return finish("done", resultPayload(resultCall.arguments), turn);
+          }
+
+          ctx.messages.push({
+            role: "tool",
+            toolCallId: resultCall.id ?? AGENT_RESULT_TOOL.function.name,
+            content:
+              "Investigate FIRST: use the tools to read the relevant files, then " +
+              "call agent_result with findings backed by file:line. Don't answer " +
+              "before looking.",
+          });
+
+          continue;
         }
 
         if (res.toolCalls.length === 0) {
@@ -368,11 +388,7 @@ export class AgentRunner {
           if (done !== null) {
             return done;
           }
-
-          continue;
         }
-
-        await runToolCalls(res.toolCalls, ctx, state);
       }
 
       return finish("max_turns", lastText, maxTurns);

--- a/packages/core/src/agent/agent-runner.ts
+++ b/packages/core/src/agent/agent-runner.ts
@@ -74,7 +74,10 @@ function isReadOnlyTool(name: string): boolean {
   return READ_ONLY_TOOL_NAMES.has(name);
 }
 
-/** The agent's advertised tools: read-only set ∩ optional spec subset. */
+/** The agent's advertised tools: read-only set ∩ optional spec subset.
+ *  `spawn_agent` is NOT among them — it is never part of `toolsFor()` (the CLI
+ *  adds it only to the orchestrator's list), so a subagent structurally cannot
+ *  delegate and recursion depth is capped at 1. */
 function agentTools(subset: readonly string[] | undefined): unknown[] {
   return toolsFor(true).filter((tool) => {
     const name = tool.function.name;

--- a/packages/core/src/agent/agent.constants.ts
+++ b/packages/core/src/agent/agent.constants.ts
@@ -1,4 +1,5 @@
 import type { ToolName } from "./agent.types";
+import type { IAgentSpec } from "./agent-spec";
 
 /**
  * The canonical tool names. Schemas, dispatch, and any name comparison reference
@@ -31,6 +32,7 @@ export const TOOL_NAME = {
   webSearch: "web_search",
   webBrowse: "web_browse",
   script: "script",
+  spawnAgent: "spawn_agent",
 } as const;
 
 /** Per-tool capability flags — the single source of truth the plan-mode set and
@@ -80,6 +82,11 @@ export const TOOL_SPECS: Readonly<Record<ToolName, IToolSpec>> = {
   [TOOL_NAME.webBrowse]: { readOnly: true, scriptExposable: true },
   // `script` mutates (it can call edit/create) and must never call itself.
   [TOOL_NAME.script]: { readOnly: false, scriptExposable: false },
+  // Delegation is itself read-only (the orchestrator only receives findings;
+  // spawned agents cannot mutate), so it survives plan mode. NOT script-exposable
+  // (no spawning from a program) and — by construction — never offered to a
+  // spawned agent, which caps recursion depth at 1 (see agent-runner agentTools).
+  [TOOL_NAME.spawnAgent]: { readOnly: true, scriptExposable: false },
 };
 
 function toolNamesWhere(
@@ -649,3 +656,59 @@ export const GIT_CONTEXT_TOOL = {
     },
   },
 };
+
+/**
+ * The model-invoked delegation tool (like Claude Code's Task tool). The
+ * orchestrator calls it — the user never names an agent — to hand a focused,
+ * self-contained, read-only investigation to a specialist and get its findings
+ * back. Multiple calls in one turn run in parallel (see runToolCalls). The
+ * `subagent_type` enum is built from the loaded specs so the model sees exactly
+ * which specialists exist. Returns null when no specs are available (nothing to
+ * delegate to), so the caller offers the tool only when it's useful.
+ */
+export function buildSpawnAgentTool(specs: readonly IAgentSpec[]): {
+  type: "function";
+  function: { name: string } & Record<string, unknown>;
+} | null {
+  if (specs.length === 0) {
+    return null;
+  }
+
+  const ids = specs.map((s) => s.id);
+  const roster = specs
+    .map((s) =>
+      s.description === undefined ? s.id : `${s.id} (${s.description})`
+    )
+    .join("; ");
+
+  return {
+    type: "function",
+    function: {
+      name: TOOL_NAME.spawnAgent,
+      description:
+        "Delegate a focused, READ-ONLY investigation to a specialist subagent and get its findings back as the tool result. Spawn one per independent line of inquiry — several in the same turn run in PARALLEL, each with its own fresh context, and only YOU (the orchestrator) edit files. Use it to explore an unfamiliar subsystem, research external docs/APIs, or verify a claim, without spending your own context on the digging. The subagent does NOT see this conversation, so put everything it needs in `prompt`. " +
+        `Available specialists: ${roster}.`,
+      parameters: {
+        type: "object",
+        properties: {
+          subagent_type: {
+            type: "string",
+            enum: ids,
+            description: "which specialist to delegate to",
+          },
+          description: {
+            type: "string",
+            description:
+              "a 3-5 word label for this subtask, shown in the live agent tree (e.g. 'trace auth flow')",
+          },
+          prompt: {
+            type: "string",
+            description:
+              "the complete, self-contained task for the subagent — it cannot see this conversation, so include the goal and any file paths or context it needs",
+          },
+        },
+        required: ["subagent_type", "description", "prompt"],
+      },
+    },
+  };
+}

--- a/packages/core/src/agent/builtin-specs.ts
+++ b/packages/core/src/agent/builtin-specs.ts
@@ -1,0 +1,119 @@
+/**
+ * Built-in specialist subagents — shipped in-binary so delegation works out of
+ * the box with ZERO configuration. The orchestrator (`spawn_agent`) picks one by
+ * id; the user never authors JSON. A project/global `.tsforge/agents/<id>.json`
+ * still overrides a built-in by the same id (see config/agent-specs precedence:
+ * built-in < global < project).
+ *
+ * All are read-only `chat` agents. Each `systemPrompt` mandates real
+ * investigation + `file:line` citations — the difference (proven live against
+ * DeepSeek-V4-Flash) between grounded findings and confident hallucination.
+ * Image/asset specialists (`kind: "generate"`, e.g. Flux.2 for game sprites)
+ * are a reserved seam — added when a real endpoint exists (Phase D).
+ */
+import { TOOL_NAME } from "./agent.constants";
+import type { IAgentSpec } from "./agent-spec";
+
+const READONLY_MANDATE =
+  "You are read-only: you cannot edit files or run mutating commands. " +
+  "You MUST investigate with the tools before answering — never answer from " +
+  "memory or guess. Open the actual files the task names, follow the references, " +
+  "and back every claim with a `file:line` you saw. A final answer with no " +
+  "`file:line` citations means you did not investigate and is wrong. Return ONE " +
+  "final message: concise, concrete conclusions — not a raw dump of what you read.";
+
+export const BUILTIN_SPECS: readonly IAgentSpec[] = [
+  {
+    id: "explore",
+    description:
+      "Maps a subsystem or traces how something works, and reports conclusions with file:line references.",
+    kind: "chat",
+    tools: [
+      TOOL_NAME.read,
+      TOOL_NAME.search,
+      TOOL_NAME.symbolSearch,
+      TOOL_NAME.findReferences,
+      TOOL_NAME.typeAt,
+      TOOL_NAME.diagnostics,
+      TOOL_NAME.gitContext,
+    ],
+    maxTurns: 14,
+    systemPrompt:
+      "You are an EXPLORER subagent inside a coding harness. Your job: understand " +
+      "the part of the codebase the task is about — where things live, how data " +
+      "flows, which functions call which — and report it so the orchestrator can " +
+      "act without re-reading everything. Start broad with `search`/`symbol_search`, " +
+      "then `read` the specific files, and use `find_references`/`type_at` to trace " +
+      "usage and types. " +
+      READONLY_MANDATE,
+  },
+  {
+    id: "research",
+    description:
+      "Researches external docs, package APIs, and the web; reports findings with source URLs.",
+    kind: "chat",
+    tools: [
+      TOOL_NAME.webSearch,
+      TOOL_NAME.webFetch,
+      TOOL_NAME.webBrowse,
+      TOOL_NAME.packageInfo,
+      TOOL_NAME.packageDocs,
+      TOOL_NAME.read,
+    ],
+    maxTurns: 10,
+    systemPrompt:
+      "You are a RESEARCH subagent inside a coding harness. Your job: answer a " +
+      "question about an external library, API, spec, or current best practice " +
+      "using the web + package tools. Prefer official docs; use `package_docs`/" +
+      "`package_info` for installed or npm packages and `web_search`→`web_fetch` " +
+      "for everything else. Cite the source URL or the local docs path for every " +
+      "claim; when versions differ, say which version you checked. Never invent an " +
+      "API — verify it. Return ONE final message: the concrete answer plus sources.",
+  },
+  {
+    id: "verify",
+    description:
+      "Adversarially checks a specific claim or finding against the real code and reports a verdict.",
+    kind: "chat",
+    tools: [
+      TOOL_NAME.read,
+      TOOL_NAME.search,
+      TOOL_NAME.gitContext,
+      TOOL_NAME.diagnostics,
+      TOOL_NAME.findReferences,
+    ],
+    maxTurns: 10,
+    systemPrompt:
+      "You are a VERIFIER subagent inside a coding harness. You are given a claim " +
+      "(a suspected bug, a proposed fix, an assumption). Your job: try to REFUTE " +
+      "it by reading the actual code. Default to skeptical — assume the claim is " +
+      "wrong until the code proves it. Open the exact lines involved and check the " +
+      "control/data flow. " +
+      READONLY_MANDATE +
+      " End with an explicit verdict: CONFIRMED or REFUTED, and the `file:line` " +
+      "evidence that decided it.",
+  },
+  {
+    id: "review-lens",
+    description:
+      "Reviews a change for correctness/regressions from a senior-engineer lens; reports issues with file:line.",
+    kind: "chat",
+    tools: [
+      TOOL_NAME.read,
+      TOOL_NAME.search,
+      TOOL_NAME.gitContext,
+      TOOL_NAME.findReferences,
+      TOOL_NAME.diagnostics,
+    ],
+    maxTurns: 12,
+    systemPrompt:
+      "You are a REVIEW subagent inside a coding harness. Your job: review the " +
+      "change described in the task like a senior engineer — correctness, edge " +
+      "cases, regressions in callers, and broken invariants. Use `git_context` to " +
+      "see the diff, `find_references` to check the blast radius of changed " +
+      "exports, and `read` the surrounding code. " +
+      READONLY_MANDATE +
+      " Report only real, specific issues (each with `file:line` and why it " +
+      "breaks); say so plainly if the change looks sound.",
+  },
+];

--- a/packages/core/src/cli/logging.ts
+++ b/packages/core/src/cli/logging.ts
@@ -10,7 +10,12 @@ import { mkdirSync } from "node:fs";
 import { readdir } from "node:fs/promises";
 import { makeSpinner, spinnerPhase } from "../render/spinner";
 import { renderEvent } from "../render";
-import { LedgerWriter, ledgerTypeFor, type Reporter } from "../loop";
+import {
+  LedgerWriter,
+  ledgerTypeFor,
+  type Reporter,
+  type ILoopEvent,
+} from "../loop";
 import { logsDir } from "../session-store";
 import { trace } from "../lib/trace";
 import { OutputRouter } from "./output-router";
@@ -21,7 +26,19 @@ export const spinner = makeSpinner();
  *  sink at boot and clears it on exit; agent sinks come and go per subagent. */
 export const outputRouter = new OutputRouter();
 
+/** A live observer of EVERY rendered event — the REPL registers one to drive the
+ *  agent tree (folding `agent_*` lifecycle events and diverting subagent output).
+ *  Module-level because `render` is the one choke point all events pass through;
+ *  null when no REPL is attached (headless/one-shot). */
+let eventObserver: ((event: ILoopEvent) => void) | null = null;
+
+export function observeEvents(fn: ((event: ILoopEvent) => void) | null): void {
+  eventObserver = fn;
+}
+
 const render: Reporter = (event) => {
+  eventObserver?.(event);
+
   const phase = spinnerPhase(event);
 
   if (phase !== null) {

--- a/packages/core/src/cli/logging.ts
+++ b/packages/core/src/cli/logging.ts
@@ -37,7 +37,13 @@ export function observeEvents(fn: ((event: ILoopEvent) => void) | null): void {
 }
 
 const render: Reporter = (event) => {
-  eventObserver?.(event);
+  // The observer (the REPL's agent-tree feeder) must never take down rendering:
+  // a throw here would propagate out of the reporter and crash the turn/session.
+  try {
+    eventObserver?.(event);
+  } catch (err) {
+    trace("cli.eventObserver", err);
+  }
 
   const phase = spinnerPhase(event);
 

--- a/packages/core/src/cli/repl.ts
+++ b/packages/core/src/cli/repl.ts
@@ -29,6 +29,7 @@ import {
   PLAN_APPROVED_NOTE,
   type Reporter,
   type SetupWebFn,
+  type ILoopEvent,
 } from "../loop";
 import { loadRecipes } from "../config/recipes";
 import { loadAgentSpecs } from "../config/agent-specs";
@@ -56,7 +57,10 @@ import {
   STYLE,
   paint,
   PROMPT_COLS,
+  renderAgentTree,
+  AgentTreeModel,
   type IStatusInfo,
+  type IAgentRow,
 } from "../render";
 import { loadLedger, activeRules, forgetMemory } from "../loop/memory";
 import {
@@ -82,7 +86,13 @@ import {
   getUpdateNotice,
   refreshUpdateCacheInBackground,
 } from "../update-check";
-import { spinner, outputRouter, makeReporter, resolveLogPath } from "./logging";
+import {
+  spinner,
+  outputRouter,
+  makeReporter,
+  resolveLogPath,
+  observeEvents,
+} from "./logging";
 import {
   modelInfo,
   detectContextWindow,
@@ -308,6 +318,15 @@ export async function repl(args: ICliArgs): Promise<number> {
     activeModelEntry,
   } = await initReplSession(args);
 
+  // Load delegation inputs HERE — before readline is created below. Any `await`
+  // between `createInterface` and the `rl.on("line")` listener would yield the
+  // event loop with readline live but unlistened, dropping the first typed line
+  // (a real pty regression the e2e caught). All boot IO must finish up front.
+  const agentSpecs = await loadAgentSpecs(args.dir, (m) =>
+    process.stdout.write(`  ↳ ${m}\n`)
+  );
+  const delegationConfig = await loadTsforgeConfig(args.dir);
+
   let session = initialSession;
   let activeName = initialActiveName;
   let contextWindow = initialContextWindow;
@@ -476,10 +495,9 @@ export async function repl(args: ICliArgs): Promise<number> {
   // subagents via the `spawn_agent` tool — the user never names an agent.
   // Specialists ship built-in (explore/research/verify/review-lens); a
   // project/global `.tsforge/agents/*.json` extends or overrides them.
-  const agentSpecs = await loadAgentSpecs(args.dir, (m) =>
-    process.stdout.write(`  ↳ ${m}\n`)
-  );
-  const delegationConfig = await loadTsforgeConfig(args.dir);
+  // Build the delegation runner from the specs/config loaded up front (sync — no
+  // await here, so readline's line listener attaches in the same tick as the
+  // rest of the interactive setup; see the load site above).
   const spawnAgentFn = makeSpawnAgentFn({
     specs: agentSpecs,
     cwd: args.dir,
@@ -543,6 +561,7 @@ export async function repl(args: ICliArgs): Promise<number> {
       // post-turn hint (plan-mode notice, PLAN review, etc.) lands BELOW the card
       // instead of inside it — which would break the rail. Idempotent.
       closeAgentTurn();
+      resetTree(); // clear the live agent tree once the turn's delegation is done
     }
 
     await persist();
@@ -913,6 +932,154 @@ export async function repl(args: ICliArgs): Promise<number> {
   // inactive and `prompt()` falls back to the inline status line (pipes, --log).
   const statusBar = new StatusBar(process.stdout, true, true, useInputRow);
 
+  // --- live agent tree ------------------------------------------------------
+  // When the orchestrator delegates (`spawn_agent`), its subagents render as a
+  // live tree pinned above the input row, with the focused agent's streaming
+  // output beneath it — so a run is never a black box. Each subagent's output is
+  // diverted to a per-agent buffer (via the OutputRouter) instead of interleaving
+  // into the transcript; only the orchestrator writes the transcript.
+  let agentTree = new AgentTreeModel();
+  const agentOutput = new Map<string, string[]>();
+  let treeFrame = 0;
+  let treeActive = false;
+  // The detail pane auto-follows the newest running agent; ↑/↓ overrides it.
+  let focusedAgentId: string | null = null;
+  let userPickedFocus = false;
+  const AGENT_DETAIL_LINES = 8;
+  // Strip SGR color codes from captured subagent output. Built via fromCharCode
+  // so the literal carries no control byte (no-control-regex).
+  const SGR_RE = new RegExp(`${String.fromCharCode(27)}\\[[0-9;]*m`, "gu");
+
+  const treeCols = (): number =>
+    process.stdout.columns > 0 ? process.stdout.columns : 80;
+
+  const detailPane = (rows: readonly IAgentRow[]): string[] => {
+    const id = focusedAgentId ?? rows.at(-1)?.id;
+
+    if (id === undefined) {
+      return [];
+    }
+
+    const label = rows.find((r) => r.id === id)?.label ?? id;
+    const buf = agentOutput.get(id) ?? [];
+    const width = Math.max(10, treeCols() - 5);
+    const body =
+      buf.length === 0
+        ? [paint("    (working…)", STYLE.dim, true)]
+        : buf.slice(-AGENT_DETAIL_LINES).map((l) => `    ${l.slice(0, width)}`);
+
+    return [paint(`  ↳ ${label}`, STYLE.dim, true), ...body];
+  };
+
+  const repaintTree = (): void => {
+    if (!statusBar.active) {
+      return;
+    }
+
+    const rows = agentTree.rows();
+
+    if (rows.length === 0) {
+      statusBar.setAgentTree([]);
+
+      return;
+    }
+
+    const viewportRows = process.stdout.rows > 0 ? process.stdout.rows : 24;
+    const tree = renderAgentTree(rows, {
+      columns: treeCols(),
+      frame: treeFrame,
+      maxRows: Math.max(3, viewportRows - AGENT_DETAIL_LINES - 4),
+      ...(focusedAgentId === null ? {} : { selectedId: focusedAgentId }),
+    });
+
+    statusBar.setAgentTree([...tree, ...detailPane(rows)]);
+  };
+
+  const pushAgentOutput = (agentId: string, text: string): void => {
+    const buf = agentOutput.get(agentId) ?? [];
+
+    for (const raw of text.split(/\r?\n/u)) {
+      const line = raw.replace(SGR_RE, "").replace(/\s+$/u, "");
+
+      if (line.length > 0) {
+        buf.push(line);
+      }
+    }
+
+    agentOutput.set(agentId, buf.slice(-200));
+
+    if (agentId === focusedAgentId) {
+      repaintTree();
+    }
+  };
+
+  const feedTree = (event: ILoopEvent): void => {
+    const id = event.agentId;
+
+    if (id !== undefined && event.kind === "agent_spawned") {
+      outputRouter.setAgentSink(id, (t) => {
+        pushAgentOutput(id, t);
+      });
+      treeActive = true;
+    }
+
+    if (
+      id !== undefined &&
+      event.kind === "agent_started" &&
+      !userPickedFocus
+    ) {
+      focusedAgentId = id; // auto-follow the newest running agent
+    }
+
+    if (
+      event.kind === "agent_spawned" ||
+      event.kind === "agent_started" ||
+      event.kind === "agent_result"
+    ) {
+      agentTree.applyEvent(event);
+      repaintTree();
+    }
+  };
+
+  // Move the detail-pane focus between rows (↑/↓ while agents run).
+  const moveTreeFocus = (delta: number): void => {
+    const rows = agentTree.rows();
+
+    if (rows.length === 0) {
+      return;
+    }
+
+    const current = rows.findIndex((r) => r.id === focusedAgentId);
+    const next = Math.min(
+      rows.length - 1,
+      Math.max(0, (current < 0 ? 0 : current) + delta)
+    );
+
+    focusedAgentId = rows[next]?.id ?? null;
+    userPickedFocus = true;
+    repaintTree();
+  };
+
+  // Fresh tree next turn; drop the per-agent sinks so output routes normally.
+  const resetTree = (): void => {
+    if (!treeActive) {
+      return;
+    }
+
+    for (const id of agentOutput.keys()) {
+      outputRouter.clearAgentSink(id);
+    }
+
+    agentOutput.clear();
+    agentTree = new AgentTreeModel();
+    focusedAgentId = null;
+    userPickedFocus = false;
+    treeActive = false;
+    statusBar.clearAgentTree();
+  };
+
+  observeEvents(feedTree);
+
   // Switch the interactive mode (via the extensible registry) and reflect it in
   // the status bar. The single entry point for /plan, Shift+Tab, and startup —
   // so `planMode`, `currentModeId`, and the bar never drift apart.
@@ -1110,6 +1277,12 @@ export async function repl(args: ICliArgs): Promise<number> {
   spinner.onTick(() => {
     if (statusBar.active && !resizing) {
       statusBar.update(statusInfo());
+
+      // Advance the tree's spinner so running agent rows animate in step.
+      if (treeActive) {
+        treeFrame += 1;
+        repaintTree();
+      }
     }
   });
 
@@ -1565,34 +1738,46 @@ export async function repl(args: ICliArgs): Promise<number> {
     if (process.stdin.isTTY && !useEditor && !flags.basicInput()) {
       // Only set up keypress detection for readline mode (not editor mode).
       emitKeypressEvents(process.stdin);
-      process.stdin.on("keypress", (str: string | undefined) => {
-        syncInput(); // keep the pinned input row in sync as the user types
+      process.stdin.on(
+        "keypress",
+        (str: string | undefined, key: { name?: string } | undefined) => {
+          // Navigate the live agent tree while subagents run — checked BEFORE the
+          // busy guard, because a turn is exactly when the tree is active. ↑/↓
+          // move the detail-pane focus between agents.
+          if (treeActive && (key?.name === "up" || key?.name === "down")) {
+            moveTreeFocus(key.name === "up" ? -1 : 1);
 
-        if (busy || paletteOpen) {
-          return;
-        }
+            return;
+          }
 
-        if (str === "/" && rl !== null) {
-          setImmediate(() => {
-            if (!busy && !paletteOpen && rl.line === "/") {
-              void openPalette();
-            }
-          });
-        } else if (str === "@" && useInputRow && rl !== null) {
-          // The inline dropdown renders above the input row, so it needs that row
-          // (a tall-enough TTY). Without it we skip the picker — `@path` typed by
-          // hand still expands at send time (composeMessage), just no live popup.
-          setImmediate(() => {
-            if (
-              !busy &&
-              !paletteOpen &&
-              shouldOpenAtPicker(rl.line, rl.cursor)
-            ) {
-              void openFilePicker();
-            }
-          });
+          syncInput(); // keep the pinned input row in sync as the user types
+
+          if (busy || paletteOpen) {
+            return;
+          }
+
+          if (str === "/" && rl !== null) {
+            setImmediate(() => {
+              if (!busy && !paletteOpen && rl.line === "/") {
+                void openPalette();
+              }
+            });
+          } else if (str === "@" && useInputRow && rl !== null) {
+            // The inline dropdown renders above the input row, so it needs that row
+            // (a tall-enough TTY). Without it we skip the picker — `@path` typed by
+            // hand still expands at send time (composeMessage), just no live popup.
+            setImmediate(() => {
+              if (
+                !busy &&
+                !paletteOpen &&
+                shouldOpenAtPicker(rl.line, rl.cursor)
+              ) {
+                void openFilePicker();
+              }
+            });
+          }
         }
-      });
+      );
     }
 
     // Event-driven (not for-await) so stdin is read DURING a run: a line typed
@@ -1704,6 +1889,7 @@ export async function repl(args: ICliArgs): Promise<number> {
       closed = true;
       editorHandle?.close();
       statusBar.teardown();
+      observeEvents(null); // stop feeding the agent tree once the REPL is gone
       maybeFinish();
     });
 

--- a/packages/core/src/cli/repl.ts
+++ b/packages/core/src/cli/repl.ts
@@ -498,10 +498,11 @@ export async function repl(args: ICliArgs): Promise<number> {
   // Build the delegation runner from the specs/config loaded up front (sync — no
   // await here, so readline's line listener attaches in the same tick as the
   // rest of the interactive setup; see the load site above).
+  const delegationCap = resolveAgentConcurrency(delegationConfig);
   const spawnAgentFn = makeSpawnAgentFn({
     specs: agentSpecs,
     cwd: args.dir,
-    concurrency: resolveAgentConcurrency(delegationConfig),
+    concurrency: delegationCap,
     policyMode: isPolicyMode(args.policyMode)
       ? args.policyMode
       : (delegationConfig.policy?.mode ?? "default"),
@@ -520,6 +521,16 @@ export async function repl(args: ICliArgs): Promise<number> {
   };
 
   wireDelegation();
+
+  // Make the delegation setup visible so the concurrency cap is never a mystery
+  // (cap 1 ⇒ subagents run serially; raise agents.concurrency to overlap them).
+  if (agentSpecs.length > 0) {
+    const names = agentSpecs.map((s) => s.id).join(", ");
+
+    process.stdout.write(
+      `  ↳ delegation: ${String(agentSpecs.length)} specialists (${names}) · cap ${String(delegationCap)}\n`
+    );
+  }
 
   // Last-turn summary, surfaced in the status line shown before each prompt.
   let lastTurns = 0;
@@ -943,6 +954,11 @@ export async function repl(args: ICliArgs): Promise<number> {
   // into the transcript; only the orchestrator writes the transcript.
   let agentTree = new AgentTreeModel();
   const agentOutput = new Map<string, string[]>();
+  // Every agentId we installed an OutputRouter sink for — tracked separately from
+  // agentOutput because a subagent that produces no routed output never gets an
+  // agentOutput entry, yet its sink still needs clearing (else it leaks + keeps
+  // diverting that id's future chunks away from the transcript).
+  const agentSinkIds = new Set<string>();
   let treeFrame = 0;
   let treeActive = false;
   // The detail pane auto-follows the newest running agent; ↑/↓ overrides it.
@@ -1037,6 +1053,7 @@ export async function repl(args: ICliArgs): Promise<number> {
         outputRouter.setAgentSink(id, (t) => {
           pushAgentOutput(id, t);
         });
+        agentSinkIds.add(id);
       }
 
       treeActive = true;
@@ -1087,10 +1104,13 @@ export async function repl(args: ICliArgs): Promise<number> {
       return;
     }
 
-    for (const id of agentOutput.keys()) {
+    // Clear EVERY sink we installed (not just ids with buffered output — an agent
+    // that streamed nothing still has a live sink that would otherwise leak).
+    for (const id of agentSinkIds) {
       outputRouter.clearAgentSink(id);
     }
 
+    agentSinkIds.clear();
     agentOutput.clear();
     agentTree = new AgentTreeModel();
     focusedAgentId = null;

--- a/packages/core/src/cli/repl.ts
+++ b/packages/core/src/cli/repl.ts
@@ -31,6 +31,12 @@ import {
   type SetupWebFn,
 } from "../loop";
 import { loadRecipes } from "../config/recipes";
+import { loadAgentSpecs } from "../config/agent-specs";
+import {
+  loadTsforgeConfig,
+  resolveAgentConcurrency,
+} from "../config/tsforge-config";
+import { makeSpawnAgentFn } from "./spawn-runner";
 import { scopeOf, WHOLE_REPO, resolveCliProfile, type ICliArgs } from "./args";
 import { isPolicyMode } from "../policy";
 import { startEditor, type IEditorHandle } from "../editor";
@@ -466,6 +472,34 @@ export async function repl(args: ICliArgs): Promise<number> {
 
   session.setSetupWeb(setupWeb);
 
+  // Model-driven delegation: the orchestrator can spawn read-only specialist
+  // subagents via the `spawn_agent` tool — the user never names an agent.
+  // Specialists ship built-in (explore/research/verify/review-lens); a
+  // project/global `.tsforge/agents/*.json` extends or overrides them.
+  const agentSpecs = await loadAgentSpecs(args.dir, (m) =>
+    process.stdout.write(`  ↳ ${m}\n`)
+  );
+  const delegationConfig = await loadTsforgeConfig(args.dir);
+  const spawnAgentFn = makeSpawnAgentFn({
+    specs: agentSpecs,
+    cwd: args.dir,
+    concurrency: resolveAgentConcurrency(delegationConfig),
+    policyMode: isPolicyMode(args.policyMode)
+      ? args.policyMode
+      : (delegationConfig.policy?.mode ?? "default"),
+    ...(delegationConfig.policy?.rules === undefined
+      ? {}
+      : { policyRules: delegationConfig.policy.rules }),
+    ...(args.model.length > 0 ? { defaultModel: args.model } : {}),
+  });
+
+  // Re-applied after `/clear` rebuilds the session (like setSetupWeb).
+  const wireDelegation = (): void => {
+    session.setDelegation(agentSpecs, spawnAgentFn);
+  };
+
+  wireDelegation();
+
   // Last-turn summary, surfaced in the status line shown before each prompt.
   let lastTurns = 0;
   // Turns the last GREEN run took (the loop-efficiency signal shown in /metrics).
@@ -676,6 +710,7 @@ export async function repl(args: ICliArgs): Promise<number> {
           ...(profile === undefined ? {} : { profile }),
         });
         session.setSetupWeb(setupWeb);
+        wireDelegation(); // re-offer spawn_agent on the rebuilt session
         session.setPlanMode(planMode); // a /clear must not silently drop the mode
         planDiscussed = false;
         await persist();

--- a/packages/core/src/cli/repl.ts
+++ b/packages/core/src/cli/repl.ts
@@ -961,12 +961,18 @@ export async function repl(args: ICliArgs): Promise<number> {
     }
 
     const label = rows.find((r) => r.id === id)?.label ?? id;
-    const buf = agentOutput.get(id) ?? [];
     const width = Math.max(10, treeCols() - 5);
+    // Show the last N non-blank lines (the reassembled stream may end on an empty
+    // in-progress line; blanks would waste rows in the small pane).
+    const lines = (agentOutput.get(id) ?? [])
+      .map((l) => l.replace(/\s+$/u, ""))
+      .filter((l) => l.length > 0);
     const body =
-      buf.length === 0
+      lines.length === 0
         ? [paint("    (working…)", STYLE.dim, true)]
-        : buf.slice(-AGENT_DETAIL_LINES).map((l) => `    ${l.slice(0, width)}`);
+        : lines
+            .slice(-AGENT_DETAIL_LINES)
+            .map((l) => `    ${l.slice(0, width)}`);
 
     return [paint(`  ↳ ${label}`, STYLE.dim, true), ...body];
   };
@@ -996,14 +1002,17 @@ export async function repl(args: ICliArgs): Promise<number> {
   };
 
   const pushAgentOutput = (agentId: string, text: string): void => {
-    const buf = agentOutput.get(agentId) ?? [];
+    const buf = agentOutput.get(agentId) ?? [""];
+    // Streaming chunks are small and often newline-free (mid-word), so we can't
+    // treat each chunk as a whole line. The LAST buffered entry is the line still
+    // in progress: the chunk's first segment continues it, and each embedded
+    // newline starts a new line. This reassembles fragments into coherent lines.
+    const segments = text.replace(SGR_RE, "").split(/\r?\n/u);
 
-    for (const raw of text.split(/\r?\n/u)) {
-      const line = raw.replace(SGR_RE, "").replace(/\s+$/u, "");
+    buf[buf.length - 1] = `${buf[buf.length - 1] ?? ""}${segments[0] ?? ""}`;
 
-      if (line.length > 0) {
-        buf.push(line);
-      }
+    for (let k = 1; k < segments.length; k += 1) {
+      buf.push(segments[k] ?? "");
     }
 
     agentOutput.set(agentId, buf.slice(-200));
@@ -1017,9 +1026,16 @@ export async function repl(args: ICliArgs): Promise<number> {
     const id = event.agentId;
 
     if (id !== undefined && event.kind === "agent_spawned") {
-      outputRouter.setAgentSink(id, (t) => {
-        pushAgentOutput(id, t);
-      });
+      // Only DIVERT a subagent's output to the (invisible) detail buffer when the
+      // tree can actually render it. With the bar inactive (non-TTY / tiny
+      // terminal) we leave the sink unset so output routes to the parent/stdout
+      // and stays visible instead of being swallowed.
+      if (statusBar.active) {
+        outputRouter.setAgentSink(id, (t) => {
+          pushAgentOutput(id, t);
+        });
+      }
+
       treeActive = true;
     }
 
@@ -1049,11 +1065,13 @@ export async function repl(args: ICliArgs): Promise<number> {
       return;
     }
 
-    const current = rows.findIndex((r) => r.id === focusedAgentId);
-    const next = Math.min(
-      rows.length - 1,
-      Math.max(0, (current < 0 ? 0 : current) + delta)
-    );
+    // Start from the CURRENTLY-shown row: when nothing is explicitly picked yet
+    // the pane auto-follows the last row, so resolve that same id first — else the
+    // first ↑/↓ would jump to row 0 instead of stepping from what's on screen.
+    const activeId = focusedAgentId ?? rows.at(-1)?.id;
+    const current = rows.findIndex((r) => r.id === activeId);
+    const base = current < 0 ? rows.length - 1 : current;
+    const next = Math.min(rows.length - 1, Math.max(0, base + delta));
 
     focusedAgentId = rows[next]?.id ?? null;
     userPickedFocus = true;

--- a/packages/core/src/cli/repl.ts
+++ b/packages/core/src/cli/repl.ts
@@ -509,6 +509,9 @@ export async function repl(args: ICliArgs): Promise<number> {
       ? {}
       : { policyRules: delegationConfig.policy.rules }),
     ...(args.model.length > 0 ? { defaultModel: args.model } : {}),
+    // Reuse the session's TS LanguageService across subagents (read lazily so it
+    // tracks the current session after /clear) instead of building one per child.
+    getTsService: () => session.tsService,
   });
 
   // Re-applied after `/clear` rebuilds the session (like setSetupWeb).

--- a/packages/core/src/cli/spawn-runner.ts
+++ b/packages/core/src/cli/spawn-runner.ts
@@ -59,8 +59,10 @@ export interface ISpawnRunnerOptions {
   /** Model for agents whose spec doesn't pin one; undefined ⇒ the active model
    *  (so every agent uses the session's model unless a spec overrides it). */
   readonly defaultModel?: string;
-  /** Reuse the session's TsService rather than building one per child. */
-  readonly tsService?: TsService | null;
+  /** Returns the session's TsService (or null) so each child REUSES it instead of
+   *  building its own — read lazily (a getter, not a value) so it tracks the
+   *  current session across `/clear`. Absent ⇒ the child builds its own. */
+  readonly getTsService?: () => TsService | null;
 }
 
 export function makeSpawnAgentFn(opts: ISpawnRunnerOptions): SpawnAgentFn {
@@ -114,9 +116,9 @@ export function makeSpawnAgentFn(opts: ISpawnRunnerOptions): SpawnAgentFn {
           ...(opts.policyRules === undefined
             ? {}
             : { policyRules: opts.policyRules }),
-          ...(opts.tsService === undefined
+          ...(opts.getTsService === undefined
             ? {}
-            : { tsService: opts.tsService }),
+            : { tsService: opts.getTsService() }),
         });
 
         lifecycle("agent_result", result.status === "done");

--- a/packages/core/src/cli/spawn-runner.ts
+++ b/packages/core/src/cli/spawn-runner.ts
@@ -16,8 +16,11 @@ import { makeProvider } from "./model-setup";
 
 /** A minimal async semaphore: at most `max` `run()` bodies execute at once; the
  *  rest queue. Caps concurrent subagents so a burst of `spawn_agent` calls in
- *  one turn honors `agents.concurrency` instead of hammering the endpoint. */
-function makeLimiter(max: number): <T>(fn: () => Promise<T>) => Promise<T> {
+ *  one turn honors `agents.concurrency` instead of hammering the endpoint.
+ *  Exported for a direct concurrency-cap test. */
+export function makeLimiter(
+  max: number
+): <T>(fn: () => Promise<T>) => Promise<T> {
   const limit = Math.max(1, Math.floor(max));
   let active = 0;
   const queue: (() => void)[] = [];

--- a/packages/core/src/cli/spawn-runner.ts
+++ b/packages/core/src/cli/spawn-runner.ts
@@ -1,0 +1,134 @@
+/**
+ * Builds the `spawn_agent` runner callback the interactive session wires in
+ * (`session.setDelegation`). This is the CLI-side half of delegation: it owns
+ * model resolution, a fresh provider per child, the read-only AgentRunner, the
+ * concurrency limiter, and the agent-tree lifecycle events. The tool handler
+ * (`loop/tools/spawn-agent.ts`) only validates args and calls this.
+ */
+import { AgentRunner, type IAgentResult } from "../agent";
+import { findAgentSpec } from "../config/agent-specs";
+import type { IAgentSpec } from "../agent/agent-spec";
+import type { PolicyMode, IPolicyRules } from "../policy";
+import type { TsService } from "../lsp";
+import type { SpawnAgentFn } from "../loop/tools";
+import { resolveModelByName } from "../models-config";
+import { makeProvider } from "./model-setup";
+
+/** A minimal async semaphore: at most `max` `run()` bodies execute at once; the
+ *  rest queue. Caps concurrent subagents so a burst of `spawn_agent` calls in
+ *  one turn honors `agents.concurrency` instead of hammering the endpoint. */
+function makeLimiter(max: number): <T>(fn: () => Promise<T>) => Promise<T> {
+  const limit = Math.max(1, Math.floor(max));
+  let active = 0;
+  const queue: (() => void)[] = [];
+
+  const release = (): void => {
+    active -= 1;
+    queue.shift()?.();
+  };
+
+  return async <T>(fn: () => Promise<T>): Promise<T> => {
+    if (active >= limit) {
+      await new Promise<void>((resolve) => queue.push(resolve));
+    }
+
+    active += 1;
+
+    try {
+      return await fn();
+    } finally {
+      release();
+    }
+  };
+}
+
+/** Compact the child's outcome into the tool-result string the orchestrator
+ *  reads — tagged with the specialist and (only when not clean) its status. */
+function formatResult(id: string, result: IAgentResult): string {
+  const tag = result.status === "done" ? id : `${id} [${result.status}]`;
+
+  return `[${tag}]\n${result.output}`;
+}
+
+export interface ISpawnRunnerOptions {
+  readonly specs: readonly IAgentSpec[];
+  readonly cwd: string;
+  readonly concurrency: number;
+  readonly policyMode: PolicyMode;
+  readonly policyRules?: IPolicyRules;
+  /** Model for agents whose spec doesn't pin one; undefined ⇒ the active model
+   *  (so every agent uses the session's model unless a spec overrides it). */
+  readonly defaultModel?: string;
+  /** Reuse the session's TsService rather than building one per child. */
+  readonly tsService?: TsService | null;
+}
+
+export function makeSpawnAgentFn(opts: ISpawnRunnerOptions): SpawnAgentFn {
+  const limit = makeLimiter(opts.concurrency);
+
+  return async (req, { signal, report }): Promise<string> => {
+    const spec = findAgentSpec(opts.specs, req.subagentType);
+
+    if (spec === undefined) {
+      return `spawn_agent: unknown subagent_type "${req.subagentType}"`;
+    }
+
+    const agentId = `${req.parentTaskId}:${spec.id}`;
+
+    const lifecycle = (
+      kind: "agent_spawned" | "agent_started" | "agent_result",
+      passed?: boolean
+    ): void => {
+      report({
+        kind,
+        task: req.parentTaskId,
+        agentId,
+        message: req.description,
+        ...(passed === undefined ? {} : { passed }),
+      });
+    };
+
+    // Announced immediately (a pending tree row) even while it waits for a slot.
+    lifecycle("agent_spawned");
+
+    return limit(async () => {
+      if (signal?.aborted === true) {
+        lifecycle("agent_result", false);
+
+        return `[${spec.id} [aborted]]\n(cancelled before start)`;
+      }
+
+      lifecycle("agent_started");
+
+      try {
+        const modelName = spec.model ?? opts.defaultModel;
+        const { entry } = await resolveModelByName(modelName);
+        const result = await new AgentRunner(spec).run({
+          provider: makeProvider(entry),
+          cwd: opts.cwd,
+          parentTaskId: req.parentTaskId,
+          task: req.prompt,
+          report,
+          ...(signal === undefined ? {} : { signal }),
+          policyMode: opts.policyMode,
+          ...(opts.policyRules === undefined
+            ? {}
+            : { policyRules: opts.policyRules }),
+          ...(opts.tsService === undefined
+            ? {}
+            : { tsService: opts.tsService }),
+        });
+
+        lifecycle("agent_result", result.status === "done");
+
+        return formatResult(spec.id, result);
+      } catch (err) {
+        lifecycle("agent_result", false);
+
+        const message = err instanceof Error ? err.message : String(err);
+
+        return `[${spec.id} [error]]\n${message}`;
+      }
+    });
+  };
+}

--- a/packages/core/src/config/agent-specs.ts
+++ b/packages/core/src/config/agent-specs.ts
@@ -8,6 +8,7 @@ import { readdir, readFile } from "node:fs/promises";
 import { homedir } from "node:os";
 import { join } from "node:path";
 import { isRecord } from "../lib/guards";
+import { BUILTIN_SPECS } from "../agent/builtin-specs";
 import type {
   AgentKind,
   AgentOutputMode,
@@ -176,6 +177,12 @@ export async function loadAgentSpecs(
   report: (message: string) => void = () => undefined
 ): Promise<IAgentSpec[]> {
   const byId = new Map<string, IAgentSpec>();
+
+  // Built-in specialists first (lowest precedence) so delegation works out of the
+  // box; a global then project `.tsforge/agents/<id>.json` overrides by id.
+  for (const spec of BUILTIN_SPECS) {
+    byId.set(spec.id, spec);
+  }
 
   await loadDir(join(homeBase(), ".tsforge", "agents"), byId, report);
   await loadDir(join(cwd, ".tsforge", "agents"), byId, report);

--- a/packages/core/src/config/tsforge-config.ts
+++ b/packages/core/src/config/tsforge-config.ts
@@ -1,4 +1,4 @@
-import { join } from "node:path";
+import { join, dirname } from "node:path";
 import { isRecord } from "../lib/guards";
 import { PACK_REGISTRY } from "../stack-detection";
 import { parseMcpServers, type IMcpServerConfig } from "../mcp";
@@ -622,17 +622,41 @@ export function resolveAgentConcurrency(config: ITsforgeProjectConfig): number {
 }
 
 /** Load tsforge.config.json from cwd, defaulting to empty config on missing/invalid files. */
+/** Find the nearest `tsforge.config.json` walking UP from `startDir` to the
+ *  filesystem root (git/eslint/tsconfig-style discovery). Returns null if none.
+ *  This is why running from a subdirectory (e.g. the CLI's `--cwd packages/core`)
+ *  still picks up the project's config — otherwise `agents.concurrency`, the
+ *  profile, and policy would all silently fall back to defaults. */
+async function findConfigUp(startDir: string): Promise<string | null> {
+  let dir = startDir;
+
+  for (;;) {
+    const candidate = join(dir, "tsforge.config.json");
+
+    if (await Bun.file(candidate).exists()) {
+      return candidate;
+    }
+
+    const parent = dirname(dir);
+
+    if (parent === dir) {
+      return null; // reached the filesystem root
+    }
+
+    dir = parent;
+  }
+}
+
 export async function loadTsforgeConfig(
   cwd: string
 ): Promise<ITsforgeProjectConfig> {
-  const configPath = join(cwd, "tsforge.config.json");
-  const file = Bun.file(configPath);
+  const configPath = await findConfigUp(cwd);
 
-  const exists = await file.exists();
-
-  if (!exists) {
+  if (configPath === null) {
     return {};
   }
+
+  const file = Bun.file(configPath);
 
   try {
     const text = await file.text();

--- a/packages/core/src/loop/session.ts
+++ b/packages/core/src/loop/session.ts
@@ -422,10 +422,14 @@ function systemPrompt(
   return `${buildChatSystem(conventions)}\n\n${tdd}${prefix}${lines.join("\n")}`;
 }
 
+/** Stable prefix of the delegation block — the sentinel `setDelegation` checks to
+ *  stay idempotent across resumed/rebuilt sessions (so the prompt can't grow). */
+const DELEGATION_MARKER = "DELEGATION:";
+
 /** The system-prompt block that tells the orchestrator delegation exists and
  *  names the specialists, so it picks the right one without the user ever naming
  *  an agent. Appended (not baked into buildChatSystem) because the roster is
- *  known only after specs load. */
+ *  known only after specs load. Starts with {@link DELEGATION_MARKER}. */
 function delegationGuidance(specs: readonly IAgentSpec[]): string {
   const roster = specs
     .map((s) =>
@@ -434,7 +438,7 @@ function delegationGuidance(specs: readonly IAgentSpec[]): string {
     .join("\n");
 
   return [
-    "DELEGATION: you can hand focused, read-only investigation to specialist subagents with the `spawn_agent` tool — exploring an unfamiliar part of the codebase, researching an external API/library, or verifying a claim — instead of spending your own turns and context on it. Spawn several in one turn for independent lines of inquiry; they run in parallel, each with its own context, and only YOU edit files. The user thinks in tasks and features, never in subagents — it is YOUR call when delegation helps.",
+    `${DELEGATION_MARKER} you can hand focused, read-only investigation to specialist subagents with the \`spawn_agent\` tool — exploring an unfamiliar part of the codebase, researching an external API/library, or verifying a claim — instead of spending your own turns and context on it. Spawn several in one turn for independent lines of inquiry; they run in parallel, each with its own context, and only YOU edit files. The user thinks in tasks and features, never in subagents — it is YOUR call when delegation helps.`,
     `Specialists available:\n${roster}`,
   ].join("\n\n");
 }
@@ -838,8 +842,23 @@ export class Session {
     }
 
     this.ctx.tool.spawnAgent = fn;
-    this.tools = [...this.tools, tool];
-    this.guide(delegationGuidance(specs));
+
+    // Idempotent: setDelegation runs on EVERY REPL launch, and a resumed
+    // (`--continue`) session reuses persisted history whose system message
+    // already carries the guidance. Re-adding the tool or re-appending the block
+    // would duplicate them (the prompt would grow each launch). Guard on the
+    // tool name and the guidance marker so a rebuilt/fresh session gets them once.
+    if (!this.tools.some((t) => t.function.name === tool.function.name)) {
+      this.tools = [...this.tools, tool];
+    }
+
+    const system = this.ctx.messages[0];
+
+    if (
+      !(system?.role === "system" && system.content.includes(DELEGATION_MARKER))
+    ) {
+      this.guide(delegationGuidance(specs));
+    }
   }
 
   /** Append opinionated guidance to the SYSTEM prompt (e.g. after classifying a

--- a/packages/core/src/loop/session.ts
+++ b/packages/core/src/loop/session.ts
@@ -48,6 +48,7 @@ import { mineLessons, consolidate as consolidateMemory } from "./memory";
 import { buildChatSystem, buildTddGuidance, COMPACT_SYSTEM } from "./prompt";
 import { resolveConventions } from "../infer-rules/conventions";
 import type { IConventions } from "../infer-rules/conventions.types";
+import type { TsService } from "../lsp";
 import {
   buildTsService,
   BUILD_NUDGE,
@@ -692,6 +693,13 @@ export class Session {
   /** The editable scope globs. */
   get scope(): string[] {
     return this.ctx.task.files;
+  }
+
+  /** The session's TS LanguageService (null when the workspace has no tsconfig),
+   *  exposed so spawned subagents can reuse it instead of each building their own
+   *  (expensive, and it would negate the concurrency win). */
+  get tsService(): TsService | null {
+    return this.ctx.tsService;
   }
 
   /** Real token usage of the most recent model call (undefined until the first

--- a/packages/core/src/loop/session.ts
+++ b/packages/core/src/loop/session.ts
@@ -13,8 +13,10 @@ import {
   SEARCH_TOOL,
   ADD_DEPENDENCY_TOOL,
   TOOL_NAME,
+  buildSpawnAgentTool,
 } from "../agent";
-import type { SetupWebFn } from "./tools";
+import type { IAgentSpec } from "../agent/agent-spec";
+import type { SetupWebFn, SpawnAgentFn } from "./tools";
 import type { PolicyMode } from "../policy";
 import type { ProfileId } from "../config/profiles";
 import { flags } from "../config";
@@ -420,6 +422,23 @@ function systemPrompt(
   return `${buildChatSystem(conventions)}\n\n${tdd}${prefix}${lines.join("\n")}`;
 }
 
+/** The system-prompt block that tells the orchestrator delegation exists and
+ *  names the specialists, so it picks the right one without the user ever naming
+ *  an agent. Appended (not baked into buildChatSystem) because the roster is
+ *  known only after specs load. */
+function delegationGuidance(specs: readonly IAgentSpec[]): string {
+  const roster = specs
+    .map((s) =>
+      s.description === undefined ? `- ${s.id}` : `- ${s.id}: ${s.description}`
+    )
+    .join("\n");
+
+  return [
+    "DELEGATION: you can hand focused, read-only investigation to specialist subagents with the `spawn_agent` tool — exploring an unfamiliar part of the codebase, researching an external API/library, or verifying a claim — instead of spending your own turns and context on it. Spawn several in one turn for independent lines of inquiry; they run in parallel, each with its own context, and only YOU edit files. The user thinks in tasks and features, never in subagents — it is YOUR call when delegation helps.",
+    `Specialists available:\n${roster}`,
+  ].join("\n\n");
+}
+
 export class Session {
   private readonly provider: IProvider;
   private readonly cfg: ISessionConfig;
@@ -430,6 +449,7 @@ export class Session {
     | typeof SCAFFOLD_ROUTES_TOOL
     | typeof SCAFFOLD_WEB_TOOL
     | typeof ADD_DEPENDENCY_TOOL
+    | NonNullable<ReturnType<typeof buildSpawnAgentTool>>
   )[];
   private hasGate: boolean;
   private readonly ctx: ILoopCtx;
@@ -803,6 +823,23 @@ export class Session {
    *  callback closes over this session to reconfigure it. */
   setSetupWeb(fn: SetupWebFn): void {
     this.ctx.tool.setupWeb = fn;
+  }
+
+  /** Enable model-driven delegation: offer the `spawn_agent` tool (its
+   *  `subagent_type` enum built from the available specialists), wire the runner
+   *  callback, and tell the model it can delegate. Late-bound (after create)
+   *  because the callback is built by the CLI, which owns model resolution and
+   *  the concurrency limiter. No specs ⇒ no-op (nothing to delegate to). */
+  setDelegation(specs: readonly IAgentSpec[], fn: SpawnAgentFn): void {
+    const tool = buildSpawnAgentTool(specs);
+
+    if (tool === null) {
+      return;
+    }
+
+    this.ctx.tool.spawnAgent = fn;
+    this.tools = [...this.tools, tool];
+    this.guide(delegationGuidance(specs));
   }
 
   /** Append opinionated guidance to the SYSTEM prompt (e.g. after classifying a

--- a/packages/core/src/loop/tools/execute-tool.ts
+++ b/packages/core/src/loop/tools/execute-tool.ts
@@ -13,6 +13,7 @@ import { doWebSearch } from "./web-search";
 import { doWebBrowse } from "./web-browse";
 import { doPackageInfo, doPackageDocs } from "./package-info";
 import { doScript } from "./script-tool";
+import { doSpawnAgent } from "./spawn-agent";
 import { reject, type IToolContext } from "./tool-context";
 import {
   classifyAction,
@@ -57,6 +58,7 @@ const HANDLERS: Record<ToolName, ToolHandler> = {
   // script-tool.ts never imports this module (no cycle), and a nested `script`
   // call is rejected (script is not in SCRIPT_EXPOSABLE_TOOLS).
   [TOOL_NAME.script]: (a, c) => doScript(a, c, { execute: executeTool }),
+  [TOOL_NAME.spawnAgent]: doSpawnAgent,
 };
 
 function isToolName(name: string): name is ToolName {

--- a/packages/core/src/loop/tools/index.ts
+++ b/packages/core/src/loop/tools/index.ts
@@ -1,2 +1,2 @@
 export { executeTool } from "./execute-tool";
-export type { IToolContext, SetupWebFn } from "./tool-context";
+export type { IToolContext, SetupWebFn, SpawnAgentFn } from "./tool-context";

--- a/packages/core/src/loop/tools/spawn-agent.ts
+++ b/packages/core/src/loop/tools/spawn-agent.ts
@@ -1,0 +1,54 @@
+import { TOOL_NAME } from "../../agent";
+import { str, reject, type IToolContext } from "./tool-context";
+
+/** Monotonic per-process counter → a unique `parentTaskId` per spawn, so the
+ *  child's `agentId` (`${parentTaskId}:${spec.id}`) is unique even when the
+ *  orchestrator spawns two of the same specialist in one turn. */
+let spawnSeq = 0;
+
+/**
+ * The `spawn_agent` tool: the orchestrator delegates one focused, read-only
+ * investigation to a specialist subagent and gets its findings back as the tool
+ * result. The heavy lifting (spec resolution, fresh provider, the read-only
+ * AgentRunner, lifecycle events, the concurrency limiter) lives in the CLI-wired
+ * `ctx.spawnAgent` callback — this handler only validates args and forwards.
+ * Absent callback ⇒ delegation isn't available here (headless one-shot).
+ */
+export async function doSpawnAgent(
+  args: Record<string, unknown>,
+  ctx: IToolContext
+): Promise<string> {
+  const spawn = ctx.spawnAgent;
+
+  if (spawn === undefined) {
+    return reject(
+      ctx,
+      TOOL_NAME.spawnAgent,
+      "delegation is not available in this context"
+    );
+  }
+
+  const subagentType = str(args, "subagent_type").trim();
+  const prompt = str(args, "prompt").trim();
+  const description = str(args, "description").trim();
+
+  if (subagentType === "" || prompt === "") {
+    return reject(
+      ctx,
+      TOOL_NAME.spawnAgent,
+      "`subagent_type` and `prompt` are required"
+    );
+  }
+
+  spawnSeq += 1;
+
+  return spawn(
+    {
+      subagentType,
+      description: description === "" ? subagentType : description,
+      prompt,
+      parentTaskId: `${ctx.task}#${String(spawnSeq)}`,
+    },
+    { signal: ctx.signal, report: ctx.report }
+  );
+}

--- a/packages/core/src/loop/tools/tool-context.ts
+++ b/packages/core/src/loop/tools/tool-context.ts
@@ -14,6 +14,24 @@ export type SetupWebFn = (
   options?: { signal?: AbortSignal }
 ) => Promise<{ files: readonly string[]; depsInstalled: boolean }>;
 
+/** One model-invoked delegation to a read-only specialist subagent (the
+ *  `spawn_agent` tool). Wired by the CLI/session, which owns model resolution,
+ *  the built-in + user specs, and the concurrency limiter; absent ⇒ delegation
+ *  isn't available here (headless one-shot) and the tool says so. Emits
+ *  `agent_spawned`/`agent_started`/`agent_result` via `report` so the live tree
+ *  renders, tagging a UNIQUE `agentId` derived from `parentTaskId` (so two
+ *  spawns of the same specialist don't collide). Resolves with the subagent's
+ *  final findings as text — the tool result the orchestrator reads. */
+export type SpawnAgentFn = (
+  req: {
+    readonly subagentType: string;
+    readonly description: string;
+    readonly prompt: string;
+    readonly parentTaskId: string;
+  },
+  opts: { signal?: AbortSignal; report: Reporter }
+) => Promise<string>;
+
 export interface IToolContext {
   cwd: string;
   /** Editable scope — `edit`/`create` outside it are rejected. */
@@ -62,6 +80,9 @@ export interface IToolContext {
    *  here. These are external context/tool sources — they never touch the editable
    *  scope or the deterministic gate. Absent ⇒ no MCP configured. */
   mcpRegistry?: McpRegistry;
+  /** Run one read-only specialist subagent for the `spawn_agent` tool. Wired by
+   *  the interactive CLI (headless one-shot leaves it absent). See {@link SpawnAgentFn}. */
+  spawnAgent?: SpawnAgentFn;
 }
 
 /** A required string arg, or "" if missing/wrong-type. */

--- a/packages/core/src/loop/turn.ts
+++ b/packages/core/src/loop/turn.ts
@@ -9,6 +9,7 @@ import {
   type ErrorSet,
   type IErrorItem,
 } from "../validate";
+import { TOOL_NAME } from "../agent/agent.constants";
 import { isInScope } from "../lib/scope";
 import { trace } from "../lib/trace";
 import type { PolicyMode, IPolicyRules } from "../policy";
@@ -18,7 +19,12 @@ import type { IRunResult, Reporter } from "./loop.types";
 import { flags } from "../config";
 import type { IStackProfile } from "../stack-detection";
 import { gateFeedback } from "./feedback";
-import { executeTool, type SetupWebFn, type IToolContext } from "./tools";
+import {
+  executeTool,
+  type SetupWebFn,
+  type SpawnAgentFn,
+  type IToolContext,
+} from "./tools";
 import {
   astGrepFix,
   dropRedundantAnnotations,
@@ -184,6 +190,9 @@ export interface ILoopCtxTool {
    *  enforce on this set, so they cover what the agent wrote regardless of git.
    *  Shared BY REFERENCE with the tool context. */
   touched?: Set<string>;
+  /** Wired by the interactive CLI: run one read-only specialist subagent (the
+   *  `spawn_agent` tool). Threaded into the tool context. */
+  spawnAgent?: SpawnAgentFn;
 }
 
 /** Gate/VALIDATION options — what `settleGate` and the write-guard consume. */
@@ -294,10 +303,47 @@ function toolContextFor(ctx: ILoopCtx, report: Reporter): IToolContext {
   };
 }
 
+/** Stable per-call key, matching the `toolCallId` the loop emits below. */
+function callKey(call: IToolCall, index: number): string {
+  return call.id ?? `call_${index}`;
+}
+
+/**
+ * Delegation runs concurrently. `spawn_agent` calls never write the workspace,
+ * so — unlike every other tool — several in one turn can run in PARALLEL up
+ * front (the CLI-wired callback enforces the concurrency cap and emits the tree
+ * lifecycle events). Their results are cached by call key; the sequential loop
+ * below then emits each tool reply in submission order, so message ordering is
+ * unchanged while the agents actually overlapped. Non-spawn turns → empty map.
+ */
+async function precomputeSpawns(
+  toolCalls: readonly IToolCall[],
+  ctx: ILoopCtx
+): Promise<Map<string, string>> {
+  const spawns = toolCalls
+    .map((call, index) => ({ call, index }))
+    .filter(({ call }) => call.name === TOOL_NAME.spawnAgent);
+
+  if (spawns.length === 0) {
+    return new Map();
+  }
+
+  const entries = await Promise.all(
+    spawns.map(async ({ call, index }) => {
+      const out = await executeTool(call, toolContextFor(ctx, ctx.report));
+
+      return [callKey(call, index), out] as const;
+    })
+  );
+
+  return new Map(entries);
+}
+
 /**
  * Run the model's tool calls: execute each, feed the result back, and report
  * whether any touched an editable file (which means we should re-gate). Mutates
  * `state.edits`. The semantic WRITE tools (rename/organize) also touch disk.
+ * `spawn_agent` calls are run concurrently up front (see precomputeSpawns).
  */
 export async function runToolCalls(
   toolCalls: readonly IToolCall[],
@@ -305,6 +351,7 @@ export async function runToolCalls(
   state: ILoopState
 ): Promise<boolean> {
   let touchedEditable = false;
+  const spawnResults = await precomputeSpawns(toolCalls, ctx);
 
   for (let i = 0; i < toolCalls.length; i += 1) {
     const call = toolCalls[i];
@@ -349,7 +396,11 @@ export async function runToolCalls(
       ctx.report(event);
     };
 
-    const result = await executeTool(call, toolContextFor(ctx, report));
+    // Spawns already ran concurrently up front — reuse the cached result so we
+    // don't run the delegation twice; every other tool executes here in order.
+    const cached = spawnResults.get(callKey(call, i));
+    const result =
+      cached ?? (await executeTool(call, toolContextFor(ctx, report)));
 
     let feedback = "";
 

--- a/packages/core/src/loop/turn.ts
+++ b/packages/core/src/loop/turn.ts
@@ -308,42 +308,122 @@ function callKey(call: IToolCall, index: number): string {
   return call.id ?? `call_${index}`;
 }
 
-/**
- * Delegation runs concurrently. `spawn_agent` calls never write the workspace,
- * so — unlike every other tool — several in one turn can run in PARALLEL up
- * front (the CLI-wired callback enforces the concurrency cap and emits the tree
- * lifecycle events). Their results are cached by call key; the sequential loop
- * below then emits each tool reply in submission order, so message ordering is
- * unchanged while the agents actually overlapped. Non-spawn turns → empty map.
- */
-async function precomputeSpawns(
-  toolCalls: readonly IToolCall[],
-  ctx: ILoopCtx
-): Promise<Map<string, string>> {
-  const spawns = toolCalls
-    .map((call, index) => ({ call, index }))
-    .filter(({ call }) => call.name === TOOL_NAME.spawnAgent);
-
-  if (spawns.length === 0) {
-    return new Map();
-  }
-
-  const entries = await Promise.all(
-    spawns.map(async ({ call, index }) => {
-      const out = await executeTool(call, toolContextFor(ctx, ctx.report));
-
-      return [callKey(call, index), out] as const;
-    })
-  );
-
-  return new Map(entries);
+/** One position in the tool-call list, kept with its original index so the tool
+ *  reply carries the right `toolCallId` even after we group spawns. */
+interface IIndexedCall {
+  readonly call: IToolCall;
+  readonly index: number;
 }
 
 /**
- * Run the model's tool calls: execute each, feed the result back, and report
- * whether any touched an editable file (which means we should re-gate). Mutates
- * `state.edits`. The semantic WRITE tools (rename/organize) also touch disk.
- * `spawn_agent` calls are run concurrently up front (see precomputeSpawns).
+ * Run ONE non-spawn tool call: execute it, apply the write-guard + mutation
+ * accounting, and push its tool reply. Returns whether it touched an editable
+ * file (⇒ the caller re-gates). `state.edits` is bumped per in-scope write.
+ */
+async function runOneToolCall(
+  call: IToolCall,
+  index: number,
+  ctx: ILoopCtx,
+  state: ILoopState
+): Promise<boolean> {
+  let touchedEditable = false;
+  // EVERY in-scope file written during this tool call — a Set, not a single
+  // path, because ONE call can write MANY files (a `script` program's edit/create
+  // stubs each report through this callback). We read the path from the handler's
+  // `edit`/`create` event (already normalized), not the raw arg, so a write the
+  // handler normalized into scope still counts. Fires only on a successful write.
+  const wrote = new Set<string>();
+  // Files mutated by a tool the model did NOT hand-write (semantic ops, scaffolds):
+  // they re-gate and join the change scope but skip the per-write guard.
+  const mutated: string[] = [];
+
+  const report: Reporter = (event) => {
+    if (
+      (event.kind === "edit" || event.kind === "create") &&
+      event.file !== undefined &&
+      isInScope(event.file, ctx.task.files)
+    ) {
+      wrote.add(event.file);
+    }
+
+    if (event.mutated !== undefined) {
+      for (const f of event.mutated) {
+        if (countsAsMutation(f, ctx.task.files)) {
+          mutated.push(f);
+        }
+      }
+    }
+
+    ctx.report(event);
+  };
+
+  const result = await executeTool(call, toolContextFor(ctx, report));
+  let feedback = "";
+
+  if (wrote.size > 0) {
+    touchedEditable = true;
+    state.edits += wrote.size;
+    const written = [...wrote];
+
+    recordTouched(ctx, written);
+
+    for (const path of written) {
+      feedback += await runWriteGuard(ctx, path);
+    }
+  }
+
+  if (mutated.length > 0) {
+    touchedEditable = true;
+    recordTouched(ctx, mutated);
+  }
+
+  ctx.messages.push({
+    role: "tool",
+    content: `${result}${feedback}`,
+    toolCallId: callKey(call, index),
+  });
+
+  return touchedEditable;
+}
+
+/**
+ * Run a CONSECUTIVE run of read-only `spawn_agent` calls concurrently — they
+ * never write, so ordering among them is irrelevant and overlapping them is the
+ * whole point (the CLI callback caps real concurrency + emits tree events). A
+ * failure is isolated to its own tool reply (never rejects the batch), and
+ * replies are pushed in submission order. Non-spawn tools are NOT part of a batch
+ * (the caller treats them as ordering barriers), so an `edit` before a spawn is
+ * applied first and the subagent reads post-edit state.
+ */
+async function runSpawnBatch(
+  group: readonly IIndexedCall[],
+  ctx: ILoopCtx
+): Promise<void> {
+  const results = await Promise.all(
+    group.map(async ({ call }) => {
+      try {
+        return await executeTool(call, toolContextFor(ctx, ctx.report));
+      } catch (err) {
+        return `spawn_agent failed: ${err instanceof Error ? err.message : String(err)}`;
+      }
+    })
+  );
+
+  group.forEach(({ call, index }, k) => {
+    ctx.messages.push({
+      role: "tool",
+      content: results[k] ?? "",
+      toolCallId: callKey(call, index),
+    });
+  });
+}
+
+/**
+ * Run the model's tool calls in order, reporting whether any touched an editable
+ * file (⇒ re-gate). A maximal run of consecutive `spawn_agent` calls executes
+ * concurrently as one batch; every other tool runs sequentially and acts as an
+ * ordering barrier, so tool effects (edits/mutations) never get reordered around
+ * delegation.
  */
 export async function runToolCalls(
   toolCalls: readonly IToolCall[],
@@ -351,90 +431,39 @@ export async function runToolCalls(
   state: ILoopState
 ): Promise<boolean> {
   let touchedEditable = false;
-  const spawnResults = await precomputeSpawns(toolCalls, ctx);
+  let i = 0;
 
-  for (let i = 0; i < toolCalls.length; i += 1) {
+  while (i < toolCalls.length) {
     const call = toolCalls[i];
 
     if (call === undefined) {
+      i += 1;
       continue;
     }
 
-    // Count an edit/create ONLY when it actually wrote an in-scope file. We read
-    // this from the handler's `edit`/`create` event — which carries the path it
-    // ACTUALLY wrote, already normalized (absolute / repeated-root / backslash
-    // paths resolved). Scope-checking the raw tool arg here instead would miss a
-    // write the handler normalized into scope, skipping the gate. The event fires
-    // only on a successful write, so failures/rejects never count. See P1/P2.
-    // EVERY in-scope file written during this tool call — a Set, not a single
-    // path, because ONE call can write MANY files: the `script` tool runs a
-    // program whose edit/create stubs each report a write through this same
-    // callback. Tracking only the last path would skip the write-guard + touched
-    // (and thus change-scoped rules like test-sibling-required) for the rest.
-    const wrote = new Set<string>();
-    // Files mutated by a tool the model did NOT hand-write (semantic ops,
-    // scaffolds). These re-gate and join the change scope but skip the write-guard.
-    const mutated: string[] = [];
+    if (call.name === TOOL_NAME.spawnAgent) {
+      const group: IIndexedCall[] = [];
 
-    const report: Reporter = (event) => {
-      if (
-        (event.kind === "edit" || event.kind === "create") &&
-        event.file !== undefined &&
-        isInScope(event.file, ctx.task.files)
+      while (
+        i < toolCalls.length &&
+        toolCalls[i]?.name === TOOL_NAME.spawnAgent
       ) {
-        wrote.add(event.file);
-      }
+        const c = toolCalls[i];
 
-      if (event.mutated !== undefined) {
-        for (const f of event.mutated) {
-          if (countsAsMutation(f, ctx.task.files)) {
-            mutated.push(f);
-          }
+        if (c !== undefined) {
+          group.push({ call: c, index: i });
         }
+
+        i += 1;
       }
 
-      ctx.report(event);
-    };
-
-    // Spawns already ran concurrently up front — reuse the cached result so we
-    // don't run the delegation twice; every other tool executes here in order.
-    const cached = spawnResults.get(callKey(call, i));
-    const result =
-      cached ?? (await executeTool(call, toolContextFor(ctx, report)));
-
-    let feedback = "";
-
-    if (wrote.size > 0) {
-      touchedEditable = true;
-      state.edits += wrote.size;
-      const written = [...wrote];
-
-      // Record EVERY file written so change-scoped gate rules (test-sibling-
-      // required) enforce on all of them, then write-guard each.
-      recordTouched(ctx, written);
-
-      for (const path of written) {
-        feedback += await runWriteGuard(ctx, path);
-      }
+      await runSpawnBatch(group, ctx);
+      continue;
     }
 
-    // A tool that mutated files without the model hand-writing them (a successful
-    // semantic op or scaffold) must re-gate so the change is verified — the signal
-    // comes from the handler's `mutated` event, emitted ONLY on a real change.
-    // Keying off the tool NAME (the old approach) miscounted a rejected/no-op op
-    // as a mutation, letting a green gate claim "done" though nothing happened, and
-    // missed scaffolds entirely, letting them skip the gate. These paths join the
-    // change scope but are NOT write-guarded — generated shells aren't re-checked.
-    if (mutated.length > 0) {
-      touchedEditable = true;
-      recordTouched(ctx, mutated);
-    }
-
-    ctx.messages.push({
-      role: "tool",
-      content: `${result}${feedback}`,
-      toolCallId: call.id ?? `call_${i}`,
-    });
+    touchedEditable =
+      (await runOneToolCall(call, i, ctx, state)) || touchedEditable;
+    i += 1;
   }
 
   return touchedEditable;

--- a/packages/core/src/policy/classify.ts
+++ b/packages/core/src/policy/classify.ts
@@ -28,6 +28,9 @@ const KIND_BY_TOOL: Readonly<Record<string, ActionKind>> = {
   // `script` runs a program that can call other tools — classify as shell so the
   // policy treats it like `run` (its stub calls are each re-classified on dispatch).
   [TOOL_NAME.script]: "shell",
+  // Delegating to a read-only subagent — its own class so a repo can deny/ask it
+  // specifically; the child's tool calls are re-classified as they dispatch.
+  [TOOL_NAME.spawnAgent]: "spawn_agent",
   [TOOL_NAME.packageInfo]: "network",
   [TOOL_NAME.packageDocs]: "network",
   [TOOL_NAME.webFetch]: "network",

--- a/packages/core/src/policy/policy.ts
+++ b/packages/core/src/policy/policy.ts
@@ -41,6 +41,7 @@ export const ACTION_KINDS: readonly ActionKind[] = [
   "network",
   "mcp_tool",
   "plugin_tool",
+  "spawn_agent",
   "unknown",
 ];
 
@@ -84,6 +85,7 @@ const MODE_MATRIX: Readonly<
     network: "allow",
     mcp_tool: "allow",
     plugin_tool: "allow",
+    spawn_agent: "allow",
     unknown: "ask",
   },
   plan: {
@@ -97,6 +99,7 @@ const MODE_MATRIX: Readonly<
     network: "allow",
     mcp_tool: "deny",
     plugin_tool: "deny",
+    spawn_agent: "allow",
     unknown: "deny",
   },
   acceptEdits: {
@@ -108,6 +111,7 @@ const MODE_MATRIX: Readonly<
     network: "deny",
     mcp_tool: "allow",
     plugin_tool: "allow",
+    spawn_agent: "allow",
     unknown: "deny",
   },
   ci: {
@@ -119,6 +123,7 @@ const MODE_MATRIX: Readonly<
     network: "deny",
     mcp_tool: "allow",
     plugin_tool: "allow",
+    spawn_agent: "allow",
     unknown: "deny",
   },
   dontAsk: {
@@ -130,6 +135,7 @@ const MODE_MATRIX: Readonly<
     network: "deny",
     mcp_tool: "allow",
     plugin_tool: "allow",
+    spawn_agent: "allow",
     unknown: "deny",
   },
   bypassPermissions: {
@@ -141,6 +147,7 @@ const MODE_MATRIX: Readonly<
     network: "allow",
     mcp_tool: "allow",
     plugin_tool: "allow",
+    spawn_agent: "allow",
     unknown: "allow",
   },
 };

--- a/packages/core/src/policy/policy.types.ts
+++ b/packages/core/src/policy/policy.types.ts
@@ -29,6 +29,10 @@ export type ActionKind =
   | "network"
   | "mcp_tool"
   | "plugin_tool"
+  /** Delegating a read-only investigation to a subagent (`spawn_agent`). The
+   *  spawn itself mutates nothing; the child is read-only-enforced separately.
+   *  Its own action class so a repo can deny/ask delegation specifically. */
+  | "spawn_agent"
   | "unknown";
 
 export type RiskLevel = "low" | "medium" | "high" | "critical";

--- a/packages/core/src/render/agent-tree.ts
+++ b/packages/core/src/render/agent-tree.ts
@@ -131,6 +131,9 @@ export interface IAgentTreeOptions {
   /** Max rows before overflow collapses; ≥1. */
   readonly maxRows?: number;
   readonly color?: boolean;
+  /** Id of the currently-selected row (bold + `▸` marker) when the tree is being
+   *  navigated. Absent ⇒ no selection highlight. */
+  readonly selectedId?: string;
 }
 
 interface ISegment {
@@ -200,22 +203,27 @@ function rowLine(
   isLast: boolean,
   frame: number,
   columns: number,
-  color: boolean
+  color: boolean,
+  selected: boolean
 ): string {
   const connector = isLast ? CONNECT_END : CONNECT_MID;
   const glyph = statusGlyph(row.status, frame);
-  // connector + glyph + the single space before the label.
+  // connector + glyph + the single space before the label (+ a `▸` when selected).
+  const marker = selected ? "▸" : " ";
   const prefixWidth = displayWidth(connector) + displayWidth(glyph.text) + 1;
   const budget = Math.max(0, columns - 1 - prefixWidth);
   const meta = rowMeta(row);
   const showMeta = meta.length > 0 && displayWidth(meta) <= budget;
   const labelBudget = showMeta ? budget - displayWidth(meta) : budget;
   const label = fitLabel(row.label ?? row.id, labelBudget);
+  const painted = selected
+    ? paint(label, `${STYLE.bold}${STYLE.brand}`, color)
+    : label;
 
   return (
     paint(connector, STYLE.dim, color) +
     paint(glyph.text, glyph.code, color) +
-    ` ${label}` +
+    `${marker}${painted}` +
     (showMeta ? paint(meta, STYLE.dim, color) : "")
   );
 }
@@ -272,7 +280,9 @@ export function renderAgentTree(
   shown.forEach((row, i) => {
     const isLast = !overflow && i === shown.length - 1;
 
-    lines.push(rowLine(row, isLast, frame, columns, color));
+    lines.push(
+      rowLine(row, isLast, frame, columns, color, row.id === opts.selectedId)
+    );
   });
 
   if (overflow) {

--- a/packages/core/src/render/status-bar.ts
+++ b/packages/core/src/render/status-bar.ts
@@ -249,6 +249,10 @@ export class StatusBar {
   private editorCursorCol = 0;
   /** Extra lines shown ABOVE the input surface (the `@`-picker / command palette). */
   private overlayLines: readonly string[] = [];
+  /** The live agent tree (+ optional detail pane), pinned at the TOP of the live
+   *  region — above the overlay and input — while subagents run. Its own slot so
+   *  it composes with the `@`-picker/palette overlay instead of fighting it. */
+  private agentTreeLines: readonly string[] = [];
   /** While a drag-resize storm is in flight, ALL painting is suspended and streamed
    *  output is buffered; flushed once the size settles (so the region isn't churned
    *  against a reflowing terminal). */
@@ -290,7 +294,7 @@ export class StatusBar {
   } {
     const columns = this.out.columns ?? 80;
     const info = this.lastInfo;
-    const lines: string[] = [...this.overlayLines];
+    const lines: string[] = [...this.agentTreeLines, ...this.overlayLines];
     let cursorRow: number;
     let cursorCol: number;
 
@@ -502,6 +506,30 @@ export class StatusBar {
     }
   }
 
+  /** Show/replace the live agent tree above the input row, then repaint. `[]`
+   *  clears it. Repainted through the same relative-redraw as everything else,
+   *  so it composes with a streaming transcript and the input surface. */
+  setAgentTree(lines: readonly string[]): void {
+    this.agentTreeLines = lines;
+
+    if (this.installed && this.withInput) {
+      this.renderRegion();
+    }
+  }
+
+  /** Erase the agent tree and repaint. Idempotent. */
+  clearAgentTree(): void {
+    if (this.agentTreeLines.length === 0) {
+      return;
+    }
+
+    this.agentTreeLines = [];
+
+    if (this.installed && this.withInput) {
+      this.renderRegion();
+    }
+  }
+
   /** Erase the `@`-picker dropdown and repaint. Idempotent. */
   clearOverlay(info: IStatusInfo): void {
     this.lastInfo = info;
@@ -602,6 +630,7 @@ export class StatusBar {
     this.liveCursorRow = 0;
     this.editorActive = false;
     this.overlayLines = [];
+    this.agentTreeLines = [];
     this.paused = false;
     this.pendingStream = "";
   }

--- a/packages/core/tests/agent-runner.test.ts
+++ b/packages/core/tests/agent-runner.test.ts
@@ -240,9 +240,14 @@ describe("loadAgentSpecs", () => {
 
       const reports: string[] = [];
       const specs = await loadAgentSpecs(cwd, (m) => reports.push(m));
+      const ids = specs.map((s) => s.id);
 
-      expect(specs.map((s) => s.id)).toEqual(["explore"]);
-      expect(specs[0]?.model).toBe("project-model");
+      // The user's project `explore.json` overrides BOTH the global one and the
+      // built-in of the same id (project wins; built-in < global < project).
+      expect(ids).toContain("explore");
+      expect(specs.find((s) => s.id === "explore")?.model).toBe("project-model");
+      // Built-in specialists are always present (delegation works out of the box).
+      expect(ids).toContain("research");
       expect(reports.some((m) => m.includes("broken.json"))).toBe(true);
       expect(reports.some((m) => m.includes("bogus"))).toBe(true);
     } finally {

--- a/packages/core/tests/agent-runner.test.ts
+++ b/packages/core/tests/agent-runner.test.ts
@@ -245,7 +245,9 @@ describe("loadAgentSpecs", () => {
       // The user's project `explore.json` overrides BOTH the global one and the
       // built-in of the same id (project wins; built-in < global < project).
       expect(ids).toContain("explore");
-      expect(specs.find((s) => s.id === "explore")?.model).toBe("project-model");
+      expect(specs.find((s) => s.id === "explore")?.model).toBe(
+        "project-model"
+      );
       // Built-in specialists are always present (delegation works out of the box).
       expect(ids).toContain("research");
       expect(reports.some((m) => m.includes("broken.json"))).toBe(true);

--- a/packages/core/tests/agent-runner.test.ts
+++ b/packages/core/tests/agent-runner.test.ts
@@ -177,17 +177,29 @@ describe("AgentRunner (read-only loop against this repo)", () => {
     expect(AGENT_LIMITS.maxTurns).toBeGreaterThan(0);
   });
 
-  test("structured mode: prose gets nudged, agent_result delivers the payload", async () => {
+  test("structured mode: agent_result before investigating is rejected, accepted after a real tool call", async () => {
     const { provider, seenTools } = scripted([
-      { content: "here is my answer in prose", toolCalls: [] },
+      // Turn 1: tries to answer immediately. `agent_result` alone satisfies
+      // toolChoice:"required", but with real tools available and no investigation
+      // yet it MUST be rejected (else a structured agent answers from memory).
       {
         content: "",
         toolCalls: [
-          {
-            id: "1",
-            name: "agent_result",
-            arguments: { result: "structured-answer" },
-          },
+          { id: "1", name: "agent_result", arguments: { result: "premature" } },
+        ],
+      },
+      // Turn 2: forced to actually investigate.
+      {
+        content: "",
+        toolCalls: [
+          { id: "2", name: "read", arguments: { file: "package.json" } },
+        ],
+      },
+      // Turn 3: now the result is accepted.
+      {
+        content: "",
+        toolCalls: [
+          { id: "3", name: "agent_result", arguments: { result: "grounded" } },
         ],
       },
     ]);
@@ -198,8 +210,32 @@ describe("AgentRunner (read-only loop against this repo)", () => {
 
     expect(seenTools()).toContain("agent_result");
     expect(result.status).toBe("done");
-    expect(result.output).toBe("structured-answer");
-    expect(result.turns).toBe(2);
+    // The premature turn-1 answer was NOT accepted; the grounded one (after a
+    // real read) was.
+    expect(result.output).toBe("grounded");
+    expect(result.turns).toBe(3);
+  });
+
+  test("structured agent with NO real tools accepts agent_result immediately", async () => {
+    const { provider } = scripted([
+      {
+        content: "",
+        toolCalls: [
+          { id: "1", name: "agent_result", arguments: { result: "answer" } },
+        ],
+      },
+    ]);
+    // `tools: []` ⇒ the only advertised tool is agent_result, so there's nothing
+    // to investigate WITH — the investigation gate must not deadlock it.
+    const result = await new AgentRunner({
+      id: "structured",
+      outputMode: "structured",
+      tools: [],
+    }).run({ provider, cwd: REPO, parentTaskId: "r", task: "t" });
+
+    expect(result.status).toBe("done");
+    expect(result.output).toBe("answer");
+    expect(result.turns).toBe(1);
   });
 
   test("generate kind is rejected until Phase D", async () => {

--- a/packages/core/tests/agent-tree.test.ts
+++ b/packages/core/tests/agent-tree.test.ts
@@ -201,6 +201,26 @@ describe("renderAgentTree", () => {
       expect(displayWidth(line)).toBeLessThanOrEqual(9);
     }
   });
+
+  test("selectedId marks exactly one row with the ▸ caret", () => {
+    const rows: IAgentRow[] = [
+      { id: "a", label: "explore", status: "running" },
+      { id: "b", label: "verify", status: "running" },
+    ];
+    const lines = renderAgentTree(rows, {
+      columns: 60,
+      color: false,
+      frame: 0,
+      selectedId: "b",
+    });
+
+    // The unselected row keeps the plain space; the selected row gets `▸`
+    // (which replaces the label's leading space, so column alignment holds).
+    expect(lines[1]?.includes("▸")).toBe(false);
+    expect(lines[2]?.includes("▸verify")).toBe(true);
+    // Exactly one caret across the whole tree.
+    expect(lines.filter((l) => l.includes("▸"))).toHaveLength(1);
+  });
 });
 
 describe("AgentTreeModel", () => {

--- a/packages/core/tests/policy-evaluation.test.ts
+++ b/packages/core/tests/policy-evaluation.test.ts
@@ -53,10 +53,34 @@ describe("classifyAction", () => {
       ["web_fetch", "network"],
       ["web_search", "network"],
       ["web_browse", "network"],
+      ["spawn_agent", "spawn_agent"],
     ];
 
     for (const [name, kind] of cases) {
       expect(classifyAction({ name, arguments: {} }, CWD).kind).toBe(kind);
+    }
+  });
+
+  test("spawn_agent is allowed in every mode (read-only delegation, not unknown)", () => {
+    const action = classifyAction(
+      {
+        name: "spawn_agent",
+        arguments: { subagent_type: "explore", description: "x", prompt: "y" },
+      },
+      CWD
+    );
+
+    // Regression: before its own action class it fell to `unknown` and was
+    // DENIED in plan/ci/dontAsk — which silently killed delegation.
+    for (const mode of ["default", "plan", "ci", "dontAsk"] as const) {
+      expect(
+        evaluatePolicy(action, {
+          mode,
+          cwd: CWD,
+          files: [],
+          interactive: false,
+        }).decision
+      ).toBe("allow");
     }
   });
 

--- a/packages/core/tests/spawn-concurrency.test.ts
+++ b/packages/core/tests/spawn-concurrency.test.ts
@@ -1,0 +1,69 @@
+import { test, expect } from "bun:test";
+import { makeLimiter } from "../src/cli/spawn-runner";
+
+/** Resolve after a macrotask so overlapping tasks actually interleave. */
+function tick(ms = 5): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+// The concurrency the user configures (`agents.concurrency`) becomes this
+// semaphore's cap; it's what makes multiple `spawn_agent` calls in one turn
+// actually overlap instead of serializing. Without it a burst would hammer the
+// endpoint; with a stale cap of 1 they'd run one at a time (the bug the missing
+// config-walk-up caused).
+test("makeLimiter runs up to `cap` bodies at once and no more", async () => {
+  const cap = 3;
+  const limit = makeLimiter(cap);
+  let active = 0;
+  let peak = 0;
+
+  const task = (): Promise<void> =>
+    limit(async () => {
+      active += 1;
+      peak = Math.max(peak, active);
+      await tick();
+      active -= 1;
+    });
+
+  // Fire 8 concurrently — at most `cap` may run at any instant.
+  await Promise.all(Array.from({ length: 8 }, () => task()));
+
+  expect(peak).toBe(cap);
+  expect(active).toBe(0);
+});
+
+test("makeLimiter with cap 1 serializes; a higher cap overlaps", async () => {
+  const serialPeak = { value: 0 };
+  const parallelPeak = { value: 0 };
+
+  const run = async (cap: number, peak: { value: number }): Promise<void> => {
+    const limit = makeLimiter(cap);
+    let active = 0;
+
+    await Promise.all(
+      Array.from({ length: 4 }, () =>
+        limit(async () => {
+          active += 1;
+          peak.value = Math.max(peak.value, active);
+          await tick();
+          active -= 1;
+        })
+      )
+    );
+  };
+
+  await run(1, serialPeak);
+  await run(4, parallelPeak);
+
+  expect(serialPeak.value).toBe(1); // cap 1 ⇒ strictly serial
+  expect(parallelPeak.value).toBe(4); // cap 4 ⇒ all four overlap
+});
+
+test("makeLimiter clamps a bad cap to at least 1 (never deadlocks)", async () => {
+  for (const bad of [0, -3, Number.NaN]) {
+    const limit = makeLimiter(bad);
+    const out = await limit(() => Promise.resolve("ok"));
+
+    expect(out).toBe("ok");
+  }
+});

--- a/packages/core/tests/tool-accounting.test.ts
+++ b/packages/core/tests/tool-accounting.test.ts
@@ -1,4 +1,5 @@
 import { test, expect } from "bun:test";
+import { existsSync } from "node:fs";
 import { mkdtemp, rm, mkdir, chmod } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
@@ -837,6 +838,73 @@ test("a generated *.gen.ts file is editable (the vendored block is gone)", async
     expect(await Bun.file(join(dir, "src/routeTree.gen.ts")).exists()).toBe(
       true
     );
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+// Codex P2a + Gemini G4: `spawn_agent` calls used to be pre-run in one batch
+// BEFORE the sequential loop, so an `edit`→`spawn` turn made the subagent read
+// the PRE-edit workspace. Now a non-spawn tool is an ordering barrier: the edit
+// applies first. Consecutive spawns still batch, and one failing spawn is
+// isolated to its own reply (never sinks its sibling).
+test("a preceding edit applies BEFORE a spawn (barrier); a failing spawn is isolated", async () => {
+  const dir = await mkdtemp(join(tmpdir(), "tsforge-spawn-order-"));
+
+  try {
+    const seen = { markerAtSpawn: false, ids: [] as string[] };
+    const ctx = ctxFor(dir, ["**/*"]);
+
+    ctx.tool.spawnAgent = (req) => {
+      // The `create` below precedes the spawns — with the barrier it has already
+      // written marker.ts by the time any subagent runs.
+      seen.markerAtSpawn =
+        seen.markerAtSpawn || existsSync(join(dir, "marker.ts"));
+      seen.ids.push(req.subagentType);
+
+      if (req.subagentType === "boom") {
+        throw new Error("kaboom");
+      }
+
+      return Promise.resolve(`[${req.subagentType}] ok`);
+    };
+
+    const ctxMessages = ctx.messages;
+
+    await runToolCalls(
+      [
+        {
+          name: "create",
+          arguments: { file: "marker.ts", content: "export const m = 1;\n" },
+        },
+        {
+          name: "spawn_agent",
+          arguments: {
+            subagent_type: "explore",
+            description: "d",
+            prompt: "p",
+          },
+        },
+        {
+          name: "spawn_agent",
+          arguments: { subagent_type: "boom", description: "d", prompt: "p" },
+        },
+      ],
+      ctx,
+      freshState()
+    );
+
+    // Barrier: the edit ran first, so the subagent saw the created file.
+    expect(seen.markerAtSpawn).toBe(true);
+    // Both consecutive spawns ran (batched), in order.
+    expect(seen.ids).toEqual(["explore", "boom"]);
+    // Three tool replies (create + two spawns); the failing spawn is isolated.
+    const toolReplies = ctxMessages.filter((m) => m.role === "tool");
+
+    expect(toolReplies).toHaveLength(3);
+    expect(toolReplies[1]?.content).toContain("[explore] ok");
+    // The sibling failure is surfaced in ITS OWN reply (isolated) with the reason.
+    expect(toolReplies[2]?.content).toContain("kaboom");
   } finally {
     await rm(dir, { recursive: true, force: true });
   }

--- a/packages/core/tests/tool-accounting.test.ts
+++ b/packages/core/tests/tool-accounting.test.ts
@@ -852,7 +852,10 @@ test("a preceding edit applies BEFORE a spawn (barrier); a failing spawn is isol
   const dir = await mkdtemp(join(tmpdir(), "tsforge-spawn-order-"));
 
   try {
-    const seen = { markerAtSpawn: false, ids: [] as string[] };
+    const seen: { markerAtSpawn: boolean; ids: string[] } = {
+      markerAtSpawn: false,
+      ids: [],
+    };
     const ctx = ctxFor(dir, ["**/*"]);
 
     ctx.tool.spawnAgent = (req) => {

--- a/packages/core/tests/tsforge-config.test.ts
+++ b/packages/core/tests/tsforge-config.test.ts
@@ -1,5 +1,5 @@
 import { describe, test, expect, beforeAll, afterAll } from "bun:test";
-import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import {
@@ -39,6 +39,29 @@ describe("loadTsforgeConfig", () => {
       expect(config).toEqual({});
     } finally {
       rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test("walks UP to find the nearest config (running from a subdirectory)", async () => {
+    // The CLI runs with cwd = packages/core (its own dir has no config), so the
+    // loader must climb to the project root — otherwise agents.concurrency (and
+    // profile/policy) silently fall back to defaults. Regression for cap-1 spawns.
+    const root = mkdtempSync(join(tmpdir(), "tsforge-root-"));
+
+    try {
+      writeFileSync(
+        join(root, "tsforge.config.json"),
+        JSON.stringify({ agents: { concurrency: 4 } })
+      );
+      const nested = join(root, "packages", "core");
+
+      mkdirSync(nested, { recursive: true });
+
+      const config = await loadTsforgeConfig(nested);
+
+      expect(config.agents?.concurrency).toBe(4);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
     }
   });
 

--- a/scripts/e2e-agents-pty.py
+++ b/scripts/e2e-agents-pty.py
@@ -20,6 +20,7 @@ import tempfile
 sys.path.insert(0, os.path.join(os.path.dirname(os.path.abspath(__file__)), "lib"))
 from ptyharness import (  # noqa: E402
     Checker,
+    content_chunks,
     read_until,
     reap,
     spawn_tsforge,
@@ -35,11 +36,15 @@ def strip(text):
     return ANSI.sub("", text)
 
 
-def _decide(_messages):
-    """Every agent turn: return the structured result tool call → 1-turn 'done'."""
-    return toolcall_chunks(
-        "agent_result", {"result": "Explored the workspace; nothing to report."}
-    )
+def _decide(messages):
+    """A read-only (text) subagent, realistically: the runner forces a tool call
+    first (no answering from memory), so investigate (search) then answer once the
+    tool result is back. (These specs are text-mode — `agent_result` isn't offered
+    to them, so we must NOT fake it.)"""
+    last = messages[-1] if messages else {}
+    if last.get("role") == "tool":
+        return content_chunks("Explored the workspace — mapped the entry points.")
+    return toolcall_chunks("search", {"pattern": "export"})
 
 
 def _write_spec(agents_dir, spec_id, description):

--- a/scripts/e2e-spawn-agent-pty.py
+++ b/scripts/e2e-spawn-agent-pty.py
@@ -1,0 +1,171 @@
+#!/usr/bin/env python3
+"""Real-PTY e2e for model-driven delegation (the `spawn_agent` tool + live tree).
+
+Drives the REAL tsforge REPL in a REAL pty against the deterministic stub model.
+The stub plays TWO roles keyed off the system prompt: as the ORCHESTRATOR it
+emits two `spawn_agent` tool calls in one turn; as a SUBAGENT (built-in explore
+spec) it must investigate first (the runner forces a tool call), then answers.
+We assert on the REAL byte stream that the live agent tree rendered — header,
+both child rows, the focused agent's output pane — and that the orchestrator got
+the findings back and produced a final answer.
+
+Run: python3 scripts/e2e-spawn-agent-pty.py
+"""
+import json
+import os
+import re
+import sys
+import tempfile
+
+sys.path.insert(0, os.path.join(os.path.dirname(os.path.abspath(__file__)), "lib"))
+from ptyharness import (  # noqa: E402
+    Checker,
+    content_chunks,
+    read_until,
+    reap,
+    sse,
+    spawn_tsforge,
+    start_stub_server,
+)
+
+ANSI = re.compile(r"\x1b\[[0-9;?]*[A-Za-z]")
+
+
+def strip(text):
+    return ANSI.sub("", text)
+
+
+def two_spawns():
+    """One assistant turn emitting TWO parallel spawn_agent tool calls."""
+    yield sse(
+        {
+            "choices": [
+                {
+                    "index": 0,
+                    "delta": {
+                        "tool_calls": [
+                            {
+                                "index": 0,
+                                "id": "call_a",
+                                "type": "function",
+                                "function": {
+                                    "name": "spawn_agent",
+                                    "arguments": json.dumps(
+                                        {
+                                            "subagent_type": "explore",
+                                            "description": "trace scheduler",
+                                            "prompt": "How does AgentScheduler cap concurrency? Cite file:line.",
+                                        }
+                                    ),
+                                },
+                            },
+                            {
+                                "index": 1,
+                                "id": "call_b",
+                                "type": "function",
+                                "function": {
+                                    "name": "spawn_agent",
+                                    "arguments": json.dumps(
+                                        {
+                                            "subagent_type": "verify",
+                                            "description": "check abort race",
+                                            "prompt": "Is there an abort race in AgentScheduler? Cite file:line.",
+                                        }
+                                    ),
+                                },
+                            },
+                        ]
+                    },
+                }
+            ]
+        }
+    )
+
+
+def search_call():
+    yield sse(
+        {
+            "choices": [
+                {
+                    "index": 0,
+                    "delta": {
+                        "tool_calls": [
+                            {
+                                "index": 0,
+                                "id": "call_s",
+                                "type": "function",
+                                "function": {
+                                    "name": "search",
+                                    "arguments": json.dumps({"pattern": "concurrency"}),
+                                },
+                            }
+                        ]
+                    },
+                }
+            ]
+        }
+    )
+
+
+def _decide(messages):
+    system = ""
+    if messages and messages[0].get("role") == "system":
+        system = messages[0].get("content") or ""
+    last = messages[-1] if messages else {}
+    is_orchestrator = "DELEGATION" in system
+
+    if is_orchestrator:
+        if last.get("role") == "tool":
+            return content_chunks(
+                "Both specialists confirm AgentScheduler caps concurrency and wires "
+                "per-unit AbortControllers. Done."
+            )
+        return two_spawns()
+
+    # A subagent (built-in explore/verify). The runner forces a tool call first,
+    # so search, then answer once the tool result is back.
+    if last.get("role") == "tool":
+        return content_chunks("Confirmed at agent-scheduler.ts:60 — cap honored.")
+    return search_call()
+
+
+def main():
+    srv, port = start_stub_server(_decide)
+    print(f"stub model @ 127.0.0.1:{port}")
+    chk = Checker()
+
+    work = tempfile.mkdtemp(prefix="tsforge-spawn-")
+    home = tempfile.mkdtemp(prefix="tsforge-home-")
+    # Editor mode (the default): the live agent tree renders in the pinned region.
+    pid, master = spawn_tsforge(port, {}, cwd=work, home=home)
+    try:
+        read_until(master, lambda b: "◆ plan" in b, 60)
+        # Switch to normal mode (Shift+Tab, editor) so the orchestrator acts.
+        os.write(master, b"\x1b[Z")
+        _, buf = read_until(master, lambda b: "◆ normal" in b, 15)
+
+        os.write(master, b"Explain how AgentScheduler caps concurrency.\r")
+
+        # Accumulate through the orchestrator's post-delegation answer so every
+        # frame the tree painted is in the captured stream (erased frames stay in
+        # the byte stream — the erase is an escape sequence, not a deletion).
+        got, buf = read_until(master, lambda b: "Done." in strip(b), 60, buf)
+        clean = strip(buf)
+
+        chk.check("orchestrator produced a final answer after delegating", got)
+        chk.check("live agent tree header rendered (● agents)", "● agents" in clean)
+        chk.check("tree connectors rendered", "├─" in clean or "└─" in clean)
+        chk.check(
+            "both spawned rows shown with their labels",
+            "trace scheduler" in clean and "check abort race" in clean,
+        )
+        chk.check("focused agent output pane shown (↳ <label>)", "↳ trace" in clean)
+    finally:
+        reap(pid, master)
+
+    srv.shutdown()
+    sys.exit(chk.finish())
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## What

Makes multiagent **orchestrator-driven**, the way Claude Code works: you describe a task ("fix this bug", "build a 2D game") and the main model decides *whether* to delegate, to *which* specialist, and *how many* — spawning read-only subagents via a `spawn_agent` tool. **No ids, no comma-separated lists, no slash commands.** Specialists ship built-in (zero JSON). While they run, a **live, navigable tree** renders above the input row with each agent's streaming output — never a black box.

This replaces the awkward surfaces from Phase B (`tsforge agents <ids>` subcommand + hand-written `.tsforge/agents/*.json`) with the model doing the orchestration.

## How

- **`spawn_agent` tool** (`agent.constants.ts` `buildSpawnAgentTool`): `subagent_type` enum built from the loaded specs, `readOnly` (survives plan mode), not script-exposable, and excluded from a subagent's own tools → recursion depth capped at 1. Handler in `loop/tools/spawn-agent.ts` forwards to a `ctx.tool.spawnAgent` callback wired like `setupWeb`.
- **Runner** (`cli/spawn-runner.ts` `makeSpawnAgentFn`): resolves the spec + a fresh provider, runs the read-only `AgentRunner`, emits `agent_spawned/started/result` lifecycle events, and caps concurrency with a semaphore.
- **Concurrent spawns**: `runToolCalls` pre-runs a turn's `spawn_agent` calls in parallel (they never write), caches results, and the sequential loop emits tool replies in submission order.
- **Built-in specialists** (`agent/builtin-specs.ts`): `explore` / `research` / `verify` / `review-lens`, seeded first in `loadAgentSpecs` (built-in < global < project). Each has a strong prompt mandating file:line-cited investigation.
- **Runner quality** (proven live): temperature 0.2 (not greedy 0, which early-stops into empty answers), forced first tool call so the agent can't answer from memory, empty-final-answer guard.
- **Live navigable tree**: `logging.observeEvents` (the one reporter choke point) feeds an `AgentTreeModel` and diverts each subagent's output to a per-agent buffer via the `OutputRouter`; `StatusBar` gains an agent-tree slot; the spinner tick animates running rows; the detail pane auto-follows the newest agent (↑/↓ override in the readline path).
- **Policy**: `spawn_agent` gets its own action class — `allow` in every mode (read-only delegation), so a repo can still deny/ask it specifically.

## Two bugs the tests caught (and fixed)

1. **Policy denied delegation.** `spawn_agent` classified as `unknown` → denied in plan/ci/dontAsk, silently killing it. Fixed with a dedicated action class.
2. **A pty input regression.** An `await` between `createInterface` and its `line` listener yielded the event loop with readline live-but-unlistened, dropping the first typed line. `e2e-pty.py` caught it; all boot IO now loads before `createInterface`.

## Tests

- **Real-PTY e2e** (`scripts/e2e-spawn-agent-pty.py`, in `e2e:pty`): the orchestrator delegates, two subagents run concurrently, and the labeled tree rows + connectors + focused-agent output pane render in the real terminal buffer — **5/5**.
- Unit: `selectedId` caret highlight; `spawn_agent` classified + allowed in every policy mode; built-in precedence/override.
- Full `bun run validate` green.

## Follow-ups
- Live DGX adoption check (does the local model *choose* to spawn?) — the eval-gate question; capability ships regardless per the plan.
- Arrow-key tree navigation is wired in the readline path; editor mode uses auto-follow (a focused follow-up).

Phase C of the multiagent initiative (A1 #73, A2 #74, B1 #75, B2 #76, B3 #77).