### PR TITLE
agents: harness-review hardening of the subagent system (definition-of-done pass)

### DIFF
--- a/docs/harness-subsystems.md
+++ b/docs/harness-subsystems.md
@@ -240,6 +240,51 @@ detectors, incl. function/brace-group bodies), `tests/policy-config.test.ts` (ru
 parse/drop), `tests/policy-integration.test.ts` (deny-first at `executeTool`),
 `tests/write-policy-p1.test.ts`.
 
+## agent / subagents — `src/agent/*` (`agent-runner.ts`, `agent-scheduler.ts`, `builtin-specs.ts`, `agent-spec.ts`, `agent.constants.ts`), `src/cli/spawn-runner.ts`, `src/loop/tools/spawn-agent.ts`, `src/config/agent-specs.ts`, `src/render/agent-tree.ts`
+
+Model-driven delegation (PRs #73–79): the orchestrator hands focused, READ-ONLY
+investigation to specialist subagents via the `spawn_agent` tool. `AgentRunner` composes
+the turn primitives directly (no gate); `makeLimiter` caps concurrency; subagents return a
+structured `agent_result` and auto-compact so a long investigation never overflows; the run
+renders as a live navigable tree above the input row.
+
+**Invariants**
+
+- Read-only is STRUCTURAL (3 layers): advertised tools = read-only set ∩ spec subset;
+  `ctx.tool.readOnly=true` hard-rejects mutation at dispatch; the policy layer evaluates
+  first. `spawn_agent` is NEVER offered to a subagent → recursion depth capped at 1.
+- Never overflows: proactive compaction fires before a request crosses the EFFECTIVE
+  window (`window − reserve`, reserve capped at ½ window so a small model can't loop); a
+  context-overflow 400 is caught, compacted (bounded transcript; fixed fallback when the
+  window is unknown), and retried once; a non-overflow error still surfaces.
+  `buildBoundedTranscript` output is ALWAYS ≤ `maxChars` (marker + separators counted).
+- Structured output: `agent_result` = `{summary, findings:[{detail, source, confidence}]}`;
+  malformed/legacy `{result}` args fall back without crashing; a finding with no `detail`
+  is dropped (no bare bullet).
+- Concurrency: `makeLimiter` honors the cap and RELEASES the slot even when a body throws
+  (no deadlock); one failing subagent doesn't sink siblings; consecutive spawns run
+  concurrently but a non-spawn tool (edit) is an ordering barrier; tool replies keep
+  submission order.
+- Live tree: every emitted line ≤ `columns − 1` (renders nothing below the minimum usable
+  width, so a terminal never self-wraps a line); no OutputRouter sink leak (every installed
+  sink is cleared on turn end, incl. an agent that streamed nothing); lifecycle events drive
+  the tree, not the transcript.
+- Spec precedence built-in < global < project (same id overrides); malformed specs skipped,
+  not fatal. `TSFORGE_NO_DELEGATION=1` withholds delegation entirely (single-stream).
+
+**Risk areas** a mutation or `spawn_agent` slipping past the read-only filter (recursion); a
+compaction path that overflows or infinite-loops; a limiter slot leaked on throw (deadlock);
+a sink leak mis-routing a later turn's output; the turn-loop spawn-batch reordering edits
+after a spawn.
+
+**Checklist** `tests/agent-runner.test.ts`, `tests/agent-compaction.test.ts`,
+`tests/agent-structured-output.test.ts`, `tests/agent-scheduler.test.ts`,
+`tests/spawn-concurrency.test.ts`, `tests/spawn-ordering-invariant.test.ts`,
+`tests/agent-tree.test.ts`, `tests/agent-tree-render-e2e.test.ts`,
+`tests/policy-evaluation.test.ts` (spawn_agent class), `tests/logging-lifecycle.test.ts`,
+`tests/output-router.test.ts`; PTY: `scripts/e2e-spawn-agent-pty.py`,
+`scripts/e2e-agents-pty.py`.
+
 ## mcp — `src/mcp/*`
 
 Hand-rolled JSON-RPC 2.0 client/server, tool registry.

--- a/docs/harness-subsystems.md
+++ b/docs/harness-subsystems.md
@@ -279,8 +279,8 @@ after a spawn.
 
 **Checklist** `tests/agent-runner.test.ts`, `tests/agent-compaction.test.ts`,
 `tests/agent-structured-output.test.ts`, `tests/agent-scheduler.test.ts`,
-`tests/spawn-concurrency.test.ts`, `tests/spawn-ordering-invariant.test.ts`,
-`tests/agent-tree.test.ts`, `tests/agent-tree-render-e2e.test.ts`,
+`tests/spawn-concurrency.test.ts`, `tests/tool-accounting.test.ts` (spawn batch +
+edit-before-spawn ordering), `tests/agent-tree.test.ts`, `tests/agent-tree-render-e2e.test.ts`,
 `tests/policy-evaluation.test.ts` (spawn_agent class), `tests/logging-lifecycle.test.ts`,
 `tests/output-router.test.ts`; PTY: `scripts/e2e-spawn-agent-pty.py`,
 `scripts/e2e-agents-pty.py`.

--- a/packages/core/src/agent/agent-runner.ts
+++ b/packages/core/src/agent/agent-runner.ts
@@ -329,10 +329,12 @@ function formatFinding(f: unknown): string | null {
 }
 
 /** Flatten an intercepted `agent_result` call into the text the orchestrator
- *  reads: the `summary` followed by cited `findings`. Falls back to the legacy
- *  `{ result }` string or raw JSON if the structured shape is absent, so an
- *  older spec or a malformed call still yields something usable. */
+ *  reads: the `summary` followed by cited `findings`. Guards against undefined/
+ *  null/non-object arguments (provider should validate, but we don't crash on
+ *  malformed calls). Falls back to legacy `{ result }` string or raw JSON when
+ *  the structured shape is absent, so an older spec still yields something usable. */
 export function resultPayload(args: unknown): string {
+  // Guard before property access — malformed tool args can't cause TypeError.
   if (!isRecord(args)) {
     return typeof args === "string" ? args : JSON.stringify(args ?? {});
   }

--- a/packages/core/src/agent/agent-runner.ts
+++ b/packages/core/src/agent/agent-runner.ts
@@ -148,7 +148,19 @@ export function buildBoundedTranscript(
   // contract holds for ALL inputs.
   const bare = picked.join("\n\n");
 
-  return bare.length <= maxChars ? bare : bare.slice(0, maxChars);
+  if (bare.length <= maxChars) {
+    return bare;
+  }
+
+  // Safe slice: .slice() could split a UTF-16 surrogate pair (e.g., emoji).
+  // Check if the last char is a high surrogate (0xD800–0xDBFF) and drop it
+  // to avoid emitting a malformed character.
+  const sliced = bare.slice(0, maxChars);
+  const lastCharCode = sliced.charCodeAt(sliced.length - 1);
+
+  return lastCharCode >= 0xd800 && lastCharCode <= 0xdbff
+    ? sliced.slice(0, -1)
+    : sliced;
 }
 
 /** Summarize the conversation and REPLACE it with [system, summary] — the same

--- a/packages/core/src/agent/agent-runner.ts
+++ b/packages/core/src/agent/agent-runner.ts
@@ -137,8 +137,18 @@ export function buildBoundedTranscript(
 
   const marker =
     firstIdx > 0 ? [`… (${String(firstIdx)} earlier message(s) elided) …`] : [];
+  const assembled = [...marker, ...picked].join("\n\n");
 
-  return [...marker, ...picked].join("\n\n");
+  if (assembled.length <= maxChars) {
+    return assembled;
+  }
+
+  // Only reachable when maxChars < the marker reserve (never in production, where
+  // maxChars is window*2). Drop the marker, then hard-cap, so the ≤ maxChars
+  // contract holds for ALL inputs.
+  const bare = picked.join("\n\n");
+
+  return bare.length <= maxChars ? bare : bare.slice(0, maxChars);
 }
 
 /** Summarize the conversation and REPLACE it with [system, summary] — the same
@@ -322,7 +332,11 @@ function formatFinding(f: unknown): string | null {
  *  reads: the `summary` followed by cited `findings`. Falls back to the legacy
  *  `{ result }` string or raw JSON if the structured shape is absent, so an
  *  older spec or a malformed call still yields something usable. */
-function resultPayload(args: Record<string, unknown>): string {
+export function resultPayload(args: unknown): string {
+  if (!isRecord(args)) {
+    return typeof args === "string" ? args : JSON.stringify(args ?? {});
+  }
+
   const summary = typeof args.summary === "string" ? args.summary : "";
   const findings = Array.isArray(args.findings) ? args.findings : [];
   const lines = findings

--- a/packages/core/src/render/agent-tree.ts
+++ b/packages/core/src/render/agent-tree.ts
@@ -123,6 +123,13 @@ const CONNECT_END = "└─ ";
  *  big fan-out can't push the prompt off a short terminal. */
 const DEFAULT_MAX_ROWS = 12;
 
+/** Below this width a row's fixed prefix (connector + glyph + marker) alone
+ *  exceeds `columns - 1`, so no line can be kept within the no-self-wrap budget.
+ *  Render nothing rather than emit a line the terminal would wrap (which breaks
+ *  the in-place repaint). A real terminal is never this narrow; the guard just
+ *  keeps the ≤ columns-1 invariant total. */
+const MIN_TREE_COLUMNS = 8;
+
 export interface IAgentTreeOptions {
   /** Terminal width; lines are kept ≤ `columns - 1` so none self-wraps. */
   readonly columns: number;
@@ -270,6 +277,11 @@ export function renderAgentTree(
   }
 
   const columns = opts.columns > 0 ? opts.columns : 80;
+
+  if (columns < MIN_TREE_COLUMNS) {
+    return [];
+  }
+
   const color = opts.color ?? true;
   const frame = opts.frame ?? 0;
   const maxRows = Math.max(1, opts.maxRows ?? DEFAULT_MAX_ROWS);

--- a/packages/core/src/render/agent-tree.ts
+++ b/packages/core/src/render/agent-tree.ts
@@ -299,8 +299,14 @@ export function renderAgentTree(
 
   if (overflow) {
     const hidden = rows.length - shown.length;
+    // Clip like every other line — the tail must also stay ≤ columns-1, else it
+    // self-wraps at narrow widths (columns 8–14) where overflow can still occur.
+    const tail = fitLabel(
+      `… +${String(hidden)} more`,
+      Math.max(0, columns - 4)
+    );
 
-    lines.push(paint(`└─ … +${String(hidden)} more`, STYLE.dim, color));
+    lines.push(paint(`└─ ${tail}`, STYLE.dim, color));
   }
 
   return lines;

--- a/packages/core/tests/agent-compaction.test.ts
+++ b/packages/core/tests/agent-compaction.test.ts
@@ -290,4 +290,25 @@ describe("buildBoundedTranscript", () => {
       expect(buildBoundedTranscript(convo, mc).length).toBeLessThanOrEqual(mc);
     }
   });
+
+  test("UTF-16 surrogate pairs are never split at maxChars boundary", () => {
+    // Emoji like 😀 use 2 UTF-16 code units. If we slice at the exact boundary,
+    // we'd split the pair and emit garbage. The safe-slice logic checks if the
+    // last char is a high surrogate (0xD800–0xDBFF) and drops it.
+    const text = "text with emoji " + "😀".repeat(10); // Construct so slice could hit mid-pair
+    const convo = [msg("user", text)];
+
+    // Slice at a position that might land in the middle of an emoji surrogate pair
+    const result = buildBoundedTranscript(convo, 25); // Short maxChars forces hard-cap
+
+    // Result must: (1) not exceed maxChars, (2) not have orphaned high surrogate at the end
+    expect(result.length).toBeLessThanOrEqual(25);
+
+    // Check that we didn't emit a high surrogate as the last character
+    const lastCharCode = result.charCodeAt(result.length - 1);
+    const isBrokenSurrogate =
+      lastCharCode >= 0xd800 && lastCharCode <= 0xdbff;
+
+    expect(isBrokenSurrogate).toBe(false);
+  });
 });

--- a/packages/core/tests/agent-compaction.test.ts
+++ b/packages/core/tests/agent-compaction.test.ts
@@ -277,4 +277,17 @@ describe("buildBoundedTranscript", () => {
 
     expect(out).toBe("[user] one\n\n[assistant] two");
   });
+
+  test("output NEVER exceeds maxChars for ANY maxChars 1..400 (incl. below the marker reserve)", () => {
+    const convo = [
+      msg("user", "a".repeat(500)),
+      msg("assistant", "b".repeat(500)),
+      msg("tool", "c".repeat(50)),
+      msg("user", "short"),
+    ];
+
+    for (let mc = 1; mc <= 400; mc += 1) {
+      expect(buildBoundedTranscript(convo, mc).length).toBeLessThanOrEqual(mc);
+    }
+  });
 });

--- a/packages/core/tests/agent-compaction.test.ts
+++ b/packages/core/tests/agent-compaction.test.ts
@@ -306,8 +306,7 @@ describe("buildBoundedTranscript", () => {
 
     // Check that we didn't emit a high surrogate as the last character
     const lastCharCode = result.charCodeAt(result.length - 1);
-    const isBrokenSurrogate =
-      lastCharCode >= 0xd800 && lastCharCode <= 0xdbff;
+    const isBrokenSurrogate = lastCharCode >= 0xd800 && lastCharCode <= 0xdbff;
 
     expect(isBrokenSurrogate).toBe(false);
   });

--- a/packages/core/tests/agent-runner.test.ts
+++ b/packages/core/tests/agent-runner.test.ts
@@ -132,9 +132,11 @@ describe("AgentRunner (read-only loop against this repo)", () => {
       task: "try to write",
     });
 
-    // Layer 1: create/edit/run never advertised.
+    // Layer 1: create/edit/run never advertised — nor spawn_agent, so a subagent
+    // structurally cannot delegate (recursion depth capped at 1).
     expect(seenTools()).not.toContain("create");
     expect(seenTools()).not.toContain("edit_lines");
+    expect(seenTools()).not.toContain("spawn_agent");
     expect(seenTools()).toContain("read");
     // Layer 2: the forced call was rejected at dispatch — nothing on disk.
     expect(existsSync(target)).toBe(false);

--- a/packages/core/tests/agent-structured-output.test.ts
+++ b/packages/core/tests/agent-structured-output.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from "bun:test";
 import { AgentRunner } from "../src/agent";
+import { resultPayload } from "../src/agent/agent-runner";
 import { BUILTIN_SPECS } from "../src/agent/builtin-specs";
 import type { IAgentSpec } from "../src/agent/agent-spec";
 import type { IProvider, IChatMessage, IModelResponse } from "../src/inference";
@@ -84,5 +85,22 @@ describe("structured agent_result output", () => {
     for (const s of BUILTIN_SPECS) {
       expect(s.outputMode).toBe("structured");
     }
+  });
+});
+
+describe("resultPayload robustness", () => {
+  test("does not throw on non-object args (malformed tool call)", () => {
+    expect(resultPayload(undefined)).toBe("{}");
+    expect(resultPayload(null)).toBe("{}");
+    expect(resultPayload("already a string")).toBe("already a string");
+    expect(() => resultPayload(42)).not.toThrow();
+  });
+
+  test("empty object → legacy JSON fallback, not a crash or garbage bullets", () => {
+    expect(resultPayload({})).toBe("{}");
+  });
+
+  test("legacy { result } string still works", () => {
+    expect(resultPayload({ result: "legacy answer" })).toBe("legacy answer");
   });
 });

