### PR TITLE
agents: click-into-subagent navigation + auto-compaction (exploration never overflows)

### DIFF
--- a/apps/docs/src/content/docs/agent/delegation.mdx
+++ b/apps/docs/src/content/docs/agent/delegation.mdx
@@ -49,7 +49,9 @@ While subagents run, they render as a live tree pinned above the input row — s
 └─ ⠹ verify
 ```
 
-Rows appear the moment they're spawned, animate a spinner while running, and finish with their wall-clock and turn count. Beneath the tree, a detail pane streams the **focused** agent's live output (the files it reads, what it finds) — it follows the active agent automatically. The tree repaints in place (it never scrolls your transcript) and collapses to `… +N more` past a dozen rows. Ctrl-C cancels the turn and all its subagents.
+Rows appear the moment they're spawned, animate a spinner while running, and finish with their wall-clock and turn count. Beneath the tree, a detail pane streams the **focused** agent's live output (the files it reads, what it finds) — it follows the newest running agent automatically. The tree repaints in place (it never scrolls your transcript) and collapses to `… +N more` past a dozen rows. Ctrl-C cancels the turn and all its subagents.
+
+**Watch any agent.** Press **↑/↓** while subagents are running to move the detail pane between them — pick one and watch what it's doing, instead of only seeing the newest. This works in both input modes (the default multi-line editor and the basic input row); in the editor it's only bound while the input is empty, so the arrows still edit a message you're composing mid-run. Auto-follow resumes on a fresh turn.
 
 ## Concurrency
 

--- a/apps/docs/src/content/docs/agent/delegation.mdx
+++ b/apps/docs/src/content/docs/agent/delegation.mdx
@@ -24,6 +24,8 @@ These ship in the binary — delegation works with zero configuration:
 
 Each is a read-only agent with a prompt that mandates real investigation and cited findings — it must read before it answers.
 
+**Structured findings.** A specialist doesn't return a wall of prose. It finishes by calling `agent_result` with a **structured** payload — a one-line `summary` plus a list of `findings`, each carrying its own `source` (a `file:line` for code, a URL for external docs) and a `confidence`. The schema *forces* evidence onto every point, which is exactly what separates a grounded answer from a confident hallucination; the orchestrator receives a consistent `summary + cited findings` block it can act on directly.
+
 ### Add or override a specialist
 
 Drop a JSON file in `.tsforge/agents/<id>.json` (project) or `~/.tsforge/agents/<id>.json` (global). Precedence is **built-in < global < project**, so a file with the same id as a built-in overrides it.
@@ -73,4 +75,9 @@ If you set `concurrency` above 1 but agents still run serially, either the cap i
 
 - **Read-only.** A subagent's tools are the read-only set ∩ its spec; the executor hard-rejects any mutation, and the policy layer evaluates every call.
 - **No recursion.** A subagent is never offered `spawn_agent`, so delegation depth is capped at one.
+- **Never overflows.** A subagent auto-compacts its own conversation before a request would exceed the model's context window (and recovers from an overflow rejection by compacting and retrying) — so a long, read-heavy investigation can't fail on length.
 - **Policy-aware.** Delegation is its own policy action class — a repo can `deny`/`ask` it via [permissions](/guardrails/policy/), and each subagent inherits the session's policy mode.
+
+## Turning it off
+
+Delegation is on by default. Set `TSFORGE_NO_DELEGATION=1` to withhold the `spawn_agent` tool entirely — the orchestrator runs as a single stream with no subagents (the startup line reads `↳ delegation: OFF`). Useful as a control when measuring delegation's effect, or to force a pure single-agent run.

--- a/apps/docs/src/content/docs/reference/flags.mdx
+++ b/apps/docs/src/content/docs/reference/flags.mdx
@@ -40,6 +40,7 @@ headless environments — never something you'd change interactively:
 | `TSFORGE_NO_LSP_TOOLS` | off | withhold the LSP navigation tools (`=1`) |
 | `TSFORGE_NO_GIT_TOOL` | off | withhold the `git_context` tool (`=1`) |
 | `TSFORGE_NO_SCRIPT` | off | withhold the `script` (programmatic tool calling) tool (`=1`) |
+| `TSFORGE_NO_DELEGATION` | off | withhold `spawn_agent` — run single-stream with no subagents (`=1`); see [delegation](/agent/delegation/) |
 
 ## Git context
 

--- a/packages/core/scripts/agents-concurrency-eval.ts
+++ b/packages/core/scripts/agents-concurrency-eval.ts
@@ -1,0 +1,232 @@
+/**
+ * Delegation eval: is `agents.concurrency > 1` ACTUALLY faster on the live
+ * endpoint, and do read-only subagents ever fail exploration?
+ *
+ * Runs the same fan-out of `explore` subagents (one per subsystem) against the
+ * REAL model at several concurrency caps, and reports for each cap:
+ *   - wall-clock (the number that matters — does parallelism shorten it?)
+ *   - aggregate completion tok/s (does the endpoint serve N streams faster than
+ *     one? if MTP already saturates the GPU, aggregate ≈ single-stream and cap>1
+ *     is a wash)
+ *   - per-agent status / turns / PEAK prompt tokens / failure text (so a 400
+ *     context-overflow is captured verbatim, not swallowed)
+ *
+ * Usage:
+ *   TSFORGE_BASE_URL=http://192.168.20.108:8000/v1 \
+ *   TSFORGE_MODEL=deepseek-ai/DeepSeek-V4-Flash \
+ *   bun packages/core/scripts/agents-concurrency-eval.ts [caps=1,2,4] [repeats=1]
+ */
+import { performance } from "node:perf_hooks";
+import { AgentRunner, type IAgentResult } from "../src/agent";
+import { BUILTIN_SPECS } from "../src/agent/builtin-specs";
+import type {
+  IProvider,
+  ICompleteOptions,
+  IModelResponse,
+  IChatMessage,
+} from "../src/inference";
+import { OpenAICompatibleProvider } from "../src/inference";
+import { resolveActiveModel } from "../src/models-config";
+import { detectContextWindow, providerConfig } from "../src/cli/model-setup";
+import { makeLimiter } from "../src/cli/spawn-runner";
+import type { ILoopEvent, Reporter } from "../src/loop";
+
+// One exploration task per subsystem — mirrors the real screenshot fan-out.
+const TASKS: readonly { label: string; prompt: string }[] = [
+  {
+    label: "loop",
+    prompt:
+      "Explore the loop subsystem in packages/core/src/loop. Trace how a turn runs and how the gate decides a run is done. Report the key files and functions with file:line citations.",
+  },
+  {
+    label: "rule-packs",
+    prompt:
+      "Explore the rule-packs subsystem in packages/core/src/stack-detection and the ESLint rule packs. Report how packs are selected and applied, with file:line citations.",
+  },
+  {
+    label: "meta-rules",
+    prompt:
+      "Explore the meta-rules subsystem. Report what meta-rules exist and how they are enforced, with file:line citations.",
+  },
+  {
+    label: "cli-config",
+    prompt:
+      "Explore the CLI and config subsystem in packages/core/src/cli and packages/core/src/config. Report how the config is loaded and how the REPL boots, with file:line citations.",
+  },
+];
+
+interface IAgentStat {
+  label: string;
+  status: IAgentResult["status"];
+  turns: number;
+  durationMs: number;
+  peakPromptTokens: number;
+  completionTokens: number;
+  failure: string | null;
+}
+
+/** Wraps a provider to tally real token usage and capture the exact failure. */
+class CountingProvider implements IProvider {
+  peakPromptTokens = 0;
+  completionTokens = 0;
+  failure: string | null = null;
+
+  constructor(private readonly inner: IProvider) {}
+
+  async complete(
+    messages: IChatMessage[],
+    opts?: ICompleteOptions
+  ): Promise<IModelResponse> {
+    try {
+      const res = await this.inner.complete(messages, opts);
+
+      if (res.usage !== undefined) {
+        this.peakPromptTokens = Math.max(
+          this.peakPromptTokens,
+          res.usage.promptTokens
+        );
+        this.completionTokens += res.usage.completionTokens;
+      }
+
+      return res;
+    } catch (err) {
+      this.failure = err instanceof Error ? err.message : String(err);
+
+      throw err;
+    }
+  }
+}
+
+async function runOneCap(
+  cap: number,
+  entry: Parameters<typeof providerConfig>[0],
+  cwd: string
+): Promise<{ cap: number; wallMs: number; stats: IAgentStat[] }> {
+  const limit = makeLimiter(cap);
+  const explore = BUILTIN_SPECS.find((s) => s.id === "explore");
+
+  if (explore === undefined) {
+    throw new Error("explore spec missing");
+  }
+
+  const silent: Reporter = (_e: ILoopEvent) => {
+    // discard — this eval measures timing/tokens, not rendered output
+  };
+
+  const start = performance.now();
+
+  const stats = await Promise.all(
+    TASKS.map((task, i) =>
+      limit(async (): Promise<IAgentStat> => {
+        const counter = new CountingProvider(
+          new OpenAICompatibleProvider(providerConfig(entry))
+        );
+        const agentStart = performance.now();
+        const result = await new AgentRunner(explore).run({
+          provider: counter,
+          cwd,
+          parentTaskId: `cap${cap}-${i}`,
+          task: task.prompt,
+          report: silent,
+          policyMode: "bypassPermissions",
+        });
+
+        return {
+          label: task.label,
+          status: result.status,
+          turns: result.turns,
+          durationMs: performance.now() - agentStart,
+          peakPromptTokens: counter.peakPromptTokens,
+          completionTokens: counter.completionTokens,
+          failure: counter.failure,
+        };
+      })
+    )
+  );
+
+  return { cap, wallMs: performance.now() - start, stats };
+}
+
+const winText = (window: number, fallback: string): string =>
+  window > 0 ? String(window) : fallback;
+
+/** Print one cap's run and return its one-line summary. */
+function reportCap(
+  cap: number,
+  runLabel: string,
+  wallMs: number,
+  stats: readonly IAgentStat[],
+  window: number
+): string {
+  const wallS = wallMs / 1000;
+  const aggCompletion = stats.reduce((n, s) => n + s.completionTokens, 0);
+  const peak = Math.max(...stats.map((s) => s.peakPromptTokens));
+  const fails = stats.filter((s) => s.status === "error");
+  const tokPerSec = wallS > 0 ? aggCompletion / wallS : 0;
+
+  process.stdout.write(
+    `── cap ${cap}${runLabel} ──\n` +
+      `  wall: ${wallS.toFixed(1)}s · agg completion: ${aggCompletion} tok · agg tok/s: ${tokPerSec.toFixed(1)} · peak prompt: ${peak}/${winText(window, "?")} tok\n`
+  );
+
+  for (const s of stats) {
+    const flag =
+      s.status === "done" ? "✓" : s.status === "error" ? "✗" : s.status;
+    const fail =
+      s.failure === null ? "" : `\n        FAIL: ${s.failure.slice(0, 300)}`;
+
+    process.stdout.write(
+      `    ${flag} ${s.label.padEnd(12)} turns=${s.turns} ${(s.durationMs / 1000).toFixed(1)}s peakPrompt=${s.peakPromptTokens} completion=${s.completionTokens}${fail}\n`
+    );
+  }
+
+  process.stdout.write("\n");
+
+  return `cap ${cap}: wall ${wallS.toFixed(1)}s · ${tokPerSec.toFixed(1)} agg tok/s · ${fails.length}/${stats.length} failed · peak ${peak} tok`;
+}
+
+async function main(): Promise<number> {
+  const argv = process.argv.slice(2);
+  const caps = (argv[0] ?? "1,2,4")
+    .split(",")
+    .map((s) => Math.max(1, parseInt(s, 10)));
+  const repeats = Math.max(1, parseInt(argv[1] ?? "1", 10));
+
+  const active = await resolveActiveModel();
+  const window = (await detectContextWindow(active.entry)) ?? 0;
+
+  process.stdout.write(
+    `model: ${active.entry.model} @ ${active.entry.baseUrl}\n` +
+      `context window: ${winText(window, "unknown")} tokens · ${TASKS.length} explore agents · caps [${caps.join(", ")}] · ${repeats}× each\n\n`
+  );
+
+  const rows: string[] = [];
+
+  for (const cap of caps) {
+    for (let r = 0; r < repeats; r += 1) {
+      const { wallMs, stats } = await runOneCap(
+        cap,
+        active.entry,
+        process.cwd()
+      );
+      const runLabel = repeats > 1 ? ` (run ${r + 1})` : "";
+
+      rows.push(reportCap(cap, runLabel, wallMs, stats, window));
+    }
+  }
+
+  process.stdout.write("=== summary ===\n" + rows.join("\n") + "\n");
+
+  return 0;
+}
+
+main().then(
+  (code) => process.exit(code),
+  (err: unknown) => {
+    const detail =
+      err instanceof Error ? (err.stack ?? err.message) : String(err);
+
+    process.stderr.write(`eval crashed: ${detail}\n`);
+    process.exit(1);
+  }
+);

--- a/packages/core/scripts/agents-concurrency-eval.ts
+++ b/packages/core/scripts/agents-concurrency-eval.ts
@@ -29,6 +29,7 @@ import { OpenAICompatibleProvider } from "../src/inference";
 import { resolveActiveModel } from "../src/models-config";
 import { detectContextWindow, providerConfig } from "../src/cli/model-setup";
 import { makeLimiter } from "../src/cli/spawn-runner";
+import { COMPACT_SYSTEM } from "../src/loop/prompt";
 import type { ILoopEvent, Reporter } from "../src/loop";
 
 // One exploration task per subsystem — mirrors the real screenshot fan-out.
@@ -62,13 +63,16 @@ interface IAgentStat {
   durationMs: number;
   peakPromptTokens: number;
   completionTokens: number;
+  compactions: number;
   failure: string | null;
 }
 
-/** Wraps a provider to tally real token usage and capture the exact failure. */
+/** Wraps a provider to tally real token usage, count auto-compaction calls (a
+ *  request whose system prompt is COMPACT_SYSTEM), and capture the exact failure. */
 class CountingProvider implements IProvider {
   peakPromptTokens = 0;
   completionTokens = 0;
+  compactions = 0;
   failure: string | null = null;
 
   constructor(private readonly inner: IProvider) {}
@@ -77,6 +81,10 @@ class CountingProvider implements IProvider {
     messages: IChatMessage[],
     opts?: ICompleteOptions
   ): Promise<IModelResponse> {
+    if (messages[0]?.content === COMPACT_SYSTEM) {
+      this.compactions += 1;
+    }
+
     try {
       const res = await this.inner.complete(messages, opts);
 
@@ -138,6 +146,7 @@ async function runOneCap(
           durationMs: performance.now() - agentStart,
           peakPromptTokens: counter.peakPromptTokens,
           completionTokens: counter.completionTokens,
+          compactions: counter.compactions,
           failure: counter.failure,
         };
       })
@@ -176,7 +185,7 @@ function reportCap(
       s.failure === null ? "" : `\n        FAIL: ${s.failure.slice(0, 300)}`;
 
     process.stdout.write(
-      `    ${flag} ${s.label.padEnd(12)} turns=${s.turns} ${(s.durationMs / 1000).toFixed(1)}s peakPrompt=${s.peakPromptTokens} completion=${s.completionTokens}${fail}\n`
+      `    ${flag} ${s.label.padEnd(12)} turns=${s.turns} ${(s.durationMs / 1000).toFixed(1)}s peakPrompt=${s.peakPromptTokens} completion=${s.completionTokens} compactions=${s.compactions}${fail}\n`
     );
   }
 

--- a/packages/core/scripts/agents-concurrency-eval.ts
+++ b/packages/core/scripts/agents-concurrency-eval.ts
@@ -108,7 +108,8 @@ class CountingProvider implements IProvider {
 async function runOneCap(
   cap: number,
   entry: Parameters<typeof providerConfig>[0],
-  cwd: string
+  cwd: string,
+  contextWindow: number
 ): Promise<{ cap: number; wallMs: number; stats: IAgentStat[] }> {
   const limit = makeLimiter(cap);
   const explore = BUILTIN_SPECS.find((s) => s.id === "explore");
@@ -137,6 +138,9 @@ async function runOneCap(
           task: task.prompt,
           report: silent,
           policyMode: "bypassPermissions",
+          // Without this, auto-compaction is OFF and the eval can't exercise the
+          // very behavior it measures (compactions would stay 0).
+          contextWindow,
         });
 
         return {
@@ -216,7 +220,8 @@ async function main(): Promise<number> {
       const { wallMs, stats } = await runOneCap(
         cap,
         active.entry,
-        process.cwd()
+        process.cwd(),
+        window
       );
       const runLabel = repeats > 1 ? ` (run ${r + 1})` : "";
 

--- a/packages/core/scripts/delegation-ab-eval.ts
+++ b/packages/core/scripts/delegation-ab-eval.ts
@@ -1,0 +1,288 @@
+/**
+ * A/B: does model-driven delegation (spawn_agent subagents) actually earn its keep?
+ *
+ * Runs the SAME investigation task through a real Session twice — delegation ON
+ * vs OFF — on the current endpoint, and reports the metrics that matter:
+ *   - orchestrator PEAK prompt tokens  (the context-isolation claim: ON should be
+ *     LOWER — the parent offloads reading into subagents' own contexts)
+ *   - total tokens (orchestrator + subagents), turns, wall-clock, effective tok/s
+ *   - the final answer (dumped to a file per arm, for a side-by-side quality read)
+ *
+ * The task is deliberately multi-part and read-heavy — the regime delegation is
+ * FOR. On a small task both arms behave identically (the model correctly won't
+ * delegate), so this picks a task where a difference, if any, will show.
+ *
+ * Config-agnostic + re-runnable: run under MTP-on AND MTP-off to fill the 2x2.
+ *
+ * Usage:
+ *   TSFORGE_BASE_URL=http://192.168.20.108:8000/v1 \
+ *   TSFORGE_MODEL=deepseek-ai/DeepSeek-V4-Flash \
+ *   bun packages/core/scripts/delegation-ab-eval.ts [repeats=1] [cwd=tsforge repo]
+ */
+import { performance } from "node:perf_hooks";
+import { writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { Session, type Reporter, type ILoopEvent } from "../src/loop";
+import type { SpawnAgentFn } from "../src/loop/tools";
+import { AgentRunner } from "../src/agent";
+import { findAgentSpec, loadAgentSpecs } from "../src/config/agent-specs";
+import {
+  loadTsforgeConfig,
+  resolveAgentConcurrency,
+} from "../src/config/tsforge-config";
+import { makeLimiter } from "../src/cli/spawn-runner";
+import { OpenAICompatibleProvider } from "../src/inference";
+import type {
+  IProvider,
+  ICompleteOptions,
+  IModelResponse,
+  IChatMessage,
+} from "../src/inference";
+import { resolveActiveModel, resolveModelByName } from "../src/models-config";
+import { detectContextWindow, providerConfig } from "../src/cli/model-setup";
+import { logsDir } from "../src/session-store";
+
+const TASK =
+  "Investigate these THREE things INDEPENDENTLY and report each with file:line " +
+  "citations:\n" +
+  "1) how the gate decides a run is done (what command runs, how pass/fail is read);\n" +
+  "2) how AgentScheduler caps concurrency (the limiter/semaphore mechanism);\n" +
+  "3) how tsforge.config.json is discovered and loaded (the walk-up + parsing).\n" +
+  "Give a concise, cited summary of each — no code changes.";
+
+interface ITally {
+  peakPrompt: number;
+  completion: number;
+  prompt: number;
+  calls: number;
+}
+
+const newTally = (): ITally => ({
+  peakPrompt: 0,
+  completion: 0,
+  prompt: 0,
+  calls: 0,
+});
+
+/** Wraps a provider to tally token usage into a shared record. */
+class CountingProvider implements IProvider {
+  constructor(
+    private readonly inner: IProvider,
+    private readonly tally: ITally
+  ) {}
+
+  async complete(
+    messages: IChatMessage[],
+    opts?: ICompleteOptions
+  ): Promise<IModelResponse> {
+    const res = await this.inner.complete(messages, opts);
+
+    this.tally.calls += 1;
+
+    if (res.usage !== undefined) {
+      this.tally.peakPrompt = Math.max(
+        this.tally.peakPrompt,
+        res.usage.promptTokens
+      );
+      this.tally.prompt += res.usage.promptTokens;
+      this.tally.completion += res.usage.completionTokens;
+    }
+
+    return res;
+  }
+}
+
+/** A delegation runner that mirrors the real makeSpawnAgentFn but wraps each
+ *  subagent's provider so we can tally subagent tokens separately. */
+function makeCountingSpawnFn(opts: {
+  specs: Awaited<ReturnType<typeof loadAgentSpecs>>;
+  cwd: string;
+  concurrency: number;
+  contextWindow: number;
+  defaultModel?: string;
+  subTally: ITally;
+}): SpawnAgentFn {
+  const limit = makeLimiter(opts.concurrency);
+
+  return async (req, { signal, report }): Promise<string> => {
+    const spec = findAgentSpec(opts.specs, req.subagentType);
+
+    if (spec === undefined) {
+      return `spawn_agent: unknown subagent_type "${req.subagentType}"`;
+    }
+
+    return limit(async () => {
+      const { entry } = await resolveModelByName(
+        spec.model ?? opts.defaultModel
+      );
+      const provider = new CountingProvider(
+        new OpenAICompatibleProvider(providerConfig(entry)),
+        opts.subTally
+      );
+      const result = await new AgentRunner(spec).run({
+        provider,
+        cwd: opts.cwd,
+        parentTaskId: req.parentTaskId,
+        task: req.prompt,
+        report,
+        contextWindow: opts.contextWindow,
+        policyMode: "bypassPermissions",
+        ...(signal === undefined ? {} : { signal }),
+      });
+
+      return `[${spec.id}${result.status === "done" ? "" : ` [${result.status}]`}]\n${result.output}`;
+    });
+  };
+}
+
+interface IArmResult {
+  arm: string;
+  status: string;
+  turns: number;
+  wallMs: number;
+  orch: ITally;
+  sub: ITally;
+  subSpawns: number;
+  answer: string;
+}
+
+async function runArm(
+  arm: "delegation-ON" | "delegation-OFF",
+  cwd: string,
+  contextWindow: number,
+  entry: Parameters<typeof providerConfig>[0]
+): Promise<IArmResult> {
+  const orch = newTally();
+  const sub = newTally();
+  let subSpawns = 0;
+  let answer = "";
+
+  const report: Reporter = (e: ILoopEvent) => {
+    if (e.kind === "agent_spawned") {
+      subSpawns += 1;
+    }
+
+    if (e.kind === "message" && e.agentId === undefined) {
+      answer = e.message; // the orchestrator's final answer
+    }
+  };
+
+  const provider = new CountingProvider(
+    new OpenAICompatibleProvider(providerConfig(entry)),
+    orch
+  );
+  const session = await Session.create({
+    provider,
+    cwd,
+    accept: "", // investigation only — no gate
+    contextWindow,
+    report,
+    enableThinking: false,
+  });
+
+  if (arm === "delegation-ON") {
+    const specs = await loadAgentSpecs(cwd, () => {
+      // spec-load notices are irrelevant to the measurement
+    });
+    const config = await loadTsforgeConfig(cwd);
+
+    session.setDelegation(
+      specs,
+      makeCountingSpawnFn({
+        specs,
+        cwd,
+        concurrency: resolveAgentConcurrency(config),
+        contextWindow,
+        subTally: sub,
+      })
+    );
+  }
+
+  const start = performance.now();
+  const result = await session.send(TASK);
+  const wallMs = performance.now() - start;
+
+  return {
+    arm,
+    status: result.status,
+    turns: result.turns,
+    wallMs,
+    orch,
+    sub,
+    subSpawns,
+    answer,
+  };
+}
+
+function report(r: IArmResult): void {
+  const wallS = r.wallMs / 1000;
+  const totalCompletion = r.orch.completion + r.sub.completion;
+  const tokPerSec = wallS > 0 ? totalCompletion / wallS : 0;
+
+  process.stdout.write(
+    `── ${r.arm} ──\n` +
+      `  status=${r.status} turns=${r.turns} wall=${wallS.toFixed(1)}s\n` +
+      `  ORCH  peakPrompt=${r.orch.peakPrompt} calls=${r.orch.calls} completion=${r.orch.completion}\n` +
+      `  SUBS  spawned=${r.subSpawns} peakPrompt=${r.sub.peakPrompt} calls=${r.sub.calls} completion=${r.sub.completion}\n` +
+      `  TOTAL completion=${totalCompletion} · effective tok/s=${tokPerSec.toFixed(1)}\n\n`
+  );
+}
+
+async function main(): Promise<number> {
+  const argv = process.argv.slice(2);
+  const repeats = Math.max(1, parseInt(argv[0] ?? "1", 10));
+  const cwd = argv[1] ?? join(import.meta.dir, "..", "..", "..");
+
+  const { entry } = await resolveActiveModel();
+  const contextWindow = (await detectContextWindow(entry)) ?? 131072;
+
+  process.stdout.write(
+    `A/B delegation eval — ${entry.model} @ ${entry.baseUrl}\n` +
+      `cwd: ${cwd}\ncontext window: ${contextWindow} · ${repeats}× each arm\n\n`
+  );
+
+  const rows: IArmResult[] = [];
+
+  for (let i = 0; i < repeats; i += 1) {
+    // Fresh arm each iteration; ON then OFF so any endpoint drift hits both.
+    for (const arm of ["delegation-ON", "delegation-OFF"] as const) {
+      const r = await runArm(arm, cwd, contextWindow, entry);
+
+      report(r);
+      rows.push(r);
+      writeFileSync(
+        join(logsDir(), `ab-${arm}-${String(i)}.answer.txt`),
+        r.answer
+      );
+    }
+  }
+
+  const on = rows.filter((r) => r.arm === "delegation-ON");
+  const off = rows.filter((r) => r.arm === "delegation-OFF");
+  const avg = (xs: number[]): number =>
+    xs.length === 0 ? 0 : xs.reduce((a, b) => a + b, 0) / xs.length;
+  const onPeak = avg(on.map((r) => r.orch.peakPrompt));
+  const offPeak = avg(off.map((r) => r.orch.peakPrompt));
+
+  process.stdout.write(
+    "=== summary (avg) ===\n" +
+      `orchestrator peak prompt: ON ${onPeak.toFixed(0)} vs OFF ${offPeak.toFixed(0)} tok` +
+      ` (ON is ${offPeak > 0 ? (((offPeak - onPeak) / offPeak) * 100).toFixed(0) : "?"}% ${onPeak < offPeak ? "LOWER" : "HIGHER"})\n` +
+      `wall: ON ${avg(on.map((r) => r.wallMs / 1000)).toFixed(1)}s vs OFF ${avg(off.map((r) => r.wallMs / 1000)).toFixed(1)}s\n` +
+      `subagents spawned per ON run: ${avg(on.map((r) => r.subSpawns)).toFixed(1)}\n` +
+      `answers dumped to ${logsDir()}/ab-*.answer.txt\n`
+  );
+
+  return 0;
+}
+
+main().then(
+  (code) => process.exit(code),
+  (err: unknown) => {
+    const detail =
+      err instanceof Error ? (err.stack ?? err.message) : String(err);
+
+    process.stderr.write(`ab-eval crashed: ${detail}\n`);
+    process.exit(1);
+  }
+);

--- a/packages/core/scripts/headless-build.ts
+++ b/packages/core/scripts/headless-build.ts
@@ -32,6 +32,13 @@ import {
 import { OpenAICompatibleProvider, PROVIDER_LIMITS } from "../src/inference";
 import { resolveActiveModel, resolveApiKey } from "../src/models-config";
 import { Session, LOOP_LIMITS, type Reporter } from "../src/loop";
+import { detectContextWindow } from "../src/cli/model-setup";
+import { loadAgentSpecs } from "../src/config/agent-specs";
+import {
+  loadTsforgeConfig,
+  resolveAgentConcurrency,
+} from "../src/config/tsforge-config";
+import { makeSpawnAgentFn } from "../src/cli/spawn-runner";
 import { renderEvent } from "../src/render";
 import { logsDir } from "../src/session-store";
 import type { WebFramework } from "../src/web-templates";
@@ -177,9 +184,14 @@ async function main(): Promise<void> {
   const { entry } = await resolveActiveModel();
   const model = entry.model;
   const envWindow = Number(process.env.TSFORGE_CONTEXT_WINDOW);
+  // Prefer an explicit entry/env window; otherwise PROBE the server for the real
+  // max_model_len (like the REPL does) instead of assuming 262144 — a mismatch
+  // mis-calibrates auto-compaction and the build can overflow the real window.
   const contextWindow =
     entry.contextWindow ??
-    (Number.isFinite(envWindow) && envWindow > 0 ? envWindow : 262_144);
+    (Number.isFinite(envWindow) && envWindow > 0
+      ? envWindow
+      : ((await detectContextWindow(entry)) ?? 262_144));
 
   // EACH RUN GETS ITS OWN DIRECTORY: evals/runs/<timestamp>-<label>/ — so you
   // always know exactly where this build's code is, and prior runs are never
@@ -280,6 +292,26 @@ async function main(): Promise<void> {
     maxTurns: LOOP_LIMITS.webMaxTurns,
     report,
   });
+
+  // Model-driven delegation: let the orchestrator spawn read-only specialist
+  // subagents (explore/research/verify/review-lens) DURING the build, so this
+  // harness exercises the multiagent path end-to-end — not just the main loop.
+  const agentSpecs = await loadAgentSpecs(dir, (m) =>
+    process.stdout.write(`  ↳ ${m}\n`)
+  );
+  const delegationConfig = await loadTsforgeConfig(dir);
+
+  session.setDelegation(
+    agentSpecs,
+    makeSpawnAgentFn({
+      specs: agentSpecs,
+      cwd: dir,
+      concurrency: resolveAgentConcurrency(delegationConfig),
+      policyMode: "bypassPermissions",
+      contextWindow,
+      getTsService: () => session.tsService,
+    })
+  );
 
   const result = planMode
     ? await runPlanned(session, prompt, framework, dir)

--- a/packages/core/src/agent/agent-runner.ts
+++ b/packages/core/src/agent/agent-runner.ts
@@ -22,13 +22,114 @@ import {
   type ILoopState,
 } from "../loop/turn";
 import { DEFAULT_TEMPERATURE } from "../loop/loop.constants";
+import { PROVIDER_LIMITS } from "../inference";
+import { COMPACT_SYSTEM } from "../loop/prompt";
 import { TOOL_SPECS } from "./agent.constants";
 import type { IAgentSpec } from "./agent-spec";
 
 export const AGENT_LIMITS = {
   /** Default turn cap for a subagent — exploration, not an open-ended session. */
   maxTurns: 12,
+  /** Compact the conversation once the server-reported prompt tokens reach this
+   *  fraction of the context window — mirrors the main loop's auto-compaction
+   *  (session.ts). Without it a subagent's history grows unbounded (every re-read
+   *  re-appends the whole file) until the request overflows the window and the
+   *  endpoint 400s — so exploration could FAIL for no reason other than length. */
+  autoCompactAt: 0.8,
 } as const;
+
+/** A vLLM/OpenAI-style context-overflow rejection ("This model's maximum context
+ *  length is N tokens. However, you requested M…"). Matched so it can be RECOVERED
+ *  (compact + retry) instead of failing the agent. */
+function isContextOverflow(err: unknown): boolean {
+  const msg = err instanceof Error ? err.message : String(err);
+
+  return /maximum context length|context length|context window|too many tokens|reduce the length|too long/iu.test(
+    msg
+  );
+}
+
+/** Join the conversation (system excluded) into a summarizer prompt, but bounded
+ *  to `maxChars` so the compaction request itself can never overflow the window:
+ *  always keep the first message (the task) and as many of the MOST RECENT
+ *  messages as fit, eliding the middle. maxChars ≤ 0 ⇒ unbounded. */
+function buildBoundedTranscript(
+  conversation: readonly { role: string; content?: string }[],
+  maxChars: number
+): string {
+  const line = (m: { role: string; content?: string }): string =>
+    `[${m.role}] ${m.content ?? ""}`;
+
+  if (maxChars <= 0 || conversation.length === 0) {
+    return conversation.map(line).join("\n\n");
+  }
+
+  const head = conversation[0] === undefined ? "" : line(conversation[0]);
+  const tail: string[] = [];
+  let used = head.length;
+
+  for (let i = conversation.length - 1; i >= 1; i -= 1) {
+    const msg = conversation[i];
+
+    if (msg === undefined) {
+      continue;
+    }
+
+    const text = line(msg);
+
+    if (used + text.length > maxChars) {
+      break;
+    }
+
+    tail.unshift(text);
+    used += text.length;
+  }
+
+  const elided = conversation.length - 1 - tail.length;
+  const marker =
+    elided > 0 ? [`… (${String(elided)} earlier message(s) elided) …`] : [];
+
+  return [head, ...marker, ...tail].join("\n\n");
+}
+
+/** Summarize the conversation and REPLACE it with [system, summary] — the same
+ *  shape the main loop's Session.compact uses — freeing context while preserving
+ *  the task, findings, and decisions. The summarizer input is bounded to a safe
+ *  fraction of the window so this call itself can't overflow. */
+async function compactAgentMessages(
+  ctx: ILoopCtx,
+  provider: IProvider,
+  window: number,
+  signal?: AbortSignal
+): Promise<boolean> {
+  const conversation = ctx.messages.filter((m) => m.role !== "system");
+
+  if (conversation.length === 0) {
+    return false;
+  }
+
+  // ~4 chars/token; give the summarizer at most half the window of input so
+  // system+transcript+its own output always fit.
+  const maxChars = window > 0 ? window * 2 : 0;
+  const transcript = buildBoundedTranscript(conversation, maxChars);
+  const res = await provider.complete(
+    [
+      { role: "system", content: COMPACT_SYSTEM },
+      { role: "user", content: transcript },
+    ],
+    { temperature: 0, ...(signal === undefined ? {} : { signal }) }
+  );
+
+  const system = ctx.messages[0];
+  const summary = {
+    role: "user" as const,
+    content: `[Summary of the investigation so far]\n${res.content}`,
+  };
+
+  ctx.messages = system?.role === "system" ? [system, summary] : [summary];
+
+  return true;
+}
 
 const DEFAULT_SYSTEM = [
   "You are a focused read-only investigator inside a coding harness.",
@@ -115,6 +216,10 @@ export interface IAgentRunOptions {
   /** Reuse the parent's TsService — building one per concurrent agent is
    *  heavy. `null` = workspace has none; undefined = build our own. */
   tsService?: TsService | null;
+  /** The model's context window (tokens). When set, the runner auto-compacts its
+   *  conversation before a request would overflow it — so a long investigation
+   *  (many/large reads) never fails on length. Omitted ⇒ no compaction. */
+  contextWindow?: number;
 }
 
 /** Pull the structured payload out of an intercepted agent_result call. */
@@ -302,6 +407,9 @@ export class AgentRunner {
     // switch to "auto" so it can produce its final answer.
     let hasInvestigated = false;
     const hasRealTools = tools.length > (structured ? 1 : 0);
+    // Server-reported prompt tokens from the previous turn — the trigger for
+    // proactive compaction (mirrors the main loop, which reads its lastUsage).
+    const budget = { lastPromptTokens: 0 };
 
     {
       for (let turn = 1; turn <= maxTurns; turn += 1) {
@@ -318,23 +426,29 @@ export class AgentRunner {
           message: `agent ${this.spec.id} · turn ${turn}`,
         });
 
-        const res = await opts.provider.complete(ctx.messages, {
-          tools,
-          toolChoice: nextToolChoice(
-            hasRealTools,
-            hasInvestigated,
-            turn,
-            maxTurns
-          ),
-          // Match the main loop's default (0.2), NOT greedy: temperature 0 makes
-          // this model early-stop into empty/one-line answers on a long
-          // tool-result context. A caller can still override.
-          temperature: opts.temperature ?? DEFAULT_TEMPERATURE,
-          ...(opts.signal === undefined ? {} : { signal: opts.signal }),
-          onToken: (text) => {
-            report({ kind: "token", task: agentId, message: text });
+        const res = await this.completeWithCompaction(
+          ctx,
+          opts,
+          {
+            tools,
+            toolChoice: nextToolChoice(
+              hasRealTools,
+              hasInvestigated,
+              turn,
+              maxTurns
+            ),
+            // Match the main loop's default (0.2), NOT greedy: temperature 0 makes
+            // this model early-stop into empty/one-line answers on a long
+            // tool-result context. A caller can still override.
+            temperature: opts.temperature ?? DEFAULT_TEMPERATURE,
+            ...(opts.signal === undefined ? {} : { signal: opts.signal }),
+            onToken: (text) => {
+              report({ kind: "token", task: agentId, message: text });
+            },
           },
-        });
+          budget,
+          report
+        );
 
         pushAssistant(ctx, res);
         lastText = res.content.length > 0 ? res.content : lastText;
@@ -426,5 +540,75 @@ export class AgentRunner {
     }
 
     return done();
+  }
+
+  /** Run one model turn with context management around it:
+   *  - PROACTIVE: compact before the request when the previous turn's prompt
+   *    tokens crossed the auto-compact fraction of the window.
+   *  - REACTIVE: if the request still overflows (e.g. one giant tool result
+   *    jumped past the threshold in a single turn), compact and retry ONCE —
+   *    so a read-only investigation never hard-fails on length.
+   *  Updates `budget.lastPromptTokens` from the server's usage. */
+  private async completeWithCompaction(
+    ctx: ILoopCtx,
+    opts: IAgentRunOptions,
+    callOpts: Parameters<IProvider["complete"]>[1],
+    budget: { lastPromptTokens: number },
+    report: Reporter
+  ): Promise<IModelResponse> {
+    const window = opts.contextWindow ?? 0;
+    const provider = opts.provider;
+    // vLLM counts prompt + reserved OUTPUT tokens against the window, so the
+    // real ceiling for the PROMPT is `window - maxTokens`. Trigger compaction
+    // against that effective budget — otherwise a request can 400 while the
+    // prompt alone is still under `window` (observed: 114689 prompt + 16384 out
+    // = 131073 > 131072). The reactive path below is the backstop for a single
+    // read that jumps past the threshold in one turn.
+    const effectiveWindow = Math.max(1, window - PROVIDER_LIMITS.maxTokens);
+    const at = AGENT_LIMITS.autoCompactAt;
+
+    const compact = async (reason: string): Promise<void> => {
+      const did = await compactAgentMessages(
+        ctx,
+        provider,
+        window,
+        opts.signal
+      );
+
+      if (did) {
+        budget.lastPromptTokens = 0;
+        report({
+          kind: "tool",
+          task: `${opts.parentTaskId}:${this.spec.id}`,
+          message: `↯ compacted context (${reason})`,
+        });
+      }
+    };
+
+    if (window > 0 && budget.lastPromptTokens / effectiveWindow >= at) {
+      await compact(`near ${String(window)}-token window`);
+    }
+
+    let res: IModelResponse;
+
+    try {
+      res = await provider.complete(ctx.messages, callOpts);
+    } catch (err) {
+      if (
+        opts.signal?.aborted === true ||
+        !isContextOverflow(err) ||
+        ctx.messages.length <= 2
+      ) {
+        throw err;
+      }
+
+      await compact("recovering from a context-overflow");
+      res = await provider.complete(ctx.messages, callOpts);
+    }
+
+    budget.lastPromptTokens =
+      res.usage?.promptTokens ?? budget.lastPromptTokens;
+
+    return res;
   }
 }

--- a/packages/core/src/agent/agent-runner.ts
+++ b/packages/core/src/agent/agent-runner.ts
@@ -24,6 +24,7 @@ import {
 import { DEFAULT_TEMPERATURE } from "../loop/loop.constants";
 import { PROVIDER_LIMITS } from "../inference";
 import { COMPACT_SYSTEM } from "../loop/prompt";
+import { isRecord } from "../lib/guards";
 import { TOOL_SPECS } from "./agent.constants";
 import type { IAgentSpec } from "./agent-spec";
 
@@ -38,22 +39,48 @@ export const AGENT_LIMITS = {
   autoCompactAt: 0.8,
 } as const;
 
+/** Best-effort human-readable message from an unknown throw. Handles the common
+ *  provider shapes without casts: an Error, or a plain object carrying `message`
+ *  (or a nested `error.message`, as some HTTP clients surface API errors). */
+function errorText(err: unknown): string {
+  if (err instanceof Error) {
+    return err.message;
+  }
+
+  if (isRecord(err)) {
+    if (typeof err.message === "string") {
+      return err.message;
+    }
+
+    if (isRecord(err.error) && typeof err.error.message === "string") {
+      return err.error.message;
+    }
+  }
+
+  return String(err);
+}
+
 /** A vLLM/OpenAI-style context-overflow rejection ("This model's maximum context
  *  length is N tokens. However, you requested M…"). Matched so it can be RECOVERED
- *  (compact + retry) instead of failing the agent. */
-function isContextOverflow(err: unknown): boolean {
-  const msg = err instanceof Error ? err.message : String(err);
-
+ *  (compact + retry) instead of failing the agent. Exported for unit tests. */
+export function isContextOverflow(err: unknown): boolean {
   return /maximum context length|context length|context window|too many tokens|reduce the length|too long/iu.test(
-    msg
+    errorText(err)
   );
 }
 
-/** Join the conversation (system excluded) into a summarizer prompt, but bounded
- *  to `maxChars` so the compaction request itself can never overflow the window:
- *  always keep the first message (the task) and as many of the MOST RECENT
- *  messages as fit, eliding the middle. maxChars ≤ 0 ⇒ unbounded. */
-function buildBoundedTranscript(
+/** Chars reserved for the elision marker + join separators, so the assembled
+ *  transcript stays within `maxChars` even after they're added. */
+const TRANSCRIPT_MARKER_RESERVE = 64;
+
+/** Join the conversation (system excluded) into a summarizer prompt bounded to
+ *  `maxChars` so the compaction request itself can never overflow the window.
+ *  Fills from the MOST RECENT message backward (recent context matters most and
+ *  is the reason for the overflow) and ALWAYS includes at least the newest
+ *  message — head-truncating it if it alone exceeds the budget — then walks back
+ *  through older turns while they fit, eliding the rest. maxChars ≤ 0 ⇒ unbounded.
+ *  Exported for unit tests. */
+export function buildBoundedTranscript(
   conversation: readonly { role: string; content?: string }[],
   maxChars: number
 ): string {
@@ -64,32 +91,45 @@ function buildBoundedTranscript(
     return conversation.map(line).join("\n\n");
   }
 
-  const head = conversation[0] === undefined ? "" : line(conversation[0]);
-  const tail: string[] = [];
-  let used = head.length;
+  // No single message may exceed the budget — truncate an oversized one so it
+  // can still be included (the newest is often a giant tool result).
+  const budget = Math.max(1, maxChars - TRANSCRIPT_MARKER_RESERVE);
 
-  for (let i = conversation.length - 1; i >= 1; i -= 1) {
+  const capped = (m: { role: string; content?: string }): string => {
+    const text = line(m);
+
+    return text.length <= budget
+      ? text
+      : `${text.slice(0, Math.max(1, budget - 15))} …[truncated]`;
+  };
+
+  const picked: string[] = [];
+  let used = 0;
+  let firstIdx = conversation.length;
+
+  for (let i = conversation.length - 1; i >= 0; i -= 1) {
     const msg = conversation[i];
 
     if (msg === undefined) {
       continue;
     }
 
-    const text = line(msg);
+    const text = capped(msg);
 
-    if (used + text.length > maxChars) {
+    // Always keep at least the newest (picked is empty on the first iteration).
+    if (picked.length > 0 && used + text.length > budget) {
       break;
     }
 
-    tail.unshift(text);
+    picked.unshift(text);
     used += text.length;
+    firstIdx = i;
   }
 
-  const elided = conversation.length - 1 - tail.length;
   const marker =
-    elided > 0 ? [`… (${String(elided)} earlier message(s) elided) …`] : [];
+    firstIdx > 0 ? [`… (${String(firstIdx)} earlier message(s) elided) …`] : [];
 
-  return [head, ...marker, ...tail].join("\n\n");
+  return [...marker, ...picked].join("\n\n");
 }
 
 /** Summarize the conversation and REPLACE it with [system, summary] — the same
@@ -562,9 +602,15 @@ export class AgentRunner {
     // real ceiling for the PROMPT is `window - maxTokens`. Trigger compaction
     // against that effective budget — otherwise a request can 400 while the
     // prompt alone is still under `window` (observed: 114689 prompt + 16384 out
-    // = 131073 > 131072). The reactive path below is the backstop for a single
-    // read that jumps past the threshold in one turn.
-    const effectiveWindow = Math.max(1, window - PROVIDER_LIMITS.maxTokens);
+    // = 131073 > 131072). The reserve is CAPPED at half the window so a small
+    // model (window ≤ maxTokens) can't collapse the effective budget to ~0 and
+    // compact on every single turn. The reactive path below is the backstop for
+    // a single read that jumps past the threshold in one turn.
+    const reserve = Math.min(
+      PROVIDER_LIMITS.maxTokens,
+      Math.floor(window * 0.5)
+    );
+    const effectiveWindow = Math.max(1, window - reserve);
     const at = AGENT_LIMITS.autoCompactAt;
 
     const compact = async (reason: string): Promise<void> => {

--- a/packages/core/src/agent/agent-runner.ts
+++ b/packages/core/src/agent/agent-runner.ts
@@ -73,6 +73,12 @@ export function isContextOverflow(err: unknown): boolean {
  *  transcript stays within `maxChars` even after they're added. */
 const TRANSCRIPT_MARKER_RESERVE = 64;
 
+/** Conservative summarizer-input bound (chars ≈ 4/token → ~12k tokens) used when
+ *  the context window is UNKNOWN (window ≤ 0). Small enough to fit any real
+ *  model's window + output reserve, so a reactive-recovery compaction can't
+ *  itself overflow. */
+const FALLBACK_COMPACT_CHARS = 48_000;
+
 /** Join the conversation (system excluded) into a summarizer prompt bounded to
  *  `maxChars` so the compaction request itself can never overflow the window.
  *  Fills from the MOST RECENT message backward (recent context matters most and
@@ -103,6 +109,9 @@ export function buildBoundedTranscript(
       : `${text.slice(0, Math.max(1, budget - 15))} …[truncated]`;
   };
 
+  // Each joined part also costs a "\n\n" separator — count it, or many short
+  // messages slip past `budget` in aggregate.
+  const SEP = "\n\n".length;
   const picked: string[] = [];
   let used = 0;
   let firstIdx = conversation.length;
@@ -117,12 +126,12 @@ export function buildBoundedTranscript(
     const text = capped(msg);
 
     // Always keep at least the newest (picked is empty on the first iteration).
-    if (picked.length > 0 && used + text.length > budget) {
+    if (picked.length > 0 && used + text.length + SEP > budget) {
       break;
     }
 
     picked.unshift(text);
-    used += text.length;
+    used += text.length + SEP;
     firstIdx = i;
   }
 
@@ -149,8 +158,10 @@ async function compactAgentMessages(
   }
 
   // ~4 chars/token; give the summarizer at most half the window of input so
-  // system+transcript+its own output always fit.
-  const maxChars = window > 0 ? window * 2 : 0;
+  // system+transcript+its own output always fit. When the window is UNKNOWN
+  // (reactive recovery with no contextWindow), fall back to a conservative fixed
+  // bound so the compaction call itself can't overflow — never unbounded.
+  const maxChars = window > 0 ? window * 2 : FALLBACK_COMPACT_CHARS;
   const transcript = buildBoundedTranscript(conversation, maxChars);
   const res = await provider.complete(
     [

--- a/packages/core/src/agent/agent-runner.ts
+++ b/packages/core/src/agent/agent-runner.ts
@@ -183,22 +183,53 @@ const DEFAULT_SYSTEM = [
 ].join(" ");
 
 /** The structured-output control tool: intercepted by the runner itself (never
- *  dispatched to executeTool), so the parent gets a parseable final payload. */
+ *  dispatched to executeTool), so the parent gets a PARSEABLE final payload —
+ *  a headline `summary` plus a list of concrete `findings`, each carrying its
+ *  own `source` (`file:line` for code, a URL for external docs). Forcing this
+ *  shape both keeps output consistent for the orchestrator and pushes the model
+ *  to attach evidence to every point instead of emitting uncited prose. */
 const AGENT_RESULT_TOOL = {
   type: "function",
   function: {
     name: "agent_result",
     description:
-      "Return your final result and finish. Call exactly once, when done.",
+      "Return your final result and finish. Call exactly once, when done. Put the " +
+      "headline conclusion (or verdict) in `summary`, and each concrete point in " +
+      "`findings` — every code point MUST carry the `file:line` you saw in `source`.",
     parameters: {
       type: "object",
       properties: {
-        result: {
+        summary: {
           type: "string",
-          description: "Your complete findings/answer.",
+          description: "1–3 sentence headline conclusion or verdict.",
+        },
+        findings: {
+          type: "array",
+          description:
+            "The concrete points; empty only if there is genuinely none.",
+          items: {
+            type: "object",
+            properties: {
+              detail: {
+                type: "string",
+                description: "One specific observation, issue, or fact.",
+              },
+              source: {
+                type: "string",
+                description:
+                  "Where you saw it: `path/to/file.ts:123` for code, or a URL for external docs.",
+              },
+              confidence: {
+                type: "string",
+                enum: ["high", "medium", "low"],
+                description: "How sure you are of this point.",
+              },
+            },
+            required: ["detail"],
+          },
         },
       },
-      required: ["result"],
+      required: ["summary", "findings"],
     },
   },
 } as const;
@@ -262,9 +293,36 @@ export interface IAgentRunOptions {
   contextWindow?: number;
 }
 
-/** Pull the structured payload out of an intercepted agent_result call. */
+/** Render one structured finding as `- detail (source) [confidence]`. */
+function formatFinding(f: unknown): string | null {
+  if (!isRecord(f) || typeof f.detail !== "string" || f.detail.length === 0) {
+    return null;
+  }
+
+  const source =
+    typeof f.source === "string" && f.source.length > 0 ? ` (${f.source})` : "";
+  const confidence =
+    typeof f.confidence === "string" ? ` [${f.confidence}]` : "";
+
+  return `- ${f.detail}${source}${confidence}`;
+}
+
+/** Flatten an intercepted `agent_result` call into the text the orchestrator
+ *  reads: the `summary` followed by cited `findings`. Falls back to the legacy
+ *  `{ result }` string or raw JSON if the structured shape is absent, so an
+ *  older spec or a malformed call still yields something usable. */
 function resultPayload(args: Record<string, unknown>): string {
-  return typeof args.result === "string" ? args.result : JSON.stringify(args);
+  const summary = typeof args.summary === "string" ? args.summary : "";
+  const findings = Array.isArray(args.findings) ? args.findings : [];
+  const lines = findings
+    .map(formatFinding)
+    .filter((l): l is string => l !== null);
+
+  if (summary.length === 0 && lines.length === 0) {
+    return typeof args.result === "string" ? args.result : JSON.stringify(args);
+  }
+
+  return [summary, ...lines].filter((s) => s.length > 0).join("\n");
 }
 
 /** Force the first move (`"required"`) while real tools exist and nothing has

--- a/packages/core/src/agent/builtin-specs.ts
+++ b/packages/core/src/agent/builtin-specs.ts
@@ -18,9 +18,11 @@ const READONLY_MANDATE =
   "You are read-only: you cannot edit files or run mutating commands. " +
   "You MUST investigate with the tools before answering — never answer from " +
   "memory or guess. Open the actual files the task names, follow the references, " +
-  "and back every claim with a `file:line` you saw. A final answer with no " +
-  "`file:line` citations means you did not investigate and is wrong. Return ONE " +
-  "final message: concise, concrete conclusions — not a raw dump of what you read.";
+  "and back every claim with a `file:line` you saw. When done, call `agent_result` " +
+  "with a short `summary` and a `findings` list — one concrete point each, every " +
+  "code point carrying its `file:line` in `source`. A finding with no `source` " +
+  "means you did not investigate and is wrong. Be concise — conclusions, not a " +
+  "raw dump of what you read.";
 
 export const BUILTIN_SPECS: readonly IAgentSpec[] = [
   {
@@ -28,6 +30,7 @@ export const BUILTIN_SPECS: readonly IAgentSpec[] = [
     description:
       "Maps a subsystem or traces how something works, and reports conclusions with file:line references.",
     kind: "chat",
+    outputMode: "structured",
     tools: [
       TOOL_NAME.read,
       TOOL_NAME.search,
@@ -52,6 +55,7 @@ export const BUILTIN_SPECS: readonly IAgentSpec[] = [
     description:
       "Researches external docs, package APIs, and the web; reports findings with source URLs.",
     kind: "chat",
+    outputMode: "structured",
     tools: [
       TOOL_NAME.webSearch,
       TOOL_NAME.webFetch,
@@ -68,13 +72,15 @@ export const BUILTIN_SPECS: readonly IAgentSpec[] = [
       "`package_info` for installed or npm packages and `web_search`→`web_fetch` " +
       "for everything else. Cite the source URL or the local docs path for every " +
       "claim; when versions differ, say which version you checked. Never invent an " +
-      "API — verify it. Return ONE final message: the concrete answer plus sources.",
+      "API — verify it. When done, call `agent_result`: the answer in `summary`, " +
+      "each fact a `finding` with its source URL (or local docs path) in `source`.",
   },
   {
     id: "verify",
     description:
       "Adversarially checks a specific claim or finding against the real code and reports a verdict.",
     kind: "chat",
+    outputMode: "structured",
     tools: [
       TOOL_NAME.read,
       TOOL_NAME.search,
@@ -90,14 +96,15 @@ export const BUILTIN_SPECS: readonly IAgentSpec[] = [
       "wrong until the code proves it. Open the exact lines involved and check the " +
       "control/data flow. " +
       READONLY_MANDATE +
-      " End with an explicit verdict: CONFIRMED or REFUTED, and the `file:line` " +
-      "evidence that decided it.",
+      " Put the verdict — CONFIRMED or REFUTED — in `summary`, with the deciding " +
+      "`file:line` evidence in `findings`.",
   },
   {
     id: "review-lens",
     description:
       "Reviews a change for correctness/regressions from a senior-engineer lens; reports issues with file:line.",
     kind: "chat",
+    outputMode: "structured",
     tools: [
       TOOL_NAME.read,
       TOOL_NAME.search,

--- a/packages/core/src/cli/logging.ts
+++ b/packages/core/src/cli/logging.ts
@@ -36,6 +36,12 @@ export function observeEvents(fn: ((event: ILoopEvent) => void) | null): void {
   eventObserver = fn;
 }
 
+const LIFECYCLE_KINDS: ReadonlySet<string> = new Set([
+  "agent_spawned",
+  "agent_started",
+  "agent_result",
+]);
+
 const render: Reporter = (event) => {
   // The observer (the REPL's agent-tree feeder) must never take down rendering:
   // a throw here would propagate out of the reporter and crash the turn/session.
@@ -43,6 +49,16 @@ const render: Reporter = (event) => {
     eventObserver?.(event);
   } catch (err) {
     trace("cli.eventObserver", err);
+  }
+
+  // Subagent lifecycle events are STRUCTURAL — they drive the live tree, not the
+  // transcript. When a tree observer is attached it renders them (a row + the
+  // `↳ label` detail header); routing their text too would divert the agent's
+  // own description into its detail buffer and print the label two more times
+  // under the tree. So skip rendering here once the observer has been notified.
+  // Headless/one-shot has no observer, so they still render as linear-log lines.
+  if (eventObserver !== null && LIFECYCLE_KINDS.has(event.kind)) {
+    return;
   }
 
   const phase = spinnerPhase(event);

--- a/packages/core/src/cli/repl.ts
+++ b/packages/core/src/cli/repl.ts
@@ -518,8 +518,15 @@ export async function repl(args: ICliArgs): Promise<number> {
     getTsService: () => session.tsService,
   });
 
-  // Re-applied after `/clear` rebuilds the session (like setSetupWeb).
+  // Re-applied after `/clear` rebuilds the session (like setSetupWeb). Skipped
+  // entirely under TSFORGE_NO_DELEGATION — the A/B control arm / pure single-stream.
+  const delegationOff = flags.noDelegation();
+
   const wireDelegation = (): void => {
+    if (delegationOff) {
+      return;
+    }
+
     session.setDelegation(agentSpecs, spawnAgentFn);
   };
 
@@ -527,7 +534,9 @@ export async function repl(args: ICliArgs): Promise<number> {
 
   // Make the delegation setup visible so the concurrency cap is never a mystery
   // (cap 1 ⇒ subagents run serially; raise agents.concurrency to overlap them).
-  if (agentSpecs.length > 0) {
+  if (delegationOff) {
+    process.stdout.write("  ↳ delegation: OFF (TSFORGE_NO_DELEGATION)\n");
+  } else if (agentSpecs.length > 0) {
     const names = agentSpecs.map((s) => s.id).join(", ");
 
     process.stdout.write(

--- a/packages/core/src/cli/repl.ts
+++ b/packages/core/src/cli/repl.ts
@@ -503,6 +503,9 @@ export async function repl(args: ICliArgs): Promise<number> {
     specs: agentSpecs,
     cwd: args.dir,
     concurrency: delegationCap,
+    // Subagents auto-compact against the same window as the main loop, so a
+    // long read-only investigation never overflows and 400s.
+    contextWindow,
     policyMode: isPolicyMode(args.policyMode)
       ? args.policyMode
       : (delegationConfig.policy?.mode ?? "default"),

--- a/packages/core/src/cli/repl.ts
+++ b/packages/core/src/cli/repl.ts
@@ -1922,6 +1922,18 @@ export async function repl(args: ICliArgs): Promise<number> {
       editorHandle.onCycleMode(() => {
         setMode(nextMode(currentModeId).id);
       });
+      // ↑/↓ on an empty input row navigate the live agent tree (parity with the
+      // readline path at the keypress handler above). Consumed only while a tree
+      // is active; otherwise the editor keeps the arrows for history/cursor.
+      editorHandle.onNavigateTree((delta) => {
+        if (!treeActive) {
+          return false;
+        }
+
+        moveTreeFocus(delta);
+
+        return true;
+      });
     } else if (rl !== null) {
       rl.on("line", submitLine);
     }

--- a/packages/core/src/cli/spawn-runner.ts
+++ b/packages/core/src/cli/spawn-runner.ts
@@ -66,6 +66,10 @@ export interface ISpawnRunnerOptions {
    *  building its own — read lazily (a getter, not a value) so it tracks the
    *  current session across `/clear`. Absent ⇒ the child builds its own. */
   readonly getTsService?: () => TsService | null;
+  /** The model's context window (tokens). Threaded to each AgentRunner so it
+   *  auto-compacts before a request would overflow — a long investigation never
+   *  fails on length. Omitted ⇒ no compaction. */
+  readonly contextWindow?: number;
 }
 
 export function makeSpawnAgentFn(opts: ISpawnRunnerOptions): SpawnAgentFn {
@@ -122,6 +126,9 @@ export function makeSpawnAgentFn(opts: ISpawnRunnerOptions): SpawnAgentFn {
           ...(opts.getTsService === undefined
             ? {}
             : { tsService: opts.getTsService() }),
+          ...(opts.contextWindow === undefined
+            ? {}
+            : { contextWindow: opts.contextWindow }),
         });
 
         lifecycle("agent_result", result.status === "done");

--- a/packages/core/src/config/config.constants.ts
+++ b/packages/core/src/config/config.constants.ts
@@ -8,4 +8,5 @@ export const ENV_FLAG = {
   noScriptTool: "TSFORGE_NO_SCRIPT",
   noGitTool: "TSFORGE_NO_GIT_TOOL",
   basicInput: "TSFORGE_BASIC_INPUT",
+  noDelegation: "TSFORGE_NO_DELEGATION",
 } as const;

--- a/packages/core/src/config/flags.ts
+++ b/packages/core/src/config/flags.ts
@@ -35,4 +35,8 @@ export const flags = {
   /** Fall back to basic readline input (no multiline editor) in interactive mode.
    *  Default OFF — the editor is on. Set to "1" to disable the editor. */
   basicInput: (): boolean => isOn(ENV_FLAG.basicInput),
+  /** Withhold model-driven delegation (the `spawn_agent` tool + specialists).
+   *  Default OFF — delegation is on. Set to "1" for the A/B control arm (measure
+   *  the harness WITHOUT subagents) or to force a pure single-stream run. */
+  noDelegation: (): boolean => isOn(ENV_FLAG.noDelegation),
 };

--- a/packages/core/src/editor/controller.ts
+++ b/packages/core/src/editor/controller.ts
@@ -19,6 +19,12 @@ export interface IEditorHandle {
   /** Shift+Tab — cycle the session mode (plan/normal/…). The host decides what
    *  cycling means; the editor just forwards the keypress. */
   onCycleMode(cb: () => void): void;
+  /** ↑/↓ while the input buffer is EMPTY — offer the keypress to the host so it
+   *  can navigate an out-of-band overlay (the live agent tree). `delta` is -1 for
+   *  up, +1 for down; the callback returns `true` to consume the key, `false` to
+   *  let the editor handle it as cursor/history movement. Only consulted on an
+   *  empty buffer so it never hijacks arrows while the user is composing. */
+  onNavigateTree(cb: (delta: number) => boolean): void;
   getBuffer(): EditorBuffer;
   /** Update the terminal dimensions and repaint. The CLI calls this on a
    *  terminal resize; without it the editor keeps wrapping/windowing at the
@@ -197,6 +203,13 @@ export function startEditor(deps: IStartEditorDeps): IEditorHandle {
   const interruptCallbacks: (() => void)[] = [];
   const exitCallbacks: (() => void)[] = [];
   const cycleModeCallbacks: (() => void)[] = [];
+  const navigateTreeCallbacks: ((delta: number) => boolean)[] = [];
+
+  // Offer an empty-buffer ↑/↓ to the host (live agent tree). Returns true if a
+  // callback consumed it, so the editor should skip its own cursor/history move.
+  const dispatchNavigateTree = (delta: number): boolean =>
+    buffer.getText().length === 0 &&
+    navigateTreeCallbacks.some((cb) => cb(delta));
 
   // In-session history: submitted messages for up/down navigation
   const history: string[] = [];
@@ -476,6 +489,11 @@ export function startEditor(deps: IStartEditorDeps): IEditorHandle {
 
     // History navigation: up/down at buffer edges
     if (name === "up") {
+      // Empty buffer: let the host navigate the agent tree (if one is live).
+      if (dispatchNavigateTree(-1)) {
+        return;
+      }
+
       const { line } = buffer.getCursor();
 
       if (line === 0) {
@@ -492,6 +510,10 @@ export function startEditor(deps: IStartEditorDeps): IEditorHandle {
     }
 
     if (name === "down") {
+      if (dispatchNavigateTree(1)) {
+        return;
+      }
+
       const { line } = buffer.getCursor();
       const lines = buffer.getText().split("\n");
       const lastLine = lines.length - 1;
@@ -643,6 +665,10 @@ export function startEditor(deps: IStartEditorDeps): IEditorHandle {
 
     onCycleMode(cb: () => void) {
       cycleModeCallbacks.push(cb);
+    },
+
+    onNavigateTree(cb: (delta: number) => boolean) {
+      navigateTreeCallbacks.push(cb);
     },
 
     getBuffer(): EditorBuffer {

--- a/packages/core/src/loop/staged-build.ts
+++ b/packages/core/src/loop/staged-build.ts
@@ -86,6 +86,33 @@ export const CONTRACT_GLOBS: readonly string[] = [
   "src/**/*.constants.ts",
 ];
 
+/** All source files, scanned to decide whether phase 1 already BUILT the app. */
+const IMPLEMENTATION_GLOBS: readonly string[] = ["src/**/*.ts", "src/**/*.tsx"];
+
+/** True when `path` is real app IMPLEMENTATION — NOT a type/constant declaration,
+ *  a generated/test file, a scaffolded UI primitive, or the entry point. This is
+ *  what distinguishes "phase 1 over-delivered and built the whole app" (skip the
+ *  rebuild) from "phase 1 wrote only the type contract" — the NORMAL case, where
+ *  the empty scaffold still compiles, so the gate is green yet nothing is built. */
+export function isImplementationFile(path: string): boolean {
+  const base = path.split("/").pop() ?? "";
+
+  if (/\.(types|constants|d|gen|test)\.tsx?$/u.test(base)) {
+    return false;
+  }
+
+  if (path.includes("/components/ui/")) {
+    return false; // scaffolded theme primitives, not app code
+  }
+
+  return base !== "main.ts" && base !== "main.tsx";
+}
+
+/** Whether any of `paths` is real app implementation (see isImplementationFile). */
+export function hasImplementation(paths: readonly string[]): boolean {
+  return paths.some(isImplementationFile);
+}
+
 /** Format the designed `.types.ts`/`.constants.ts` files as a precise reference
  *  block for the implement phase — so the model builds against the EXACT current
  *  signatures instead of its (lossy) recollection of them. Empty string when
@@ -164,23 +191,35 @@ export async function designBuild(
 
 /**
  * PHASE 2 — implement against the designed types, driving to green. If phase 1
- * already produced a fully-green app (it ignored "types only" and built
- * everything), this returns done WITHOUT rebuilding — else the model concludes
- * the prior phase did "only the data layer" and `rm -rf`s its own finished UI to
+ * already BUILT the app (it ignored "types only" and built everything) AND it is
+ * green, this returns done WITHOUT rebuilding — else the model concludes the
+ * prior phase did "only the data layer" and `rm -rf`s its own finished UI to
  * rebuild (observed: 23-00-52 went green at turn 146, then phase 2 wiped every
- * file). `planNotes` (human plan-mode edits) are injected into the implement step.
+ * file). CRUCIAL: the skip demands REAL implementation files, not just a green
+ * gate — a types-only phase 1 leaves the empty scaffold, which trivially passes
+ * typecheck+lint+build, so skipping on green ALONE shipped a hollow app (all
+ * `*.types.ts`, no code; the model announced "Ready for STEP 2" and got cut off).
+ * `planNotes` (human plan-mode edits) are injected into the implement step.
  */
 export async function implementBuild(
   host: IStagedBuildHost,
   planNotes = "",
   opts: ISendOptions = {}
 ): Promise<ISendResult> {
-  if (await host.fullGatePasses()) {
+  // Cheap check first: did phase 1 write any real implementation? In the normal
+  // types-only flow it did not, so we skip the (expensive) gate probe and go
+  // straight to building. Only when the model over-delivered do we confirm green
+  // and skip the rebuild.
+  const built = hasImplementation(
+    (await readFiles(host.cwd, IMPLEMENTATION_GLOBS)).map((f) => f.path)
+  );
+
+  if (built && (await host.fullGatePasses())) {
     host.report({
       kind: "tool",
       task: host.taskId,
       message:
-        "phase 1 already produced a fully-green app — skipping phase 2 (no rebuild)",
+        "phase 1 already built a fully-green app — skipping phase 2 (no rebuild)",
     });
 
     return { status: "done", turns: 0 };

--- a/packages/core/tests/agent-compaction.test.ts
+++ b/packages/core/tests/agent-compaction.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, test } from "bun:test";
 import { AgentRunner } from "../src/agent";
+import {
+  buildBoundedTranscript,
+  isContextOverflow,
+} from "../src/agent/agent-runner";
 import type { IAgentSpec } from "../src/agent/agent-spec";
 import type {
   IProvider,
@@ -148,5 +152,93 @@ describe("AgentRunner auto-compaction", () => {
 
     expect(provider.compactionCalls).toBe(0);
     expect(status).toBe("error");
+  });
+
+  // A small model (window ≤ the output reserve) must not collapse the effective
+  // budget to ~0 and compact on every turn (the reviewer's infinite-loop case).
+  test("a small context window does NOT trigger compaction every turn", async () => {
+    const result = await new AgentRunner(SPEC).run({
+      provider: new ScriptedProvider([
+        answer("", 2000), // ~25% of an 8k window — well under any sane threshold
+        answer("final answer", 2000),
+      ]),
+      cwd: process.cwd(),
+      parentTaskId: "t",
+      task: "explore",
+      contextWindow: 8000, // < the 16384 output reserve
+      tsService: null,
+      policyMode: "bypassPermissions",
+    });
+
+    expect(result.status).toBe("done");
+    expect(compacted(result.events).length).toBe(0);
+  });
+});
+
+describe("isContextOverflow", () => {
+  test("matches vLLM/OpenAI context-overflow messages", () => {
+    expect(
+      isContextOverflow(
+        new Error(
+          "400 This model's maximum context length is 131072 tokens. However, you requested 131073."
+        )
+      )
+    ).toBe(true);
+    expect(
+      isContextOverflow(new Error("reduce the length of the messages"))
+    ).toBe(true);
+  });
+
+  test("extracts the message from a non-Error object (nested error.message)", () => {
+    expect(
+      isContextOverflow({
+        error: { message: "maximum context length exceeded" },
+      })
+    ).toBe(true);
+    expect(isContextOverflow({ message: "context window is full" })).toBe(true);
+  });
+
+  test("is false for unrelated errors", () => {
+    expect(isContextOverflow(new Error("500 internal server error"))).toBe(
+      false
+    );
+    expect(isContextOverflow(null)).toBe(false);
+    expect(isContextOverflow("timed out")).toBe(false);
+  });
+});
+
+describe("buildBoundedTranscript", () => {
+  const msg = (role: string, content: string) => ({ role, content });
+
+  test("always includes the newest message, truncating it if it alone exceeds the budget", () => {
+    const huge = "Z".repeat(5000);
+    const out = buildBoundedTranscript(
+      [msg("user", "task"), msg("assistant", "a"), msg("tool", huge)],
+      500
+    );
+
+    expect(out).toContain("[tool]"); // the newest message is present…
+    expect(out).toContain("…[truncated]"); // …truncated to fit
+    expect(out.length).toBeLessThanOrEqual(500); // bound respected
+  });
+
+  test("elides older messages with a marker and stays within the budget", () => {
+    const conversation = Array.from({ length: 20 }, (_v, i) =>
+      msg("tool", `finding ${i} `.repeat(20))
+    );
+    const out = buildBoundedTranscript(conversation, 400);
+
+    expect(out).toContain("earlier message(s) elided");
+    expect(out.length).toBeLessThanOrEqual(400);
+    expect(out).toContain("finding 19"); // newest kept
+  });
+
+  test("maxChars ≤ 0 means unbounded (returns the full transcript)", () => {
+    const out = buildBoundedTranscript(
+      [msg("user", "one"), msg("assistant", "two")],
+      0
+    );
+
+    expect(out).toBe("[user] one\n\n[assistant] two");
   });
 });

--- a/packages/core/tests/agent-compaction.test.ts
+++ b/packages/core/tests/agent-compaction.test.ts
@@ -143,6 +143,30 @@ describe("AgentRunner auto-compaction", () => {
     expect(output).toBe("recovered answer");
   });
 
+  test("REACTIVE recovery works even when the context window is UNKNOWN (bounded fallback)", async () => {
+    // No contextWindow → the reactive path must still bound the summarizer input
+    // (fixed fallback), not build an unbounded transcript that overflows again.
+    const provider = new ScriptedProvider([
+      answer("", 50), // turn 1: nudge, history grows past 2 messages
+      new Error("model request failed: 400 maximum context length exceeded"), // turn 2: overflow
+      answer("recovered", 60), // retry after bounded compaction
+    ]);
+
+    const result = await new AgentRunner(SPEC).run({
+      provider,
+      cwd: process.cwd(),
+      parentTaskId: "t",
+      task: "explore",
+      tsService: null,
+      policyMode: "bypassPermissions",
+      // contextWindow deliberately omitted (window = 0)
+    });
+
+    expect(provider.compactionCalls).toBe(1);
+    expect(result.status).toBe("done");
+    expect(result.output).toBe("recovered");
+  });
+
   test("a non-overflow provider error is NOT swallowed (still an error)", async () => {
     const provider = new ScriptedProvider([
       new Error("model request failed: 500 internal server error"),
@@ -231,6 +255,18 @@ describe("buildBoundedTranscript", () => {
     expect(out).toContain("earlier message(s) elided");
     expect(out.length).toBeLessThanOrEqual(400);
     expect(out).toContain("finding 19"); // newest kept
+  });
+
+  test("MANY short messages stay within budget (join separators counted)", () => {
+    // 200 tiny messages: without counting the "\n\n" separators, the aggregate
+    // would blow past a small maxChars even though each message is trivial.
+    const conversation = Array.from({ length: 200 }, (_v, i) =>
+      msg("user", `m${i}`)
+    );
+    const out = buildBoundedTranscript(conversation, 300);
+
+    expect(out.length).toBeLessThanOrEqual(300);
+    expect(out).toContain("m199"); // newest kept
   });
 
   test("maxChars ≤ 0 means unbounded (returns the full transcript)", () => {

--- a/packages/core/tests/agent-compaction.test.ts
+++ b/packages/core/tests/agent-compaction.test.ts
@@ -1,0 +1,152 @@
+import { describe, expect, test } from "bun:test";
+import { AgentRunner } from "../src/agent";
+import type { IAgentSpec } from "../src/agent/agent-spec";
+import type {
+  IProvider,
+  ICompleteOptions,
+  IModelResponse,
+  IChatMessage,
+} from "../src/inference";
+import { COMPACT_SYSTEM } from "../src/loop/prompt";
+import type { ILoopEvent } from "../src/loop";
+
+// Must exceed the 16384-token output reserve the runner subtracts to get the
+// effective prompt budget (effectiveWindow = WINDOW - 16384 = 83616; the
+// compaction threshold is 0.8 of that ≈ 66893).
+const WINDOW = 100_000;
+
+// A scripted provider: NON-compaction calls consume `script` in order (an entry
+// is either a response or an Error to throw); a compaction call (system ===
+// COMPACT_SYSTEM) returns a fixed summary and is counted separately.
+class ScriptedProvider implements IProvider {
+  compactionCalls = 0;
+  normalCalls = 0;
+
+  constructor(private readonly script: (IModelResponse | Error)[]) {}
+
+  complete(
+    messages: IChatMessage[],
+    _opts?: ICompleteOptions
+  ): Promise<IModelResponse> {
+    if (messages[0]?.content === COMPACT_SYSTEM) {
+      this.compactionCalls += 1;
+
+      return Promise.resolve({
+        content: "SUMMARY of findings so far",
+        toolCalls: [],
+        usage: { promptTokens: 20, completionTokens: 5, totalTokens: 25 },
+      });
+    }
+
+    const next = this.script[this.normalCalls];
+
+    this.normalCalls += 1;
+
+    if (next instanceof Error) {
+      return Promise.reject(next);
+    }
+
+    if (next === undefined) {
+      return Promise.resolve({ content: "done", toolCalls: [] });
+    }
+
+    return Promise.resolve(next);
+  }
+}
+
+const answer = (content: string, promptTokens: number): IModelResponse => ({
+  content,
+  toolCalls: [],
+  usage: { promptTokens, completionTokens: 5, totalTokens: promptTokens + 5 },
+});
+
+// A no-tools spec: the runner accepts a non-empty text answer as the final
+// result, and an empty answer nudges for another turn — enough to drive ≥2 turns
+// deterministically without executing real tools.
+const SPEC: IAgentSpec = {
+  id: "test-explore",
+  description: "test",
+  systemPrompt: "investigate",
+  tools: [],
+};
+
+async function run(
+  provider: IProvider
+): Promise<{ status: string; output: string; events: ILoopEvent[] }> {
+  return new AgentRunner(SPEC).run({
+    provider,
+    cwd: process.cwd(),
+    parentTaskId: "t",
+    task: "explore the thing",
+    contextWindow: WINDOW,
+    tsService: null,
+    policyMode: "bypassPermissions",
+  });
+}
+
+const compacted = (events: ILoopEvent[]): ILoopEvent[] =>
+  events.filter((e) => e.message.includes("↯ compacted"));
+
+describe("AgentRunner auto-compaction", () => {
+  test("PROACTIVE: compacts before the next turn once prompt tokens cross the window fraction", async () => {
+    // Turn 1: empty answer (→ nudge, another turn) but reports promptTokens at
+    // 90% of the window. Before turn 2 the runner must compact.
+    const provider = new ScriptedProvider([
+      answer("", 90_000), // turn 1: above the effective-budget threshold (~66893)
+      answer("final answer", 30), // turn 2 (post-compaction): finishes
+    ]);
+
+    const { status, output, events } = await run(provider);
+
+    expect(provider.compactionCalls).toBe(1);
+    expect(compacted(events).length).toBe(1);
+    expect(status).toBe("done");
+    expect(output).toBe("final answer");
+  });
+
+  test("does NOT compact while prompt tokens stay under the fraction", async () => {
+    const provider = new ScriptedProvider([
+      answer("", 20_000), // turn 1: well under the threshold
+      answer("final answer", 40), // turn 2
+    ]);
+
+    const { status, events } = await run(provider);
+
+    expect(provider.compactionCalls).toBe(0);
+    expect(compacted(events).length).toBe(0);
+    expect(status).toBe("done");
+  });
+
+  test("REACTIVE: a context-overflow rejection is recovered by compacting and retrying", async () => {
+    // Turn 1 finishes empty (low tokens, no proactive compaction) → history grows
+    // to >2 messages. Turn 2 the request OVERFLOWS; the runner compacts and
+    // retries the same turn, which then succeeds.
+    const provider = new ScriptedProvider([
+      answer("", 50), // turn 1: low tokens, nudge
+      new Error(
+        "model request failed: 400 This model's maximum context length is 1000 tokens. However, you requested 1200 tokens."
+      ), // turn 2: overflow
+      answer("recovered answer", 60), // turn 2 retry after compaction
+    ]);
+
+    const { status, output, events } = await run(provider);
+
+    expect(provider.compactionCalls).toBe(1);
+    expect(
+      compacted(events).some((e) => e.message.includes("recovering"))
+    ).toBe(true);
+    expect(status).toBe("done");
+    expect(output).toBe("recovered answer");
+  });
+
+  test("a non-overflow provider error is NOT swallowed (still an error)", async () => {
+    const provider = new ScriptedProvider([
+      new Error("model request failed: 500 internal server error"),
+    ]);
+
+    const { status } = await run(provider);
+
+    expect(provider.compactionCalls).toBe(0);
+    expect(status).toBe("error");
+  });
+});

--- a/packages/core/tests/agent-structured-output.test.ts
+++ b/packages/core/tests/agent-structured-output.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, test } from "bun:test";
+import { AgentRunner } from "../src/agent";
+import { BUILTIN_SPECS } from "../src/agent/builtin-specs";
+import type { IAgentSpec } from "../src/agent/agent-spec";
+import type { IProvider, IChatMessage, IModelResponse } from "../src/inference";
+
+// A no-tools structured spec: the runner accepts an agent_result call
+// immediately (nothing to investigate), so one scripted response drives it.
+const SPEC: IAgentSpec = {
+  id: "test-structured",
+  description: "t",
+  systemPrompt: "investigate",
+  tools: [],
+  outputMode: "structured",
+};
+
+function runWith(res: IModelResponse): ReturnType<AgentRunner["run"]> {
+  const provider: IProvider = {
+    complete: (_m: IChatMessage[]) => Promise.resolve(res),
+  };
+
+  return new AgentRunner(SPEC).run({
+    provider,
+    cwd: process.cwd(),
+    parentTaskId: "t",
+    task: "explore",
+    tsService: null,
+    policyMode: "bypassPermissions",
+  });
+}
+
+const resultCall = (args: Record<string, unknown>): IModelResponse => ({
+  content: "",
+  toolCalls: [{ name: "agent_result", arguments: args }],
+});
+
+describe("structured agent_result output", () => {
+  test("formats summary + cited findings into readable text", async () => {
+    const r = await runWith(
+      resultCall({
+        summary: "The gate runs `bun run` and reads the exit code.",
+        findings: [
+          {
+            detail: "exit 0 = pass",
+            source: "core-gate.ts:80",
+            confidence: "high",
+          },
+          {
+            detail: "GATE_SKIP bypasses the command",
+            source: "core-gate.ts:44",
+          },
+        ],
+      })
+    );
+
+    expect(r.status).toBe("done");
+    expect(r.output).toContain("The gate runs `bun run`");
+    expect(r.output).toContain("- exit 0 = pass (core-gate.ts:80) [high]");
+    expect(r.output).toContain(
+      "- GATE_SKIP bypasses the command (core-gate.ts:44)"
+    );
+  });
+
+  test("a finding with no detail is dropped (never a bare bullet)", async () => {
+    const r = await runWith(
+      resultCall({
+        summary: "S",
+        findings: [{ source: "x.ts:1" }, { detail: "real point" }],
+      })
+    );
+
+    expect(r.output).toBe("S\n- real point");
+  });
+
+  test("falls back to a legacy { result } string", async () => {
+    const r = await runWith(resultCall({ result: "plain legacy answer" }));
+
+    expect(r.output).toBe("plain legacy answer");
+  });
+
+  test("all built-in specs request structured output", () => {
+    expect(BUILTIN_SPECS.length).toBeGreaterThan(0);
+
+    for (const s of BUILTIN_SPECS) {
+      expect(s.outputMode).toBe("structured");
+    }
+  });
+});

--- a/packages/core/tests/editor-controller.test.ts
+++ b/packages/core/tests/editor-controller.test.ts
@@ -130,6 +130,58 @@ describe("EditorController", () => {
     expect(submits).toEqual([]);
   });
 
+  test("↑/↓ on an empty buffer route to onNavigateTree (agent-tree nav)", () => {
+    const { stdin, handle } = makeHarness();
+    const deltas: number[] = [];
+
+    handle.onNavigateTree((delta) => {
+      deltas.push(delta);
+
+      return true; // consume — a tree is live
+    });
+
+    stdin.feed("\x1b[A"); // up
+    stdin.feed("\x1b[B"); // down
+    stdin.feed("\x1b[A"); // up
+    expect(deltas).toEqual([-1, 1, -1]);
+    expect(handle.getBuffer().getText()).toBe(""); // buffer untouched
+  });
+
+  test("onNavigateTree is NOT consulted while the user is composing (buffer non-empty)", () => {
+    const { stdin, handle } = makeHarness();
+    let calls = 0;
+
+    handle.onNavigateTree(() => {
+      calls += 1;
+
+      return true;
+    });
+
+    stdin.feed("a");
+    stdin.feed("\x1b[13;2u"); // Shift+Enter → newline, not submit
+    stdin.feed("b"); // two-line draft; cursor on the last line
+    stdin.feed("\x1b[A"); // up → moves the cursor within the draft, not the tree
+    expect(calls).toBe(0);
+    expect(handle.getBuffer().getText()).toBe("a\nb"); // draft preserved
+  });
+
+  test("a declined onNavigateTree (no live tree) falls through to history nav", () => {
+    const { stdin, handle, submits } = makeHarness();
+
+    handle.onNavigateTree(() => false); // no tree active — decline every key
+
+    stdin.feed("first");
+    stdin.feed("\r");
+    stdin.feed("second");
+    stdin.feed("\r");
+    expect(submits).toEqual(["first", "second"]);
+
+    stdin.feed("\x1b[A"); // up on empty buffer → previous history item
+    expect(handle.getBuffer().getText()).toBe("second");
+    stdin.feed("\x1b[A");
+    expect(handle.getBuffer().getText()).toBe("first");
+  });
+
   test("Shift+Enter inserts a newline, does NOT submit", () => {
     const { stdin, handle, submits } = makeHarness();
 

--- a/packages/core/tests/logging-lifecycle.test.ts
+++ b/packages/core/tests/logging-lifecycle.test.ts
@@ -1,0 +1,67 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { makeReporter, observeEvents, outputRouter } from "../src/cli/logging";
+import type { ILoopEvent } from "../src/loop";
+
+// The shared reporter (`makeReporter("")` returns the internal `render`) plus the
+// module-level `outputRouter`/`observeEvents` singletons. Every test restores the
+// singletons in afterEach so ordering can't leak an installed sink/observer.
+const report = makeReporter("", "run-test");
+
+afterEach(() => {
+  observeEvents(null);
+  outputRouter.setParentSink(null);
+  outputRouter.clearAgentSink("run:explore");
+});
+
+const started = (agentId: string, label: string): ILoopEvent => ({
+  kind: "agent_started",
+  task: "run",
+  agentId,
+  message: label,
+});
+
+describe("subagent lifecycle rendering", () => {
+  test("with a tree observer attached, lifecycle text is NOT routed to the agent's detail sink", () => {
+    const sink: string[] = [];
+    const seen: string[] = [];
+
+    observeEvents((e) => seen.push(e.kind)); // a tree is attached
+    outputRouter.setAgentSink("run:explore", (t) => sink.push(t));
+
+    report(started("run:explore", "explore meta-rules subsystem"));
+
+    // The observer (tree) still sees the event...
+    expect(seen).toEqual(["agent_started"]);
+    // ...but its label is NOT diverted into the agent's own detail pane buffer
+    // (that would print the label a second time under the tree row).
+    expect(sink).toEqual([]);
+  });
+
+  test("with a tree observer attached, the agent's real work (tool/token) STILL routes to its sink", () => {
+    const sink: string[] = [];
+
+    observeEvents(() => {});
+    outputRouter.setAgentSink("run:explore", (t) => sink.push(t));
+
+    report({
+      kind: "tool",
+      task: "run",
+      agentId: "run:explore",
+      message: "✎ read meta-rules.ts",
+    });
+
+    expect(sink.length).toBe(1);
+    expect(sink.join("")).toContain("read meta-rules.ts");
+  });
+
+  test("headless (no observer): lifecycle events still render as a linear-log line", () => {
+    const parent: string[] = [];
+
+    // No observeEvents() → no tree. A parent sink stands in for stdout.
+    outputRouter.setParentSink((t) => parent.push(t));
+
+    report(started("run:explore", "explore meta-rules subsystem"));
+
+    expect(parent.join("")).toContain("explore meta-rules subsystem");
+  });
+});

--- a/packages/core/tests/staged-build.test.ts
+++ b/packages/core/tests/staged-build.test.ts
@@ -8,6 +8,8 @@ import {
   implementBuild,
   generatePlan,
   formatTypeContract,
+  hasImplementation,
+  isImplementationFile,
   type IStagedBuildHost,
 } from "../src/loop/staged-build";
 import type { ISendResult } from "../src/loop/session";
@@ -117,15 +119,70 @@ describe("buildStaged", () => {
 
     await buildStaged(host, "build it");
 
-    expect(host.calls).toContain("fullGatePasses");
+    // Types-only phase 1 (empty cwd) → implement runs. The gate probe is now
+    // skipped in this case (no implementation to protect from a rebuild), so the
+    // proof that phase 2 ran is the second send carrying STEP 2 — not a gate call.
+    expect(host.calls).not.toContain("fullGatePasses");
     expect(host.sent).toHaveLength(2);
     expect(host.sent[1]?.message).toContain("STEP 2 of 2");
   });
 });
 
+describe("isImplementationFile / hasImplementation", () => {
+  test("type/constant/generated/test files and scaffold are NOT implementation", () => {
+    for (const p of [
+      "src/game/game.types.ts",
+      "src/game/game.constants.ts",
+      "src/vite-env.d.ts",
+      "src/routeTree.gen.ts",
+      "src/lib/format.test.ts",
+      "src/components/ui/button.tsx",
+      "src/main.ts",
+      "src/main.tsx",
+    ]) {
+      expect(isImplementationFile(p)).toBe(false);
+    }
+  });
+
+  test("views/components/store/hooks ARE implementation", () => {
+    for (const p of [
+      "src/views/Home/index.tsx",
+      "src/store/store.ts",
+      "src/views/Home/home.hooks.ts",
+      "src/game/game.ts",
+    ]) {
+      expect(isImplementationFile(p)).toBe(true);
+    }
+  });
+
+  test("the hollow platformer file set has NO implementation; a real app does", () => {
+    expect(
+      hasImplementation([
+        "src/main.ts",
+        "src/vite-env.d.ts",
+        "src/game/game.types.ts",
+        "src/game/game.constants.ts",
+        "src/physics/physics.types.ts",
+      ])
+    ).toBe(false);
+    expect(
+      hasImplementation(["src/main.tsx", "src/views/Home/index.tsx"])
+    ).toBe(true);
+  });
+});
+
 describe("implementBuild", () => {
-  test("skips phase 2 when the full gate is already green (no rebuild)", async () => {
-    const host = makeHost({ gatePasses: true });
+  test("skips phase 2 when phase 1 BUILT a real app and it is green (no rebuild)", async () => {
+    // Phase 1 over-delivered: a real implementation file exists (not just types).
+    const dir = mkdtempSync(join(tmpdir(), "staged-built-"));
+
+    mkdirSync(join(dir, "src", "views", "Home"), { recursive: true });
+    writeFileSync(
+      join(dir, "src", "views", "Home", "index.tsx"),
+      "export function Home() { return null; }\n"
+    );
+
+    const host = makeHost({ cwd: dir, gatePasses: true });
 
     const result = await implementBuild(host);
 
@@ -134,6 +191,35 @@ describe("implementBuild", () => {
     expect(
       host.events.some((e) => e.message.includes("skipping phase 2"))
     ).toBe(true);
+  });
+
+  test("does NOT skip when phase 1 wrote ONLY types/constants, even if green (the hollow-app bug)", async () => {
+    // The regression: a types-only phase 1 leaves the empty scaffold, which
+    // passes the gate — but the app was never built. Phase 2 MUST run.
+    const dir = mkdtempSync(join(tmpdir(), "staged-typesonly-"));
+
+    mkdirSync(join(dir, "src", "game"), { recursive: true });
+    writeFileSync(
+      join(dir, "src", "game", "game.types.ts"),
+      "export interface GameState { score: number }\n"
+    );
+    writeFileSync(
+      join(dir, "src", "game", "game.constants.ts"),
+      "export const GRAVITY = 0.6;\n"
+    );
+    // The untouched scaffold entry point — must NOT count as implementation.
+    writeFileSync(join(dir, "src", "main.ts"), 'document.title = "app";\n');
+
+    const host = makeHost({ cwd: dir, gatePasses: true });
+
+    const result = await implementBuild(host);
+
+    // Phase 2 ran (send called), NOT skipped.
+    expect(host.calls).toContain("send");
+    expect(
+      host.events.some((e) => e.message.includes("skipping phase 2"))
+    ).toBe(false);
+    expect(result.turns).not.toBe(0);
   });
 
   test("injects human plan notes under the approved-plan heading", async () => {

--- a/scripts/e2e-spawn-agent-pty.py
+++ b/scripts/e2e-spawn-agent-pty.py
@@ -109,6 +109,43 @@ def search_call():
     )
 
 
+def agent_result_call():
+    """A subagent's structured final answer (built-in specs are outputMode:structured)."""
+    yield sse(
+        {
+            "choices": [
+                {
+                    "index": 0,
+                    "delta": {
+                        "tool_calls": [
+                            {
+                                "index": 0,
+                                "id": "call_r",
+                                "type": "function",
+                                "function": {
+                                    "name": "agent_result",
+                                    "arguments": json.dumps(
+                                        {
+                                            "summary": "AgentScheduler caps concurrency; no abort race.",
+                                            "findings": [
+                                                {
+                                                    "detail": "cap honored via the limiter",
+                                                    "source": "agent-scheduler.ts:60",
+                                                    "confidence": "high",
+                                                }
+                                            ],
+                                        }
+                                    ),
+                                },
+                            }
+                        ]
+                    },
+                }
+            ]
+        }
+    )
+
+
 def _decide(messages):
     system = ""
     if messages and messages[0].get("role") == "system":
@@ -129,10 +166,11 @@ def _decide(messages):
             )
         return two_spawns()
 
-    # A subagent (built-in explore/verify). The runner forces a tool call first,
-    # so search, then answer once the tool result is back.
+    # A subagent (built-in explore/verify — outputMode:structured). The runner
+    # forces a tool call first, so search, then finish with a STRUCTURED
+    # agent_result once the tool result is back (plain text would be nudged).
     if last.get("role") == "tool":
-        return content_chunks("Confirmed at agent-scheduler.ts:60 — cap honored.")
+        return agent_result_call()
     return search_call()
 
 

--- a/scripts/e2e-spawn-agent-pty.py
+++ b/scripts/e2e-spawn-agent-pty.py
@@ -6,8 +6,9 @@ The stub plays TWO roles keyed off the system prompt: as the ORCHESTRATOR it
 emits two `spawn_agent` tool calls in one turn; as a SUBAGENT (built-in explore
 spec) it must investigate first (the runner forces a tool call), then answers.
 We assert on the REAL byte stream that the live agent tree rendered — header,
-both child rows, the focused agent's output pane — and that the orchestrator got
-the findings back and produced a final answer.
+both child rows, the focused agent's output pane — that ↑/↓ on the empty editor
+input row navigate the detail pane between agents (editor-mode tree nav), and
+that the orchestrator got the findings back and produced a final answer.
 
 Run: python3 scripts/e2e-spawn-agent-pty.py
 """
@@ -16,6 +17,7 @@ import os
 import re
 import sys
 import tempfile
+import time
 
 sys.path.insert(0, os.path.join(os.path.dirname(os.path.abspath(__file__)), "lib"))
 from ptyharness import (  # noqa: E402
@@ -116,6 +118,11 @@ def _decide(messages):
 
     if is_orchestrator:
         if last.get("role") == "tool":
+            # Both subagents are done; the tree is on screen (both rows ✓). Hold the
+            # orchestrator's final answer a few seconds so the tree stays painted
+            # while the test drives ↑/↓ over it, then finish the turn.
+            time.sleep(4)
+
             return content_chunks(
                 "Both specialists confirm AgentScheduler caps concurrency and wires "
                 "per-unit AbortControllers. Done."
@@ -146,20 +153,41 @@ def main():
 
         os.write(master, b"Explain how AgentScheduler caps concurrency.\r")
 
-        # Accumulate through the orchestrator's post-delegation answer so every
-        # frame the tree painted is in the captured stream (erased frames stay in
-        # the byte stream — the erase is an escape sequence, not a deletion).
-        got, buf = read_until(master, lambda b: "Done." in strip(b), 60, buf)
-        clean = strip(buf)
-
-        chk.check("orchestrator produced a final answer after delegating", got)
-        chk.check("live agent tree header rendered (● agents)", "● agents" in clean)
-        chk.check("tree connectors rendered", "├─" in clean or "└─" in clean)
+        # The detail pane auto-follows the newest running agent. At cap=1 (the
+        # default) the two spawns run serially: explore first, then verify — so
+        # auto-follow lands on `verify` (check abort race) by the time both finish.
+        got, buf = read_until(master, lambda b: "↳ check abort" in strip(b), 60, buf)
+        chk.check("live agent tree header rendered (● agents)", "● agents" in strip(buf))
+        chk.check("tree connectors rendered", "├─" in strip(buf) or "└─" in strip(buf))
         chk.check(
             "both spawned rows shown with their labels",
-            "trace scheduler" in clean and "check abort race" in clean,
+            "trace scheduler" in strip(buf) and "check abort race" in strip(buf),
         )
-        chk.check("focused agent output pane shown (↳ <label>)", "↳ trace" in clean)
+        chk.check("detail pane auto-followed to the newest agent (verify)", got)
+
+        # --- Editor-mode arrow navigation over the live tree --------------------
+        # Auto-follow only ever moves FORWARD to the newest agent. Pressing ↑ to
+        # bring focus BACK to the earlier `explore` agent is something ONLY
+        # arrow-nav can produce — so a `↳ trace scheduler` header appearing in the
+        # stream AFTER our keypress proves editor-mode nav works. We search only
+        # the suffix that arrives after each press (buf is cumulative).
+        mark = len(buf)
+        os.write(master, b"\x1b[A")  # ↑ on the empty input row → tree nav
+        up_ok, buf = read_until(
+            master, lambda b: "↳ trace scheduler" in strip(b[mark:]), 20, buf
+        )
+        chk.check("↑ moved detail focus back to the explore agent", up_ok)
+
+        mark = len(buf)
+        os.write(master, b"\x1b[B")  # ↓ → forward again to verify
+        down_ok, buf = read_until(
+            master, lambda b: "↳ check abort" in strip(b[mark:]), 20, buf
+        )
+        chk.check("↓ moved detail focus forward to the verify agent", down_ok)
+
+        # The turn still completes cleanly after arrow navigation.
+        got, buf = read_until(master, lambda b: "Done." in strip(b), 30, buf)
+        chk.check("orchestrator produced a final answer after delegating", got)
     finally:
         reap(pid, master)
 


### PR DESCRIPTION
Follow-up to #78 (model-driven delegation). Two threads: finish the **navigable** half of the live agent tree, and make subagent exploration **robust** — a subagent must never fail just because its context grew.

## What's here

### 1. Editor-mode ↑/↓ agent navigation (`9d67daf`)
The arrow-key "click into an agent and watch it" navigation shipped in #78 only worked in the readline input path; the default multi-line editor owns stdin exclusively and consumed ↑/↓ for cursor/history. Now, on an **empty** input row, ↑/↓ move the detail-pane focus between running subagents; while you're composing a mid-run steering message the arrows still edit text (never hijacked). Parity with the readline path via a new `onNavigateTree` editor hook.

### 2. Detail-pane label-echo fix (`22f3972`)
`renderEvent` had no case for the `agent_*` lifecycle kinds, so they fell through to the default branch and their text got routed into the agent's **own** detail buffer — printing the label 2–3 times under the tree row. Lifecycle events are structural (the tree renders them); when a tree observer is attached their text is no longer routed. Headless/one-shot keeps the linear-log line.

### 3. Subagent auto-compaction — the real robustness fix (`e895365`)
A read-only subagent (`AgentRunner`) composes the turn loop directly and never used `Session`, so it inherited **none** of the main loop's auto-compaction. History grew unbounded (every re-read re-appends the whole file) until the request overflowed the model window and the endpoint 400'd — failing exploration for no reason other than length.

**Confirmed live** on DeepSeek-V4-Flash (see the eval harness): `prompt 114689 + reserved output 16384 = 131073 > 131072 window`.

Fix mirrors `Session.compact`:
- **Proactive** — before a turn, if the previous prompt crossed 0.8 of the *effective* window (`window − reserved max_tokens`; that reserve is why the baseline 400'd at only 78.7% of the full window), summarize into `[system, summary]` and continue. The summarizer input is itself bounded so it can't overflow.
- **Reactive** — if one large read still jumps past the limit in a single turn, catch the context-overflow 400, compact, and retry once. Non-overflow errors still surface.
- Threads the session's context window into every subagent.

### 4. Eval harness (`scripts/agents-concurrency-eval.ts`)
Reusable harness that fans out `explore` subagents at several concurrency caps against the live endpoint and reports wall-clock, aggregate tok/s, peak prompt tokens, per-agent compaction count, and verbatim failures. This is what measured the 400 and the concurrency behaviour (cap>1 is currently a net negative on the MTP endpoint — the subagent value is context isolation, not wall-clock; default `agents.concurrency: 1` stays correct).

## Tests
- `agent-compaction` — proactive / no-op / reactive-recovery / non-overflow-not-swallowed
- `editor-controller` — ↑/↓ forwarded on empty buffer, NOT while composing, declined keys fall through to history
- `logging-lifecycle` — lifecycle text not routed to the agent sink under a tree; real tool/token output still routed; headless linear-log preserved
- `scripts/e2e-spawn-agent-pty.py` — real-PTY: drives ↑/↓ in editor mode and asserts the detail pane moves BACK to the earlier agent (impossible via auto-follow), then forward again

Full `bun run validate` green: **2023 pass / 0 fail**, all PTY suites pass, docs build clean.