### PR TITLE
feat(image): vision + image generation via generic capability routing

### DIFF
--- a/apps/docs/src/content/docs/inference/models-json.mdx
+++ b/apps/docs/src/content/docs/inference/models-json.mdx
@@ -37,6 +37,7 @@ The entry **key** (`"deepseek"`) is just a local label. The field that's sent to
 | `maxTokens` | no | Output-token cap (default 16384). |
 | `extraBody` | no | Arbitrary JSON merged into the request body (overrides built-ins) — the escape hatch for any provider param. |
 | `extraHeaders` | no | Arbitrary request headers; `${VAR}` values are interpolated from the environment. |
+| `imageApi` | no | For an `imageGen` capability entry only: wire shape — `chat-modalities` (default; `/chat/completions` with `modalities:["image","text"]`, e.g. OpenRouter/Gemini) or `images-generations` (OpenAI `/images/generations`). |
 
 ## Reasoning dialects
 
@@ -82,6 +83,33 @@ tsforge **auto-detects** the `deepseek` dialect when `baseUrl`/`model` contains 
   "reasoningEffort": "medium"
 }
 ```
+
+## Extra capabilities (vision, image generation)
+
+The primary chat model is often text-only (e.g. a local DeepSeek). When it can't read or generate images, route **just those capabilities** to a separate backend with a top-level `capabilities` block — a sibling of `active`/`models`, **not** inside `models`. Each value names a `models` entry, so the vision/image backend reuses the same endpoint config (key resolution, headers) as any chat model. Absent → the capability (and its `read_image` / `generate_image` tool + the drag/paste/`@` attachment UX) stays off.
+
+```jsonc
+{
+  "active": "deepseek-v4-flash",          // local chat, unchanged
+  "capabilities": {
+    "vision": "openrouter-vision",        // reads images (drag / paste / @ / read_image)
+    "imageGen": "openrouter-image"        // generate_image → .tsforge/images/
+  },
+  "models": {
+    "deepseek-v4-flash": { "baseUrl": "http://localhost:8000/v1", "model": "deepseek-ai/DeepSeek-V4-Flash", "thinking": false },
+    "openrouter-vision":  { "baseUrl": "https://openrouter.ai/api/v1", "model": "google/gemini-2.5-flash-lite", "apiKey": "sk-or-..." },
+    "openrouter-image":   { "baseUrl": "https://openrouter.ai/api/v1", "model": "google/gemini-3.1-flash-lite-image", "apiKey": "sk-or-...", "imageApi": "chat-modalities" }
+  }
+}
+```
+
+How it works: an attached image is sent to the `vision` backend and only its **text** description enters the conversation (the chat model stays text-only). `generate_image` calls the `imageGen` backend, saves the result under `.tsforge/images/`, and previews it inline in iTerm2. When local hardware arrives, point `capabilities.vision`/`imageGen` at a local entry — no code change.
+
+Env overrides (an ad-hoc backend without editing the file): `TSFORGE_VISION_BASE_URL` / `TSFORGE_VISION_MODEL` / `TSFORGE_VISION_API_KEY` and the `TSFORGE_IMAGE_*` equivalents (+ `TSFORGE_IMAGE_API`). See the [attachment UX](/cli/interactive/) and the [flags reference](/reference/flags/).
+
+:::caution
+`apiKeyEnv` is the **name of an environment variable**, not the key. Putting a literal `sk-...` as its value makes tsforge look up an env var named `sk-...` → no auth. Use `apiKey` for an inline key.
+:::
 
 ### Any other provider — `extraBody` / `extraHeaders`
 

--- a/apps/docs/src/content/docs/reference/flags.mdx
+++ b/apps/docs/src/content/docs/reference/flags.mdx
@@ -58,6 +58,19 @@ Opt-in, free, and no required service keys. Turn on **Web tools** in [`/config`]
 | `TSFORGE_SEARXNG_URL` | unset | route `web_search` to a SearXNG instance you already run (e.g. `http://localhost:8888`) |
 | `TSFORGE_WEB_SEARCH_BACKEND` | auto | `duckduckgo` or `searxng`; `searxng` fails closed if no SearXNG URL is set |
 