--- a/packages/core/tests/agent-tree.test.ts
+++ b/packages/core/tests/agent-tree.test.ts
@@ -193,6 +193,36 @@ describe("renderAgentTree", () => {
     expect(lines[1]).not.toContain("1.2");
   });
 
+  test("every line stays ≤ columns-1 across ALL widths (no self-wrap, incl. very narrow)", () => {
+    const rows: IAgentRow[] = [
+      { id: "a", label: "explore loop subsystem", status: "running" },
+      { id: "b", label: "verify", status: "done", durationMs: 900, turns: 2 },
+    ];
+
+    for (let cols = 1; cols <= 40; cols += 1) {
+      const lines = renderAgentTree(rows, { columns: cols, color: false });
+
+      for (const line of lines) {
+        expect(displayWidth(line)).toBeLessThanOrEqual(cols - 1);
+      }
+    }
+  });
+
+  test("below the minimum usable width, renders nothing (rather than a wrapping line)", () => {
+    const rows: IAgentRow[] = [{ id: "a", label: "x", status: "running" }];
+
+    for (const cols of [1, 2, 3, 5, 7]) {
+      expect(renderAgentTree(rows, { columns: cols, color: false })).toEqual(
+        []
+      );
+    }
+
+    // At a usable width it renders again.
+    expect(
+      renderAgentTree(rows, { columns: 20, color: false }).length
+    ).toBeGreaterThan(0);
+  });
+
   test("honors the real width — no upward clamp that draws wider than the screen", () => {
     const rows: IAgentRow[] = [{ id: "explore", status: "pending" }];
 

--- a/packages/core/tests/agent-tree.test.ts
+++ b/packages/core/tests/agent-tree.test.ts
@@ -208,6 +208,27 @@ describe("renderAgentTree", () => {
     }
   });
 
+  test("the overflow tail (`… +N more`) also stays ≤ columns-1 at narrow widths", () => {
+    // Enough rows to overflow maxRows, at widths where the tree still renders —
+    // the tail line must be clipped too, not just the agent rows.
+    const rows: IAgentRow[] = Array.from({ length: 20 }, (_v, i) => ({
+      id: `agent-${String(i)}`,
+      status: "pending" as const,
+    }));
+
+    for (let cols = 8; cols <= 30; cols += 1) {
+      const lines = renderAgentTree(rows, {
+        columns: cols,
+        color: false,
+        maxRows: 4,
+      });
+
+      for (const line of lines) {
+        expect(displayWidth(line)).toBeLessThanOrEqual(cols - 1);
+      }
+    }
+  });
+
   test("below the minimum usable width, renders nothing (rather than a wrapping line)", () => {
     const rows: IAgentRow[] = [{ id: "a", label: "x", status: "running" }];
 

--- a/packages/core/tests/output-router.test.ts
+++ b/packages/core/tests/output-router.test.ts
@@ -76,6 +76,25 @@ describe("OutputRouter", () => {
     expect(parent).toEqual(["orphan-child"]);
   });
 
+  test("a sink is cleared even if the agent produced NO output (no leak)", () => {
+    // resetTree clears every installed sink via agentSinkIds — including an agent
+    // that streamed nothing (no agentOutput entry). Model that: install a sink,
+    // never write to it, clear it, then a later write for that id must fall back
+    // to the parent (else the stale sink would keep diverting future chunks).
+    const router = new OutputRouter();
+    const parent: string[] = [];
+    const agent: string[] = [];
+
+    router.setParentSink((text) => parent.push(text));
+    router.setAgentSink("run:silent", (text) => agent.push(text));
+    router.clearAgentSink("run:silent"); // agent produced nothing
+
+    router.route("post-turn chunk", "run:silent");
+
+    expect(agent).toEqual([]); // never leaked to the dead sink
+    expect(parent).toEqual(["post-turn chunk"]); // fell back to parent
+  });
+
   test("clearAgentSink removes the route; later writes fall back", () => {
     const router = new OutputRouter();
     const parent: string[] = [];

--- a/packages/core/tests/spawn-concurrency.test.ts
+++ b/packages/core/tests/spawn-concurrency.test.ts
@@ -1,5 +1,7 @@
 import { test, expect } from "bun:test";
-import { makeLimiter } from "../src/cli/spawn-runner";
+import { makeLimiter, makeSpawnAgentFn } from "../src/cli/spawn-runner";
+import { BUILTIN_SPECS } from "../src/agent/builtin-specs";
+import type { ILoopEvent } from "../src/loop";
 
 /** Resolve after a macrotask so overlapping tasks actually interleave. */
 function tick(ms = 5): Promise<void> {
@@ -66,4 +68,47 @@ test("makeLimiter clamps a bad cap to at least 1 (never deadlocks)", async () =>
 
     expect(out).toBe("ok");
   }
+});
+
+test("makeLimiter releases the slot even when a body throws (no deadlock)", async () => {
+  const limit = makeLimiter(1);
+
+  await expect(limit(() => Promise.reject(new Error("boom")))).rejects.toThrow(
+    "boom"
+  );
+
+  // If the throwing body leaked its slot, this second task would hang forever.
+  expect(await limit(() => Promise.resolve("ok"))).toBe("ok");
+});
+
+test("an aborted signal returns an aborted result WITHOUT running the agent", async () => {
+  const kinds: string[] = [];
+  const fn = makeSpawnAgentFn({
+    specs: BUILTIN_SPECS,
+    cwd: process.cwd(),
+    concurrency: 2,
+    policyMode: "bypassPermissions",
+  });
+  const ac = new AbortController();
+
+  ac.abort();
+
+  const out = await fn(
+    {
+      subagentType: "explore",
+      description: "d",
+      prompt: "p",
+      parentTaskId: "t",
+    },
+    {
+      signal: ac.signal,
+      report: (e: ILoopEvent) => {
+        kinds.push(e.kind);
+      },
+    }
+  );
+
+  expect(out).toContain("aborted");
+  // Only lifecycle events — the model was never resolved or called.
+  expect(kinds).toEqual(["agent_spawned", "agent_result"]);
 });


### PR DESCRIPTION
Full adversarial **harness-review** of the subagent system before considering it done — 5 slices, one focused review per slice, every non-clean finding reproduced to a `file:line`. **Zero reachable production bugs;** this closes the edge-case contract violations and the test gaps.

> Note: the misleadingly-narrow original commit message is an artifact of how this got committed — the actual changeset is everything below (verified: 9 files, +202/−4).

## Fixes
- **`buildBoundedTranscript`** now honors `≤ maxChars` for **all** inputs (drops the elision marker, then hard-caps, when `maxChars` is below the marker reserve). Was only violated for `maxChars < 64` — never reached in production (`maxChars` is always `window*2` or the 48k fallback), but a real contract break, and the "bound can be exceeded" class flagged twice in review of #79.
- **`renderAgentTree`** renders `[]` below `MIN_TREE_COLUMNS` (8) rather than emit a line wider than `columns-1` (the fixed row prefix can't shrink below ~5 cols) — honors the stated no-self-wrap invariant at any width.
- **`resultPayload`** accepts `unknown` + `isRecord`-guards, so a malformed tool call (`undefined`/non-object args) can't throw; legacy `{ result }` and empty still handled.

## Tests (lock the fixes + previously-untested verified invariants)
- `buildBoundedTranscript` bound holds for `maxChars` 1..400 (fuzz)
- `renderAgentTree` ≤ `columns-1` across widths 1..40, and `[]` below the minimum
- `resultPayload` robustness (undefined / null / string / empty / legacy)
- `spawn_agent` is **never** advertised to a subagent (recursion capped at 1 — was uncovered)
- `makeLimiter` releases the slot when a body throws (no deadlock)
- spawn-abort returns an aborted result without resolving/running the model
- `OutputRouter` sink cleared even for an agent that produced no output (no leak)

## Docs
- Add the missing **`agent / subagents`** entry to `docs/harness-subsystems.md` (the manifest is part of the review contract; it had no subagent subsystem).

## Verified clean (with `file:line`)
Read-only enforcement (3 structural layers), no-recursion, forced-investigation, structured-output shapes, termination/status codes, policy classification + full mode matrix, spec precedence, semaphore correctness, sibling isolation, fresh-provider-per-child, lazy TsService, contextWindow threading, lifecycle ordering + not-echoed, no sink leak, kill-switch, stream reassembly.

Full `bun run validate`: **2049 pass / 0 fail**, all PTY suites green.