+## Image capabilities (vision, generation)
+
+When the chat model is text-only, route **reading** and **generating** images to a separate backend — configured in [`models.json` `capabilities`](/inference/models-json/#extra-capabilities-vision-image-generation) or the env vars below. Each capability is off unless configured; when on, it enables the `read_image` / `generate_image` tools and the drag / paste / `@` attachment UX ([interactive](/cli/interactive/)). The env trio is an ad-hoc backend without editing the file; a `_MODEL` alone (no `_BASE_URL`) names an existing registry entry.
+
+| Variable | Default | Effect |
+| --- | --- | --- |
+| `TSFORGE_VISION_BASE_URL` / `TSFORGE_VISION_MODEL` / `TSFORGE_VISION_API_KEY` | unset | ad-hoc vision (image-reading) backend |
+| `TSFORGE_IMAGE_BASE_URL` / `TSFORGE_IMAGE_MODEL` / `TSFORGE_IMAGE_API_KEY` | unset | ad-hoc image-generation backend |
+| `TSFORGE_IMAGE_API` | `chat-modalities` | image-gen wire shape: `chat-modalities` or `images-generations` |
+| `TSFORGE_IMAGE_PROTOCOL` | auto | inline preview of generated images: `iterm2` to force, `off`/`none` to disable (auto-detects iTerm2, disabled under tmux) |
+
+Generated images are saved under `.tsforge/images/`. Pasting an image is **Ctrl+V** (a terminal app can't receive Cmd+V); identical images are described once (no duplicate cost). Model IDs + costs: OpenRouter runs everything through `/chat/completions` (no `/images` endpoint) — e.g. `google/gemini-2.5-flash-lite` (read) and `google/gemini-3.1-flash-lite-image` (generate).
+
 ## Opt-in gate oracles
 
 Extra gate steps (default off; each skips cleanly when nothing applies). See [How tsforge builds the gate](/loop/gate-floor/).

--- a/apps/docs/src/content/docs/reference/input-editor.mdx
+++ b/apps/docs/src/content/docs/reference/input-editor.mdx
@@ -54,9 +54,21 @@ When your cursor is at the **top** of the buffer (line 0, any column), press **�
 
 ## Multi-line paste
 
-Paste a block of text with Ctrl+V (or ⌘V on macOS). The pasted content lands in the buffer as-is and may span multiple lines. You can edit it like any buffer text. When you press Enter, the entire buffer (including pasted lines) is submitted as a single message.
+Paste a block of text with your terminal's paste (⌘V on macOS / Ctrl+Shift+V on Linux) — the terminal delivers it as a bracketed paste. The pasted content lands in the buffer as-is and may span multiple lines; edit it like any buffer text. When you press Enter, the entire buffer (including pasted lines) is submitted as a single message.
 
 Very large pastes are displayed as `[paste #N +M lines]` in the UI and expand to their full content when sent.
+
+## Attaching images
+
+Requires a [`vision` capability](/inference/models-json/#extra-capabilities-vision-image-generation) configured. Three ways to attach an image; each is sent to the vision backend and its text description is folded into your message (the chat model stays text-only):
+
+| Method | Action |
+| --- | --- |
+| **Ctrl+V** | Paste an image from the clipboard. A `📋 reading clipboard…` hint shows during the read, then an `[image #N]` chip lands in the buffer. (Falls back to pasting clipboard text if there's no image.) |
+| **Drag & drop** | Drag an image file onto the terminal — it drops the path, which is attached on send. |
+| **`@` mention** | `@path/to/image.png` — the picker lists image files too. |
+
+**Why Ctrl+V, not ⌘V:** the terminal emulator intercepts ⌘V and, for an image, hands the app nothing — a terminal program can only receive Ctrl+V (a real control byte). Identical images attached more than once are described **once** (no duplicate cost). See also [generating images](/reference/flags/#image-capabilities-vision-generation).
 
 ## Command palette and file picker
 

--- a/packages/core/src/agent/agent.constants.ts
+++ b/packages/core/src/agent/agent.constants.ts
@@ -33,6 +33,8 @@ export const TOOL_NAME = {
   webBrowse: "web_browse",
   script: "script",
   spawnAgent: "spawn_agent",
+  readImage: "read_image",
+  generateImage: "generate_image",
 } as const;
 
 /** Per-tool capability flags — the single source of truth the plan-mode set and
@@ -87,6 +89,12 @@ export const TOOL_SPECS: Readonly<Record<ToolName, IToolSpec>> = {
   // (no spawning from a program) and — by construction — never offered to a
   // spawned agent, which caps recursion depth at 1 (see agent-runner agentTools).
   [TOOL_NAME.spawnAgent]: { readOnly: true, scriptExposable: false },
+  // Vision reading is a read-only network call (no workspace mutation) → usable
+  // while planning. Image GENERATION writes a file to disk, so it is not read-only
+  // and is withheld in plan mode. Both are gated on a configured capability
+  // backend (see toolsFor). Not script-exposable initially (network + I/O heavy).
+  [TOOL_NAME.readImage]: { readOnly: true, scriptExposable: false },
+  [TOOL_NAME.generateImage]: { readOnly: false, scriptExposable: false },
 };
 
 function toolNamesWhere(
@@ -653,6 +661,62 @@ export const GIT_CONTEXT_TOOL = {
         },
       },
       required: ["op"],
+    },
+  },
+};
+
+/** Vision (image reading) — offered only when a `vision` capability backend is
+ *  configured (`~/.tsforge/models.json` `capabilities.vision` or a
+ *  `TSFORGE_VISION_*` env). The primary chat model is text-only, so this delegates
+ *  to that backend and returns a text description the model can act on. */
+export const READ_IMAGE_TOOL = {
+  type: "function",
+  function: {
+    name: TOOL_NAME.readImage,
+    description:
+      "Look at an image file in the workspace and get back a text description/answer. Use it to understand a screenshot, mockup, diagram, or photo — pass the path and, optionally, a specific question (e.g. 'what error does this show?'). Routes to the configured vision model; returns text only.",
+    parameters: {
+      type: "object",
+      properties: {
+        file: {
+          type: "string",
+          description:
+            "path to the image file (png/jpeg/webp/gif), relative to the working directory",
+        },
+        question: {
+          type: "string",
+          description:
+            "optional specific question about the image; omit for a general description",
+        },
+      },
+      required: ["file"],
+    },
+  },
+};
+
+/** Image generation — offered only when an `imageGen` capability backend is
+ *  configured. Saves the result under `.tsforge/images/` and returns the path (and
+ *  previews it inline in a supporting terminal). */
+export const GENERATE_IMAGE_TOOL = {
+  type: "function",
+  function: {
+    name: TOOL_NAME.generateImage,
+    description:
+      "Generate an image from a text prompt and save it to .tsforge/images/. Use it when the user asks for an image/asset/illustration. Returns the saved file path; the image is previewed inline in terminals that support it. Routes to the configured image model.",
+    parameters: {
+      type: "object",
+      properties: {
+        prompt: {
+          type: "string",
+          description: "a detailed description of the image to generate",
+        },
+        size: {
+          type: "string",
+          description:
+            "optional WxH hint, e.g. '1024x1024' (honored by some backends)",
+        },
+      },
+      required: ["prompt"],
     },
   },
 };

--- a/packages/core/src/cli/image-input.ts
+++ b/packages/core/src/cli/image-input.ts
@@ -137,6 +137,11 @@ export async function resolveImageInput(
   const prompt =
     cleanedLine.trim().length > 0 ? cleanedLine.trim() : DEFAULT_VISION_PROMPT;
   const blocks: string[] = [];
+  // Describe each DISTINCT image once. Pasting the same screenshot three times (or
+  // @-mentioning the same file twice) would otherwise fire that many identical —
+  // and identically-billed — vision calls. Dedupe by content (base64 of the bytes).
+  const describedByContent = new Map<string, string>();
+  let described = 0;
 
   for (const abs of all) {
     const image = await deps.load(abs);
@@ -146,9 +151,18 @@ export async function resolveImageInput(
       continue;
     }
 
+    const cached = describedByContent.get(image.base64);
+
+    if (cached !== undefined) {
+      blocks.push(`[Attached image "${basename(abs)}": ${cached}]`);
+      continue;
+    }
+
     try {
       const text = await deps.describe(vision, { prompt, images: [image] });
 
+      described += 1;
+      describedByContent.set(image.base64, "same as above");
       blocks.push(`[Attached image "${basename(abs)}":\n${text}\n]`);
     } catch (err) {
       const message = err instanceof Error ? err.message : String(err);
@@ -162,7 +176,8 @@ export async function resolveImageInput(
   return {
     cleanedLine,
     contextBlock: `${blocks.join("\n\n")}\n\n`,
-    imageCount: all.length,
+    // Unique images actually described (= billed vision calls), not raw attach count.
+    imageCount: described,
   };
 }
 

--- a/packages/core/src/cli/image-input.ts
+++ b/packages/core/src/cli/image-input.ts
@@ -1,0 +1,171 @@
+import { isAbsolute, resolve, basename } from "node:path";
+import {
+  resolveVisionConfig,
+  loadImageFile,
+  isSupportedImagePath,
+} from "../loop/tools/image-tools";
+import { describeImage, DEFAULT_VISION_PROMPT } from "../inference/vision";
+import type { IOpenAICompatibleConfig } from "../inference";
+import type { IImageInput } from "../inference/vision";
+
+/**
+ * The interactive image-attachment flow: turn images a user drops onto the
+ * session (a dragged path, an `@`-mentioned image, or a clipboard temp file) into
+ * TEXT the primary model can use. The image is sent to the configured vision
+ * backend and its description is injected into the outgoing message — the core
+ * message stays plain text (see the delegation rationale in inference/vision.ts).
+ */
+const IMAGE_EXT = "(?:png|jpe?g|gif|webp)";
+
+// A quoted image path (single or double quotes; may contain spaces).
+const QUOTED = new RegExp(
+  `(['"])((?:\\\\.|(?!\\1).)*\\.${IMAGE_EXT})\\1`,
+  "giu"
+);
+
+// An unquoted, optionally `@`-prefixed image path token; backslash-escaped spaces
+// (how a terminal drag-drop escapes them) are part of the token.
+const BARE = new RegExp(
+  `(^|\\s)@?((?:\\\\ |[^\\s'"])*\\.${IMAGE_EXT})(?=\\s|$)`,
+  "giu"
+);
+
+export interface IExtractedImages {
+  /** The line with image tokens replaced by an inline `[image: name]` marker. */
+  cleanedLine: string;
+  /** Absolute paths of the referenced images, in first-seen order. */
+  paths: string[];
+}
+
+/** Pull image references out of a submitted line (quoted, `@`-mentioned, dragged)
+ *  and resolve them to absolute paths against `cwd`. Non-image tokens are left
+ *  untouched so ordinary `@file` mentions still flow to composeMessage. */
+export function extractImagePaths(line: string, cwd: string): IExtractedImages {
+  const toAbs = (raw: string): string => {
+    const unescaped = raw.replace(/\\ /g, " ");
+
+    return isAbsolute(unescaped) ? unescaped : resolve(cwd, unescaped);
+  };
+
+  // Collect matches from the ORIGINAL line WITH their positions, so paths come out
+  // in reading order (their descriptions then line up with the inline markers),
+  // regardless of which pattern matched.
+  const hits: { abs: string; index: number }[] = [];
+
+  for (const m of line.matchAll(QUOTED)) {
+    if (m[2] !== undefined) {
+      hits.push({ abs: toAbs(m[2]), index: m.index });
+    }
+  }
+
+  for (const m of line.matchAll(BARE)) {
+    if (m[2] !== undefined) {
+      hits.push({ abs: toAbs(m[2]), index: m.index + (m[1]?.length ?? 0) });
+    }
+  }
+
+  const paths: string[] = [];
+
+  for (const { abs } of hits.sort((a, b) => a.index - b.index)) {
+    if (!paths.includes(abs)) {
+      paths.push(abs);
+    }
+  }
+
+  const marker = (raw: string): string =>
+    `[image: ${basename(raw.replace(/\\ /g, " "))}]`;
+  const cleaned = line
+    .replace(QUOTED, (_whole, _q: string, path: string) => marker(path))
+    .replace(
+      BARE,
+      (_whole, pre: string, path: string) => `${pre}${marker(path)}`
+    );
+
+  return { cleanedLine: cleaned, paths };
+}
+
+export interface IResolveImageInputDeps {
+  resolveVision: () => Promise<IOpenAICompatibleConfig | null>;
+  load: (absPath: string) => Promise<IImageInput | null>;
+  describe: typeof describeImage;
+}
+
+const DEFAULT_DEPS: IResolveImageInputDeps = {
+  resolveVision: resolveVisionConfig,
+  load: loadImageFile,
+  describe: describeImage,
+};
+
+export interface IResolvedImageInput {
+  /** The user's line with image tokens replaced by `[image: name]` markers. */
+  cleanedLine: string;
+  /** Text describing each attached image, to prepend to the outgoing message
+   *  (empty when there are no images). */
+  contextBlock: string;
+  imageCount: number;
+}
+
+/**
+ * Resolve every image referenced in `rawLine` (plus any `extraPaths`, e.g.
+ * clipboard temp files) into a description block via the vision backend. When no
+ * vision backend is configured, a short note is injected instead of a description
+ * so the model (and user) knows why the image wasn't read.
+ */
+export async function resolveImageInput(
+  rawLine: string,
+  cwd: string,
+  opts: { extraPaths?: string[]; deps?: IResolveImageInputDeps } = {}
+): Promise<IResolvedImageInput> {
+  const deps = opts.deps ?? DEFAULT_DEPS;
+  const { cleanedLine, paths } = extractImagePaths(rawLine, cwd);
+  const all = [...paths, ...(opts.extraPaths ?? [])];
+
+  if (all.length === 0) {
+    return { cleanedLine, contextBlock: "", imageCount: 0 };
+  }
+
+  const vision = await deps.resolveVision();
+
+  if (vision === null) {
+    return {
+      cleanedLine,
+      contextBlock: `[${String(all.length)} image(s) attached, but no vision backend is configured — set capabilities.vision in ~/.tsforge/models.json to read them.]\n\n`,
+      imageCount: all.length,
+    };
+  }
+
+  const prompt =
+    cleanedLine.trim().length > 0 ? cleanedLine.trim() : DEFAULT_VISION_PROMPT;
+  const blocks: string[] = [];
+
+  for (const abs of all) {
+    const image = await deps.load(abs);
+
+    if (image === null) {
+      blocks.push(`[Attached image "${basename(abs)}": could not read file]`);
+      continue;
+    }
+
+    try {
+      const text = await deps.describe(vision, { prompt, images: [image] });
+
+      blocks.push(`[Attached image "${basename(abs)}":\n${text}\n]`);
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+
+      blocks.push(
+        `[Attached image "${basename(abs)}": vision failed — ${message}]`
+      );
+    }
+  }
+
+  return {
+    cleanedLine,
+    contextBlock: `${blocks.join("\n\n")}\n\n`,
+    imageCount: all.length,
+  };
+}
+
+/** True when a bare path (e.g. a drag-dropped token) points at a supported image
+ *  — used to decide whether a dropped path should be treated as an attachment. */
+export { isSupportedImagePath };

--- a/packages/core/src/cli/image-input.ts
+++ b/packages/core/src/cli/image-input.ts
@@ -30,6 +30,11 @@ const BARE = new RegExp(
   "giu"
 );
 
+// The inline markers this module substitutes for attachments: `[image: name]`
+// (extracted path) and `[image #N]` (clipboard chip). Stripped when deriving the
+// vision prompt so an image-only send isn't "described" against marker text.
+const ATTACHMENT_MARKER = /\[image(?::[^\]]*|\s*#\d+)\]/gu;
+
 export interface IExtractedImages {
   /** The line with image tokens replaced by an inline `[image: name]` marker. */
   cleanedLine: string;
@@ -134,8 +139,13 @@ export async function resolveImageInput(
     };
   }
 
-  const prompt =
-    cleanedLine.trim().length > 0 ? cleanedLine.trim() : DEFAULT_VISION_PROMPT;
+  // The vision prompt is the user's REAL text. cleanedLine still contains the
+  // attachment markers (`[image: a.png]`, `[image #1]`) we substituted for the
+  // paths/chips — an image-only send is nothing BUT markers, so strip them before
+  // deciding: markers-only → fall back to the default describe/transcribe prompt
+  // (otherwise the model was asked to answer about the literal marker text).
+  const userText = cleanedLine.replace(ATTACHMENT_MARKER, "").trim();
+  const prompt = userText.length > 0 ? userText : DEFAULT_VISION_PROMPT;
   const blocks: string[] = [];
   // Describe each DISTINCT image once. Pasting the same screenshot three times (or
   // @-mentioning the same file twice) would otherwise fire that many identical —

--- a/packages/core/src/cli/image-input.ts
+++ b/packages/core/src/cli/image-input.ts
@@ -30,14 +30,13 @@ const BARE = new RegExp(
   "giu"
 );
 
-// The inline markers this module substitutes for attachments: `[image: name]`
-// (extracted path) and `[image #N]` (clipboard chip). Stripped when deriving the
-// vision prompt so an image-only send isn't "described" against marker text.
-const ATTACHMENT_MARKER = /\[image(?::[^\]]*|\s*#\d+)\]/gu;
-
 export interface IExtractedImages {
   /** The line with image tokens replaced by an inline `[image: name]` marker. */
   cleanedLine: string;
+  /** The user's own text with image tokens REMOVED entirely (not markered) — the
+   *  basis for the vision prompt, so a filename containing `]` can't leak into it
+   *  (which stripping the bracketed markers back out would). */
+  residualText: string;
   /** Absolute paths of the referenced images, in first-seen order. */
   paths: string[];
 }
@@ -86,7 +85,19 @@ export function extractImagePaths(line: string, cwd: string): IExtractedImages {
       (_whole, pre: string, path: string) => `${pre}${marker(path)}`
     );
 
-  return { cleanedLine: cleaned, paths };
+  // Residual = the line with image tokens REMOVED (not markered). Derived by the
+  // same two passes, so a filename with special chars (incl. `]`) never lands in
+  // the prompt — unlike regex-stripping the `[image: …]` markers back out. Also
+  // drop clipboard chips `[image #N]` (digits only — filename-independent, so no
+  // `]` hazard) that the editor inserts literally on Ctrl+V.
+  const residualText = line
+    .replace(QUOTED, "")
+    .replace(BARE, (_whole, pre: string) => pre)
+    .replace(/\[image #\d+\]/gu, "")
+    .replace(/\s+/gu, " ")
+    .trim();
+
+  return { cleanedLine: cleaned, residualText, paths };
 }
 
 export interface IResolveImageInputDeps {
@@ -119,10 +130,14 @@ export interface IResolvedImageInput {
 export async function resolveImageInput(
   rawLine: string,
   cwd: string,
-  opts: { extraPaths?: string[]; deps?: IResolveImageInputDeps } = {}
+  opts: {
+    extraPaths?: string[];
+    deps?: IResolveImageInputDeps;
+    signal?: AbortSignal;
+  } = {}
 ): Promise<IResolvedImageInput> {
   const deps = opts.deps ?? DEFAULT_DEPS;
-  const { cleanedLine, paths } = extractImagePaths(rawLine, cwd);
+  const { cleanedLine, residualText, paths } = extractImagePaths(rawLine, cwd);
   const all = [...paths, ...(opts.extraPaths ?? [])];
 
   if (all.length === 0) {
@@ -139,13 +154,10 @@ export async function resolveImageInput(
     };
   }
 
-  // The vision prompt is the user's REAL text. cleanedLine still contains the
-  // attachment markers (`[image: a.png]`, `[image #1]`) we substituted for the
-  // paths/chips — an image-only send is nothing BUT markers, so strip them before
-  // deciding: markers-only → fall back to the default describe/transcribe prompt
-  // (otherwise the model was asked to answer about the literal marker text).
-  const userText = cleanedLine.replace(ATTACHMENT_MARKER, "").trim();
-  const prompt = userText.length > 0 ? userText : DEFAULT_VISION_PROMPT;
+  // The vision prompt is the user's REAL text (image tokens already removed in
+  // extraction → residualText). Image-only send → no residual → the default
+  // describe/transcribe prompt, never the literal marker/filename text.
+  const prompt = residualText.length > 0 ? residualText : DEFAULT_VISION_PROMPT;
   const blocks: string[] = [];
   // Describe each DISTINCT image once. Pasting the same screenshot three times (or
   // @-mentioning the same file twice) would otherwise fire that many identical —
@@ -169,7 +181,11 @@ export async function resolveImageInput(
     }
 
     try {
-      const text = await deps.describe(vision, { prompt, images: [image] });
+      const text = await deps.describe(
+        vision,
+        { prompt, images: [image] },
+        { signal: opts.signal }
+      );
 
       described += 1;
       describedByContent.set(image.base64, "same as above");

--- a/packages/core/src/cli/repl.ts
+++ b/packages/core/src/cli/repl.ts
@@ -549,8 +549,9 @@ export async function repl(args: ICliArgs): Promise<number> {
 
   // Image capabilities: offer read_image/generate_image when their backends are
   // configured, and wire the inline preview for generated images. The preview
-  // emits the terminal's inline-image escape (iTerm2 today) directly to stdout;
-  // on an unsupported terminal it's a no-op and the tool just reports the path.
+  // emits the terminal's inline-image escape (iTerm2 today) via the StatusBar
+  // stream so the pinned bar re-anchors below it; unsupported terminal → no-op
+  // (the tool still reports the saved path).
   // A small budget stops a runaway loop from flooding the scrollback. Re-applied
   // after /clear (like setSetupWeb/wireDelegation) since /clear rebuilds session.
   const imageProtocol = detectImageProtocol();
@@ -596,15 +597,23 @@ export async function repl(args: ICliArgs): Promise<number> {
 
   const previewGeneratedImage: NonNullable<
     Parameters<typeof session.setPreviewImage>[0]
-  > = ({ base64, mimeType }) => {
+  > = ({ path, base64 }) => {
     if (imageProtocol === "none" || !imageBudget.take()) {
       return;
     }
 
-    const escape = renderInlineImage(base64, imageProtocol, { name: mimeType });
+    // `name` is a human-readable filename (base64-encoded into the OSC-1337
+    // params), so use the saved file's basename — not the mime type.
+    const name = path.split("/").pop() ?? "image";
+    const escape = renderInlineImage(base64, imageProtocol, { name });
 
     if (escape !== null) {
-      process.stdout.write(`${escape}\n`);
+      // Route through the StatusBar stream channel (NOT raw stdout): it commits the
+      // content to scrollback and re-anchors the pinned bar/input row at the cursor
+      // the terminal left below the image. A raw write left the bar's cursor
+      // tracking stale, so it painted over the image (overlapping text). Bracket
+      // with newlines so the image sits on its own committed lines.
+      statusBar.writeStream(`\n${escape}\n`);
     }
   };
 

--- a/packages/core/src/cli/repl.ts
+++ b/packages/core/src/cli/repl.ts
@@ -24,6 +24,17 @@ import {
 } from "../render/file-menu";
 import { listWorkspaceFiles } from "../lib/fs";
 import { composeMessage } from "../loop/prompt";
+import { resolveImageInput } from "./image-input";
+import { resolveImageCapabilityFlags } from "../loop/tools/image-tools";
+import {
+  captureClipboardImageToFile,
+  readClipboardText,
+} from "../lib/clipboard/clipboard-image";
+import {
+  detectImageProtocol,
+  renderInlineImage,
+  makeImageBudget,
+} from "../render/terminal-image";
 import {
   Session,
   PLAN_APPROVED_NOTE,
@@ -326,6 +337,10 @@ export async function repl(args: ICliArgs): Promise<number> {
     process.stdout.write(`  ↳ ${m}\n`)
   );
   const delegationConfig = await loadTsforgeConfig(args.dir);
+  // Which image capabilities are configured — decides whether read_image /
+  // generate_image are offered and whether attached images get described.
+  // Resolved up front (a boot IO), so the wiring below stays synchronous.
+  const imageCaps = await resolveImageCapabilityFlags();
 
   let session = initialSession;
   let activeName = initialActiveName;
@@ -532,6 +547,66 @@ export async function repl(args: ICliArgs): Promise<number> {
 
   wireDelegation();
 
+  // Image capabilities: offer read_image/generate_image when their backends are
+  // configured, and wire the inline preview for generated images. The preview
+  // emits the terminal's inline-image escape (iTerm2 today) directly to stdout;
+  // on an unsupported terminal it's a no-op and the tool just reports the path.
+  // A small budget stops a runaway loop from flooding the scrollback. Re-applied
+  // after /clear (like setSetupWeb/wireDelegation) since /clear rebuilds session.
+  const imageProtocol = detectImageProtocol();
+  const imageBudget = makeImageBudget();
+  // Absolute temp-file paths captured from the clipboard (Ctrl+V of image bytes),
+  // consumed (described + cleared) on the next send by resolveImageInput.
+  const pendingImages: string[] = [];
+
+  // Ctrl+V in the editor: a clipboard IMAGE becomes a `[image #N]` chip + a pending
+  // attachment (described on send); otherwise fall back to pasting clipboard text.
+  // (Cmd+V is swallowed by the terminal — for text it arrives as a bracketed paste;
+  // an image on the clipboard never reaches an in-terminal app, hence Ctrl+V.)
+  const pasteFromClipboard = async (): Promise<string | null> => {
+    const captured = await captureClipboardImageToFile();
+
+    if (captured !== null) {
+      pendingImages.push(captured);
+
+      return `[image #${String(pendingImages.length)}]`;
+    }
+
+    const text = await readClipboardText();
+
+    return text.length > 0 ? text : null;
+  };
+
+  const previewGeneratedImage: NonNullable<
+    Parameters<typeof session.setPreviewImage>[0]
+  > = ({ base64, mimeType }) => {
+    if (imageProtocol === "none" || !imageBudget.take()) {
+      return;
+    }
+
+    const escape = renderInlineImage(base64, imageProtocol, { name: mimeType });
+
+    if (escape !== null) {
+      process.stdout.write(`${escape}\n`);
+    }
+  };
+
+  const wireImages = (): void => {
+    session.setImageCapabilities(imageCaps);
+    session.setPreviewImage(previewGeneratedImage);
+  };
+
+  wireImages();
+
+  if (imageCaps.vision || imageCaps.imageGen) {
+    const on = [
+      ...(imageCaps.vision ? ["read"] : []),
+      ...(imageCaps.imageGen ? ["generate"] : []),
+    ].join(" + ");
+
+    process.stdout.write(`  ↳ image: ${on} (drag/@ to attach)\n`);
+  }
+
   // Make the delegation setup visible so the concurrency cap is never a mystery
   // (cap 1 ⇒ subagents run serially; raise agents.concurrency to overlap them).
   if (delegationOff) {
@@ -598,9 +673,22 @@ export async function repl(args: ICliArgs): Promise<number> {
   // plan-approval / staged-build sends call session.send directly and are not
   // touched, so only ordinary messages get mention expansion.
   const runSend = (line: string): Promise<void> =>
-    drive(async (opts) =>
-      session.send(await composeMessage(args.dir, line), opts)
-    );
+    drive(async (opts) => {
+      // Images the user attached (dragged/quoted paths or @-mentioned image files
+      // in the line, plus any clipboard captures) are sent to the vision backend
+      // and their descriptions prepended as text — the primary model is text-only.
+      // The image tokens are stripped from the line before @-file expansion.
+      const { cleanedLine, contextBlock } = await resolveImageInput(
+        line,
+        args.dir,
+        { extraPaths: pendingImages }
+      );
+
+      pendingImages.length = 0;
+      const composed = await composeMessage(args.dir, cleanedLine);
+
+      return session.send(`${contextBlock}${composed}`, opts);
+    });
 
   // A from-scratch web build: stage it (plan + types, then implement) so the
   // model designs the type contract before writing UI — far less API invention.
@@ -756,6 +844,7 @@ export async function repl(args: ICliArgs): Promise<number> {
         });
         session.setSetupWeb(setupWeb);
         wireDelegation(); // re-offer spawn_agent on the rebuilt session
+        wireImages(); // re-offer read_image/generate_image + preview on the rebuild
         session.setPlanMode(planMode); // a /clear must not silently drop the mode
         planDiscussed = false;
         await persist();
@@ -1907,6 +1996,7 @@ export async function repl(args: ICliArgs): Promise<number> {
         openPalette,
         openFilePicker,
         completion: editorCompletion,
+        pasteFromClipboard,
       });
 
       resizeEditor = (columns, rows): void => {

--- a/packages/core/src/cli/repl.ts
+++ b/packages/core/src/cli/repl.ts
@@ -582,9 +582,11 @@ export async function repl(args: ICliArgs): Promise<number> {
         return `[image #${String(pendingImages.length)}]`;
       }
 
+      // Nothing to paste (empty clipboard, or only whitespace/newline — which
+      // otherwise injected a blank line). Insert only when there's real content.
       const text = await readClipboardText();
 
-      return text.length > 0 ? text : null;
+      return text.trim().length > 0 ? text : null;
     } finally {
       if (hinting) {
         statusBar.clearEditorOverlay();

--- a/packages/core/src/cli/repl.ts
+++ b/packages/core/src/cli/repl.ts
@@ -564,17 +564,32 @@ export async function repl(args: ICliArgs): Promise<number> {
   // (Cmd+V is swallowed by the terminal — for text it arrives as a bracketed paste;
   // an image on the clipboard never reaches an in-terminal app, hence Ctrl+V.)
   const pasteFromClipboard = async (): Promise<string | null> => {
-    const captured = await captureClipboardImageToFile();
+    // Reading the clipboard shells out (osascript can take ~1s), so show a
+    // transient hint above the input so the pause reads as "working", not hung.
+    // (Install `pngpaste` to make it instant — the reader prefers it.)
+    const hinting = statusBar.active;
 
-    if (captured !== null) {
-      pendingImages.push(captured);
-
-      return `[image #${String(pendingImages.length)}]`;
+    if (hinting) {
+      statusBar.setEditorOverlay(["📋 reading clipboard…"]);
     }
 
-    const text = await readClipboardText();
+    try {
+      const captured = await captureClipboardImageToFile();
 
-    return text.length > 0 ? text : null;
+      if (captured !== null) {
+        pendingImages.push(captured);
+
+        return `[image #${String(pendingImages.length)}]`;
+      }
+
+      const text = await readClipboardText();
+
+      return text.length > 0 ? text : null;
+    } finally {
+      if (hinting) {
+        statusBar.clearEditorOverlay();
+      }
+    }
   };
 
   const previewGeneratedImage: NonNullable<

--- a/packages/core/src/cli/repl.ts
+++ b/packages/core/src/cli/repl.ts
@@ -29,6 +29,7 @@ import { resolveImageCapabilityFlags } from "../loop/tools/image-tools";
 import {
   captureClipboardImageToFile,
   readClipboardText,
+  discardClipboardImages,
 } from "../lib/clipboard/clipboard-image";
 import {
   detectImageProtocol,
@@ -603,8 +604,9 @@ export async function repl(args: ICliArgs): Promise<number> {
     }
 
     // `name` is a human-readable filename (base64-encoded into the OSC-1337
-    // params), so use the saved file's basename — not the mime type.
-    const name = path.split("/").pop() ?? "image";
+    // params), so use the saved file's basename — not the mime type. Split on
+    // both separators so a Windows path resolves too.
+    const name = path.split(/[\\/]/u).pop() ?? "image";
     const escape = renderInlineImage(base64, imageProtocol, { name });
 
     if (escape !== null) {
@@ -704,13 +706,33 @@ export async function repl(args: ICliArgs): Promise<number> {
       // in the line, plus any clipboard captures) are sent to the vision backend
       // and their descriptions prepended as text — the primary model is text-only.
       // The image tokens are stripped from the line before @-file expansion.
+      //
+      // Only keep clipboard captures whose `[image #N]` chip SURVIVES in the line
+      // (paste is `pendingImages[i]` ↔ chip `#${i+1}`) — a deleted chip / cleared
+      // buffer must not smuggle a hidden image into a later send. Consumed and
+      // dropped temp files are unlinked so tmpdir doesn't accumulate.
+      const captures = pendingImages.map((path, i) => ({
+        path,
+        chip: `[image #${String(i + 1)}]`,
+      }));
+
+      pendingImages.length = 0;
+      const kept = captures
+        .filter((c) => line.includes(c.chip))
+        .map((c) => c.path);
+      const dropped = captures
+        .filter((c) => !line.includes(c.chip))
+        .map((c) => c.path);
+
+      await discardClipboardImages(dropped);
+
       const { cleanedLine, contextBlock } = await resolveImageInput(
         line,
         args.dir,
-        { extraPaths: pendingImages }
+        { extraPaths: kept, signal: opts.signal }
       );
 
-      pendingImages.length = 0;
+      await discardClipboardImages(kept);
       const composed = await composeMessage(args.dir, cleanedLine);
 
       return session.send(`${contextBlock}${composed}`, opts);
@@ -871,6 +893,9 @@ export async function repl(args: ICliArgs): Promise<number> {
         session.setSetupWeb(setupWeb);
         wireDelegation(); // re-offer spawn_agent on the rebuilt session
         wireImages(); // re-offer read_image/generate_image + preview on the rebuild
+        // Drop any un-sent clipboard captures — /clear wipes the buffer (and its
+        // chips), so their temp files are now orphaned.
+        void discardClipboardImages(pendingImages.splice(0));
         session.setPlanMode(planMode); // a /clear must not silently drop the mode
         planDiscussed = false;
         await persist();

--- a/packages/core/src/editor/controller.ts
+++ b/packages/core/src/editor/controller.ts
@@ -399,7 +399,10 @@ export function startEditor(deps: IStartEditorDeps): IEditorHandle {
         pasting = true;
         pasteFromClipboard()
           .then((insert) => {
-            if (insert !== null && insert.length > 0) {
+            // The read is async (~1s); the editor may have been closed meanwhile.
+            // Mutating/repainting after close() (raw mode + bracketed paste already
+            // torn down) would corrupt output — drop the result if we're gone.
+            if (isOpen && insert !== null && insert.length > 0) {
               buffer.insert(insert);
               repaint();
               notifyChange();

--- a/packages/core/src/editor/controller.ts
+++ b/packages/core/src/editor/controller.ts
@@ -65,6 +65,12 @@ export interface IStartEditorDeps {
   openPalette?: () => Promise<void>;
   openFilePicker?: () => Promise<void>;
   completion?: IEditorCompletionSource;
+  /** Ctrl+V handler: read the system clipboard and return the text to insert at
+   *  the cursor (an image capture returns a `[image #N]` chip and registers the
+   *  attachment as a side effect; otherwise the clipboard text), or null to insert
+   *  nothing. Async because reading the clipboard shells out. Absent ⇒ Ctrl+V is a
+   *  no-op (the terminal's own Cmd+V bracketed paste still handles text). */
+  pasteFromClipboard?: () => Promise<string | null>;
 }
 
 type KeyAction = (buffer: EditorBuffer) => void;
@@ -178,6 +184,7 @@ export function startEditor(deps: IStartEditorDeps): IEditorHandle {
     openPalette,
     openFilePicker,
     completion: completionSource,
+    pasteFromClipboard,
   } = deps;
 
   // Mutable so a terminal resize can update them (see the handle's `resize`);
@@ -374,6 +381,27 @@ export function startEditor(deps: IStartEditorDeps): IEditorHandle {
       exitCallbacks.forEach((cb) => {
         cb();
       });
+
+      return;
+    }
+
+    // Ctrl-V: paste from the system clipboard (image → [image #N] chip + attachment,
+    // else clipboard text). Async — insert on resolve, like openPalette. Without a
+    // handler, swallow the key (don't insert a literal "v").
+    if (ctrl && text === "v") {
+      if (pasteFromClipboard !== undefined) {
+        pasteFromClipboard()
+          .then((insert) => {
+            if (insert !== null && insert.length > 0) {
+              buffer.insert(insert);
+              repaint();
+              notifyChange();
+            }
+          })
+          .catch((err: unknown) => {
+            trace("editor.paste", err);
+          });
+      }
 
       return;
     }

--- a/packages/core/src/editor/controller.ts
+++ b/packages/core/src/editor/controller.ts
@@ -197,6 +197,9 @@ export function startEditor(deps: IStartEditorDeps): IEditorHandle {
   const keyDispatchTable = buildKeyDispatchTable();
 
   let isOpen = true;
+  // True while an async clipboard paste (Ctrl+V) is in flight — drops repeats so a
+  // slow (osascript) read can't be triggered concurrently and double-insert.
+  let pasting = false;
   // True while an overlay (file picker / command palette) owns stdin: the editor
   // detaches its `data` listener so it doesn't also consume the overlay's keystrokes.
   let suspended = false;
@@ -387,9 +390,13 @@ export function startEditor(deps: IStartEditorDeps): IEditorHandle {
 
     // Ctrl-V: paste from the system clipboard (image → [image #N] chip + attachment,
     // else clipboard text). Async — insert on resolve, like openPalette. Without a
-    // handler, swallow the key (don't insert a literal "v").
+    // handler, swallow the key (don't insert a literal "v"). The `pasting` latch
+    // drops repeat Ctrl+V while a read is in flight: the clipboard read can take
+    // ~1s (osascript), so key-repeat/spam would otherwise fire concurrent reads and
+    // double-insert.
     if (ctrl && text === "v") {
-      if (pasteFromClipboard !== undefined) {
+      if (pasteFromClipboard !== undefined && !pasting) {
+        pasting = true;
         pasteFromClipboard()
           .then((insert) => {
             if (insert !== null && insert.length > 0) {
@@ -400,6 +407,9 @@ export function startEditor(deps: IStartEditorDeps): IEditorHandle {
           })
           .catch((err: unknown) => {
             trace("editor.paste", err);
+          })
+          .finally(() => {
+            pasting = false;
           });
       }
 

--- a/packages/core/src/inference/image-gen.ts
+++ b/packages/core/src/inference/image-gen.ts
@@ -1,0 +1,263 @@
+import { mkdir, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+import type { IOpenAICompatibleConfig } from "./inference.types";
+import type { ImageApi } from "../models-config";
+import { PROVIDER_LIMITS } from "./inference.constants";
+import { buildRequestHeaders, chatCompletionsUrl } from "./request";
+import { fetchWithRetry } from "./transport";
+import { isRecord } from "../lib/guards";
+
+/**
+ * Image generation as a side-channel capability (mirrors `vision.ts`): the
+ * primary text-only model can't produce pixels, so a configured `imageGen`
+ * backend does, and the harness saves the bytes + returns a path. One shared
+ * `generateImage()` so both the `generate_image` tool and the (future) reserved
+ * `kind: "generate"` agent seam call the same code.
+ *
+ * Two OpenAI-compatible wire shapes are supported, selected per entry:
+ *  - `chat-modalities` (default, OpenRouter): POST `/chat/completions` with
+ *    `modalities:["image","text"]`; images come back on the assistant message.
+ *  - `images-generations` (OpenAI/xAI/DALL·E): POST `/images/generations` with a
+ *    `prompt` and `response_format:"b64_json"`.
+ */
+export interface IGeneratedImage {
+  bytes: Uint8Array;
+  mimeType: string;
+}
+
+export interface IGenerateImageInput {
+  prompt: string;
+  /** Wire shape; defaults to `chat-modalities`. */
+  api?: ImageApi;
+  /** e.g. `1024x1024` — only honored by the `images-generations` shape. */
+  size?: string;
+  /** How many images to request (images-generations `n`; default 1). */
+  n?: number;
+}
+
+export interface IGenerateImageOptions {
+  signal?: AbortSignal;
+  fetch?: typeof fetch;
+}
+
+const MIME_EXT: Readonly<Record<string, string>> = {
+  "image/png": "png",
+  "image/jpeg": "jpg",
+  "image/webp": "webp",
+  "image/gif": "gif",
+};
+
+/** File extension for a mime type (defaults to png). */
+export function extForMime(mimeType: string): string {
+  return MIME_EXT[mimeType] ?? "png";
+}
+
+/** Generate one or more images. Throws (with status + body head) on a non-2xx or
+ *  when the response carries no decodable image, so a caller surfaces a real
+ *  error instead of writing an empty file. */
+export async function generateImage(
+  cfg: IOpenAICompatibleConfig,
+  input: IGenerateImageInput,
+  opts: IGenerateImageOptions = {}
+): Promise<IGeneratedImage[]> {
+  const api: ImageApi = input.api ?? "chat-modalities";
+  const doFetch = opts.fetch ?? cfg.fetch ?? fetch;
+  const url =
+    api === "images-generations"
+      ? imagesGenerationsUrl(cfg.baseUrl)
+      : chatCompletionsUrl(cfg.baseUrl);
+  const body =
+    api === "images-generations"
+      ? imagesBody(cfg, input)
+      : chatBody(cfg, input);
+
+  const res = await fetchWithRetry(
+    doFetch,
+    url,
+    buildRequestHeaders(cfg),
+    body,
+    cfg.timeoutMs ?? PROVIDER_LIMITS.requestTimeoutMs,
+    opts.signal,
+    cfg.connectRetryMs
+  );
+
+  if (!res.ok) {
+    const head = (await res.text()).slice(0, 500);
+
+    throw new Error(
+      `image-gen request failed (${String(res.status)}): ${head}`
+    );
+  }
+
+  const payload: unknown = await res.json();
+  const refs =
+    api === "images-generations"
+      ? imageRefsFromImagesApi(payload)
+      : imageRefsFromChat(payload);
+
+  if (refs.length === 0) {
+    throw new Error("image-gen response: no image content");
+  }
+
+  return Promise.all(refs.map((ref) => resolveRef(ref, doFetch, opts.signal)));
+}
+
+/** Write generated images to `dir` (created if needed) as `<baseName>-<i>.<ext>`;
+ *  returns the absolute paths. A single image drops the index suffix. */
+export async function saveGeneratedImages(
+  images: IGeneratedImage[],
+  dir: string,
+  baseName: string
+): Promise<string[]> {
+  await mkdir(dir, { recursive: true });
+
+  return Promise.all(
+    images.map(async (image, i) => {
+      const ext = extForMime(image.mimeType);
+      const name =
+        images.length === 1
+          ? `${baseName}.${ext}`
+          : `${baseName}-${String(i)}.${ext}`;
+      const path = join(dir, name);
+
+      await writeFile(path, image.bytes);
+
+      return path;
+    })
+  );
+}
+
+function chatBody(
+  cfg: IOpenAICompatibleConfig,
+  input: IGenerateImageInput
+): string {
+  return JSON.stringify({
+    model: cfg.model,
+    messages: [{ role: "user", content: input.prompt }],
+    modalities: ["image", "text"],
+    ...(cfg.extraBody ?? {}),
+  });
+}
+
+function imagesBody(
+  cfg: IOpenAICompatibleConfig,
+  input: IGenerateImageInput
+): string {
+  return JSON.stringify({
+    model: cfg.model,
+    prompt: input.prompt,
+    n: input.n ?? 1,
+    response_format: "b64_json",
+    ...(input.size === undefined ? {} : { size: input.size }),
+    ...(cfg.extraBody ?? {}),
+  });
+}
+
+function imagesGenerationsUrl(baseUrl: string): string {
+  const trimmed = baseUrl.replace(/\/+$/, "");
+
+  return trimmed.endsWith("/images/generations")
+    ? trimmed
+    : `${trimmed}/images/generations`;
+}
+
+/** An image reference extracted from a response: either an inline data URI /
+ *  base64 payload, or an http(s) URL to fetch. */
+type ImageRef =
+  | { kind: "data"; base64: string; mimeType: string }
+  | { kind: "url"; url: string };
+
+/** OpenRouter-style: images ride on `choices[0].message.images[]` as
+ *  `{ image_url: { url } }`; also tolerate content-part arrays. */
+function imageRefsFromChat(payload: unknown): ImageRef[] {
+  if (!isRecord(payload) || !Array.isArray(payload.choices)) {
+    return [];
+  }
+
+  const message: unknown = isRecord(payload.choices[0])
+    ? payload.choices[0].message
+    : undefined;
+
+  if (!isRecord(message)) {
+    return [];
+  }
+
+  const urls: string[] = [];
+
+  const collect = (item: unknown): void => {
+    const imageUrl: unknown = isRecord(item) ? item.image_url : undefined;
+    const url: unknown = isRecord(imageUrl) ? imageUrl.url : undefined;
+
+    if (typeof url === "string") {
+      urls.push(url);
+    }
+  };
+
+  if (Array.isArray(message.images)) {
+    message.images.forEach(collect);
+  }
+
+  if (Array.isArray(message.content)) {
+    message.content.forEach(collect);
+  }
+
+  return urls.map(refFromUrl);
+}
+
+/** OpenAI `/images/generations`: `data[]` with `b64_json` or `url`. */
+function imageRefsFromImagesApi(payload: unknown): ImageRef[] {
+  if (!isRecord(payload) || !Array.isArray(payload.data)) {
+    return [];
+  }
+
+  const refs: ImageRef[] = [];
+
+  for (const item of payload.data) {
+    if (!isRecord(item)) {
+      continue;
+    }
+
+    if (typeof item.b64_json === "string") {
+      refs.push({ kind: "data", base64: item.b64_json, mimeType: "image/png" });
+    } else if (typeof item.url === "string") {
+      refs.push(refFromUrl(item.url));
+    }
+  }
+
+  return refs;
+}
+
+/** Classify a url as an inline data URI (decode locally) vs a remote url (fetch). */
+function refFromUrl(url: string): ImageRef {
+  const match = /^data:([^;]+);base64,(.*)$/s.exec(url);
+
+  return match?.[1] !== undefined && match[2] !== undefined
+    ? { kind: "data", base64: match[2], mimeType: match[1] }
+    : { kind: "url", url };
+}
+
+async function resolveRef(
+  ref: ImageRef,
+  doFetch: typeof fetch,
+  signal?: AbortSignal
+): Promise<IGeneratedImage> {
+  if (ref.kind === "data") {
+    return {
+      bytes: new Uint8Array(Buffer.from(ref.base64, "base64")),
+      mimeType: ref.mimeType,
+    };
+  }
+
+  const res = await doFetch(ref.url, { signal });
+
+  if (!res.ok) {
+    throw new Error(
+      `image-gen: fetching image url failed (${String(res.status)})`
+    );
+  }
+
+  return {
+    bytes: new Uint8Array(await res.arrayBuffer()),
+    mimeType: res.headers.get("content-type") ?? "image/png",
+  };
+}

--- a/packages/core/src/inference/image-gen.ts
+++ b/packages/core/src/inference/image-gen.ts
@@ -6,6 +6,18 @@ import { PROVIDER_LIMITS } from "./inference.constants";
 import { buildRequestHeaders, chatCompletionsUrl } from "./request";
 import { fetchWithRetry } from "./transport";
 import { isRecord } from "../lib/guards";
+import {
+  validateFetchUrl,
+  assertPublicResolution,
+  realResolve,
+  type ResolveHost,
+} from "../lib/net/ssrf";
+
+/** Cap on a provider image (bytes) — matches read_image; bounds memory when a
+ *  hostile/compromised provider returns a huge or unbounded response. */
+const MAX_IMAGE_BYTES = 20 * 1024 * 1024;
+/** Redirect hops allowed when fetching a provider image URL. */
+const MAX_IMAGE_REDIRECTS = 3;
 
 /**
  * Image generation as a side-channel capability (mirrors `vision.ts`): the
@@ -38,6 +50,9 @@ export interface IGenerateImageInput {
 export interface IGenerateImageOptions {
   signal?: AbortSignal;
   fetch?: typeof fetch;
+  /** DNS resolver for the SSRF guard on a provider-returned image URL; injected
+   *  so tests stay offline. Defaults to a real node lookup. */
+  resolve?: ResolveHost;
 }
 
 const MIME_EXT: Readonly<Record<string, string>> = {
@@ -104,7 +119,11 @@ export async function generateImage(
     throw new Error(`image model ${noImageReason(payload)}`);
   }
 
-  return Promise.all(refs.map((ref) => resolveRef(ref, doFetch, opts.signal)));
+  return Promise.all(
+    refs.map((ref) =>
+      resolveRef(ref, doFetch, opts.signal, opts.resolve ?? realResolve)
+    )
+  );
 }
 
 /** Write generated images to `dir` (created if needed) as `<baseName>-<i>.<ext>`;
@@ -306,40 +325,82 @@ function refFromUrl(url: string): ImageRef {
 async function resolveRef(
   ref: ImageRef,
   doFetch: typeof fetch,
-  signal?: AbortSignal
+  signal: AbortSignal | undefined,
+  resolve: ResolveHost
 ): Promise<IGeneratedImage> {
   if (ref.kind === "data") {
+    const bytes = new Uint8Array(Buffer.from(ref.base64, "base64"));
+
+    if (bytes.length > MAX_IMAGE_BYTES) {
+      throw new Error("image-gen: inline image exceeds the size limit");
+    }
+
+    return { bytes, mimeType: ref.mimeType };
+  }
+
+  return fetchGuardedImage(ref.url, doFetch, signal, resolve);
+}
+
+/**
+ * Fetch a provider-returned image URL with the SAME SSRF protection web_fetch
+ * uses — the URL is untrusted (a compromised/hostile provider, or a redirect
+ * chain, could point at localhost, RFC-1918, or a cloud-metadata endpoint). Each
+ * hop is validated (public http(s) host) AND DNS-resolved + re-classified; the
+ * download is size-capped so a huge/unbounded body can't exhaust memory.
+ */
+async function fetchGuardedImage(
+  start: string,
+  doFetch: typeof fetch,
+  signal: AbortSignal | undefined,
+  resolve: ResolveHost
+): Promise<IGeneratedImage> {
+  let current = start;
+
+  for (let hop = 0; hop <= MAX_IMAGE_REDIRECTS; hop += 1) {
+    const url = validateFetchUrl(current);
+
+    if (url === null) {
+      throw new Error(`image-gen: refusing non-public image url (${current})`);
+    }
+
+    await assertPublicResolution(url, resolve);
+
+    const res = await doFetch(current, { signal, redirect: "manual" });
+
+    if (res.status >= 300 && res.status < 400) {
+      const location = res.headers.get("location");
+
+      if (location === null || location.length === 0) {
+        break;
+      }
+
+      current = new URL(location, current).href;
+      continue;
+    }
+
+    if (!res.ok) {
+      throw new Error(
+        `image-gen: fetching image url failed (${String(res.status)})`
+      );
+    }
+
+    const declared = Number(res.headers.get("content-length"));
+
+    if (Number.isFinite(declared) && declared > MAX_IMAGE_BYTES) {
+      throw new Error("image-gen: image exceeds the size limit");
+    }
+
+    const bytes = new Uint8Array(await res.arrayBuffer());
+
+    if (bytes.length > MAX_IMAGE_BYTES) {
+      throw new Error("image-gen: image exceeds the size limit");
+    }
+
     return {
-      bytes: new Uint8Array(Buffer.from(ref.base64, "base64")),
-      mimeType: ref.mimeType,
+      bytes,
+      mimeType: res.headers.get("content-type") ?? "image/png",
     };
   }
 
-  // The provider hands back a URL we then fetch — untrusted, so restrict to
-  // http(s). Reject file:/data:/gopher:/etc. so a malicious/compromised endpoint
-  // can't point us at localhost, cloud-metadata IPs, or a local file.
-  let scheme: string;
-
-  try {
-    scheme = new URL(ref.url).protocol;
-  } catch {
-    throw new Error(`image-gen: refusing to fetch a malformed image url`);
-  }
-
-  if (scheme !== "http:" && scheme !== "https:") {
-    throw new Error(`image-gen: refusing non-http(s) image url (${scheme})`);
-  }
-
-  const res = await doFetch(ref.url, { signal });
-
-  if (!res.ok) {
-    throw new Error(
-      `image-gen: fetching image url failed (${String(res.status)})`
-    );
-  }
-
-  return {
-    bytes: new Uint8Array(await res.arrayBuffer()),
-    mimeType: res.headers.get("content-type") ?? "image/png",
-  };
+  throw new Error("image-gen: too many redirects fetching the image");
 }

--- a/packages/core/src/inference/image-gen.ts
+++ b/packages/core/src/inference/image-gen.ts
@@ -96,7 +96,17 @@ export async function generateImage(
       : imageRefsFromChat(payload);
 
   if (refs.length === 0) {
-    throw new Error("image-gen response: no image content");
+    // No image in a 2xx response usually means the model DECLINED (content
+    // policy — e.g. a copyrighted character) and replied with text instead.
+    // Surface that text so the caller can relay the real reason rather than a
+    // misleading "backend unavailable".
+    const refusal = api === "images-generations" ? "" : chatText(payload);
+
+    throw new Error(
+      refusal.length > 0
+        ? `image model declined: ${refusal.slice(0, 300)}`
+        : "image model returned no image"
+    );
   }
 
   return Promise.all(refs.map((ref) => resolveRef(ref, doFetch, opts.signal)));
@@ -202,6 +212,32 @@ function imageRefsFromChat(payload: unknown): ImageRef[] {
   }
 
   return urls.map(refFromUrl);
+}
+
+/** The assistant's TEXT from a chat response — the model's explanation when it
+ *  returned no image (typically a content-policy decline). */
+function chatText(payload: unknown): string {
+  if (!isRecord(payload) || !Array.isArray(payload.choices)) {
+    return "";
+  }
+
+  const message: unknown = isRecord(payload.choices[0])
+    ? payload.choices[0].message
+    : undefined;
+  const content: unknown = isRecord(message) ? message.content : undefined;
+
+  if (typeof content === "string") {
+    return content.trim();
+  }
+
+  if (Array.isArray(content)) {
+    return content
+      .map((p) => (isRecord(p) && typeof p.text === "string" ? p.text : ""))
+      .join("")
+      .trim();
+  }
+
+  return "";
 }
 
 /** OpenAI `/images/generations`: `data[]` with `b64_json` or `url`. */

--- a/packages/core/src/inference/image-gen.ts
+++ b/packages/core/src/inference/image-gen.ts
@@ -96,17 +96,12 @@ export async function generateImage(
       : imageRefsFromChat(payload);
 
   if (refs.length === 0) {
-    // No image in a 2xx response usually means the model DECLINED (content
-    // policy — e.g. a copyrighted character) and replied with text instead.
-    // Surface that text so the caller can relay the real reason rather than a
-    // misleading "backend unavailable".
-    const refusal = api === "images-generations" ? "" : chatText(payload);
-
-    throw new Error(
-      refusal.length > 0
-        ? `image model declined: ${refusal.slice(0, 300)}`
-        : "image model returned no image"
-    );
+    // A 2xx with no image is almost always a content-policy DECLINE, not a
+    // backend failure. Gemini signals it with `finish_reason: "content_filter"`
+    // (often with content/refusal/reasoning all null), so key off that and any
+    // text the provider did give — a concrete cause the caller can relay instead
+    // of hallucinating "backend unavailable".
+    throw new Error(`image model ${noImageReason(payload)}`);
   }
 
   return Promise.all(refs.map((ref) => resolveRef(ref, doFetch, opts.signal)));
@@ -214,27 +209,63 @@ function imageRefsFromChat(payload: unknown): ImageRef[] {
   return urls.map(refFromUrl);
 }
 
-/** The assistant's TEXT from a chat response — the model's explanation when it
- *  returned no image (typically a content-policy decline). */
-function chatText(payload: unknown): string {
-  if (!isRecord(payload) || !Array.isArray(payload.choices)) {
+/** Why a chat response carried no image — a concrete, relayable cause. Keys off
+ *  `finish_reason` (Gemini uses `content_filter` for a policy block, usually with
+ *  no text) and falls back to any text the model did return. */
+function noImageReason(payload: unknown): string {
+  const choice: unknown =
+    isRecord(payload) && Array.isArray(payload.choices)
+      ? payload.choices[0]
+      : undefined;
+  const finish: unknown = isRecord(choice)
+    ? (choice.finish_reason ?? choice.native_finish_reason)
+    : undefined;
+  const text = messageText(isRecord(choice) ? choice.message : undefined);
+
+  if (
+    typeof finish === "string" &&
+    /content_filter|safety|blocked|prohibited/i.test(finish)
+  ) {
+    return text.length > 0
+      ? `declined this prompt (content filter): ${text.slice(0, 200)}`
+      : "declined this prompt (content filter — often a copyrighted or restricted subject)";
+  }
+
+  return text.length > 0
+    ? `declined: ${text.slice(0, 200)}`
+    : "returned no image";
+}
+
+/** Any human-readable text on an assistant message: content, else refusal, else
+ *  reasoning (providers put a decline in different fields). */
+function messageText(message: unknown): string {
+  if (!isRecord(message)) {
     return "";
   }
 
-  const message: unknown = isRecord(payload.choices[0])
-    ? payload.choices[0].message
-    : undefined;
-  const content: unknown = isRecord(message) ? message.content : undefined;
+  const content = message.content;
 
-  if (typeof content === "string") {
+  if (typeof content === "string" && content.trim().length > 0) {
     return content.trim();
   }
 
   if (Array.isArray(content)) {
-    return content
+    const joined = content
       .map((p) => (isRecord(p) && typeof p.text === "string" ? p.text : ""))
       .join("")
       .trim();
+
+    if (joined.length > 0) {
+      return joined;
+    }
+  }
+
+  for (const field of ["refusal", "reasoning"]) {
+    const value = message[field];
+
+    if (typeof value === "string" && value.trim().length > 0) {
+      return value.trim();
+    }
   }
 
   return "";

--- a/packages/core/src/inference/image-gen.ts
+++ b/packages/core/src/inference/image-gen.ts
@@ -248,6 +248,21 @@ async function resolveRef(
     };
   }
 
+  // The provider hands back a URL we then fetch — untrusted, so restrict to
+  // http(s). Reject file:/data:/gopher:/etc. so a malicious/compromised endpoint
+  // can't point us at localhost, cloud-metadata IPs, or a local file.
+  let scheme: string;
+
+  try {
+    scheme = new URL(ref.url).protocol;
+  } catch {
+    throw new Error(`image-gen: refusing to fetch a malformed image url`);
+  }
+
+  if (scheme !== "http:" && scheme !== "https:") {
+    throw new Error(`image-gen: refusing non-http(s) image url (${scheme})`);
+  }
+
   const res = await doFetch(ref.url, { signal });
 
   if (!res.ok) {

--- a/packages/core/src/inference/vision.ts
+++ b/packages/core/src/inference/vision.ts
@@ -1,0 +1,125 @@
+import type { IOpenAICompatibleConfig } from "./inference.types";
+import { PROVIDER_LIMITS } from "./inference.constants";
+import { buildRequestHeaders, chatCompletionsUrl } from "./request";
+import { fetchWithRetry } from "./transport";
+import { isRecord } from "../lib/guards";
+
+/**
+ * Vision (image reading) as a SIDE-CHANNEL call, deliberately separate from the
+ * main `IChatMessage` pipeline. The primary chat model is text-only and can't
+ * ingest an image, so the harness asks a configured vision backend to describe
+ * the image and feeds only the resulting TEXT back into the conversation. Keeping
+ * this self-contained means the core message type stays `content: string` and the
+ * whole feature is off unless a `vision` capability is configured.
+ *
+ * The request is a one-shot OpenAI-compatible `/chat/completions` whose single
+ * user message carries a multimodal content array (`text` + `image_url` data
+ * URIs) — the shape every OpenAI-compatible vision endpoint (OpenRouter, a local
+ * vLLM VLM, ...) accepts. Header/URL/transport logic is reused from the request
+ * layer so retries and auth behave identically to a normal chat call.
+ */
+export interface IImageInput {
+  /** Base64 (no data-URI prefix) of the image bytes. */
+  base64: string;
+  /** e.g. `image/png`, `image/jpeg`, `image/webp`, `image/gif`. */
+  mimeType: string;
+}
+
+export interface IDescribeImageInput {
+  /** The question / instruction for the vision model about the image(s). */
+  prompt: string;
+  images: IImageInput[];
+}
+
+export interface IDescribeImageOptions {
+  signal?: AbortSignal;
+  /** Injectable for tests; defaults to the config's fetch or global fetch. */
+  fetch?: typeof fetch;
+}
+
+/** A default instruction used when the caller has no specific question — biased
+ *  toward what a coding agent needs out of a screenshot/mockup. */
+export const DEFAULT_VISION_PROMPT =
+  "Describe this image in detail for a software engineer. Transcribe any visible " +
+  "text, code, UI, errors, or diagrams exactly.";
+
+function dataUri(image: IImageInput): string {
+  return `data:${image.mimeType};base64,${image.base64}`;
+}
+
+/** Ask the vision backend to describe/answer about one or more images; returns
+ *  the model's text. Throws on a non-2xx response (with the status + body head)
+ *  so the caller can surface an actionable tool error rather than a silent "". */
+export async function describeImage(
+  cfg: IOpenAICompatibleConfig,
+  input: IDescribeImageInput,
+  opts: IDescribeImageOptions = {}
+): Promise<string> {
+  if (input.images.length === 0) {
+    throw new Error("describeImage: no images provided");
+  }
+
+  const content = [
+    { type: "text", text: input.prompt },
+    ...input.images.map((image) => ({
+      type: "image_url",
+      image_url: { url: dataUri(image) },
+    })),
+  ];
+
+  const body = JSON.stringify({
+    model: cfg.model,
+    messages: [{ role: "user", content }],
+    max_tokens:
+      cfg.maxTokens !== undefined && Number.isFinite(cfg.maxTokens)
+        ? cfg.maxTokens
+        : PROVIDER_LIMITS.maxTokens,
+    ...(cfg.extraBody ?? {}),
+  });
+
+  const doFetch = opts.fetch ?? cfg.fetch ?? fetch;
+  const res = await fetchWithRetry(
+    doFetch,
+    chatCompletionsUrl(cfg.baseUrl),
+    buildRequestHeaders(cfg),
+    body,
+    cfg.timeoutMs ?? PROVIDER_LIMITS.requestTimeoutMs,
+    opts.signal,
+    cfg.connectRetryMs
+  );
+
+  if (!res.ok) {
+    const head = (await res.text()).slice(0, 500);
+
+    throw new Error(`vision request failed (${String(res.status)}): ${head}`);
+  }
+
+  return extractContent(await res.json());
+}
+
+/** Pull `choices[0].message.content` out of an OpenAI-compatible response. Some
+ *  vision endpoints return `content` as a content-part array rather than a plain
+ *  string, so handle both. */
+function extractContent(payload: unknown): string {
+  if (!isRecord(payload) || !Array.isArray(payload.choices)) {
+    throw new Error("vision response: missing choices");
+  }
+
+  const first: unknown = payload.choices[0];
+  const message: unknown = isRecord(first) ? first.message : undefined;
+  const content: unknown = isRecord(message) ? message.content : undefined;
+
+  if (typeof content === "string") {
+    return content;
+  }
+
+  if (Array.isArray(content)) {
+    return content
+      .map((part) =>
+        isRecord(part) && typeof part.text === "string" ? part.text : ""
+      )
+      .join("");
+  }
+
+  throw new Error("vision response: no text content");
+}

--- a/packages/core/src/lib/clipboard/clipboard-image.ts
+++ b/packages/core/src/lib/clipboard/clipboard-image.ts
@@ -120,6 +120,19 @@ export async function captureClipboardImageToFile(
   return path;
 }
 
+/** Best-effort delete of clipboard temp files (from captureClipboardImageToFile)
+ *  once they've been consumed on send, or abandoned (chip deleted / buffer
+ *  cleared) — so they don't accumulate in tmpdir. Never throws. */
+export async function discardClipboardImages(paths: string[]): Promise<void> {
+  await Promise.all(
+    paths.map((path) =>
+      unlink(path).catch(() => {
+        /* already gone / not ours */
+      })
+    )
+  );
+}
+
 export interface IClipboardTextDeps {
   platform: NodeJS.Platform;
   run: (argv: string[]) => Promise<{ exitCode: number; stdout: string }>;

--- a/packages/core/src/lib/clipboard/clipboard-image.ts
+++ b/packages/core/src/lib/clipboard/clipboard-image.ts
@@ -1,0 +1,151 @@
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { randomUUID } from "node:crypto";
+import { unlink, writeFile } from "node:fs/promises";
+import { runArgvCommand } from "../fs/process";
+
+/**
+ * Read an image off the system clipboard (Ctrl+V of image bytes, like the drag/
+ * paste UX in Claude Code). Deliberately SHELL-BASED, not a native addon: tsforge
+ * runs on Bun with no Rust natives crate, so we shell out to `pngpaste` (if
+ * installed) or `osascript` on macOS. Both WRITE a PNG to a temp file, which we
+ * then read as bytes — no binary-through-a-string-pipe.
+ *
+ * macOS-only today (returns null elsewhere) so the REPL cleanly falls through to
+ * a normal text paste; Linux (`wl-paste`/`xclip`) and WSL are structured to slot
+ * in behind the same `platform` switch later.
+ */
+export interface IClipboardImage {
+  /** Base64 (no data-URI prefix). */
+  base64: string;
+  mimeType: string;
+}
+
+export interface IClipboardDeps {
+  platform: NodeJS.Platform;
+  /** Run an argv (no shell); resolves to the exit code. The command is expected
+   *  to WRITE the clipboard image to its last argument (a file path). */
+  run: (argv: string[]) => Promise<number>;
+  /** Read the bytes a command wrote, or null if the file is missing/empty. */
+  readFileBytes: (path: string) => Promise<Uint8Array | null>;
+}
+
+/** AppleScript that writes the clipboard's PNG to `path`. Wrapped in try/finally
+ *  so the file handle always closes; if the clipboard holds no image the write
+ *  throws and the file stays empty (→ treated as "no image"). */
+function osascriptArgs(path: string): string[] {
+  const script = [
+    `set f to (open for access (POSIX file ${JSON.stringify(path)}) with write permission)`,
+    "try",
+    "write (the clipboard as «class PNGf») to f",
+    "end try",
+    "close access f",
+  ];
+
+  return ["osascript", ...script.flatMap((line) => ["-e", line])];
+}
+
+const DEFAULT_DEPS: IClipboardDeps = {
+  platform: process.platform,
+  run: async (argv) =>
+    (await runArgvCommand(tmpdir(), argv, { timeoutMs: 5_000 })).exitCode,
+  readFileBytes: async (path) => {
+    const file = Bun.file(path);
+
+    if (!(await file.exists()) || file.size === 0) {
+      return null;
+    }
+
+    return new Uint8Array(await file.arrayBuffer());
+  },
+};
+
+/** Return the clipboard image, or null when there is none (or the platform isn't
+ *  supported). Tries `pngpaste` first (fast), then `osascript`. */
+export async function readClipboardImage(
+  deps: IClipboardDeps = DEFAULT_DEPS
+): Promise<IClipboardImage | null> {
+  if (deps.platform !== "darwin") {
+    return null;
+  }
+
+  const path = join(tmpdir(), `tsforge-clip-${randomUUID()}.png`);
+
+  try {
+    const bytes =
+      (await tryCommand(deps, ["pngpaste", path], path)) ??
+      (await tryCommand(deps, osascriptArgs(path), path));
+
+    return bytes === null
+      ? null
+      : {
+          base64: Buffer.from(bytes).toString("base64"),
+          mimeType: "image/png",
+        };
+  } finally {
+    await unlink(path).catch(() => {
+      /* best-effort cleanup */
+    });
+  }
+}
+
+/** Capture a clipboard image to a temp PNG and return its path (or null when
+ *  there's no image / unsupported platform). The REPL's Ctrl+V handler calls this
+ *  and hands the path to the attachment flow — keeping node fs/os/crypto out of
+ *  repl.ts. The temp file lives until the OS reaps tmpdir. */
+export async function captureClipboardImageToFile(
+  deps: IClipboardDeps = DEFAULT_DEPS
+): Promise<string | null> {
+  const image = await readClipboardImage(deps);
+
+  if (image === null) {
+    return null;
+  }
+
+  const path = join(tmpdir(), `tsforge-paste-${randomUUID()}.png`);
+
+  await writeFile(path, Buffer.from(image.base64, "base64"));
+
+  return path;
+}
+
+export interface IClipboardTextDeps {
+  platform: NodeJS.Platform;
+  run: (argv: string[]) => Promise<{ exitCode: number; stdout: string }>;
+}
+
+const DEFAULT_TEXT_DEPS: IClipboardTextDeps = {
+  platform: process.platform,
+  run: (argv) => runArgvCommand(tmpdir(), argv, { timeoutMs: 5_000 }),
+};
+
+/** Read the clipboard as TEXT (macOS `pbpaste`), or "" when empty/unsupported.
+ *  The fallback when a Ctrl+V paste held no image, so the shortcut still pastes
+ *  text (Cmd+V's terminal bracketed-paste is the usual text path). */
+export async function readClipboardText(
+  deps: IClipboardTextDeps = DEFAULT_TEXT_DEPS
+): Promise<string> {
+  if (deps.platform !== "darwin") {
+    return "";
+  }
+
+  const result = await deps.run(["pbpaste"]).catch(() => null);
+
+  return result !== null && result.exitCode === 0 ? result.stdout : "";
+}
+
+/** Run one clipboard command; return the bytes it wrote, or null if it failed /
+ *  wrote nothing (missing binary → exit 127, no-image → empty file). */
+async function tryCommand(
+  deps: IClipboardDeps,
+  argv: string[],
+  path: string
+): Promise<Uint8Array | null> {
+  const code = await deps.run(argv).catch(() => 1);
+
+  if (code !== 0) {
+    return null;
+  }
+
+  return deps.readFileBytes(path);
+}

--- a/packages/core/src/lib/clipboard/clipboard-image.ts
+++ b/packages/core/src/lib/clipboard/clipboard-image.ts
@@ -1,7 +1,7 @@
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { randomUUID } from "node:crypto";
-import { unlink, writeFile } from "node:fs/promises";
+import { unlink } from "node:fs/promises";
 import { runArgvCommand } from "../fs/process";
 
 /**
@@ -96,15 +96,26 @@ export async function readClipboardImage(
 export async function captureClipboardImageToFile(
   deps: IClipboardDeps = DEFAULT_DEPS
 ): Promise<string | null> {
-  const image = await readClipboardImage(deps);
-
-  if (image === null) {
+  if (deps.platform !== "darwin") {
     return null;
   }
 
+  // `pngpaste`/`osascript` write the PNG straight to `path`, so keep that file as
+  // the result instead of reading it back + re-encoding + re-writing (which the
+  // old readClipboardImage round-trip did). `tryCommand` returning bytes just
+  // confirms a non-empty write.
   const path = join(tmpdir(), `tsforge-paste-${randomUUID()}.png`);
+  const wrote =
+    (await tryCommand(deps, ["pngpaste", path], path)) ??
+    (await tryCommand(deps, osascriptArgs(path), path));
 
-  await writeFile(path, Buffer.from(image.base64, "base64"));
+  if (wrote === null) {
+    await unlink(path).catch(() => {
+      /* nothing was written */
+    });
+
+    return null;
+  }
 
   return path;
 }

--- a/packages/core/src/lib/net/ssrf.ts
+++ b/packages/core/src/lib/net/ssrf.ts
@@ -1,0 +1,99 @@
+/**
+ * SSRF guards shared by any code that fetches a URL the model or a provider
+ * supplied (web_fetch, image-gen). One implementation so the private-host
+ * classifier can't drift between callers. Extracted from web-fetch.ts.
+ */
+
+/** Loopback / link-local / RFC-1918 IPv4 (+ localhost) — blocked so a supplied
+ *  URL can't reach the host's cloud-metadata endpoint or poke internal services.
+ *  Applied to BOTH literal URL hosts and DNS-resolved IPs (same classifier). */
+const PRIVATE_HOST_RE =
+  /^(?:localhost|0\.0\.0\.0|127\.|10\.|169\.254\.|192\.168\.|172\.(?:1[6-9]|2\d|3[01])\.)/i;
+
+export function isPrivateHost(hostname: string): boolean {
+  const host = hostname.replace(/^\[|\]$/gu, "").toLowerCase();
+
+  if (host === "::1" || host === "::" || PRIVATE_HOST_RE.test(host)) {
+    return true;
+  }
+
+  // IPv4-mapped IPv6 (::ffff:…) — blocked wholesale. The URL parser canonicalizes
+  // the embedded v4 to hex (::ffff:127.0.0.1 → ::ffff:7f00:1), so matching dotted
+  // decimal is unreliable; mapped addresses have no legitimate use here and are a
+  // known SSRF evasion, so reject the whole prefix.
+  if (host.startsWith("::ffff:")) {
+    return true;
+  }
+
+  // IPv6 unique-local (fc00::/7 → fc.. / fd..) and link-local (fe80::/10).
+  return (
+    /^f[cd][0-9a-f]{0,2}:/u.test(host) || /^fe[89ab][0-9a-f]?:/u.test(host)
+  );
+}
+
+/** Parse + vet a fetch target: absolute http(s) only, public host only. Returns
+ *  the URL or null (never throws) so the caller can reject cleanly. */
+export function validateFetchUrl(raw: string): URL | null {
+  let url: URL;
+
+  try {
+    url = new URL(raw);
+  } catch {
+    return null;
+  }
+
+  if (url.protocol !== "http:" && url.protocol !== "https:") {
+    return null;
+  }
+
+  if (isPrivateHost(url.hostname)) {
+    return null;
+  }
+
+  return url;
+}
+
+/** Resolve a hostname to its IP addresses. Injected so tests stay offline. */
+export type ResolveHost = (hostname: string) => Promise<readonly string[]>;
+
+export const realResolve: ResolveHost = async (hostname) => {
+  const { lookup } = await import("node:dns/promises");
+  const records = await lookup(hostname, { all: true });
+
+  return records.map((r) => r.address);
+};
+
+/**
+ * Reject a host that RESOLVES to a private/loopback/link-local IP, even when the
+ * hostname string looks public. Wildcard-DNS services (`127-0-0-1.sslip.io`,
+ * `foo.127.0.0.1.nip.io`) defeat a string-only check; this resolves the name and
+ * re-runs the SAME IP classifier on every returned address.
+ *
+ * Residual: DNS rebinding (TOCTOU between this lookup and the runtime's own
+ * connect) is not fully closed without pinning the IP and connecting to it with a
+ * Host header — out of scope; this closes the wildcard-DNS / public-name class.
+ */
+export async function assertPublicResolution(
+  url: URL,
+  resolve: ResolveHost = realResolve
+): Promise<void> {
+  let addresses: readonly string[];
+
+  try {
+    addresses = await resolve(url.hostname);
+  } catch {
+    throw new Error(`could not resolve host (${url.hostname})`);
+  }
+
+  if (addresses.length === 0) {
+    throw new Error(`host did not resolve (${url.hostname})`);
+  }
+
+  const priv = addresses.find((ip) => isPrivateHost(ip));
+
+  if (priv !== undefined) {
+    throw new Error(
+      `blocked a host resolving to a private address (${url.hostname} → ${priv})`
+    );
+  }
+}

--- a/packages/core/src/loop/run.ts
+++ b/packages/core/src/loop/run.ts
@@ -29,6 +29,7 @@ import {
   loadProjectTtsrRules,
   applyTtsrInterrupt,
 } from "./ttsr-init";
+import { resolveImageCapabilityFlags } from "./tools/image-tools";
 import {
   type ILoopCtx,
   type ILoopState,
@@ -387,7 +388,8 @@ export async function runTask(
     },
   ];
 
-  const tools = toolsFor(hasExistingCode);
+  const caps = await resolveImageCapabilityFlags();
+  const tools = toolsFor(hasExistingCode, caps);
 
   // Mode-aware reasoning cap: scratch tasks over-think unbounded, so default
   // them to the measured knee; existing-code runs stay uncapped (the cap hurts

--- a/packages/core/src/loop/session.ts
+++ b/packages/core/src/loop/session.ts
@@ -14,9 +14,11 @@ import {
   ADD_DEPENDENCY_TOOL,
   TOOL_NAME,
   buildSpawnAgentTool,
+  READ_IMAGE_TOOL,
+  GENERATE_IMAGE_TOOL,
 } from "../agent";
 import type { IAgentSpec } from "../agent/agent-spec";
-import type { SetupWebFn, SpawnAgentFn } from "./tools";
+import type { SetupWebFn, SpawnAgentFn, IToolContext } from "./tools";
 import type { PolicyMode } from "../policy";
 import type { ProfileId } from "../config/profiles";
 import { flags } from "../config";
@@ -867,6 +869,30 @@ export class Session {
     ) {
       this.guide(delegationGuidance(specs));
     }
+  }
+
+  /** Offer the image tools when their capability backends are configured. Called
+   *  on REPL launch after capabilities are resolved; idempotent (a resumed session
+   *  re-runs it) — mirrors setDelegation's guard so the tool list can't grow on
+   *  each launch. `read_image` needs vision, `generate_image` needs imageGen. */
+  setImageCapabilities(caps: { vision: boolean; imageGen: boolean }): void {
+    const add = [
+      ...(caps.vision ? [READ_IMAGE_TOOL] : []),
+      ...(caps.imageGen ? [GENERATE_IMAGE_TOOL] : []),
+    ];
+
+    for (const tool of add) {
+      if (!this.tools.some((t) => t.function.name === tool.function.name)) {
+        this.tools = [...this.tools, tool];
+      }
+    }
+  }
+
+  /** Wire the inline-image preview callback the `generate_image` tool fires after
+   *  saving (the CLI emits the terminal's inline-image escape). Absent ⇒ the tool
+   *  just reports the saved path. */
+  setPreviewImage(fn: IToolContext["previewImage"]): void {
+    this.ctx.tool.previewImage = fn;
   }
 
   /** Append opinionated guidance to the SYSTEM prompt (e.g. after classifying a

--- a/packages/core/src/loop/tools/execute-tool.ts
+++ b/packages/core/src/loop/tools/execute-tool.ts
@@ -14,6 +14,7 @@ import { doWebBrowse } from "./web-browse";
 import { doPackageInfo, doPackageDocs } from "./package-info";
 import { doScript } from "./script-tool";
 import { doSpawnAgent } from "./spawn-agent";
+import { doReadImage, doGenerateImage } from "./image-tools";
 import { reject, type IToolContext } from "./tool-context";
 import {
   classifyAction,
@@ -59,6 +60,8 @@ const HANDLERS: Record<ToolName, ToolHandler> = {
   // call is rejected (script is not in SCRIPT_EXPOSABLE_TOOLS).
   [TOOL_NAME.script]: (a, c) => doScript(a, c, { execute: executeTool }),
   [TOOL_NAME.spawnAgent]: doSpawnAgent,
+  [TOOL_NAME.readImage]: doReadImage,
+  [TOOL_NAME.generateImage]: doGenerateImage,
 };
 
 function isToolName(name: string): name is ToolName {

--- a/packages/core/src/loop/tools/image-tools.ts
+++ b/packages/core/src/loop/tools/image-tools.ts
@@ -1,0 +1,272 @@
+import { join, resolve, relative, isAbsolute, extname } from "node:path";
+import { randomUUID } from "node:crypto";
+import {
+  resolveCapabilityModel,
+  resolveApiKey,
+  type IModelEntry,
+} from "../../models-config";
+import type { IOpenAICompatibleConfig } from "../../inference";
+import {
+  describeImage,
+  DEFAULT_VISION_PROMPT,
+  type IImageInput,
+} from "../../inference/vision";
+import {
+  generateImage,
+  saveGeneratedImages,
+  type IGeneratedImage,
+} from "../../inference/image-gen";
+import { str, reject, type IToolContext } from "./tool-context";
+
+/**
+ * The `read_image` (vision) and `generate_image` tool handlers. Both are thin:
+ * resolve the configured capability backend, call the shared inference function
+ * (`describeImage` / `generateImage`), and format a text result. Config
+ * resolution is lazy (per call) so no capability plumbing threads through the
+ * loop, and the whole surface is injectable for tests.
+ */
+const IMAGE_MIME: Readonly<Record<string, string>> = {
+  ".png": "image/png",
+  ".jpg": "image/jpeg",
+  ".jpeg": "image/jpeg",
+  ".webp": "image/webp",
+  ".gif": "image/gif",
+};
+
+/** Cap on the vision model's returned text fed back into the conversation. */
+const MAX_DESCRIPTION_CHARS = 8_000;
+
+/** Where generated images are written (under the workspace, git-ignorable). */
+export const IMAGE_OUTPUT_DIR = join(".tsforge", "images");
+
+export interface IImageToolDeps {
+  resolveCap: typeof resolveCapabilityModel;
+  describe: typeof describeImage;
+  generate: typeof generateImage;
+  save: typeof saveGeneratedImages;
+  /** Read an image file → base64 + mime, or null if unreadable/oversized. */
+  readImageFile: (
+    absPath: string
+  ) => Promise<{ base64: string; mimeType: string } | null>;
+}
+
+/** Is this path one of the image types the vision backend accepts? */
+export function isSupportedImagePath(path: string): boolean {
+  return IMAGE_MIME[extname(path).toLowerCase()] !== undefined;
+}
+
+/** Read an image file → `{ base64, mimeType }`, or null when it's missing or an
+ *  unsupported type. Shared by the `read_image` tool and the REPL attachment flow. */
+export async function loadImageFile(
+  absPath: string
+): Promise<IImageInput | null> {
+  const mimeType = IMAGE_MIME[extname(absPath).toLowerCase()];
+
+  if (mimeType === undefined) {
+    return null;
+  }
+
+  const file = Bun.file(absPath);
+
+  if (!(await file.exists())) {
+    return null;
+  }
+
+  return {
+    base64: Buffer.from(await file.arrayBuffer()).toString("base64"),
+    mimeType,
+  };
+}
+
+/** The resolved vision backend wire-config, or null when vision isn't configured.
+ *  Shared entry point for both the tool and the REPL drag/paste/@ attachment flow. */
+export async function resolveVisionConfig(
+  resolveCap: typeof resolveCapabilityModel = resolveCapabilityModel
+): Promise<IOpenAICompatibleConfig | null> {
+  const cap = await resolveCap("vision");
+
+  return cap === null ? null : entryConfig(cap.entry);
+}
+
+const DEFAULT_DEPS: IImageToolDeps = {
+  resolveCap: resolveCapabilityModel,
+  describe: describeImage,
+  generate: generateImage,
+  save: saveGeneratedImages,
+  readImageFile: loadImageFile,
+};
+
+/** Which image capabilities are configured — for tool advertisement (see
+ *  toolsFor). A misconfigured env (e.g. base url without model) resolves to
+ *  `false` rather than throwing, so a bad capability config can't crash a run;
+ *  the tool then simply isn't offered. */
+export async function resolveImageCapabilityFlags(
+  resolveCap: typeof resolveCapabilityModel = resolveCapabilityModel
+): Promise<{ vision: boolean; imageGen: boolean }> {
+  const configured = async (cap: "vision" | "imageGen"): Promise<boolean> => {
+    try {
+      return (await resolveCap(cap)) !== null;
+    } catch {
+      return false;
+    }
+  };
+
+  return {
+    vision: await configured("vision"),
+    imageGen: await configured("imageGen"),
+  };
+}
+
+/** Build the wire config for a capability entry (key resolved at use time). Small
+ *  local builder so this loop-layer module needn't import the cli `providerConfig`. */
+function entryConfig(entry: IModelEntry): IOpenAICompatibleConfig {
+  return {
+    baseUrl: entry.baseUrl,
+    model: entry.model,
+    apiKey: resolveApiKey(entry),
+    ...(entry.maxTokens === undefined ? {} : { maxTokens: entry.maxTokens }),
+    ...(entry.extraHeaders === undefined
+      ? {}
+      : { extraHeaders: entry.extraHeaders }),
+    ...(entry.extraBody === undefined ? {} : { extraBody: entry.extraBody }),
+  };
+}
+
+/** Resolve `file` under `cwd`, rejecting a path that escapes the workspace. */
+function resolveInCwd(cwd: string, file: string): string | null {
+  const abs = isAbsolute(file) ? file : resolve(cwd, file);
+  const rel = relative(cwd, abs);
+
+  return rel.startsWith("..") || isAbsolute(rel) ? null : abs;
+}
+
+export async function doReadImage(
+  args: Record<string, unknown>,
+  ctx: IToolContext,
+  deps: IImageToolDeps = DEFAULT_DEPS
+): Promise<string> {
+  const cap = await deps.resolveCap("vision");
+
+  if (cap === null) {
+    return reject(
+      ctx,
+      "read_image",
+      "vision is not configured — set a `vision` capability in ~/.tsforge/models.json " +
+        "(or TSFORGE_VISION_BASE_URL/TSFORGE_VISION_MODEL) to enable image reading."
+    );
+  }
+
+  const file = str(args, "file");
+  const abs = file.length === 0 ? null : resolveInCwd(ctx.cwd, file);
+
+  if (abs === null) {
+    return reject(
+      ctx,
+      "read_image",
+      `invalid or out-of-scope image path: ${file}`
+    );
+  }
+
+  const image = await deps.readImageFile(abs);
+
+  if (image === null) {
+    return reject(
+      ctx,
+      "read_image",
+      `cannot read image (missing or unsupported type — png/jpeg/webp/gif): ${file}`
+    );
+  }
+
+  const question = str(args, "question");
+  const prompt = question.length > 0 ? question : DEFAULT_VISION_PROMPT;
+
+  ctx.report({
+    kind: "tool",
+    task: ctx.task,
+    message: `↳ read_image ${file} → ${cap.name}`,
+  });
+
+  const images: IImageInput[] = [image];
+  const text = await deps.describe(
+    entryConfig(cap.entry),
+    { prompt, images },
+    { signal: ctx.signal }
+  );
+
+  return text.slice(0, MAX_DESCRIPTION_CHARS);
+}
+
+export async function doGenerateImage(
+  args: Record<string, unknown>,
+  ctx: IToolContext,
+  deps: IImageToolDeps = DEFAULT_DEPS
+): Promise<string> {
+  const cap = await deps.resolveCap("imageGen");
+
+  if (cap === null) {
+    return reject(
+      ctx,
+      "generate_image",
+      "image generation is not configured — set an `imageGen` capability in " +
+        "~/.tsforge/models.json (or TSFORGE_IMAGE_BASE_URL/TSFORGE_IMAGE_MODEL)."
+    );
+  }
+
+  const prompt = str(args, "prompt");
+
+  if (prompt.length === 0) {
+    return reject(ctx, "generate_image", "a non-empty `prompt` is required");
+  }
+
+  const size = str(args, "size");
+
+  ctx.report({
+    kind: "tool",
+    task: ctx.task,
+    message: `↳ generate_image → ${cap.name}`,
+  });
+
+  const images = await deps.generate(
+    entryConfig(cap.entry),
+    {
+      prompt,
+      api: cap.entry.imageApi,
+      ...(size.length > 0 ? { size } : {}),
+    },
+    { signal: ctx.signal }
+  );
+
+  const outDir = join(ctx.cwd, IMAGE_OUTPUT_DIR);
+  const baseName = `image-${randomUUID().slice(0, 8)}`;
+  const paths = await deps.save(images, outDir, baseName);
+
+  previewGenerated(ctx, images, paths);
+
+  const rels = paths.map((p) => relative(ctx.cwd, p));
+
+  return `Generated ${String(paths.length)} image(s): ${rels.join(", ")}`;
+}
+
+/** Fire the inline-preview hook (when wired) for each saved image. */
+function previewGenerated(
+  ctx: IToolContext,
+  images: IGeneratedImage[],
+  paths: string[]
+): void {
+  if (ctx.previewImage === undefined) {
+    return;
+  }
+
+  for (let i = 0; i < paths.length; i += 1) {
+    const image = images[i];
+    const path = paths[i];
+
+    if (image !== undefined && path !== undefined) {
+      ctx.previewImage({
+        path,
+        base64: Buffer.from(image.bytes).toString("base64"),
+        mimeType: image.mimeType,
+      });
+    }
+  }
+}

--- a/packages/core/src/loop/tools/image-tools.ts
+++ b/packages/core/src/loop/tools/image-tools.ts
@@ -36,6 +36,10 @@ const IMAGE_MIME: Readonly<Record<string, string>> = {
 /** Cap on the vision model's returned text fed back into the conversation. */
 const MAX_DESCRIPTION_CHARS = 8_000;
 
+/** Largest image we'll read/base64-encode (bytes). Bounds memory, and anything
+ *  bigger is rejected by the vision backends anyway. */
+const MAX_IMAGE_BYTES = 20 * 1024 * 1024;
+
 /** Where generated images are written (under the workspace, git-ignorable). */
 export const IMAGE_OUTPUT_DIR = join(".tsforge", "images");
 
@@ -68,7 +72,11 @@ export async function loadImageFile(
 
   const file = Bun.file(absPath);
 
-  if (!(await file.exists())) {
+  if (
+    !(await file.exists()) ||
+    file.size === 0 ||
+    file.size > MAX_IMAGE_BYTES
+  ) {
     return null;
   }
 
@@ -173,7 +181,7 @@ export async function doReadImage(
     return reject(
       ctx,
       "read_image",
-      `cannot read image (missing or unsupported type — png/jpeg/webp/gif): ${file}`
+      `cannot read image "${file}" — it must exist, be a supported type (png/jpeg/webp/gif), and be ≤ 20 MB`
     );
   }
 

--- a/packages/core/src/loop/tools/image-tools.ts
+++ b/packages/core/src/loop/tools/image-tools.ts
@@ -234,15 +234,26 @@ export async function doGenerateImage(
     message: `↳ generate_image → ${cap.name}`,
   });
 
-  const images = await deps.generate(
-    entryConfig(cap.entry),
-    {
-      prompt,
-      api: cap.entry.imageApi,
-      ...(size.length > 0 ? { size } : {}),
-    },
-    { signal: ctx.signal }
-  );
+  let images;
+
+  try {
+    images = await deps.generate(
+      entryConfig(cap.entry),
+      {
+        prompt,
+        api: cap.entry.imageApi,
+        ...(size.length > 0 ? { size } : {}),
+      },
+      { signal: ctx.signal }
+    );
+  } catch (err) {
+    // A decline (content policy) or per-request error — a terse, factual result.
+    // Do NOT pack model-steering instructions in here: the model echoes the tool
+    // result, so guidance text leaks into the user-facing reply.
+    const reason = err instanceof Error ? err.message : String(err);
+
+    return reject(ctx, "generate_image", `image not generated — ${reason}`);
+  }
 
   const outDir = join(ctx.cwd, IMAGE_OUTPUT_DIR);
   const baseName = `image-${randomUUID().slice(0, 8)}`;

--- a/packages/core/src/loop/tools/image-tools.ts
+++ b/packages/core/src/loop/tools/image-tools.ts
@@ -1,5 +1,6 @@
 import { join, resolve, relative, isAbsolute, extname } from "node:path";
 import { randomUUID } from "node:crypto";
+import { realpath } from "node:fs/promises";
 import {
   resolveCapabilityModel,
   resolveApiKey,
@@ -148,6 +149,25 @@ function resolveInCwd(cwd: string, file: string): string | null {
   return rel.startsWith("..") || isAbsolute(rel) ? null : abs;
 }
 
+/** Re-check containment AFTER resolving symlinks — a lexical check passes a
+ *  workspace symlink that points OUT of the tree, which the model could use to
+ *  exfiltrate an arbitrary file to the vision backend. A missing target resolves
+ *  to `true` here (the read then fails cleanly with "cannot read image"). */
+async function realpathWithinCwd(cwd: string, abs: string): Promise<boolean> {
+  const [realAbs, realCwd] = await Promise.all([
+    realpath(abs).catch(() => null),
+    realpath(cwd).catch(() => cwd),
+  ]);
+
+  if (realAbs === null) {
+    return true;
+  }
+
+  const rel = relative(realCwd, realAbs);
+
+  return rel === "" || (!rel.startsWith("..") && !isAbsolute(rel));
+}
+
 export async function doReadImage(
   args: Record<string, unknown>,
   ctx: IToolContext,
@@ -167,7 +187,7 @@ export async function doReadImage(
   const file = str(args, "file");
   const abs = file.length === 0 ? null : resolveInCwd(ctx.cwd, file);
 
-  if (abs === null) {
+  if (abs === null || !(await realpathWithinCwd(ctx.cwd, abs))) {
     return reject(
       ctx,
       "read_image",

--- a/packages/core/src/loop/tools/tool-context.ts
+++ b/packages/core/src/loop/tools/tool-context.ts
@@ -83,6 +83,15 @@ export interface IToolContext {
   /** Run one read-only specialist subagent for the `spawn_agent` tool. Wired by
    *  the interactive CLI (headless one-shot leaves it absent). See {@link SpawnAgentFn}. */
   spawnAgent?: SpawnAgentFn;
+  /** Render a just-generated image inline (the `generate_image` tool calls it).
+   *  Wired by the interactive CLI to emit the terminal's inline-image escape above
+   *  the input row; absent (headless / unsupported terminal) ⇒ the tool just
+   *  reports the saved path. */
+  previewImage?: (image: {
+    path: string;
+    base64: string;
+    mimeType: string;
+  }) => void;
 }
 
 /** A required string arg, or "" if missing/wrong-type. */

--- a/packages/core/src/loop/tools/web-fetch.ts
+++ b/packages/core/src/loop/tools/web-fetch.ts
@@ -1,59 +1,19 @@
 import { reject, str, type IToolContext } from "./tool-context";
+import {
+  isPrivateHost,
+  validateFetchUrl,
+  assertPublicResolution,
+  realResolve,
+  type ResolveHost,
+} from "../../lib/net/ssrf";
+
+export { isPrivateHost, validateFetchUrl, type ResolveHost };
 
 /** Default cap on returned content. Whole pages blow the context budget; the
  *  model can re-fetch with a higher `maxChars` when it genuinely needs more. */
 export const WEB_FETCH_MAX_CHARS = 8000;
 
 const MAX_ALLOWED_CHARS = WEB_FETCH_MAX_CHARS * 8;
-
-/** Loopback / link-local / RFC-1918 IPv4 (+ localhost) — blocked so a model-issued
- *  URL can't reach the host's cloud-metadata endpoint or poke internal services.
- *  Applied to BOTH literal URL hosts and DNS-resolved IPs (same classifier). */
-const PRIVATE_HOST_RE =
-  /^(?:localhost|0\.0\.0\.0|127\.|10\.|169\.254\.|192\.168\.|172\.(?:1[6-9]|2\d|3[01])\.)/i;
-
-function isPrivateHost(hostname: string): boolean {
-  const host = hostname.replace(/^\[|\]$/gu, "").toLowerCase();
-
-  if (host === "::1" || host === "::" || PRIVATE_HOST_RE.test(host)) {
-    return true;
-  }
-
-  // IPv4-mapped IPv6 (::ffff:…) — blocked wholesale. The URL parser canonicalizes
-  // the embedded v4 to hex (::ffff:127.0.0.1 → ::ffff:7f00:1), so matching dotted
-  // decimal is unreliable; mapped addresses have no legitimate web_fetch use and
-  // are a known SSRF evasion, so reject the whole prefix.
-  if (host.startsWith("::ffff:")) {
-    return true;
-  }
-
-  // IPv6 unique-local (fc00::/7 → fc.. / fd..) and link-local (fe80::/10).
-  return (
-    /^f[cd][0-9a-f]{0,2}:/u.test(host) || /^fe[89ab][0-9a-f]?:/u.test(host)
-  );
-}
-
-/** Parse + vet a fetch target: absolute http(s) only, public host only. Returns
- *  the URL or null (never throws) so the handler can reject cleanly. */
-export function validateFetchUrl(raw: string): URL | null {
-  let url: URL;
-
-  try {
-    url = new URL(raw);
-  } catch {
-    return null;
-  }
-
-  if (url.protocol !== "http:" && url.protocol !== "https:") {
-    return null;
-  }
-
-  if (isPrivateHost(url.hostname)) {
-    return null;
-  }
-
-  return url;
-}
 
 export interface IFetchResponse {
   ok: boolean;
@@ -166,51 +126,6 @@ export type RawFetch = (
   url: string,
   init: { redirect: "manual"; headers: Record<string, string> }
 ) => Promise<IRawResponse>;
-
-/** Resolve a hostname to its IP addresses. Injected so tests stay offline. */
-export type ResolveHost = (hostname: string) => Promise<readonly string[]>;
-
-const realResolve: ResolveHost = async (hostname) => {
-  const { lookup } = await import("node:dns/promises");
-  const records = await lookup(hostname, { all: true });
-
-  return records.map((r) => r.address);
-};
-
-/**
- * Reject a host that RESOLVES to a private/loopback/link-local IP, even when the
- * hostname string looks public. Wildcard-DNS services (`127-0-0-1.sslip.io`,
- * `foo.127.0.0.1.nip.io`) defeat a string-only check; this resolves the name and
- * re-runs the SAME IP classifier on every returned address.
- *
- * Residual: DNS rebinding (TOCTOU between this lookup and undici's own connect)
- * is not fully closed without pinning the IP and connecting to it with a Host
- * header — out of scope here; this closes the wildcard-DNS / public-name class.
- */
-async function assertPublicResolution(
-  url: URL,
-  resolve: ResolveHost
-): Promise<void> {
-  let addresses: readonly string[];
-
-  try {
-    addresses = await resolve(url.hostname);
-  } catch {
-    throw new Error(`could not resolve host (${url.hostname})`);
-  }
-
-  if (addresses.length === 0) {
-    throw new Error(`host did not resolve (${url.hostname})`);
-  }
-
-  const priv = addresses.find((ip) => isPrivateHost(ip));
-
-  if (priv !== undefined) {
-    throw new Error(
-      `blocked a host resolving to a private address (${url.hostname} → ${priv})`
-    );
-  }
-}
 
 /**
  * Follow redirects MANUALLY, re-validating EVERY hop's host. `redirect: "follow"`

--- a/packages/core/src/loop/turn.ts
+++ b/packages/core/src/loop/turn.ts
@@ -44,6 +44,8 @@ import {
   PACKAGE_DOCS_TOOL,
   SCRIPT_TOOL,
   GIT_CONTEXT_TOOL,
+  READ_IMAGE_TOOL,
+  GENERATE_IMAGE_TOOL,
 } from "../agent";
 import { TsService } from "../lsp";
 import type { McpRegistry } from "../mcp";
@@ -92,7 +94,17 @@ type AdvertisedTool =
   | typeof PACKAGE_INFO_TOOL
   | typeof PACKAGE_DOCS_TOOL
   | typeof SCRIPT_TOOL
-  | typeof GIT_CONTEXT_TOOL;
+  | typeof GIT_CONTEXT_TOOL
+  | typeof READ_IMAGE_TOOL
+  | typeof GENERATE_IMAGE_TOOL;
+
+/** Which extra capability backends are configured this run — decides whether the
+ *  image tools are advertised. Resolved once by the driver (run.ts) so
+ *  advertisement stays synchronous here. Both default off. */
+export interface ICapabilityFlags {
+  vision?: boolean;
+  imageGen?: boolean;
+}
 
 /** Free, local web tools (fetch + search) — advertised only under TSFORGE_WEB so
  *  eval sweeps stay deterministic and offline by default. Available on both
@@ -123,13 +135,34 @@ function scriptTools(): AdvertisedTool[] {
   return flags.scriptTool() ? [SCRIPT_TOOL] : [];
 }
 
-export function toolsFor(hasExistingCode: boolean): AdvertisedTool[] {
+/** Image capability tools — each advertised only when its backend is configured
+ *  (caps resolved by the driver). read_image (vision) and generate_image are
+ *  independent, so a vision-only or gen-only setup offers just the one. */
+function imageTools(caps: ICapabilityFlags): AdvertisedTool[] {
+  return [
+    ...(caps.vision === true ? [READ_IMAGE_TOOL] : []),
+    ...(caps.imageGen === true ? [GENERATE_IMAGE_TOOL] : []),
+  ];
+}
+
+export function toolsFor(
+  hasExistingCode: boolean,
+  caps: ICapabilityFlags = {}
+): AdvertisedTool[] {
   const web = webTools();
   const git = gitTools(hasExistingCode);
   const script = scriptTools();
+  const image = imageTools(caps);
 
   if (flags.noLspTools() || !hasExistingCode) {
-    return [...BASE_TOOLS, ...HASHLINE_TOOLS, ...web, ...git, ...script];
+    return [
+      ...BASE_TOOLS,
+      ...HASHLINE_TOOLS,
+      ...web,
+      ...git,
+      ...script,
+      ...image,
+    ];
   }
 
   // existing-code: base + LSP nav + (gated) web + (gated) git + (gated) script.
@@ -140,6 +173,7 @@ export function toolsFor(hasExistingCode: boolean): AdvertisedTool[] {
     ...web,
     ...git,
     ...script,
+    ...image,
   ];
 }
 
@@ -193,6 +227,9 @@ export interface ILoopCtxTool {
   /** Wired by the interactive CLI: run one read-only specialist subagent (the
    *  `spawn_agent` tool). Threaded into the tool context. */
   spawnAgent?: SpawnAgentFn;
+  /** Wired by the interactive CLI: preview a just-generated image inline (the
+   *  `generate_image` tool calls it). Threaded into the tool context. */
+  previewImage?: IToolContext["previewImage"];
 }
 
 /** Gate/VALIDATION options — what `settleGate` and the write-guard consume. */

--- a/packages/core/src/models-config.ts
+++ b/packages/core/src/models-config.ts
@@ -45,12 +45,28 @@ export interface IModelEntry {
   /** Arbitrary request headers (e.g. a non-Bearer auth scheme); `${VAR}` values
    *  are interpolated from the environment. */
   extraHeaders?: Record<string, string>;
+  /** For an `imageGen` capability entry: which wire shape the endpoint speaks.
+   *  `chat-modalities` (default) posts `/chat/completions` with
+   *  `modalities:["image","text"]` (OpenRouter-style); `images-generations`
+   *  posts the OpenAI `/images/generations` shape. Ignored for chat/vision. */
+  imageApi?: ImageApi;
 }
+
+/** How an image-generation endpoint is called on the wire. */
+export type ImageApi = "chat-modalities" | "images-generations";
+
+/** The extra capabilities the harness can borrow from a separate backend when
+ *  the primary chat model can't do them. Each value NAMES an entry in `models`,
+ *  so a capability reuses the same endpoint config (key resolution, headers) as
+ *  any chat model. Absent → the capability (and its tool/UX) stays off. */
+export type CapabilityName = "vision" | "imageGen";
 
 export interface IModelsConfig {
   /** Name of the active entry — always a key of `models`. */
   active: string;
   models: Record<string, IModelEntry>;
+  /** Optional capability→entry-name routing. e.g. `{ vision: "openrouter-vlm" }`. */
+  capabilities?: Partial<Record<CapabilityName, string>>;
 }
 
 /** The built-in local-qwen entry — matches PROVIDER_DEFAULTS so an absent
@@ -137,7 +153,47 @@ export function parseModelsConfig(raw: unknown): IModelsConfig {
     );
   }
 
-  return { active: raw.active, models };
+  const capabilities = parseCapabilities(raw.capabilities, models);
+
+  return capabilities === undefined
+    ? { active: raw.active, models }
+    : { active: raw.active, models, capabilities };
+}
+
+/** Validate the optional `capabilities` block: known keys only, each pointing at
+ *  a real model entry. Fail loud (this file's contract) so a typo'd capability
+ *  name or a dangling entry reference is caught at load, not at first image use. */
+function parseCapabilities(
+  raw: unknown,
+  models: Record<string, IModelEntry>
+): Partial<Record<CapabilityName, string>> | undefined {
+  if (raw === undefined) {
+    return undefined;
+  }
+
+  if (!isRecord(raw)) {
+    throw new Error("models.json: capabilities must be an object");
+  }
+
+  const out: Partial<Record<CapabilityName, string>> = {};
+
+  for (const [cap, target] of Object.entries(raw)) {
+    if (cap !== "vision" && cap !== "imageGen") {
+      throw new Error(
+        `models.json: unknown capability "${cap}" — expected vision, imageGen`
+      );
+    }
+
+    if (typeof target !== "string" || models[target] === undefined) {
+      throw new Error(
+        `models.json: capability "${cap}" must name a model: ${Object.keys(models).join(", ")}`
+      );
+    }
+
+    out[cap] = target;
+  }
+
+  return out;
 }
 
 /** Read the registry (read-only). Missing file → the built-in default (no write);
@@ -263,4 +319,68 @@ export async function resolveModelByName(
   return entry === undefined
     ? { name: cfg.active, entry: cfg.models[cfg.active] ?? QWEN_LOCAL }
     : { name, entry };
+}
+
+/** Resolve the backend for an extra capability (`vision`/`imageGen`), or `null`
+ *  when none is configured (the capability's tool/UX then stays off — the
+ *  primary chat model is never asked to do what it can't). Resolution order,
+ *  most-specific first, so a one-off run needs no `models.json` edit:
+ *    1. `TSFORGE_{VISION,IMAGE}_BASE_URL` (+ `_MODEL`, `_API_KEY`, `_API`) →
+ *       a fully self-contained ad-hoc entry.
+ *    2. `TSFORGE_{VISION,IMAGE}_MODEL` (without a base url) → names a registry
+ *       entry to reuse.
+ *    3. `models.json` `capabilities.{vision,imageGen}` → names a registry entry.
+ *  This mirrors the env-wins-over-registry contract of resolveActiveModel. */
+export async function resolveCapabilityModel(
+  cap: CapabilityName
+): Promise<{ name: string; entry: IModelEntry } | null> {
+  const prefix = cap === "vision" ? "TSFORGE_VISION" : "TSFORGE_IMAGE";
+  const envBase = process.env[`${prefix}_BASE_URL`];
+  const envModel = process.env[`${prefix}_MODEL`];
+
+  if (envBase !== undefined && envBase.length > 0) {
+    if (envModel === undefined || envModel.length === 0) {
+      throw new Error(
+        `${prefix}_BASE_URL is set but ${prefix}_MODEL is missing`
+      );
+    }
+
+    const entry: IModelEntry = {
+      baseUrl: envBase,
+      model: envModel,
+      apiKey: process.env[`${prefix}_API_KEY`],
+    };
+
+    if (cap === "imageGen") {
+      const api = process.env[`${prefix}_API`];
+
+      if (api === "chat-modalities" || api === "images-generations") {
+        entry.imageApi = api;
+      }
+    }
+
+    return { name: `env:${cap}`, entry };
+  }
+
+  const cfg = await loadModelsConfig();
+
+  if (envModel !== undefined && envModel.length > 0) {
+    const entry = cfg.models[envModel];
+
+    if (entry === undefined) {
+      throw new Error(
+        `${prefix}_MODEL "${envModel}" is not a configured model: ${Object.keys(cfg.models).join(", ")}`
+      );
+    }
+
+    return { name: envModel, entry };
+  }
+
+  const target = cfg.capabilities?.[cap];
+
+  if (target !== undefined && cfg.models[target] !== undefined) {
+    return { name: target, entry: cfg.models[target] };
+  }
+
+  return null;
 }

--- a/packages/core/src/models-config.ts
+++ b/packages/core/src/models-config.ts
@@ -240,7 +240,10 @@ export async function setActiveModel(name: string): Promise<IModelsConfig> {
     );
   }
 
-  const next: IModelsConfig = { active: name, models: cfg.models };
+  // Preserve everything else (notably the top-level `capabilities` block) — only
+  // `active` changes. Spreading cfg avoids silently dropping vision/imageGen
+  // routing on a `/model` switch.
+  const next: IModelsConfig = { ...cfg, active: name };
 
   await saveModelsConfig(next);
 

--- a/packages/core/src/models-config.ts
+++ b/packages/core/src/models-config.ts
@@ -121,6 +121,24 @@ function assertNumericFields(name: string, entry: unknown): void {
   }
 }
 
+/** A hand-edited `imageApi` typo (e.g. "chat-modality") would otherwise pass the
+ *  baseUrl/model-only guard and silently fall back to the chat-modalities wire
+ *  path in image-gen — fail loud with the valid options instead. */
+function assertImageApi(name: string, entry: unknown): void {
+  if (!isRecord(entry) || entry.imageApi === undefined) {
+    return;
+  }
+
+  if (
+    entry.imageApi !== "chat-modalities" &&
+    entry.imageApi !== "images-generations"
+  ) {
+    throw new Error(
+      `models.json: model "${name}" imageApi must be "chat-modalities" or "images-generations"`
+    );
+  }
+}
+
 /** Validate a parsed object into a registry, with actionable errors — the file is
  *  hand-edited, so a clear message beats a silent fallback. */
 export function parseModelsConfig(raw: unknown): IModelsConfig {
@@ -144,6 +162,7 @@ export function parseModelsConfig(raw: unknown): IModelsConfig {
     }
 
     assertNumericFields(name, entry);
+    assertImageApi(name, entry);
     models[name] = entry;
   }
 

--- a/packages/core/src/policy/classify.ts
+++ b/packages/core/src/policy/classify.ts
@@ -36,6 +36,10 @@ const KIND_BY_TOOL: Readonly<Record<string, ActionKind>> = {
   [TOOL_NAME.webFetch]: "network",
   [TOOL_NAME.webSearch]: "network",
   [TOOL_NAME.webBrowse]: "network",
+  // Both call an external capability endpoint → network egress is the salient
+  // risk (so a repo/mode can deny/ask them like the web tools).
+  [TOOL_NAME.readImage]: "network",
+  [TOOL_NAME.generateImage]: "network",
 };
 
 /** Extra path-bearing arg keys beyond the file aliases (move's source/target). */

--- a/packages/core/src/render/terminal-image.ts
+++ b/packages/core/src/render/terminal-image.ts
@@ -1,0 +1,110 @@
+/**
+ * Inline image rendering for terminals that support it. Today only the iTerm2
+ * inline-image protocol (OSC 1337) is implemented — it's what the user's terminal
+ * speaks, and unlike Kitty/Sixel it accepts JPEG/PNG/GIF/WebP as-is (no local
+ * decode/convert). Kitty and Sixel are deliberate follow-ups.
+ *
+ * The module is pure string/encoding + capability detection so it's trivially
+ * testable; the REPL decides WHEN to emit (and falls back to printing a path when
+ * the protocol is `none`).
+ */
+export type ImageProtocol = "iterm2" | "none";
+
+const ITERM2_PREFIX = "\x1b]1337;File=";
+const ITERM2_TERMINATOR = "\x07";
+
+/** The env vars `detectImageProtocol` consults (a subset of `process.env`). */
+export type IDetectImageEnv = Readonly<Record<string, string | undefined>>;
+
+/** Which inline-image protocol the current terminal supports. An explicit
+ *  `TSFORGE_IMAGE_PROTOCOL` (`iterm2` | `off`/`none`) wins so a user can force or
+ *  disable it; tmux is treated as unsupported (passthrough is unreliable and can
+ *  corrupt the pane). Otherwise iTerm2 is detected via its session env vars. */
+export function detectImageProtocol(
+  env: IDetectImageEnv = process.env
+): ImageProtocol {
+  const forced = env.TSFORGE_IMAGE_PROTOCOL;
+
+  if (forced === "iterm2") {
+    return "iterm2";
+  }
+
+  if (forced === "off" || forced === "none") {
+    return "none";
+  }
+
+  if (env.TMUX !== undefined && env.TMUX.length > 0) {
+    return "none";
+  }
+
+  if (
+    (env.ITERM_SESSION_ID !== undefined && env.ITERM_SESSION_ID.length > 0) ||
+    env.TERM_PROGRAM === "iTerm.app"
+  ) {
+    return "iterm2";
+  }
+
+  return "none";
+}
+
+export interface IEncodeImageOptions {
+  /** File name shown by the terminal (base64-encoded per the protocol). */
+  name?: string;
+  /** Width in terminal cells (e.g. `40`). Omitted → `auto`. */
+  widthCells?: number;
+  /** Height in terminal cells. Omitted → `auto`. */
+  heightCells?: number;
+}
+
+/** Build the iTerm2 OSC-1337 inline-image escape sequence for base64 image data
+ *  (no data-URI prefix). Aspect ratio is preserved; width/height default to
+ *  `auto` so the terminal sizes the image sensibly. */
+export function encodeITerm2(
+  base64: string,
+  opts: IEncodeImageOptions = {}
+): string {
+  const params = [
+    "inline=1",
+    `width=${opts.widthCells === undefined ? "auto" : String(opts.widthCells)}`,
+    `height=${opts.heightCells === undefined ? "auto" : String(opts.heightCells)}`,
+    "preserveAspectRatio=1",
+    ...(opts.name === undefined
+      ? []
+      : [`name=${Buffer.from(opts.name).toString("base64")}`]),
+  ].join(";");
+
+  return `${ITERM2_PREFIX}${params}:${base64}${ITERM2_TERMINATOR}`;
+}
+
+/** Encode `base64` for the given protocol, or `null` when inline rendering isn't
+ *  supported (caller should print a path instead). */
+export function renderInlineImage(
+  base64: string,
+  protocol: ImageProtocol,
+  opts: IEncodeImageOptions = {}
+): string | null {
+  return protocol === "iterm2" ? encodeITerm2(base64, opts) : null;
+}
+
+/** A tiny budget so a burst of generated images can't flood the scrollback. Not
+ *  a hard requirement for iTerm2 (emit-and-forget), but keeps a runaway loop from
+ *  dumping hundreds of images. `take()` returns false once the cap is reached. */
+export function makeImageBudget(max = 8): {
+  take: () => boolean;
+  used: () => number;
+} {
+  let used = 0;
+
+  return {
+    take() {
+      if (used >= max) {
+        return false;
+      }
+
+      used += 1;
+
+      return true;
+    },
+    used: () => used,
+  };
+}

--- a/packages/core/tests/clipboard-image.test.ts
+++ b/packages/core/tests/clipboard-image.test.ts
@@ -2,6 +2,7 @@ import { test, expect } from "bun:test";
 import {
   readClipboardImage,
   readClipboardText,
+  captureClipboardImageToFile,
   type IClipboardDeps,
 } from "../src/lib/clipboard/clipboard-image";
 
@@ -92,6 +93,31 @@ test("readClipboardText: returns pbpaste stdout on macOS, '' elsewhere", async (
   });
 
   expect(linux).toBe("");
+});
+
+test("captureClipboardImageToFile: keeps the written temp path, no re-encode", async () => {
+  // pngpaste 'writes' the file (faked) and readFileBytes confirms non-empty →
+  // returns that path directly (no read-back + base64 + rewrite).
+  const path = await captureClipboardImageToFile(
+    deps({
+      run: async (argv) => (argv[0] === "pngpaste" ? 0 : 1),
+      readFileBytes: async () => PNG,
+    })
+  );
+
+  expect(path).toMatch(/tsforge-paste-.*\.png$/);
+
+  // no image on clipboard → null
+  expect(
+    await captureClipboardImageToFile(
+      deps({ run: async () => 0, readFileBytes: async () => null })
+    )
+  ).toBeNull();
+
+  // non-macOS → null
+  expect(
+    await captureClipboardImageToFile(deps({ platform: "linux" }))
+  ).toBeNull();
 });
 
 test("readClipboardText: non-zero exit → empty string", async () => {

--- a/packages/core/tests/clipboard-image.test.ts
+++ b/packages/core/tests/clipboard-image.test.ts
@@ -1,0 +1,104 @@
+import { test, expect } from "bun:test";
+import {
+  readClipboardImage,
+  readClipboardText,
+  type IClipboardDeps,
+} from "../src/lib/clipboard/clipboard-image";
+
+const PNG = new Uint8Array([137, 80, 78, 71, 13, 10, 26, 10]);
+
+function deps(over: Partial<IClipboardDeps>): IClipboardDeps {
+  return {
+    platform: "darwin",
+    run: async () => 1,
+    readFileBytes: async () => null,
+    ...over,
+  };
+}
+
+test("non-macOS platforms return null (REPL falls back to text paste)", async () => {
+  const out = await readClipboardImage(
+    deps({
+      platform: "linux",
+      run: async () => 0,
+      readFileBytes: async () => PNG,
+    })
+  );
+
+  expect(out).toBeNull();
+});
+
+test("pngpaste success returns base64 PNG without trying osascript", async () => {
+  const argvs: string[][] = [];
+  const out = await readClipboardImage(
+    deps({
+      run: async (argv) => {
+        argvs.push(argv);
+
+        return argv[0] === "pngpaste" ? 0 : 1;
+      },
+      readFileBytes: async () => PNG,
+    })
+  );
+
+  expect(out?.mimeType).toBe("image/png");
+  expect(out?.base64).toBe(Buffer.from(PNG).toString("base64"));
+  // osascript must NOT be invoked once pngpaste succeeds
+  expect(argvs.map((a) => a[0])).toEqual(["pngpaste"]);
+});
+
+test("falls back to osascript when pngpaste is missing", async () => {
+  const argvs: string[][] = [];
+  const out = await readClipboardImage(
+    deps({
+      run: async (argv) => {
+        argvs.push(argv);
+
+        // pngpaste missing → 127; osascript succeeds
+        return argv[0] === "osascript" ? 0 : 127;
+      },
+      readFileBytes: async (path) => (path.endsWith(".png") ? PNG : null),
+    })
+  );
+
+  expect(out?.base64).toBe(Buffer.from(PNG).toString("base64"));
+  expect(argvs.map((a) => a[0])).toEqual(["pngpaste", "osascript"]);
+  // osascript is invoked with the temp path as a POSIX file argument
+  expect(argvs[1]?.join(" ")).toContain("class PNGf");
+});
+
+test("no image on clipboard (empty file) returns null after trying both", async () => {
+  const out = await readClipboardImage(
+    deps({ run: async () => 0, readFileBytes: async () => null })
+  );
+
+  expect(out).toBeNull();
+});
+
+test("readClipboardText: returns pbpaste stdout on macOS, '' elsewhere", async () => {
+  const text = await readClipboardText({
+    platform: "darwin",
+    run: async (argv) => ({
+      exitCode: 0,
+      stdout: argv[0] === "pbpaste" ? "hello clip" : "",
+    }),
+  });
+
+  expect(text).toBe("hello clip");
+
+  const linux = await readClipboardText({
+    platform: "linux",
+    run: async () => ({ exitCode: 0, stdout: "x" }),
+  });
+
+  expect(linux).toBe("");
+});
+
+test("readClipboardText: non-zero exit → empty string", async () => {
+  const text = await readClipboardText({
+    platform: "darwin",
+    run: async () => ({ exitCode: 1, stdout: "junk" }),
+  });
+
+  expect(text).toBe("");
+});

--- a/packages/core/tests/editor-controller.test.ts
+++ b/packages/core/tests/editor-controller.test.ts
@@ -70,6 +70,7 @@ class FakeStdin {
 function makeHarness(deps?: {
   openFilePicker?: () => Promise<void>;
   openPalette?: () => Promise<void>;
+  pasteFromClipboard?: () => Promise<string | null>;
 }) {
   const stdin = new FakeStdin();
   const outputs: string[] = [];
@@ -84,6 +85,7 @@ function makeHarness(deps?: {
     rows: 10,
     openFilePicker: deps?.openFilePicker,
     openPalette: deps?.openPalette,
+    pasteFromClipboard: deps?.pasteFromClipboard,
   });
 
   handle.onSubmit((message: string) => {
@@ -608,5 +610,41 @@ describe("EditorController @/ overlay triggers", () => {
     // Bracketed paste + coalesced keystrokes (TCP/automation) in a single chunk.
     stdin.feed("\x1b[200~pasted\x1b[201~typed");
     expect(handle.getBuffer().getText()).toBe("pastedtyped");
+  });
+
+  test("Ctrl+V calls pasteFromClipboard and inserts the returned chip (image)", async () => {
+    let calls = 0;
+    const { stdin, handle } = makeHarness({
+      pasteFromClipboard: async () => {
+        calls += 1;
+
+        return "[image #1]";
+      },
+    });
+
+    stdin.feed("\x16"); // Ctrl+V
+    // The handler is async (clipboard read shells out); insert lands on resolve.
+    await new Promise((r) => setTimeout(r, 0));
+
+    expect(calls).toBe(1);
+    expect(handle.getBuffer().getText()).toBe("[image #1]");
+  });
+
+  test("Ctrl+V with no clipboard content inserts nothing (no literal 'v')", async () => {
+    const { stdin, handle } = makeHarness({
+      pasteFromClipboard: async () => null,
+    });
+
+    stdin.feed("\x16");
+    await new Promise((r) => setTimeout(r, 0));
+
+    expect(handle.getBuffer().getText()).toBe("");
+  });
+
+  test("Ctrl+V without a handler is swallowed (no literal 'v' inserted)", () => {
+    const { stdin, handle } = makeHarness();
+
+    stdin.feed("\x16");
+    expect(handle.getBuffer().getText()).toBe("");
   });
 });

--- a/packages/core/tests/image-gen.test.ts
+++ b/packages/core/tests/image-gen.test.ts
@@ -166,6 +166,22 @@ test("generateImage throws on non-2xx and on an image-less response", async () =
   await expect(
     generateImage(CFG, { prompt: "x" }, { fetch: declineFetch })
   ).rejects.toThrow(/declined: .*copyrighted characters/s);
+
+  // The real Gemini shape: finish_reason content_filter, everything else null →
+  // a concrete "content filter" cause, not a vague "no image".
+  const filterFetch = (async () =>
+    jsonResponse({
+      choices: [
+        {
+          finish_reason: "content_filter",
+          message: { content: null, refusal: null },
+        },
+      ],
+    })) as unknown as typeof fetch;
+
+  await expect(
+    generateImage(CFG, { prompt: "homer" }, { fetch: filterFetch })
+  ).rejects.toThrow(/content filter/);
 });
 
 test("saveGeneratedImages writes files and returns paths", async () => {

--- a/packages/core/tests/image-gen.test.ts
+++ b/packages/core/tests/image-gen.test.ts
@@ -120,7 +120,7 @@ test("generateImage fetches a remote url when the response is not inline", async
   const images = await generateImage(
     CFG,
     { prompt: "x" },
-    { fetch: fakeFetch }
+    { fetch: fakeFetch, resolve: async () => ["93.184.216.34"] }
   );
 
   expect(images).toHaveLength(1);
@@ -129,17 +129,90 @@ test("generateImage fetches a remote url when the response is not inline", async
   ]);
 });
 
-test("generateImage refuses a non-http(s) image url (SSRF guard)", async () => {
-  const fakeFetch = (async () =>
-    jsonResponse({
-      choices: [
-        { message: { images: [{ image_url: { url: "file:///etc/passwd" } }] } },
-      ],
-    })) as unknown as typeof fetch;
+test("generateImage SSRF: refuses non-http(s), private-host, and redirect-to-private image urls", async () => {
+  const chatWith = (url: string) =>
+    (async (target: string) => {
+      if (target.endsWith("/chat/completions")) {
+        return jsonResponse({
+          choices: [{ message: { images: [{ image_url: { url } }] } }],
+        });
+      }
+
+      // a 302 → private host (only reached by the redirect case)
+      return new Response(null, {
+        status: 302,
+        headers: { location: "http://169.254.169.254/latest/meta-data" },
+      });
+    }) as unknown as typeof fetch;
+
+  // non-http(s) scheme
+  await expect(
+    generateImage(
+      CFG,
+      { prompt: "x" },
+      { fetch: chatWith("file:///etc/passwd") }
+    )
+  ).rejects.toThrow(/non-public image url/);
+
+  // literal private/loopback + metadata IP
+  await expect(
+    generateImage(
+      CFG,
+      { prompt: "x" },
+      { fetch: chatWith("http://127.0.0.1/admin") }
+    )
+  ).rejects.toThrow(/non-public image url/);
+  await expect(
+    generateImage(
+      CFG,
+      { prompt: "x" },
+      { fetch: chatWith("http://169.254.169.254/") }
+    )
+  ).rejects.toThrow(/non-public image url/);
+
+  // public URL that 302-redirects to a private host → blocked at the next hop
+  await expect(
+    generateImage(
+      CFG,
+      { prompt: "x" },
+      {
+        fetch: chatWith("https://cdn.example/x.png"),
+        resolve: async () => ["93.184.216.34"],
+      }
+    )
+  ).rejects.toThrow(/non-public image url/);
+});
+
+test("generateImage caps an oversized provider image (content-length)", async () => {
+  const fakeFetch = (async (target: string) => {
+    if (target.endsWith("/chat/completions")) {
+      return jsonResponse({
+        choices: [
+          {
+            message: {
+              images: [{ image_url: { url: "https://cdn.example/big.png" } }],
+            },
+          },
+        ],
+      });
+    }
+
+    return new Response(Buffer.from(PNG_B64, "base64"), {
+      status: 200,
+      headers: {
+        "content-type": "image/png",
+        "content-length": String(999 * 1024 * 1024),
+      },
+    });
+  }) as unknown as typeof fetch;
 
   await expect(
-    generateImage(CFG, { prompt: "x" }, { fetch: fakeFetch })
-  ).rejects.toThrow(/non-http\(s\)/);
+    generateImage(
+      CFG,
+      { prompt: "x" },
+      { fetch: fakeFetch, resolve: async () => ["93.184.216.34"] }
+    )
+  ).rejects.toThrow(/size limit/);
 });
 
 test("generateImage throws on non-2xx and on an image-less response", async () => {

--- a/packages/core/tests/image-gen.test.ts
+++ b/packages/core/tests/image-gen.test.ts
@@ -129,6 +129,19 @@ test("generateImage fetches a remote url when the response is not inline", async
   ]);
 });
 
+test("generateImage refuses a non-http(s) image url (SSRF guard)", async () => {
+  const fakeFetch = (async () =>
+    jsonResponse({
+      choices: [
+        { message: { images: [{ image_url: { url: "file:///etc/passwd" } }] } },
+      ],
+    })) as unknown as typeof fetch;
+
+  await expect(
+    generateImage(CFG, { prompt: "x" }, { fetch: fakeFetch })
+  ).rejects.toThrow(/non-http\(s\)/);
+});
+
 test("generateImage throws on non-2xx and on an image-less response", async () => {
   const errFetch = (async () =>
     new Response("bad model", { status: 400 })) as unknown as typeof fetch;

--- a/packages/core/tests/image-gen.test.ts
+++ b/packages/core/tests/image-gen.test.ts
@@ -150,14 +150,22 @@ test("generateImage throws on non-2xx and on an image-less response", async () =
     generateImage(CFG, { prompt: "x" }, { fetch: errFetch })
   ).rejects.toThrow(/image-gen request failed \(400\).*bad model/s);
 
-  const emptyFetch = (async () =>
+  // A 2xx with a text reply and no image = a content-policy DECLINE — surface the
+  // model's actual words so the caller relays the real reason, not "no image".
+  const declineFetch = (async () =>
     jsonResponse({
-      choices: [{ message: { content: "no image here" } }],
+      choices: [
+        {
+          message: {
+            content: "I can't create images of copyrighted characters.",
+          },
+        },
+      ],
     })) as unknown as typeof fetch;
 
   await expect(
-    generateImage(CFG, { prompt: "x" }, { fetch: emptyFetch })
-  ).rejects.toThrow(/no image content/);
+    generateImage(CFG, { prompt: "x" }, { fetch: declineFetch })
+  ).rejects.toThrow(/declined: .*copyrighted characters/s);
 });
 
 test("saveGeneratedImages writes files and returns paths", async () => {

--- a/packages/core/tests/image-gen.test.ts
+++ b/packages/core/tests/image-gen.test.ts
@@ -1,0 +1,188 @@
+import { test, expect } from "bun:test";
+import { mkdtemp, rm, readFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  generateImage,
+  saveGeneratedImages,
+  extForMime,
+} from "../src/inference/image-gen";
+import type { IOpenAICompatibleConfig } from "../src/inference/inference.types";
+
+const CFG: IOpenAICompatibleConfig = {
+  baseUrl: "https://img.example/v1",
+  model: "flux",
+  apiKey: "sk-test",
+};
+
+// one-pixel PNG bytes, base64-encoded
+const PNG_B64 =
+  "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg==";
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "content-type": "application/json" },
+  });
+}
+
+test("chat-modalities: posts modalities + decodes data-URI image from message.images", async () => {
+  let capturedUrl = "";
+  let capturedBody: unknown;
+
+  const fakeFetch = (async (url: string, init?: RequestInit) => {
+    capturedUrl = url;
+    capturedBody = JSON.parse(String(init?.body));
+
+    return jsonResponse({
+      choices: [
+        {
+          message: {
+            images: [
+              { image_url: { url: `data:image/png;base64,${PNG_B64}` } },
+            ],
+          },
+        },
+      ],
+    });
+  }) as unknown as typeof fetch;
+
+  const images = await generateImage(
+    CFG,
+    { prompt: "a cat" },
+    { fetch: fakeFetch }
+  );
+
+  expect(capturedUrl).toBe("https://img.example/v1/chat/completions");
+  expect((capturedBody as { modalities: string[] }).modalities).toEqual([
+    "image",
+    "text",
+  ]);
+  expect(images).toHaveLength(1);
+  expect(images[0]?.mimeType).toBe("image/png");
+  // decoded bytes are a real PNG (starts with the PNG magic number)
+  expect(Array.from(images[0]!.bytes.subarray(0, 4))).toEqual([
+    137, 80, 78, 71,
+  ]);
+});
+
+test("images-generations: posts prompt/b64_json and decodes data[].b64_json", async () => {
+  let capturedUrl = "";
+  let capturedBody: unknown;
+
+  const fakeFetch = (async (url: string, init?: RequestInit) => {
+    capturedUrl = url;
+    capturedBody = JSON.parse(String(init?.body));
+
+    return jsonResponse({ data: [{ b64_json: PNG_B64 }] });
+  }) as unknown as typeof fetch;
+
+  const images = await generateImage(
+    CFG,
+    { prompt: "a dog", api: "images-generations", size: "512x512" },
+    { fetch: fakeFetch }
+  );
+
+  expect(capturedUrl).toBe("https://img.example/v1/images/generations");
+  const body = capturedBody as {
+    prompt: string;
+    size: string;
+    response_format: string;
+  };
+
+  expect(body.prompt).toBe("a dog");
+  expect(body.size).toBe("512x512");
+  expect(body.response_format).toBe("b64_json");
+  expect(images).toHaveLength(1);
+});
+
+test("generateImage fetches a remote url when the response is not inline", async () => {
+  const fakeFetch = (async (url: string) => {
+    if (url.endsWith("/chat/completions")) {
+      return jsonResponse({
+        choices: [
+          {
+            message: {
+              images: [{ image_url: { url: "https://cdn.example/x.png" } }],
+            },
+          },
+        ],
+      });
+    }
+
+    // the follow-up fetch of the remote image
+    return new Response(Buffer.from(PNG_B64, "base64"), {
+      status: 200,
+      headers: { "content-type": "image/png" },
+    });
+  }) as unknown as typeof fetch;
+
+  const images = await generateImage(
+    CFG,
+    { prompt: "x" },
+    { fetch: fakeFetch }
+  );
+
+  expect(images).toHaveLength(1);
+  expect(Array.from(images[0]!.bytes.subarray(0, 4))).toEqual([
+    137, 80, 78, 71,
+  ]);
+});
+
+test("generateImage throws on non-2xx and on an image-less response", async () => {
+  const errFetch = (async () =>
+    new Response("bad model", { status: 400 })) as unknown as typeof fetch;
+
+  await expect(
+    generateImage(CFG, { prompt: "x" }, { fetch: errFetch })
+  ).rejects.toThrow(/image-gen request failed \(400\).*bad model/s);
+
+  const emptyFetch = (async () =>
+    jsonResponse({
+      choices: [{ message: { content: "no image here" } }],
+    })) as unknown as typeof fetch;
+
+  await expect(
+    generateImage(CFG, { prompt: "x" }, { fetch: emptyFetch })
+  ).rejects.toThrow(/no image content/);
+});
+
+test("saveGeneratedImages writes files and returns paths", async () => {
+  const dir = await mkdtemp(join(tmpdir(), "tsforge-img-"));
+
+  try {
+    const bytes = new Uint8Array(Buffer.from(PNG_B64, "base64"));
+    const paths = await saveGeneratedImages(
+      [{ bytes, mimeType: "image/png" }],
+      dir,
+      "gen"
+    );
+
+    expect(paths).toHaveLength(1);
+    expect(paths[0]).toBe(join(dir, "gen.png"));
+    const onDisk = await readFile(paths[0]!);
+
+    expect(Array.from(onDisk.subarray(0, 4))).toEqual([137, 80, 78, 71]);
+
+    // multiple images get an index suffix
+    const multi = await saveGeneratedImages(
+      [
+        { bytes, mimeType: "image/png" },
+        { bytes, mimeType: "image/jpeg" },
+      ],
+      dir,
+      "multi"
+    );
+
+    expect(multi[0]).toBe(join(dir, "multi-0.png"));
+    expect(multi[1]).toBe(join(dir, "multi-1.jpg"));
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test("extForMime maps known types, defaults to png", () => {
+  expect(extForMime("image/jpeg")).toBe("jpg");
+  expect(extForMime("image/webp")).toBe("webp");
+  expect(extForMime("application/octet-stream")).toBe("png");
+});

--- a/packages/core/tests/image-input.test.ts
+++ b/packages/core/tests/image-input.test.ts
@@ -1,0 +1,109 @@
+import { test, expect } from "bun:test";
+import {
+  extractImagePaths,
+  resolveImageInput,
+  type IResolveImageInputDeps,
+} from "../src/cli/image-input";
+import type { IOpenAICompatibleConfig } from "../src/inference";
+
+const VISION: IOpenAICompatibleConfig = {
+  baseUrl: "https://v/v1",
+  model: "vlm",
+};
+
+function deps(over: Partial<IResolveImageInputDeps>): IResolveImageInputDeps {
+  return {
+    resolveVision: async () => VISION,
+    load: async () => ({ base64: "AAAA", mimeType: "image/png" }),
+    describe: async () => "a login screen",
+    ...over,
+  };
+}
+
+test("extractImagePaths: @-mention, bare drag path, and quoted path", () => {
+  const r = extractImagePaths(
+    "look at @shot.png and /Users/ag/Pictures/bug.jpg plus 'my file.webp'",
+    "/work"
+  );
+
+  expect(r.paths).toEqual([
+    "/work/shot.png",
+    "/Users/ag/Pictures/bug.jpg",
+    "/work/my file.webp",
+  ]);
+  // tokens are replaced by inline markers; surrounding prose is preserved
+  expect(r.cleanedLine).toContain("[image: shot.png]");
+  expect(r.cleanedLine).toContain("[image: bug.jpg]");
+  expect(r.cleanedLine).toContain("[image: my file.webp]");
+  expect(r.cleanedLine).toContain("look at");
+});
+
+test("extractImagePaths: backslash-escaped spaces in a dragged path", () => {
+  const r = extractImagePaths("/Users/ag/My\\ Shots/a\\ b.png", "/work");
+
+  expect(r.paths).toEqual(["/Users/ag/My Shots/a b.png"]);
+});
+
+test("extractImagePaths: leaves non-image @mentions and prose alone", () => {
+  const r = extractImagePaths("read @src/index.ts and explain", "/work");
+
+  expect(r.paths).toEqual([]);
+  expect(r.cleanedLine).toBe("read @src/index.ts and explain");
+});
+
+test("resolveImageInput: describes each image and prepends a context block", async () => {
+  const seen: string[] = [];
+  const out = await resolveImageInput("what is @a.png", "/work", {
+    deps: deps({
+      describe: async (_cfg, input) => {
+        seen.push(input.images[0]!.base64);
+
+        return "a chart";
+      },
+    }),
+  });
+
+  expect(out.imageCount).toBe(1);
+  expect(out.contextBlock).toContain('[Attached image "a.png":');
+  expect(out.contextBlock).toContain("a chart");
+  expect(seen).toHaveLength(1);
+});
+
+test("resolveImageInput: includes extraPaths (e.g. clipboard temp files)", async () => {
+  const out = await resolveImageInput("here", "/work", {
+    extraPaths: ["/tmp/clip.png"],
+    deps: deps({}),
+  });
+
+  expect(out.imageCount).toBe(1);
+  expect(out.contextBlock).toContain('[Attached image "clip.png"');
+});
+
+test("resolveImageInput: note (not a crash) when vision is unconfigured", async () => {
+  const out = await resolveImageInput("see @a.png", "/work", {
+    deps: deps({ resolveVision: async () => null }),
+  });
+
+  expect(out.imageCount).toBe(1);
+  expect(out.contextBlock).toContain("no vision backend is configured");
+});
+
+test("resolveImageInput: no images → empty context, unchanged line", async () => {
+  const out = await resolveImageInput("just text", "/work", { deps: deps({}) });
+
+  expect(out.imageCount).toBe(0);
+  expect(out.contextBlock).toBe("");
+  expect(out.cleanedLine).toBe("just text");
+});
+
+test("resolveImageInput: a vision error degrades to a per-image note", async () => {
+  const out = await resolveImageInput("@a.png", "/work", {
+    deps: deps({
+      describe: async () => {
+        throw new Error("429 rate limited");
+      },
+    }),
+  });
+
+  expect(out.contextBlock).toContain("vision failed — 429 rate limited");
+});

--- a/packages/core/tests/image-input.test.ts
+++ b/packages/core/tests/image-input.test.ts
@@ -44,6 +44,16 @@ test("extractImagePaths: backslash-escaped spaces in a dragged path", () => {
   expect(r.paths).toEqual(["/Users/ag/My Shots/a b.png"]);
 });
 
+test("extractImagePaths: a filename containing ']' doesn't corrupt the residual prompt", () => {
+  const r = extractImagePaths("what is @weird].png showing", "/work");
+
+  expect(r.paths).toEqual(["/work/weird].png"]);
+  // residual (the vision-prompt basis) has NO stray marker/filename fragments
+  expect(r.residualText).toBe("what is showing");
+  expect(r.residualText).not.toContain("].png");
+  expect(r.residualText).not.toContain("[image");
+});
+
 test("extractImagePaths: leaves non-image @mentions and prose alone", () => {
   const r = extractImagePaths("read @src/index.ts and explain", "/work");
 

--- a/packages/core/tests/image-input.test.ts
+++ b/packages/core/tests/image-input.test.ts
@@ -69,6 +69,26 @@ test("resolveImageInput: describes each image and prepends a context block", asy
   expect(seen).toHaveLength(1);
 });
 
+test("resolveImageInput: identical images are described ONCE (no duplicate cost)", async () => {
+  let calls = 0;
+  const out = await resolveImageInput("look at these", "/work", {
+    // three paths, but the default load() returns the same bytes for each
+    extraPaths: ["/tmp/a.png", "/tmp/b.png", "/tmp/c.png"],
+    deps: deps({
+      describe: async () => {
+        calls += 1;
+
+        return "a Homer Simpson image";
+      },
+    }),
+  });
+
+  expect(calls).toBe(1); // one vision call, not three
+  expect(out.imageCount).toBe(1); // one unique image billed
+  expect(out.contextBlock).toContain("a Homer Simpson image");
+  expect(out.contextBlock).toContain("same as above"); // dupes reference the first
+});
+
 test("resolveImageInput: includes extraPaths (e.g. clipboard temp files)", async () => {
   const out = await resolveImageInput("here", "/work", {
     extraPaths: ["/tmp/clip.png"],

--- a/packages/core/tests/image-input.test.ts
+++ b/packages/core/tests/image-input.test.ts
@@ -89,6 +89,56 @@ test("resolveImageInput: identical images are described ONCE (no duplicate cost)
   expect(out.contextBlock).toContain("same as above"); // dupes reference the first
 });
 
+test("resolveImageInput: image-only send uses the default vision prompt (not the marker)", async () => {
+  let seenPrompt = "";
+
+  // an @-mention with no other text → cleanedLine is just "[image: a.png]"
+  await resolveImageInput("@a.png", "/work", {
+    deps: deps({
+      describe: async (_cfg, input) => {
+        seenPrompt = input.prompt;
+
+        return "desc";
+      },
+    }),
+  });
+
+  expect(seenPrompt).not.toContain("[image:");
+  expect(seenPrompt).toContain("software engineer"); // DEFAULT_VISION_PROMPT
+
+  // clipboard chip only → also falls back to the default
+  let chipPrompt = "";
+
+  await resolveImageInput("[image #1]", "/work", {
+    extraPaths: ["/tmp/clip.png"],
+    deps: deps({
+      describe: async (_cfg, input) => {
+        chipPrompt = input.prompt;
+
+        return "desc";
+      },
+    }),
+  });
+
+  expect(chipPrompt).toContain("software engineer");
+
+  // but a REAL question alongside the image is used verbatim
+  let qPrompt = "";
+
+  await resolveImageInput("what error is @shot.png showing?", "/work", {
+    deps: deps({
+      describe: async (_cfg, input) => {
+        qPrompt = input.prompt;
+
+        return "desc";
+      },
+    }),
+  });
+
+  expect(qPrompt).toContain("what error");
+  expect(qPrompt).not.toContain("[image:");
+});
+
 test("resolveImageInput: includes extraPaths (e.g. clipboard temp files)", async () => {
   const out = await resolveImageInput("here", "/work", {
     extraPaths: ["/tmp/clip.png"],

--- a/packages/core/tests/image-tools.test.ts
+++ b/packages/core/tests/image-tools.test.ts
@@ -130,6 +130,28 @@ test("generate_image: saves under .tsforge/images and previews inline", async ()
   }
 });
 
+test("generate_image: a model decline returns a clear reason, not a crash", async () => {
+  const out = await doGenerateImage(
+    { prompt: "homer simpson playing guitar" },
+    ctx("/tmp"),
+    deps({
+      resolveCap: async () => ({ name: "gen", entry: IMAGE_ENTRY }),
+      generate: async () => {
+        throw new Error(
+          "image model declined: I can't create copyrighted characters."
+        );
+      },
+    })
+  );
+
+  // terse + factual: the real reason, no crash framing, no meta-instructions the
+  // model would parrot back to the user
+  expect(out).toContain("image not generated");
+  expect(out).toContain("copyrighted characters");
+  expect(out).not.toContain("FAILED");
+  expect(out).not.toContain("backend");
+});
+
 test("generate_image: not-configured + empty-prompt rejections", async () => {
   const notConfigured = await doGenerateImage(
     { prompt: "x" },

--- a/packages/core/tests/image-tools.test.ts
+++ b/packages/core/tests/image-tools.test.ts
@@ -1,0 +1,162 @@
+import { test, expect } from "bun:test";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  doReadImage,
+  doGenerateImage,
+  resolveImageCapabilityFlags,
+  type IImageToolDeps,
+} from "../src/loop/tools/image-tools";
+import type { IToolContext } from "../src/loop/tools/tool-context";
+import type { IModelEntry } from "../src/models-config";
+
+const VISION_ENTRY: IModelEntry = { baseUrl: "https://v/v1", model: "vlm" };
+const IMAGE_ENTRY: IModelEntry = {
+  baseUrl: "https://i/v1",
+  model: "gen",
+  imageApi: "chat-modalities",
+};
+
+function ctx(cwd: string, over: Partial<IToolContext> = {}): IToolContext {
+  return {
+    cwd,
+    files: [],
+    task: "t",
+    report: () => {
+      /* swallow */
+    },
+    ...over,
+  };
+}
+
+function deps(over: Partial<IImageToolDeps>): IImageToolDeps {
+  return {
+    resolveCap: async () => null,
+    describe: async () => "described",
+    generate: async () => [
+      { bytes: new Uint8Array([1, 2, 3]), mimeType: "image/png" },
+    ],
+    save: async (_images, dir, base) => [join(dir, `${base}.png`)],
+    readImageFile: async () => ({ base64: "AAAA", mimeType: "image/png" }),
+    ...over,
+  };
+}
+
+test("read_image: reports 'not configured' when no vision capability", async () => {
+  const out = await doReadImage(
+    { file: "x.png" },
+    ctx("/tmp"),
+    deps({ resolveCap: async () => null })
+  );
+
+  expect(out).toContain("vision is not configured");
+});
+
+test("read_image: passes image + question to the vision backend", async () => {
+  let seenPrompt = "";
+  let seenImages = 0;
+
+  const out = await doReadImage(
+    { file: "shot.png", question: "what error is shown?" },
+    ctx("/work"),
+    deps({
+      resolveCap: async () => ({ name: "vlm", entry: VISION_ENTRY }),
+      describe: async (_cfg, input) => {
+        seenPrompt = input.prompt;
+        seenImages = input.images.length;
+
+        return "a stack trace";
+      },
+    })
+  );
+
+  expect(out).toBe("a stack trace");
+  expect(seenPrompt).toBe("what error is shown?");
+  expect(seenImages).toBe(1);
+});
+
+test("read_image: rejects an out-of-scope path", async () => {
+  const out = await doReadImage(
+    { file: "../../etc/passwd.png" },
+    ctx("/work"),
+    deps({ resolveCap: async () => ({ name: "vlm", entry: VISION_ENTRY }) })
+  );
+
+  expect(out).toContain("out-of-scope");
+});
+
+test("read_image: rejects an unsupported/missing file", async () => {
+  const out = await doReadImage(
+    { file: "notes.txt" },
+    ctx("/work"),
+    deps({
+      resolveCap: async () => ({ name: "vlm", entry: VISION_ENTRY }),
+      readImageFile: async () => null,
+    })
+  );
+
+  expect(out).toContain("cannot read image");
+});
+
+test("generate_image: saves under .tsforge/images and previews inline", async () => {
+  const dir = await mkdtemp(join(tmpdir(), "tsforge-gentool-"));
+
+  try {
+    const previews: string[] = [];
+    let genApi: string | undefined;
+
+    const out = await doGenerateImage(
+      { prompt: "a fox", size: "1024x1024" },
+      ctx(dir, { previewImage: (img) => previews.push(img.path) }),
+      deps({
+        resolveCap: async () => ({ name: "gen", entry: IMAGE_ENTRY }),
+        generate: async (_cfg, input) => {
+          genApi = input.api;
+
+          return [{ bytes: new Uint8Array([9]), mimeType: "image/png" }];
+        },
+        // real save so the path is under the temp cwd
+        save: (await import("../src/inference/image-gen")).saveGeneratedImages,
+      })
+    );
+
+    expect(out).toMatch(/Generated 1 image\(s\): \.tsforge\/images\/image-/);
+    expect(genApi).toBe("chat-modalities");
+    expect(previews).toHaveLength(1);
+    expect(previews[0]).toContain(join(dir, ".tsforge", "images"));
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test("generate_image: not-configured + empty-prompt rejections", async () => {
+  const notConfigured = await doGenerateImage(
+    { prompt: "x" },
+    ctx("/tmp"),
+    deps({ resolveCap: async () => null })
+  );
+
+  expect(notConfigured).toContain("image generation is not configured");
+
+  const emptyPrompt = await doGenerateImage(
+    { prompt: "" },
+    ctx("/tmp"),
+    deps({ resolveCap: async () => ({ name: "gen", entry: IMAGE_ENTRY }) })
+  );
+
+  expect(emptyPrompt).toContain("non-empty `prompt`");
+});
+
+test("resolveImageCapabilityFlags: treats a throwing resolver as unconfigured", async () => {
+  const flags = await resolveImageCapabilityFlags(async (cap) => {
+    if (cap === "vision") {
+      return { name: "v", entry: VISION_ENTRY };
+    }
+
+    throw new Error("bad env");
+  });
+
+  expect(flags.vision).toBe(true);
+  expect(flags.imageGen).toBe(false);
+});

--- a/packages/core/tests/image-tools.test.ts
+++ b/packages/core/tests/image-tools.test.ts
@@ -1,5 +1,5 @@
 import { test, expect } from "bun:test";
-import { mkdtemp, rm } from "node:fs/promises";
+import { mkdtemp, rm, writeFile, symlink } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import {
@@ -84,6 +84,36 @@ test("read_image: rejects an out-of-scope path", async () => {
   );
 
   expect(out).toContain("out-of-scope");
+});
+
+test("read_image: rejects a symlink that escapes the workspace (real fs)", async () => {
+  const root = await mkdtemp(join(tmpdir(), "tsforge-sym-"));
+  const { mkdir } = await import("node:fs/promises");
+
+  try {
+    const work = join(root, "work");
+    const secret = join(root, "secret");
+
+    await mkdir(work, { recursive: true });
+    await mkdir(secret, { recursive: true });
+    await writeFile(join(secret, "secret.png"), Buffer.from([137, 80, 78, 71]));
+    // a workspace symlink pointing OUT of the tree
+    await symlink(join(secret, "secret.png"), join(work, "link.png"));
+
+    const out = await doReadImage(
+      { file: "link.png" },
+      ctx(work),
+      deps({
+        resolveCap: async () => ({ name: "vlm", entry: VISION_ENTRY }),
+        // load would succeed — the symlink escape must be rejected BEFORE that
+        readImageFile: async () => ({ base64: "AAAA", mimeType: "image/png" }),
+      })
+    );
+
+    expect(out).toContain("out-of-scope");
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
 });
 
 test("read_image: rejects an unsupported/missing file", async () => {

--- a/packages/core/tests/models-config.test.ts
+++ b/packages/core/tests/models-config.test.ts
@@ -11,9 +11,23 @@ import {
   envModelEntry,
   resolveActiveModel,
   resolveModelByName,
+  resolveCapabilityModel,
   modelsConfigPath,
   defaultModelsConfig,
 } from "../src/models-config";
+
+// Capability env overrides — cleared before each test and restored after, so the
+// registry (not ambient env) is what's under test unless a test sets them.
+const CAP_ENV = [
+  "TSFORGE_VISION_BASE_URL",
+  "TSFORGE_VISION_MODEL",
+  "TSFORGE_VISION_API_KEY",
+  "TSFORGE_IMAGE_BASE_URL",
+  "TSFORGE_IMAGE_MODEL",
+  "TSFORGE_IMAGE_API_KEY",
+  "TSFORGE_IMAGE_API",
+] as const;
+const savedCap = new Map(CAP_ENV.map((k) => [k, process.env[k]] as const));
 
 // Sandbox the registry under a temp $TSFORGE_HOME, and clear the TSFORGE_* env
 // overrides so the registry (not the ambient env) is what's under test.
@@ -31,6 +45,10 @@ beforeEach(async () => {
   delete process.env.TSFORGE_BASE_URL;
   delete process.env.TSFORGE_MODEL;
   delete process.env.TSFORGE_API_KEY;
+
+  for (const k of CAP_ENV) {
+    Reflect.deleteProperty(process.env, k);
+  }
 });
 
 afterEach(async () => {
@@ -39,6 +57,10 @@ afterEach(async () => {
   restore("TSFORGE_BASE_URL", saved.base);
   restore("TSFORGE_MODEL", saved.model);
   restore("TSFORGE_API_KEY", saved.key);
+
+  for (const [k, v] of savedCap) {
+    restore(k, v);
+  }
 });
 
 function restore(name: string, value: string | undefined): void {
@@ -205,4 +227,105 @@ test("explicit TSFORGE_* env overrides the registry's active model", async () =>
   expect(active.name).toBe("env");
   expect(active.entry.model).toBe("deepseek-reasoner");
   expect(active.entry.baseUrl).toBe("https://api.deepseek.com/v1");
+});
+
+test("capabilities: parse validates known keys + real entry targets, round-trips", async () => {
+  await saveModelsConfig({
+    active: "qwen-local",
+    models: {
+      "qwen-local": { baseUrl: "http://x/v1", model: "qwen3.6-27b" },
+      "or-vlm": { baseUrl: "https://openrouter.ai/api/v1", model: "vlm" },
+    },
+    capabilities: { vision: "or-vlm" },
+  });
+
+  const cfg = await loadModelsConfig();
+
+  expect(cfg.capabilities?.vision).toBe("or-vlm");
+
+  // unknown capability key rejected
+  expect(() =>
+    parseModelsConfig({
+      active: "a",
+      models: { a: { baseUrl: "u", model: "m" } },
+      capabilities: { audio: "a" },
+    })
+  ).toThrow(/unknown capability "audio"/);
+
+  // dangling entry reference rejected
+  expect(() =>
+    parseModelsConfig({
+      active: "a",
+      models: { a: { baseUrl: "u", model: "m" } },
+      capabilities: { vision: "ghost" },
+    })
+  ).toThrow(/capability "vision" must name a model/);
+});
+
+test("resolveCapabilityModel: null when unconfigured, else the registry entry", async () => {
+  await saveModelsConfig({
+    active: "qwen-local",
+    models: {
+      "qwen-local": { baseUrl: "http://x/v1", model: "qwen3.6-27b" },
+      "or-vlm": { baseUrl: "https://openrouter.ai/api/v1", model: "vlm" },
+    },
+    capabilities: { vision: "or-vlm" },
+  });
+
+  const vision = await resolveCapabilityModel("vision");
+
+  expect(vision?.name).toBe("or-vlm");
+  expect(vision?.entry.model).toBe("vlm");
+  // imageGen isn't configured → off
+  expect(await resolveCapabilityModel("imageGen")).toBeNull();
+});
+
+test("resolveCapabilityModel: ad-hoc env entry wins and needs no models.json", async () => {
+  process.env.TSFORGE_VISION_BASE_URL = "https://vlm.example/v1";
+  process.env.TSFORGE_VISION_MODEL = "some-vlm";
+  process.env.TSFORGE_VISION_API_KEY = "sk-test";
+
+  const vision = await resolveCapabilityModel("vision");
+
+  expect(vision?.name).toBe("env:vision");
+  expect(vision?.entry.baseUrl).toBe("https://vlm.example/v1");
+  expect(vision?.entry.model).toBe("some-vlm");
+  expect(vision?.entry.apiKey).toBe("sk-test");
+
+  // base url without a model is an actionable error, not a silent bad entry
+  delete process.env.TSFORGE_VISION_MODEL;
+  await expect(resolveCapabilityModel("vision")).rejects.toThrow(
+    /TSFORGE_VISION_MODEL is missing/
+  );
+});
+
+test("resolveCapabilityModel: env names a registry entry; imageApi override parses", async () => {
+  await saveModelsConfig({
+    active: "qwen-local",
+    models: {
+      "qwen-local": { baseUrl: "http://x/v1", model: "qwen3.6-27b" },
+      "or-img": {
+        baseUrl: "https://openrouter.ai/api/v1",
+        model: "flux",
+        imageApi: "chat-modalities",
+      },
+    },
+  });
+
+  // env names an entry (no base url set) → reuse that registry entry
+  process.env.TSFORGE_IMAGE_MODEL = "or-img";
+  const img = await resolveCapabilityModel("imageGen");
+
+  expect(img?.name).toBe("or-img");
+  expect(img?.entry.imageApi).toBe("chat-modalities");
+
+  // ad-hoc env with an imageApi override
+  delete process.env.TSFORGE_IMAGE_MODEL;
+  process.env.TSFORGE_IMAGE_BASE_URL = "https://img.example/v1";
+  process.env.TSFORGE_IMAGE_MODEL = "dalle";
+  process.env.TSFORGE_IMAGE_API = "images-generations";
+
+  const adhoc = await resolveCapabilityModel("imageGen");
+
+  expect(adhoc?.entry.imageApi).toBe("images-generations");
 });

--- a/packages/core/tests/models-config.test.ts
+++ b/packages/core/tests/models-config.test.ts
@@ -284,6 +284,25 @@ test("capabilities: parse validates known keys + real entry targets, round-trips
   ).toThrow(/capability "vision" must name a model/);
 });
 
+test("parseModelsConfig rejects a bad imageApi (fails loud, no silent fallback)", () => {
+  expect(() =>
+    parseModelsConfig({
+      active: "a",
+      models: { a: { baseUrl: "u", model: "m", imageApi: "chat-modality" } },
+    })
+  ).toThrow(/imageApi must be/);
+
+  // valid values still parse
+  expect(
+    parseModelsConfig({
+      active: "a",
+      models: {
+        a: { baseUrl: "u", model: "m", imageApi: "images-generations" },
+      },
+    }).models.a?.imageApi
+  ).toBe("images-generations");
+});
+
 test("resolveCapabilityModel: null when unconfigured, else the registry entry", async () => {
   await saveModelsConfig({
     active: "qwen-local",

--- a/packages/core/tests/models-config.test.ts
+++ b/packages/core/tests/models-config.test.ts
@@ -196,6 +196,28 @@ test("setActiveModel switches + persists; unknown name throws with the options",
   );
 });
 
+test("setActiveModel preserves the capabilities block (does not drop it)", async () => {
+  await saveModelsConfig({
+    active: "qwen-local",
+    models: {
+      "qwen-local": { baseUrl: "http://x/v1", model: "qwen3.6-27b" },
+      deepseek: {
+        baseUrl: "https://api.deepseek.com/v1",
+        model: "deepseek-reasoner",
+      },
+      "or-vlm": { baseUrl: "https://openrouter.ai/api/v1", model: "vlm" },
+    },
+    capabilities: { vision: "or-vlm" },
+  });
+
+  const next = await setActiveModel("deepseek");
+
+  expect(next.active).toBe("deepseek");
+  // capabilities must survive a model switch (P1: was silently dropped)
+  expect(next.capabilities?.vision).toBe("or-vlm");
+  expect((await loadModelsConfig()).capabilities?.vision).toBe("or-vlm");
+});
+
 test("resolveApiKey: inline wins, else apiKeyEnv, else undefined", () => {
   expect(resolveApiKey({ baseUrl: "u", model: "m", apiKey: "inline" })).toBe(
     "inline"

--- a/packages/core/tests/terminal-image.test.ts
+++ b/packages/core/tests/terminal-image.test.ts
@@ -1,0 +1,61 @@
+import { test, expect } from "bun:test";
+import {
+  detectImageProtocol,
+  encodeITerm2,
+  renderInlineImage,
+  makeImageBudget,
+} from "../src/render/terminal-image";
+
+test("detectImageProtocol: explicit override wins over everything", () => {
+  expect(
+    detectImageProtocol({ TSFORGE_IMAGE_PROTOCOL: "iterm2", TMUX: "/tmp/x" })
+  ).toBe("iterm2");
+  expect(
+    detectImageProtocol({
+      TSFORGE_IMAGE_PROTOCOL: "off",
+      ITERM_SESSION_ID: "w0",
+    })
+  ).toBe("none");
+});
+
+test("detectImageProtocol: iTerm2 via session id or TERM_PROGRAM", () => {
+  expect(detectImageProtocol({ ITERM_SESSION_ID: "w0t0p0" })).toBe("iterm2");
+  expect(detectImageProtocol({ TERM_PROGRAM: "iTerm.app" })).toBe("iterm2");
+});
+
+test("detectImageProtocol: tmux and unknown terminals are none", () => {
+  expect(
+    detectImageProtocol({ TMUX: "/tmp/tmux", ITERM_SESSION_ID: "w0" })
+  ).toBe("none");
+  expect(detectImageProtocol({ TERM_PROGRAM: "Apple_Terminal" })).toBe("none");
+  expect(detectImageProtocol({})).toBe("none");
+});
+
+test("encodeITerm2 produces a well-formed OSC-1337 sequence", () => {
+  const seq = encodeITerm2("QUJD", { name: "cat.png", widthCells: 40 });
+
+  expect(seq.startsWith("\x1b]1337;File=")).toBe(true);
+  expect(seq.endsWith("\x07")).toBe(true);
+  expect(seq).toContain("inline=1");
+  expect(seq).toContain("width=40");
+  expect(seq).toContain("height=auto");
+  expect(seq).toContain("preserveAspectRatio=1");
+  // name is base64-encoded per the protocol
+  expect(seq).toContain(`name=${Buffer.from("cat.png").toString("base64")}`);
+  // the payload follows the last colon
+  expect(seq).toContain(":QUJD\x07");
+});
+
+test("renderInlineImage returns null for an unsupported protocol", () => {
+  expect(renderInlineImage("QUJD", "none")).toBeNull();
+  expect(renderInlineImage("QUJD", "iterm2")).toContain("inline=1");
+});
+
+test("makeImageBudget caps takes", () => {
+  const budget = makeImageBudget(2);
+
+  expect(budget.take()).toBe(true);
+  expect(budget.take()).toBe(true);
+  expect(budget.take()).toBe(false);
+  expect(budget.used()).toBe(2);
+});

--- a/packages/core/tests/tool-accounting.test.ts
+++ b/packages/core/tests/tool-accounting.test.ts
@@ -509,8 +509,13 @@ const MUTATING_TOOLS = new Set<string>([
 // run = the model's raw shell (writes are its own, not scoped harness edits);
 // script = runs a program whose tool calls (incl. edit/create) re-enter
 // executeTool and report their OWN mutations, so the script call itself accounts
-// for nothing.
-const SPECIAL_TOOLS = new Set<string>([TOOL_NAME.run, TOOL_NAME.script]);
+// for nothing; generate_image writes ONLY to the .tsforge/images artifact dir
+// (not gated source) and reports no mutation, so it triggers no re-gate.
+const SPECIAL_TOOLS = new Set<string>([
+  TOOL_NAME.run,
+  TOOL_NAME.script,
+  TOOL_NAME.generateImage,
+]);
 
 test("every registered tool is classified read-only, mutating, or special", () => {
   for (const name of Object.values(TOOL_NAME)) {

--- a/packages/core/tests/vision.test.ts
+++ b/packages/core/tests/vision.test.ts
@@ -1,0 +1,106 @@
+import { test, expect } from "bun:test";
+import { describeImage, DEFAULT_VISION_PROMPT } from "../src/inference/vision";
+import type { IOpenAICompatibleConfig } from "../src/inference/inference.types";
+
+const CFG: IOpenAICompatibleConfig = {
+  baseUrl: "https://vlm.example/v1",
+  model: "some-vlm",
+  apiKey: "sk-test",
+};
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "content-type": "application/json" },
+  });
+}
+
+test("describeImage posts a multimodal chat request and returns the text", async () => {
+  let capturedUrl = "";
+  let capturedBody: unknown;
+  let capturedAuth: string | undefined;
+
+  const fakeFetch = (async (url: string, init?: RequestInit) => {
+    capturedUrl = url;
+    capturedBody = JSON.parse(String(init?.body));
+    capturedAuth = new Headers(init?.headers).get("authorization") ?? undefined;
+
+    return jsonResponse({
+      choices: [{ message: { content: "a red button" } }],
+    });
+  }) as unknown as typeof fetch;
+
+  const text = await describeImage(
+    CFG,
+    {
+      prompt: DEFAULT_VISION_PROMPT,
+      images: [{ base64: "AAAA", mimeType: "image/png" }],
+    },
+    { fetch: fakeFetch }
+  );
+
+  expect(text).toBe("a red button");
+  expect(capturedUrl).toBe("https://vlm.example/v1/chat/completions");
+  expect(capturedAuth).toBe("Bearer sk-test");
+
+  // The user message content is a multimodal array with the image as a data URI.
+  const body = capturedBody as {
+    model: string;
+    messages: { role: string; content: unknown[] }[];
+  };
+
+  expect(body.model).toBe("some-vlm");
+  const parts = body.messages[0]?.content as {
+    type: string;
+    image_url?: { url: string };
+  }[];
+
+  expect(parts[0]?.type).toBe("text");
+  expect(parts[1]?.type).toBe("image_url");
+  expect(parts[1]?.image_url?.url).toBe("data:image/png;base64,AAAA");
+});
+
+test("describeImage handles a content-part array response", async () => {
+  const fakeFetch = (async () =>
+    jsonResponse({
+      choices: [
+        {
+          message: {
+            content: [
+              { type: "text", text: "hello " },
+              { type: "text", text: "world" },
+            ],
+          },
+        },
+      ],
+    })) as unknown as typeof fetch;
+
+  const text = await describeImage(
+    CFG,
+    { prompt: "q", images: [{ base64: "x", mimeType: "image/jpeg" }] },
+    { fetch: fakeFetch }
+  );
+
+  expect(text).toBe("hello world");
+});
+
+test("describeImage throws with status + body head on a non-2xx", async () => {
+  const fakeFetch = (async () =>
+    new Response("model not found", {
+      status: 404,
+    })) as unknown as typeof fetch;
+
+  await expect(
+    describeImage(
+      CFG,
+      { prompt: "q", images: [{ base64: "x", mimeType: "image/png" }] },
+      { fetch: fakeFetch }
+    )
+  ).rejects.toThrow(/vision request failed \(404\).*model not found/s);
+});
+
+test("describeImage rejects when no images are provided", async () => {
+  await expect(describeImage(CFG, { prompt: "q", images: [] })).rejects.toThrow(
+    /no images/
+  );
+});

--- a/scripts/live-image-smoke.ts
+++ b/scripts/live-image-smoke.ts
@@ -1,0 +1,59 @@
+// Live OpenRouter smoke test for the image capabilities. Reads your real
+// ~/.tsforge/models.json + $OPENROUTER_API_KEY, then does one real vision call
+// and one real image-generation call. Run in a shell where the key is set:
+//   OPENROUTER_API_KEY=... bun scripts/live-image-smoke.ts
+import { mkdtemp } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { resolveCapabilityModel, resolveApiKey } from "../packages/core/src/models-config";
+import { describeImage } from "../packages/core/src/inference/vision";
+import { generateImage, saveGeneratedImages } from "../packages/core/src/inference/image-gen";
+import type { IOpenAICompatibleConfig } from "../packages/core/src/inference";
+
+// 1x1 red PNG (base64, no prefix)
+const RED_PNG =
+  "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAAC0lEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg==";
+
+function cfgOf(entry: { baseUrl: string; model: string } & Record<string, unknown>): IOpenAICompatibleConfig {
+  return {
+    baseUrl: entry.baseUrl,
+    model: entry.model,
+    apiKey: resolveApiKey(entry as never),
+    ...(entry.extraHeaders === undefined ? {} : { extraHeaders: entry.extraHeaders as Record<string, string> }),
+  };
+}
+
+const vision = await resolveCapabilityModel("vision");
+const image = await resolveCapabilityModel("imageGen");
+
+console.log("vision  →", vision ? `${vision.name} (${vision.entry.model})` : "NOT CONFIGURED");
+console.log("imageGen→", image ? `${image.name} (${image.entry.model})` : "NOT CONFIGURED");
+
+if (vision === null || image === null) {
+  console.log("\nFAIL: a capability didn't resolve — check ~/.tsforge/models.json capabilities block.");
+  process.exit(1);
+}
+if (resolveApiKey(vision.entry) === undefined) {
+  console.log("\nFAIL: no API key — is OPENROUTER_API_KEY exported in this shell?");
+  process.exit(1);
+}
+
+console.log("\n[1/2] vision: describing a 1x1 red pixel…");
+const desc = await describeImage(cfgOf(vision.entry), {
+  prompt: "What color is this image? Answer in one word.",
+  images: [{ base64: RED_PNG, mimeType: "image/png" }],
+});
+console.log("  ← reply:", JSON.stringify(desc.slice(0, 200)));
+
+console.log("\n[2/2] image-gen: generating 'a small red circle on a white background'…");
+const imgs = await generateImage(cfgOf(image.entry), {
+  prompt: "a small red circle on a white background, minimal, flat",
+  api: (image.entry.imageApi as "chat-modalities" | "images-generations" | undefined) ?? "chat-modalities",
+});
+const dir = await mkdtemp(join(tmpdir(), "tsforge-live-"));
+const paths = await saveGeneratedImages(imgs, dir, "smoke");
+console.log(`  ← got ${imgs.length} image(s), ${imgs[0]?.bytes.length ?? 0} bytes, saved: ${paths[0]}`);
+
+const okPng = imgs[0] !== undefined && imgs[0].bytes.length > 100;
+console.log(okPng ? "\n==== LIVE PASS — both capabilities work against OpenRouter ====" : "\n==== FAIL: no image bytes returned ====");
+process.exit(okPng ? 0 : 1);

--- a/scripts/live-image-smoke.ts
+++ b/scripts/live-image-smoke.ts
@@ -5,7 +5,11 @@
 import { mkdtemp } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { resolveCapabilityModel, resolveApiKey } from "../packages/core/src/models-config";
+import {
+  resolveCapabilityModel,
+  resolveApiKey,
+  type IModelEntry,
+} from "../packages/core/src/models-config";
 import { describeImage } from "../packages/core/src/inference/vision";
 import { generateImage, saveGeneratedImages } from "../packages/core/src/inference/image-gen";
 import type { IOpenAICompatibleConfig } from "../packages/core/src/inference";
@@ -14,12 +18,14 @@ import type { IOpenAICompatibleConfig } from "../packages/core/src/inference";
 const RED_PNG =
   "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAAC0lEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg==";
 
-function cfgOf(entry: { baseUrl: string; model: string } & Record<string, unknown>): IOpenAICompatibleConfig {
+function cfgOf(entry: IModelEntry): IOpenAICompatibleConfig {
   return {
     baseUrl: entry.baseUrl,
     model: entry.model,
-    apiKey: resolveApiKey(entry as never),
-    ...(entry.extraHeaders === undefined ? {} : { extraHeaders: entry.extraHeaders as Record<string, string> }),
+    apiKey: resolveApiKey(entry),
+    ...(entry.extraHeaders === undefined
+      ? {}
+      : { extraHeaders: entry.extraHeaders }),
   };
 }
 
@@ -48,7 +54,7 @@ console.log("  ← reply:", JSON.stringify(desc.slice(0, 200)));
 console.log("\n[2/2] image-gen: generating 'a small red circle on a white background'…");
 const imgs = await generateImage(cfgOf(image.entry), {
   prompt: "a small red circle on a white background, minimal, flat",
-  api: (image.entry.imageApi as "chat-modalities" | "images-generations" | undefined) ?? "chat-modalities",
+  api: image.entry.imageApi ?? "chat-modalities",
 });
 const dir = await mkdtemp(join(tmpdir(), "tsforge-live-"));
 const paths = await saveGeneratedImages(imgs, dir, "smoke");


### PR DESCRIPTION
## What

Adds two capabilities the local text-only model (DeepSeek V4 Flash) can't do, routed to a **configurable backend** — OpenRouter today, a local DGX endpoint later by editing config only (never coupled to a provider):

- **Read images** — drag a file onto the session, `@`-mention it, or **Ctrl+V a clipboard image** → sent to the vision backend, text fed to the model. Plus a model-callable `read_image` tool.
- **Generate images** — `generate_image` tool → saved to `.tsforge/images/` → previewed inline in iTerm2 (path fallback elsewhere).

## Design

**Side-channel delegation, not multimodal-through-the-loop.** The core `IChatMessage.content` stays a `string`; images go to a separate configured backend and only the *text* answer enters the primary conversation. This keeps DeepSeek untouched and is what makes "capabilities = separate backends" clean (diverges from pi/oh-my-pi, which thread image content + switch the active model).

Config lives in `~/.tsforge/models.json`:
```json
"capabilities": { "vision": "openrouter-vision", "imageGen": "openrouter-image" }
```
(entry names are arbitrary; reuses `IModelEntry` + key resolution). Env overrides: `TSFORGE_{VISION,IMAGE}_{BASE_URL,MODEL,API_KEY}`.

## Notable behavior

- **Ctrl+V, not Cmd+V** — a terminal app can't receive Cmd+V (the emulator swallows it; text arrives as bracketed paste, an image never reaches the app). Ctrl+V is the terminal-native paste chord.
- **Dedup by content** — pasting the same image N times (or `@`-mentioning a file twice) is a single billed vision call.
- **Clipboard** is shell-based (`osascript`/`pngpaste` image, `pbpaste` text) — no native addon; zero-install on macOS. A `📋 reading clipboard…` hint covers the osascript read latency.
- Both tools are policy-classified `network` and advertised only when their capability resolves.

## Verification

- `bun run validate` green (2093+ tests; new unit tests for config routing, vision/image-gen wire shapes, iTerm2 encoder, clipboard reader, tool handlers, attachment flow, dedup, Ctrl+V decode).
- Verified end-to-end against a local mock OpenAI server, **and live against OpenRouter** (vision described a test pixel; `generate_image` returned + saved a real JPEG).

## Remaining

Only a human eyeball that the generated image renders **inline** in a real iTerm2 (the OSC-1337 encoding is unit-tested; the live OpenRouter round-trip is confirmed).