### PR TITLE
Self-harness + steering ladder, expert rescue, boringstack conventions & harness fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,4 @@ models.json
 /components.json
 /src/
 __pycache__/
+.claude/settings.local.json

--- a/docs/steering-ladder.md
+++ b/docs/steering-ladder.md
@@ -1,0 +1,49 @@
+# Steering Ladder — the loop steers instead of quitting
+
+## Problem
+Today the build loop is a **quitting machine**: `checkStuck` (loop/turn.ts) returns a
+terminal `stuck` result after a single (file,rule) persists `samePersist` cycles, or the
+error set is unchanged, or no net progress. The run dies and hours of work are discarded.
+Traced failure mode: model gets an app ~1–2 errors from green, a style-rule fix needs a
+multi-file refactor, it does it imperfectly, then **rewrites the whole file** (via the
+`create`-overwrite escape hatch) which re-introduces the fixed error → loops → killed.
+
+The model (DeepSeek-V4-Flash) is capable of getting unblocked **if the harness steers it**
+instead of counting to N and killing the run. A build should essentially never hard-fail;
+worst case it parks with all work saved.
+
+## Goal
+Overnight-autonomous product building: the loop keeps a run alive, escalating help until
+the model converges — never discarding progress on a wall it could climb with a nudge.
+
+## The ladder (replaces the terminal returns in `checkStuck`)
+Same trip signals as today (a (file,rule) persisting; whole-set unchanged; no net progress),
+but each trip **escalates a steer and continues** rather than terminating. A `steerLevel` in
+loop state rises; counters reset after each steer so the model gets fresh cycles at the new level.
+
+- **Rung 1 — surgical re-anchor.** "This isn't working. STOP rewriting the file. Here is its
+  CURRENT content; make a targeted edit to ONLY the flagged line(s)." Enforced by:
+  `create` may NOT overwrite an existing file (kills the whole-file-rewrite that undoes progress);
+  edit-too-large already rejected; stale anchors already re-fed via `currentFileView`.
+- **Rung 2 — rule playbook.** A worked, rule-specific recipe for the known walls
+  (`no-restricted-syntax`/as-casts, `no-jsx-computation`, `component-file-purity`, `no-self-import`,
+  `max-hooks-per-file`). E.g. jsx-computation → "make src/lib/<x>.ts, export a pure fn, import it."
+- **Rung 3 — change strategy.** Roll back to the fewest-errors checkpoint and take a different
+  decomposition, or isolate the single failing file and repair it alone.
+- **Rung 4 — expert handoff.** Hand the specific failing file + error to a stronger "expert"
+  model (configurable endpoint). It returns the fix; harness applies it; **our model continues**
+  from there. This is the user's key requirement: don't fail — call in an expert, then resume.
+- **Rung 5 — park (never discard).** If even the expert can't, checkpoint the workspace, save
+  everything, and surface for human review. No hours-of-work-thrown-away kill.
+
+## Components to build
+1. `create` never overwrites an existing file (surgical-edit enforcement). — loop/tools/file-ops.ts
+2. Steering state + `steerOrStuck` replacing `checkStuck`'s terminal returns. — loop/turn.ts
+3. Steer-message builder (per-level) + rule playbook registry. — new loop/feedback/steer.ts
+4. Expert-model handoff (config `expertModel`; scoped fix request; apply; continue). — new module
+5. Raise/retire the hard turn cap; convergence bounded by the ladder, then park.
+
+## Testing (real, not mocked)
+- Unit: each rung fires at its threshold; playbooks resolve; create-overwrite rejected.
+- Live: re-run a previously-stuck app (pm-platform / hospital) against the real endpoint and
+  show it now CONVERGES (or reaches the expert rung), instead of dying at turn ~45.

--- a/docs/superpowers/specs/2026-07-12-boringstack-fullstack-build-pivot-design.md
+++ b/docs/superpowers/specs/2026-07-12-boringstack-fullstack-build-pivot-design.md
@@ -1,0 +1,131 @@
+# BoringStack full-stack build pivot — design
+
+**Date:** 2026-07-12
+**Branch:** `feat/self-harness`
+**Status:** design — awaiting user review before writing-plans
+
+## Problem
+
+For two-plus days the web-build effort has chased a UI-only React scaffold: the AI
+loop scaffolds a throwaway Vite+React app (`scaffoldWeb` → `runWebGreenfield`) with
+no backend. Every live build (gfweb1–6) hit the same wall — the model had views but
+no data layer, so it faked persistence, and the reject-by-default judge correctly
+rejected "no real create/edit, no persistence." gfweb6 proved the pages could be
+made kind-appropriate and gate-clean, but also proved the binding constraint is a
+real data layer the UI-only path cannot provide.
+
+**Root cause:** the harness was asking the model to *invent architecture* (data
+layer, state, CRUD). That degree of freedom is what made every build oscillate.
+
+## Decision
+
+For web apps, **BoringStack is the only thing this harness ever scaffolds.** It is a
+production full-stack skeleton (Bun+Elysia API, Vite+React UI, Postgres, Drizzle,
+auth/billing, observability) with its own generators, conventions, and gate. We do
+**not** force it — a user can still point tsforge at their own greenfield or existing
+repo, like any harness. But *our* scaffold = BoringStack, full-stack, real.
+
+This dissolves the entire mock-CRUD problem: persistence is real Postgres from turn
+one; the model fills domain logic into generated, gate-clean slices instead of
+inventing a data layer.
+
+### What the audits established (facts)
+
+- **tsforge↔BoringStack integration is ~80% built and tested.** `tsforge scaffold
+  --archetype boringstack` clones at a pinned ref, reads `.tsforge/scaffold-manifest.json`,
+  runs BoringStack's own `rename-project.sh`/`setup.sh`, boots the Docker stack, polls
+  health, and composes a real gate: `(cd apps/api && bun run validate) && (cd apps/ui
+  && bun run validate) && bun run check`. (`scaffold/{clone,run-scaffold,configure,boot}.ts`,
+  fully tested.)
+- **BoringStack's per-feature workflow is its own vertical slice:**
+  1. `cd apps/api && bun run new:resource -- <Name>` → Drizzle table + Elysia
+     routes/service/schemas/types; patches schema/relations/audit.
+  2. `bun run db:generate && bun run db:migrate` → real migration.
+  3. `bun run regen` (root) → OpenAPI → typed UI client + ACL.
+  4. `cd apps/ui && bun run new:feature <Name>` → queries/mutations/Zustand store +
+     `<Feature>Page` tree.
+  5. `bun run validate` (both apps) + `bun run check`.
+  (Exact script names to be confirmed in `apps/api`/`apps/ui` package.json at impl
+  time — they are app-level, not root.)
+- Backend rule-packs (`elysia`, `drizzle`, `jwt-cookies`, `bullmq`, `authorization`,
+  `structured-logging`) and the conventions push/pull system already exist and are wired.
+- **The gap:** the AI build loop and the BoringStack scaffold are two unconnected
+  paths. The loop never clones BoringStack.
+
+## Scope — three phases
+
+### Phase A — Bank the good work, delete the dead UI-only scaffold
+
+Untangle the uncommitted changes on `feat/self-harness`, keep the general wins, delete
+the UI-only scaffold, get green, commit, open a PR, land it.
+
+**KEEP (general, reusable, wanted):**
+- Steering ladder — `loop/feedback/steer.ts`, `docs/steering-ladder.md`,
+  `loop.constants.ts` (plateau), turn.ts ladder.
+- Expert rescue — `loop/expert-handoff.ts`, `expertRescue` flag/config, turn.ts wiring.
+- Conventions (BoringStack-aligned) — `loop/conventions.ts`, `loop/tools/pull-conventions.ts`.
+- Harness fixes — broken-file deadlock (`tools/file-ops.ts`, `tools/execute-tool.ts`),
+  diag-cap (`write-guard.ts`, `session.ts`), `no-self-import` fix, `Session.setScope`.
+- Self-harness — `self-harness-campaign.ts`, `self-harness/evaluate.ts`.
+- The greenfield ENGINE (`loop/greenfield/{run,evaluate,judge}.ts`) — reused by Phase C.
+
+**DELETE (UI-only scaffold):**
+- `src/web-route-views.ts`, `src/lib/web/{web-feature-scope,generate-nav}.ts`,
+  `src/loop/greenfield/web-greenfield.ts`, and their tests
+  (`web-route-views`, `web-feature-scope`, `generate-nav`, `web-greenfield`).
+- Revert UI-only additions in `scripts/headless-build.ts` (the `TSFORGE_GREENFIELD_WEB`
+  branch), `loop/greenfield/index.ts` (web exports), `loop/greenfield/plan.ts`
+  (`planWebFeatures`/`WEB_SYSTEM`), `loop/greenfield/greenfield.types.ts` (`routes?`).
+- **Assess for removal:** `src/gate/web-gate.ts`, `scaffold/web-scaffold.ts`,
+  `web-templates.ts`, `loop/tools/scaffold-routes.ts`, and the `vite`/`--web` archetype
+  in `repl-scaffold.ts`. These exist only to serve the UI-only path. Remove unless a
+  concrete non-UI-only consumer is found. The `astro` archetype stays (it's a real
+  BoringStack archetype in the manifest).
+
+**Reconcile (flag for impl):** the `react-component-architecture` conventions/rule-pack
+assume `src/views/<Feature>/` layout; real BoringStack UI uses `src/features/<feature>/`
+with a generated `<Feature>Page` tree. These must be reconciled with BoringStack's
+actual UI conventions (its `apps/ui/docs/agents/*`), not the dead UI-only layout.
+
+**Done = A:** `bun run validate` green (read the real N pass/M fail), UI-only code gone,
+PR opened. Merge on explicit user go over the actual diff.
+
+### Phase B — Confirm the BoringStack build seam works end-to-end (manual, no AI)
+
+Before wiring the AI loop, prove the mechanical path by hand on a real clone:
+`tsforge scaffold --archetype boringstack` → boot → `new:resource`/`regen`/`new:feature`
+for one entity → `validate`. Confirms the generator command names, the exact generated
+file set, and that a booted stack + gate works locally. De-risks Phase C.
+
+### Phase C — The full-stack build loop (harness runs generators, model fills domain)
+
+A new driver (sibling to the deleted `runWebGreenfield`, reusing the greenfield engine):
+
+- **Plan:** features = domain resources/entities (not routes).
+- **Per feature (`implement`):** the DRIVER deterministically runs BoringStack's
+  generators + mechanical wiring (`new:resource`, `db:migrate`, `regen`, `new:feature`,
+  route registration), then hands the MODEL the generated slice to fill with real
+  domain fields/logic — scoped/frozen per feature via the existing `setScope`.
+- **Evaluate:** BoringStack's real gate (`apps/api validate && apps/ui validate &&
+  check`) against the running stack (real Postgres) + the reject-by-default judge.
+- **Freeze on green**, cycle.
+- **Stack boot:** boot only the always-on set (postgres/valkey/api/ui/migrate); skip
+  observability/glitchtip for build loops (manifest toggles already support this).
+
+**Done = C:** a live run builds ≥1 real full-stack feature (real API + migration + UI)
+that passes BoringStack's own gate, one frozen slice at a time.
+
+## Risks
+
+- **Docker boot weight** for the eval loop — mitigate via minimal service set.
+- **Local model driving shell sequences is fragile** — mitigated by the harness (not
+  the model) running the mechanical generator steps.
+- **Generator command names / generated file set** — verified in Phase B before C.
+- **Conventions/rule-pack drift** from real BoringStack UI layout — reconciled in Phase A.
+
+## Non-goals
+
+- Forcing BoringStack on users who bring their own repo.
+- The hosted "SaaS builder" control-plane (`.cursor/plans/tsforge_saas_builder`) — that
+  is a separate product; this pivot is the local build loop it would later wrap.
+- Keeping any UI-only scaffold as a maintained path.

--- a/evals/corpus/fix-regression/setup.sh
+++ b/evals/corpus/fix-regression/setup.sh
@@ -8,6 +8,12 @@ set -e
 git init -q
 git config user.email "eval@tsforge.local"
 git config user.name "tsforge-eval"
+# Never inherit the developer's signing setup: a global commit.gpgsign=true with
+# a locked/unavailable signer (e.g. 1Password overnight) would abort this script
+# mid-way and leave the working tree GREEN — the seed then reads "already green"
+# instead of the RED brownfield state, silently invalidating the eval.
+git config commit.gpgsign false
+git config tag.gpgsign false
 
 # Stash the buggy working version (the seed's slug.ts — what the model must fix).
 cp slug.ts .slug.buggy

--- a/package.json
+++ b/package.json
@@ -21,7 +21,8 @@
     "eval:sweep": "bun packages/core/scripts/sweep.ts",
     "eval:spec": "bun packages/core/scripts/eval-spec.ts",
     "eval:benchmark": "bun packages/core/scripts/edit-benchmark.ts",
-    "eval:report": "bun packages/core/scripts/sweep-report.ts"
+    "eval:report": "bun packages/core/scripts/sweep-report.ts",
+    "eval:self-harness": "bun packages/core/scripts/self-harness.ts"
   },
   "workspaces": [
     "apps/*",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,8 @@
     "eval:spec": "bun packages/core/scripts/eval-spec.ts",
     "eval:benchmark": "bun packages/core/scripts/edit-benchmark.ts",
     "eval:report": "bun packages/core/scripts/sweep-report.ts",
-    "eval:self-harness": "bun packages/core/scripts/self-harness.ts"
+    "eval:self-harness": "bun packages/core/scripts/self-harness.ts",
+    "eval:self-harness-campaign": "bun packages/core/scripts/self-harness-campaign.ts"
   },
   "workspaces": [
     "apps/*",

--- a/packages/core/scripts/headless-build.ts
+++ b/packages/core/scripts/headless-build.ts
@@ -40,6 +40,7 @@ import {
 } from "../src/config/tsforge-config";
 import { makeSpawnAgentFn } from "../src/cli/spawn-runner";
 import { renderEvent } from "../src/render";
+import { activeOverlay } from "../src/self-harness";
 import { logsDir } from "../src/session-store";
 import type { WebFramework } from "../src/web-templates";
 import {
@@ -165,6 +166,20 @@ async function main(): Promise<void> {
     process.argv = process.argv.filter((a) => a !== "--plan");
   }
 
+  // `--log-file <path>`: write the JSONL event log to a CALLER-CHOSEN path
+  // instead of the stamped default under ~/.tsforge/logs — the contract that
+  // lets a driver (self-harness evaluate-web) find this run's events
+  // deterministically. Stripped before positional-arg logic, like --plan.
+  let logFileOverride: string | undefined;
+  const logFlagAt = process.argv.indexOf("--log-file");
+
+  if (logFlagAt >= 0) {
+    logFileOverride = process.argv[logFlagAt + 1];
+    process.argv = process.argv.filter(
+      (_, i) => i !== logFlagAt && i !== logFlagAt + 1
+    );
+  }
+
   const request = resolveRequest();
 
   if (request === undefined) {
@@ -215,7 +230,7 @@ async function main(): Promise<void> {
   }
 
   const agentLog = join(dir, "agent.log");
-  const logFile = join(logsDir(), `${stamp}-headless.jsonl`);
+  const logFile = logFileOverride ?? join(logsDir(), `${stamp}-headless.jsonl`);
 
   mkdirSync(logsDir(), { recursive: true });
 
@@ -273,7 +288,15 @@ async function main(): Promise<void> {
     // Offer the themed-UI-primitives tool so the model generates button/card/input/
     // etc. (tested, theme-coherent) instead of re-authoring them every build.
     scaffoldUi: framework === "react",
-    guidance: webGuidance(framework),
+    // Self-harness overlay: the `extra` prompt block (append-only, byte-identical
+    // when no overlay is active) rides the web guidance — script-level injection
+    // so scaffold/ never imports self-harness/ (module-boundaries). The named
+    // implement-path blocks deliberately do NOT apply here: they'd contradict
+    // the web-specific build guidance.
+    guidance:
+      activeOverlay()?.promptBlocks.extra === undefined
+        ? webGuidance(framework)
+        : `${webGuidance(framework)}\n\n${activeOverlay()?.promptBlocks.extra?.text ?? ""}`,
     contextWindow,
     // ADAPTIVE THINKING (measured ~80% of build time is REPAIR): default thinking
     // OFF for fast creation; the Session flips it ON automatically while errors are

--- a/packages/core/scripts/self-harness-campaign.ts
+++ b/packages/core/scripts/self-harness-campaign.ts
@@ -1,0 +1,414 @@
+// The 24/7 Self-Harness campaign: prove arXiv 2606.09498 on our stack.
+//
+//   1. FREEZE h_0: evaluate the base harness on the PINNED proof split at
+//      repeats=2 → campaign/baseline.json. Never recomputed.
+//   2. LOOP until campaign/STOP exists: health-gate the endpoint, run one
+//      mining session (self-harness.ts subprocess, rotating splits), chain
+//      accepted overlays via --initial-overlay, log to CAMPAIGN.md.
+//   3. Every K sessions and on STOP: evaluate the current overlay on the
+//      proof split (repeats=2) and write PROOF.md — pass rates before/after
+//      with 95% Wilson CIs and a two-proportion z-test (the paper's Fig-4
+//      analog). The proof split is NEVER used for mining (exam ≠ homework).
+//
+// Hard rules: nothing is ever installed to ~/.tsforge/self-harness (the
+// campaign overlay lives under evals/self-harness/campaign/); the gate,
+// acceptance rule, and tolerances are never touched at runtime; all model
+// traffic is sequential (single-connection endpoint).
+//
+// Run:  bun packages/core/scripts/self-harness-campaign.ts
+//         [--max-sessions N] [--proof-every 3] [--rounds 3] [--width 3]
+// Stop: touch evals/self-harness/campaign/STOP  (in-flight session finishes)
+import { mkdir } from "node:fs/promises";
+import { existsSync } from "node:fs";
+import { join } from "node:path";
+import { OpenAICompatibleProvider } from "../src/inference";
+import type { IProvider } from "../src/inference";
+import { resolveActiveModel, resolveApiKey } from "../src/models-config";
+import { providerConfig } from "../src/cli";
+import {
+  evaluateHarness,
+  parseOverlay,
+  isEmptyPatch,
+  type IHarnessOverlay,
+} from "../src/self-harness";
+import type { IRunRecord } from "../src/eval";
+import { buildSweepReport, renderSweepReportMarkdown } from "../src/eval";
+import { isRecord } from "../src/lib/guards";
+
+/** The exam: never shown to a mining session. Spec + web mix. */
+const PROOF_SPLIT = [
+  "math",
+  "handlers",
+  "slugify",
+  "web:pm-platform",
+  "web:billing-console",
+] as const;
+
+/** Mining rotations — draw only from non-proof tasks; alternate per session. */
+const ROTATIONS = [
+  {
+    heldIn: "query,migrate,checkout,web:saas-crm",
+    heldOut: "validators,fix-regression,web:udemy",
+  },
+  {
+    heldIn: "auth,fixtures,rate-limit,web:hospital-scheduling",
+    heldOut: "debounce,query,web:warehouse-inventory",
+  },
+] as const;
+
+function argValue(name: string): string | undefined {
+  const i = process.argv.indexOf(`--${name}`);
+  const value = i >= 0 ? process.argv[i + 1] : undefined;
+
+  return value !== undefined && !value.startsWith("--") ? value : undefined;
+}
+
+const maxSessions = Number(argValue("max-sessions") ?? "1000");
+const proofEvery = Number(argValue("proof-every") ?? "3");
+const rounds = argValue("rounds") ?? "3";
+const width = argValue("width") ?? "3";
+
+const evalsRoot = join(import.meta.dir, "..", "..", "..", "evals");
+const corpusDir = join(evalsRoot, "corpus");
+const campaignDir = join(evalsRoot, "self-harness", "campaign");
+const stopFile = join(campaignDir, "STOP");
+const baselinePath = join(campaignDir, "baseline.json");
+const overlayPath = join(campaignDir, "current-overlay.json");
+const campaignLog = join(campaignDir, "CAMPAIGN.md");
+const proofPath = join(campaignDir, "PROOF.md");
+const SELF_HARNESS = join(import.meta.dir, "self-harness.ts");
+
+const say = (line: string): void => {
+  process.stdout.write(`${line}\n`);
+};
+
+const { entry } = await resolveActiveModel();
+const provider: IProvider = new OpenAICompatibleProvider(providerConfig(entry));
+
+await mkdir(campaignDir, { recursive: true });
+
+if (!existsSync(campaignLog)) {
+  await Bun.write(
+    campaignLog,
+    `# Self-Harness campaign — ${entry.model}\n\nProof split (never mined): ${PROOF_SPLIT.join(", ")}\n\n| # | time | rotation (in / out) | accepted | rejected | notes |\n|---|------|--------------------|----------|----------|-------|\n`
+  );
+}
+
+async function appendLog(line: string): Promise<void> {
+  const current = await Bun.file(campaignLog).text();
+
+  await Bun.write(campaignLog, `${current}${line}\n`);
+}
+
+function now(): string {
+  return new Date().toISOString().slice(0, 16).replace("T", " ");
+}
+
+/** One real-sized completion probe. */
+async function probeOnce(): Promise<boolean> {
+  try {
+    const key = resolveApiKey(entry);
+    const res = await fetch(`${entry.baseUrl}/chat/completions`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        ...(key === undefined ? {} : { Authorization: `Bearer ${key}` }),
+      },
+      body: JSON.stringify({
+        model: entry.model,
+        messages: [
+          {
+            role: "user",
+            content:
+              "Write a TypeScript semver parser with validation. Code only.",
+          },
+        ],
+        max_tokens: 300,
+      }),
+      signal: AbortSignal.timeout(60_000),
+    });
+
+    return res.ok;
+  } catch {
+    return false;
+  }
+}
+
+/** 3 consecutive real completions, 60s apart; retries forever (the campaign
+ *  outlives endpoint weather — that's its job). */
+async function waitForHealthyEndpoint(): Promise<void> {
+  let ok = 0;
+
+  for (;;) {
+    if (existsSync(stopFile)) {
+      return; // let the main loop observe STOP
+    }
+
+    ok = (await probeOnce()) ? ok + 1 : 0;
+
+    if (ok >= 3) {
+      say("endpoint stable (3 consecutive real completions)");
+
+      return;
+    }
+
+    await Bun.sleep(60_000);
+  }
+}
+
+async function loadCurrentOverlay(): Promise<IHarnessOverlay | null> {
+  if (!existsSync(overlayPath)) {
+    return null;
+  }
+
+  const parsed = parseOverlay(JSON.parse(await Bun.file(overlayPath).text()));
+
+  return parsed !== null && !isEmptyPatch(parsed) ? parsed : null;
+}
+
+/** Evaluate a harness variant on the proof split at repeats=2, relabelled for
+ *  the sweep report. */
+async function measureProof(
+  overlay: IHarnessOverlay | null,
+  label: string,
+  runsDir: string
+): Promise<IRunRecord[]> {
+  const outcome = await evaluateHarness([...PROOF_SPLIT], {
+    corpusDir,
+    runsDir,
+    provider,
+    repeats: 2,
+    overlay,
+    log: say,
+  });
+
+  if (outcome.score.errored > 0) {
+    throw new Error(
+      `proof measurement hit ${String(outcome.score.errored)} infrastructure-errored run(s) — measurement discarded, not recorded`
+    );
+  }
+
+  return outcome.records.map((r) => ({ ...r, label }));
+}
+
+async function loadBaseline(): Promise<IRunRecord[]> {
+  if (existsSync(baselinePath)) {
+    const parsed: unknown = JSON.parse(await Bun.file(baselinePath).text());
+
+    if (Array.isArray(parsed)) {
+      say(`baseline: loaded frozen h_0 (${String(parsed.length)} records)`);
+
+      // Trusted file written by this script; runtime-checked shape minimum.
+      return parsed.filter(
+        (r): r is IRunRecord =>
+          typeof r === "object" && r !== null && "passed" in r
+      );
+    }
+  }
+
+  say("baseline: freezing h_0 on the proof split (repeats=2)…");
+  await waitForHealthyEndpoint();
+
+  const records = await measureProof(
+    null,
+    "baseline",
+    join(campaignDir, "runs", "baseline")
+  );
+
+  await Bun.write(baselinePath, JSON.stringify(records, null, 2));
+  say(`baseline: frozen → ${baselinePath}`);
+
+  return records;
+}
+
+async function writeProof(
+  baseline: readonly IRunRecord[],
+  sessionsDone: number
+): Promise<void> {
+  const overlay = await loadCurrentOverlay();
+
+  if (overlay === null) {
+    say("proof: no accepted overlay yet — skipping measurement");
+
+    return;
+  }
+
+  say("proof: measuring current overlay on the proof split…");
+  await waitForHealthyEndpoint();
+
+  const current = await measureProof(
+    overlay,
+    "self-harness",
+    join(campaignDir, "runs", `proof-after-${String(sessionsDone)}`)
+  );
+  const report = buildSweepReport([...baseline, ...current], "baseline");
+  const md = [
+    `# PROOF — Self-Harness uplift of ${entry.model}`,
+    "",
+    `After ${String(sessionsDone)} mining session(s). Proof split (never mined): ${PROOF_SPLIT.join(", ")}. repeats=2 per measurement.`,
+    "",
+    renderSweepReportMarkdown(report),
+    "",
+    "## Promoted overlay under test",
+    "",
+    "```json",
+    JSON.stringify(overlay, null, 2),
+    "```",
+    "",
+    `_Generated ${now()}. The paper's claim reproduces iff the self-harness row shows a positive, significant delta vs baseline._`,
+    "",
+  ].join("\n");
+
+  await Bun.write(proofPath, md);
+  say(`proof → ${proofPath}`);
+}
+
+interface ISessionOutcome {
+  readonly accepted: number;
+  readonly rejected: number;
+  readonly note: string;
+}
+
+/** Accepted/rejected tallies from a session's lineage.json (guard-parsed —
+ *  a malformed file degrades to zeros, never a crash). */
+function lineageCounts(value: unknown): {
+  accepted: number;
+  rejected: number;
+} {
+  let accepted = 0;
+  let rejected = 0;
+
+  if (isRecord(value) && Array.isArray(value.rounds)) {
+    for (const round of value.rounds) {
+      if (!isRecord(round)) {
+        continue;
+      }
+
+      const ids = Array.isArray(round.acceptedIds)
+        ? round.acceptedIds.length
+        : 0;
+      const candidates = Array.isArray(round.candidates)
+        ? round.candidates.length
+        : 0;
+
+      accepted += ids;
+      rejected += candidates - ids;
+    }
+  }
+
+  return { accepted, rejected };
+}
+
+async function runSession(index: number): Promise<ISessionOutcome> {
+  const rotation = ROTATIONS[index % ROTATIONS.length];
+
+  if (rotation === undefined) {
+    throw new Error("no rotation configured");
+  }
+
+  const outDir = join(campaignDir, "sessions", `s${String(index + 1)}`);
+  const args = [
+    "bun",
+    SELF_HARNESS,
+    "--rounds",
+    rounds,
+    "--width",
+    width,
+    "--held-in",
+    rotation.heldIn,
+    "--held-out",
+    rotation.heldOut,
+    "--out-dir",
+    outDir,
+  ];
+
+  if (existsSync(overlayPath)) {
+    args.push("--initial-overlay", overlayPath);
+  }
+
+  say(`session ${String(index + 1)}: ${rotation.heldIn} / ${rotation.heldOut}`);
+
+  const proc = Bun.spawn(args, {
+    env: { ...process.env },
+    stdout: "inherit",
+    stderr: "inherit",
+  });
+  const exitCode = await proc.exited;
+
+  if (exitCode !== 0) {
+    return {
+      accepted: 0,
+      rejected: 0,
+      note: `session process exited ${String(exitCode)}`,
+    };
+  }
+
+  const lineagePath = join(outDir, "lineage.json");
+
+  if (!existsSync(lineagePath)) {
+    return { accepted: 0, rejected: 0, note: "no lineage written" };
+  }
+
+  const lineage: unknown = JSON.parse(await Bun.file(lineagePath).text());
+  const { accepted, rejected } = lineageCounts(lineage);
+
+  // Chain the lineage: the session's final overlay becomes the next session's
+  // starting harness (h_{t+1} across sessions, not just rounds).
+  if (accepted > 0) {
+    await Bun.write(overlayPath, Bun.file(join(outDir, "overlay.json")));
+    say(
+      `session ${String(index + 1)}: ${String(accepted)} edit(s) accepted → overlay chained`
+    );
+  }
+
+  return { accepted, rejected, note: "ok" };
+}
+
+// ---------------------------------------------------------------------------
+
+say(`campaign — model ${entry.model}`);
+say(`  stop with: touch ${stopFile}`);
+
+const baseline = await loadBaseline();
+let sessions = 0;
+
+while (sessions < maxSessions && !existsSync(stopFile)) {
+  await waitForHealthyEndpoint();
+
+  if (existsSync(stopFile)) {
+    break;
+  }
+
+  const outcome = await runSession(sessions);
+
+  sessions += 1;
+  await appendLog(
+    `| ${String(sessions)} | ${now()} | ${ROTATIONS[(sessions - 1) % ROTATIONS.length]?.heldIn ?? "?"} / ${ROTATIONS[(sessions - 1) % ROTATIONS.length]?.heldOut ?? "?"} | ${String(outcome.accepted)} | ${String(outcome.rejected)} | ${outcome.note} |`
+  );
+
+  if (sessions % proofEvery === 0) {
+    try {
+      await writeProof(baseline, sessions);
+    } catch (err) {
+      say(
+        `proof measurement failed: ${err instanceof Error ? err.message : String(err)}`
+      );
+    }
+  }
+}
+
+say(
+  `campaign loop ended after ${String(sessions)} session(s) — final proof measurement…`
+);
+
+try {
+  await writeProof(baseline, sessions);
+} catch (err) {
+  say(
+    `final proof failed: ${err instanceof Error ? err.message : String(err)}`
+  );
+}
+
+say(
+  "campaign done. Review PROOF.md and CAMPAIGN.md; installing any overlay stays a human decision."
+);

--- a/packages/core/scripts/self-harness-campaign.ts
+++ b/packages/core/scripts/self-harness-campaign.ts
@@ -206,19 +206,34 @@ async function loadBaseline(): Promise<IRunRecord[]> {
     }
   }
 
-  say("baseline: freezing h_0 on the proof split (repeats=2)…");
-  await waitForHealthyEndpoint();
+  // A discarded measurement (errored runs) must not kill the campaign — the
+  // whole point of the driver is to outlive endpoint weather. Retry until a
+  // CLEAN baseline exists or STOP is requested.
+  for (let attempt = 1; !existsSync(stopFile); attempt += 1) {
+    say(
+      `baseline: freezing h_0 on the proof split (repeats=2, attempt ${String(attempt)})…`
+    );
+    await waitForHealthyEndpoint();
 
-  const records = await measureProof(
-    null,
-    "baseline",
-    join(campaignDir, "runs", "baseline")
-  );
+    try {
+      const records = await measureProof(
+        null,
+        "baseline",
+        join(campaignDir, "runs", `baseline-a${String(attempt)}`)
+      );
 
-  await Bun.write(baselinePath, JSON.stringify(records, null, 2));
-  say(`baseline: frozen → ${baselinePath}`);
+      await Bun.write(baselinePath, JSON.stringify(records, null, 2));
+      say(`baseline: frozen → ${baselinePath}`);
 
-  return records;
+      return records;
+    } catch (err) {
+      say(
+        `baseline attempt ${String(attempt)} discarded: ${err instanceof Error ? err.message : String(err)}`
+      );
+    }
+  }
+
+  throw new Error("STOP requested before a clean baseline was frozen");
 }
 
 async function writeProof(

--- a/packages/core/scripts/self-harness-campaign.ts
+++ b/packages/core/scripts/self-harness-campaign.ts
@@ -29,6 +29,8 @@ import {
   evaluateHarness,
   parseOverlay,
   isEmptyPatch,
+  mergeOverlay,
+  emptyOverlay,
   type IHarnessOverlay,
 } from "../src/self-harness";
 import type { IRunRecord } from "../src/eval";
@@ -67,6 +69,12 @@ const maxSessions = Number(argValue("max-sessions") ?? "1000");
 const proofEvery = Number(argValue("proof-every") ?? "3");
 const rounds = argValue("rounds") ?? "3";
 const width = argValue("width") ?? "3";
+// Concurrent mining sessions per batch. The endpoint batches up to 10 seqs on
+// recipe-stock config; 2 leaves headroom for the human user's own coding.
+const parallel = Math.max(
+  1,
+  Math.min(Number(argValue("parallel") ?? "2"), ROTATIONS.length)
+);
 
 const evalsRoot = join(import.meta.dir, "..", "..", "..", "evals");
 const corpusDir = join(evalsRoot, "corpus");
@@ -312,6 +320,7 @@ interface ISessionOutcome {
   readonly accepted: number;
   readonly rejected: number;
   readonly note: string;
+  readonly outDir: string;
 }
 
 /** Accepted/rejected tallies from a session's lineage.json (guard-parsed —
@@ -372,11 +381,13 @@ async function runSession(index: number): Promise<ISessionOutcome> {
   }
 
   say(`session ${String(index + 1)}: ${rotation.heldIn} / ${rotation.heldOut}`);
+  await mkdir(outDir, { recursive: true });
 
+  // Per-session log file — parallel sessions must not interleave on stdout.
   const proc = Bun.spawn(args, {
     env: { ...process.env },
-    stdout: "inherit",
-    stderr: "inherit",
+    stdout: Bun.file(join(outDir, "session.log")),
+    stderr: Bun.file(join(outDir, "session.err.log")),
   });
   const exitCode = await proc.exited;
 
@@ -385,28 +396,90 @@ async function runSession(index: number): Promise<ISessionOutcome> {
       accepted: 0,
       rejected: 0,
       note: `session process exited ${String(exitCode)}`,
+      outDir,
     };
   }
 
   const lineagePath = join(outDir, "lineage.json");
 
   if (!existsSync(lineagePath)) {
-    return { accepted: 0, rejected: 0, note: "no lineage written" };
+    return { accepted: 0, rejected: 0, note: "no lineage written", outDir };
   }
 
   const lineage: unknown = JSON.parse(await Bun.file(lineagePath).text());
   const { accepted, rejected } = lineageCounts(lineage);
 
-  // Chain the lineage: the session's final overlay becomes the next session's
-  // starting harness (h_{t+1} across sessions, not just rounds).
-  if (accepted > 0) {
-    await Bun.write(overlayPath, Bun.file(join(outDir, "overlay.json")));
-    say(
-      `session ${String(index + 1)}: ${String(accepted)} edit(s) accepted → overlay chained`
-    );
+  return { accepted, rejected, note: "ok", outDir };
+}
+
+/**
+ * Chain a batch's ACCEPTED candidate patches onto the shared overlay, in
+ * session order. Parallel sessions each validated against the batch's shared
+ * starting overlay; merging their accepted edits without cross-re-validation
+ * is the paper's own MergeAccepted semantics for same-round candidates — the
+ * next proof measurement gates the combination regardless.
+ */
+/** All ACCEPTED, validated, non-empty candidate patches in a lineage. */
+function acceptedPatches(lineage: unknown): IHarnessOverlay[] {
+  if (!isRecord(lineage) || !Array.isArray(lineage.rounds)) {
+    return [];
   }
 
-  return { accepted, rejected, note: "ok" };
+  const patches: IHarnessOverlay[] = [];
+
+  for (const round of lineage.rounds) {
+    const candidates =
+      isRecord(round) && Array.isArray(round.candidates)
+        ? round.candidates
+        : [];
+
+    for (const result of candidates) {
+      if (
+        !isRecord(result) ||
+        result.accepted !== true ||
+        !isRecord(result.candidate)
+      ) {
+        continue;
+      }
+
+      const patch = parseOverlay(result.candidate.patch);
+
+      if (patch !== null && !isEmptyPatch(patch)) {
+        patches.push(patch);
+      }
+    }
+  }
+
+  return patches;
+}
+
+async function chainAcceptedPatches(
+  outcomes: readonly ISessionOutcome[]
+): Promise<number> {
+  let current = (await loadCurrentOverlay()) ?? emptyOverlay();
+  let merged = 0;
+
+  for (const outcome of outcomes) {
+    const lineagePath = join(outcome.outDir, "lineage.json");
+
+    if (!existsSync(lineagePath)) {
+      continue;
+    }
+
+    const lineage: unknown = JSON.parse(await Bun.file(lineagePath).text());
+
+    for (const patch of acceptedPatches(lineage)) {
+      current = mergeOverlay(current, patch);
+      merged += 1;
+    }
+  }
+
+  if (merged > 0) {
+    await Bun.write(overlayPath, `${JSON.stringify(current, null, 2)}\n`);
+    say(`chained ${String(merged)} accepted edit(s) → ${overlayPath}`);
+  }
+
+  return merged;
 }
 
 // ---------------------------------------------------------------------------
@@ -424,14 +497,35 @@ while (sessions < maxSessions && !existsSync(stopFile)) {
     break;
   }
 
-  const outcome = await runSession(sessions);
+  // A batch = `parallel` concurrent sessions on DISJOINT rotations. Each is
+  // its own subprocess (own overlay env, own run dirs), so there is no
+  // cross-contamination; the server batches the concurrent streams.
+  const batchSize = Math.min(parallel, maxSessions - sessions);
+  const indices = Array.from({ length: batchSize }, (_, j) => sessions + j);
 
-  sessions += 1;
-  await appendLog(
-    `| ${String(sessions)} | ${now()} | ${ROTATIONS[(sessions - 1) % ROTATIONS.length]?.heldIn ?? "?"} / ${ROTATIONS[(sessions - 1) % ROTATIONS.length]?.heldOut ?? "?"} | ${String(outcome.accepted)} | ${String(outcome.rejected)} | ${outcome.note} |`
+  say(
+    `launching ${String(batchSize)} parallel session(s): ${indices.map((i) => String(i + 1)).join(", ")}`
   );
 
-  if (sessions % proofEvery === 0) {
+  const outcomes = await Promise.all(indices.map((i) => runSession(i)));
+
+  sessions += batchSize;
+
+  for (const [j, outcome] of outcomes.entries()) {
+    const index = indices[j] ?? 0;
+    const rotation = ROTATIONS[index % ROTATIONS.length];
+
+    await appendLog(
+      `| ${String(index + 1)} | ${now()} | ${rotation?.heldIn ?? "?"} / ${rotation?.heldOut ?? "?"} | ${String(outcome.accepted)} | ${String(outcome.rejected)} | ${outcome.note} |`
+    );
+  }
+
+  await chainAcceptedPatches(outcomes);
+
+  const proofsBefore = Math.floor((sessions - batchSize) / proofEvery);
+  const proofsAfter = Math.floor(sessions / proofEvery);
+
+  if (proofsAfter > proofsBefore) {
     try {
       await writeProof(baseline, sessions);
     } catch (err) {

--- a/packages/core/scripts/self-harness-campaign.ts
+++ b/packages/core/scripts/self-harness-campaign.ts
@@ -18,7 +18,7 @@
 // Run:  bun packages/core/scripts/self-harness-campaign.ts
 //         [--max-sessions N] [--proof-every 3] [--rounds 3] [--width 3]
 // Stop: touch evals/self-harness/campaign/STOP  (in-flight session finishes)
-import { mkdir } from "node:fs/promises";
+import { mkdir, rename } from "node:fs/promises";
 import { existsSync } from "node:fs";
 import { join } from "node:path";
 import { OpenAICompatibleProvider } from "../src/inference";
@@ -37,24 +37,27 @@ import type { IRunRecord } from "../src/eval";
 import { buildSweepReport, renderSweepReportMarkdown } from "../src/eval";
 import { isRecord } from "../src/lib/guards";
 
-/** The exam: never shown to a mining session. Spec + web mix. */
-const PROOF_SPLIT = [
-  "math",
-  "handlers",
-  "slugify",
-  "web:pm-platform",
-  "web:billing-console",
-] as const;
+/** The exam: never shown to a mining session. WEB BUILDS ONLY — the simple spec
+ *  tasks (math/handlers/slugify) were dropped: they pass in 1–3 cycles every
+ *  time, so they can't show improvement OR regression and only burned wall-clock.
+ *  A web build exercises types, lint, components AND routing, so it subsumes the
+ *  basics — this is a STRICTER regression floor, not a weaker one. Kept as
+ *  pm-platform + billing-console so results stay comparable to the buggy-signal
+ *  baseline archived at baseline.buggy-5cap.json (same tasks, only the fix differs). */
+const PROOF_SPLIT = ["web:pm-platform", "web:billing-console"] as const;
 
-/** Mining rotations — draw only from non-proof tasks; alternate per session. */
+/** Mining rotations — WEB BUILDS ONLY, drawn from the 9 non-proof catalog apps
+ *  (disjoint from the proof split). These are the complex tasks the model
+ *  actually fails, i.e. where there are real weaknesses to mine and real
+ *  headroom for an overlay edit to prove itself. Alternate per session. */
 const ROTATIONS = [
   {
-    heldIn: "query,migrate,checkout,web:saas-crm",
-    heldOut: "validators,fix-regression,web:udemy",
+    heldIn: "web:saas-crm,web:udemy",
+    heldOut: "web:airline-ops,web:portfolio-manager",
   },
   {
-    heldIn: "auth,fixtures,rate-limit,web:hospital-scheduling",
-    heldOut: "debounce,query,web:warehouse-inventory",
+    heldIn: "web:hospital-scheduling,web:warehouse-inventory",
+    heldOut: "web:procurement,web:incident-management",
   },
 ] as const;
 
@@ -94,6 +97,25 @@ const { entry } = await resolveActiveModel();
 const provider: IProvider = new OpenAICompatibleProvider(providerConfig(entry));
 
 await mkdir(campaignDir, { recursive: true });
+
+// Never overwrite a previous campaign's artifacts. Each launch moves any
+// existing runs/ + sessions/ into archive/<launch-timestamp>/ before starting,
+// so relaunching gives a clean slate AND keeps the prior run intact for
+// comparison. (Per-task dirs are also wiped individually at run time; this is
+// the campaign-level guard against cross-launch mixing.)
+const launchStamp = new Date().toISOString().replace(/[:.]/gu, "-");
+
+for (const sub of ["runs", "sessions"]) {
+  const src = join(campaignDir, sub);
+
+  if (existsSync(src)) {
+    const dest = join(campaignDir, "archive", launchStamp, sub);
+
+    await mkdir(join(campaignDir, "archive", launchStamp), { recursive: true });
+    await rename(src, dest);
+    say(`archived previous ${sub}/ → archive/${launchStamp}/${sub}`);
+  }
+}
 
 if (!existsSync(campaignLog)) {
   await Bun.write(

--- a/packages/core/scripts/self-harness-campaign.ts
+++ b/packages/core/scripts/self-harness-campaign.ts
@@ -166,29 +166,59 @@ async function loadCurrentOverlay(): Promise<IHarnessOverlay | null> {
   return parsed !== null && !isEmptyPatch(parsed) ? parsed : null;
 }
 
-/** Evaluate a harness variant on the proof split at repeats=2, relabelled for
- *  the sweep report. */
+/** Per-task retry cap for infrastructure-errored measurements. */
+const TASK_MEASURE_ATTEMPTS = 3;
+
+/**
+ * Evaluate a harness variant on the proof split at repeats=2, relabelled for
+ * the sweep report. Measured TASK BY TASK so an endpoint flap mid-measurement
+ * discards (and retries) only the affected task's runs, never the whole ~1.5h
+ * measurement. Honest by construction: an errored run is a NON-result — a
+ * verdict-carrying run (pass or fail) is never re-rolled.
+ */
 async function measureProof(
   overlay: IHarnessOverlay | null,
   label: string,
   runsDir: string
 ): Promise<IRunRecord[]> {
-  const outcome = await evaluateHarness([...PROOF_SPLIT], {
-    corpusDir,
-    runsDir,
-    provider,
-    repeats: 2,
-    overlay,
-    log: say,
-  });
+  const all: IRunRecord[] = [];
 
-  if (outcome.score.errored > 0) {
-    throw new Error(
-      `proof measurement hit ${String(outcome.score.errored)} infrastructure-errored run(s) — measurement discarded, not recorded`
-    );
+  for (const taskId of PROOF_SPLIT) {
+    let done = false;
+
+    for (let attempt = 1; attempt <= TASK_MEASURE_ATTEMPTS; attempt += 1) {
+      const outcome = await evaluateHarness([taskId], {
+        corpusDir,
+        runsDir: join(
+          runsDir,
+          attempt === 1 ? "." : `retry-${String(attempt)}`
+        ),
+        provider,
+        repeats: 2,
+        overlay,
+        log: say,
+      });
+
+      if (outcome.score.errored === 0) {
+        all.push(...outcome.records.map((r) => ({ ...r, label })));
+        done = true;
+        break;
+      }
+
+      say(
+        `${taskId}: ${String(outcome.score.errored)} errored run(s) on attempt ${String(attempt)} — waiting for a healthy endpoint, then retrying the task`
+      );
+      await waitForHealthyEndpoint();
+    }
+
+    if (!done) {
+      throw new Error(
+        `${taskId}: still erroring after ${String(TASK_MEASURE_ATTEMPTS)} attempts — measurement discarded, not recorded`
+      );
+    }
   }
 
-  return outcome.records.map((r) => ({ ...r, label }));
+  return all;
 }
 
 async function loadBaseline(): Promise<IRunRecord[]> {

--- a/packages/core/scripts/self-harness.ts
+++ b/packages/core/scripts/self-harness.ts
@@ -1,0 +1,239 @@
+// Self-Harness (arXiv 2606.09498): the active model improves tsforge's own
+// harness via a regression-gated loop — evaluate → mine weaknesses → propose
+// minimal overlay edits → validate (Δin≥0 ∧ Δho≥0 ∧ max>0) → merge.
+// The outcome is a PR-ready overlay + audit report for HUMAN review; nothing
+// is auto-installed.
+//
+// Run:  bun packages/core/scripts/self-harness.ts [--rounds 3] [--width 3]
+//         [--repeats 1] [--held-in a,b,..] [--held-out c,d,..]
+//         [--dry-run] [--no-judge]
+// Judge override (else the active model judges): TSFORGE_JUDGE_URL/MODEL/KEY.
+import { mkdir } from "node:fs/promises";
+import { join } from "node:path";
+import { OpenAICompatibleProvider } from "../src/inference";
+import { resolveActiveModel, resolveApiKey } from "../src/models-config";
+import { providerConfig } from "../src/cli";
+import {
+  emitReport,
+  evaluateHarness,
+  mineWeaknesses,
+  modelSlug,
+  propose,
+  resolveSplits,
+  runSelfHarness,
+  emptyOverlay,
+  type HarnessEvaluator,
+  type ISplits,
+} from "../src/self-harness";
+import type { IProvider } from "../src/inference";
+
+function argValue(name: string): string | undefined {
+  const i = process.argv.indexOf(`--${name}`);
+  const value = i >= 0 ? process.argv[i + 1] : undefined;
+
+  return value !== undefined && !value.startsWith("--") ? value : undefined;
+}
+
+function hasFlag(name: string): boolean {
+  return process.argv.includes(`--${name}`);
+}
+
+function csv(value: string | undefined): string[] | undefined {
+  const items = (value ?? "")
+    .split(",")
+    .map((s) => s.trim())
+    .filter((s) => s.length > 0);
+
+  return items.length > 0 ? items : undefined;
+}
+
+function stamp(): string {
+  const d = new Date();
+  const p = (n: number): string => String(n).padStart(2, "0");
+
+  return `${String(d.getFullYear())}${p(d.getMonth() + 1)}${p(d.getDate())}-${p(d.getHours())}${p(d.getMinutes())}${p(d.getSeconds())}`;
+}
+
+const rounds = Number(argValue("rounds") ?? "3");
+const width = Number(argValue("width") ?? "3");
+const repeats = Number(argValue("repeats") ?? "1");
+const dryRun = hasFlag("dry-run");
+const useJudge = !hasFlag("no-judge");
+
+const evalsRoot = join(import.meta.dir, "..", "..", "..", "evals");
+const corpusDir = join(evalsRoot, "corpus");
+
+const { name: modelName, entry } = await resolveActiveModel();
+const provider: IProvider = new OpenAICompatibleProvider(providerConfig(entry));
+
+// Judge convention mirrors the eval sweep: explicit TSFORGE_JUDGE_* wins, else
+// the active model judges its own solutions (still a usable non-regression
+// signal — the SAME judge scores baseline and candidate).
+const judgeOverridden =
+  process.env.TSFORGE_JUDGE_URL !== undefined ||
+  process.env.TSFORGE_JUDGE_MODEL !== undefined;
+const judgeProvider: IProvider | undefined = useJudge
+  ? new OpenAICompatibleProvider(
+      judgeOverridden
+        ? {
+            baseUrl: process.env.TSFORGE_JUDGE_URL ?? entry.baseUrl,
+            model: process.env.TSFORGE_JUDGE_MODEL ?? entry.model,
+            apiKey: process.env.TSFORGE_JUDGE_KEY ?? resolveApiKey(entry),
+          }
+        : providerConfig(entry)
+    )
+  : undefined;
+
+const splits: ISplits = await resolveSplits(
+  corpusDir,
+  csv(argValue("held-in")),
+  csv(argValue("held-out"))
+);
+
+const outDir = join(
+  evalsRoot,
+  "self-harness",
+  `${modelSlug(entry.model)}-${stamp()}`
+);
+
+await mkdir(outDir, { recursive: true });
+
+const say = (line: string): void => {
+  process.stdout.write(`${line}\n`);
+};
+
+say(`self-harness — model ${entry.model} (registry: ${modelName})`);
+say(`  held-in:  ${splits.heldIn.join(", ")}`);
+say(`  held-out: ${splits.heldOut.join(", ")}`);
+say(
+  `  rounds=${String(rounds)} width=${String(width)} repeats=${String(repeats)} judge=${useJudge ? "on" : "off"}${dryRun ? " DRY-RUN" : ""}`
+);
+say(`  out: ${outDir}`);
+
+let evaluations = 0;
+
+/** The real corpus evaluator: one directory per (label, split); sequential —
+ *  the primary endpoint is single-connection. */
+const evaluator: HarnessEvaluator = async (overlay, s, label) => {
+  evaluations += 1;
+
+  say(
+    `  [eval ${String(evaluations)}] ${label}: held-in (${String(s.heldIn.length)} task(s) × ${String(repeats)})`
+  );
+
+  const heldIn = await evaluateHarness(s.heldIn, {
+    corpusDir,
+    runsDir: join(outDir, "runs", label, "held-in"),
+    provider,
+    repeats,
+    overlay,
+    ...(judgeProvider === undefined ? {} : { judgeProvider }),
+    log: say,
+  });
+
+  say(
+    `  [eval ${String(evaluations)}] ${label}: held-out (${String(s.heldOut.length)} task(s) × ${String(repeats)})`
+  );
+
+  const heldOut = await evaluateHarness(s.heldOut, {
+    corpusDir,
+    runsDir: join(outDir, "runs", label, "held-out"),
+    provider,
+    repeats,
+    overlay,
+    ...(judgeProvider === undefined ? {} : { judgeProvider }),
+    log: say,
+  });
+
+  return {
+    evaluation: { heldIn: heldIn.score, heldOut: heldOut.score },
+    heldInRuns: heldIn.runs,
+  };
+};
+
+if (dryRun) {
+  // Mine + propose from ONE held-in evaluation; no candidate validation runs.
+  say(
+    "dry-run: evaluating the current harness on held-in, then mining + proposing only"
+  );
+
+  const heldIn = await evaluateHarness(splits.heldIn, {
+    corpusDir,
+    runsDir: join(outDir, "runs", "dry-run", "held-in"),
+    provider,
+    repeats,
+    overlay: null,
+    log: say,
+  });
+  const bundle = mineWeaknesses(heldIn.runs);
+
+  say(
+    `mined ${String(bundle.patterns.length)} pattern(s) from ${String(bundle.failedRuns)}/${String(bundle.totalRuns)} failed run(s):`
+  );
+
+  for (const p of bundle.patterns) {
+    say(
+      `  - ${p.signature} ×${String(p.support)} (${p.taskIds.join(", ")}) — ${p.mechanism}`
+    );
+  }
+
+  const notes: string[] = [];
+  const candidates = await propose(bundle, {
+    provider,
+    width,
+    current: emptyOverlay(),
+    idPrefix: "dry",
+    notes,
+  });
+
+  for (const c of candidates) {
+    say(
+      `candidate ${c.id}: targets ${c.audit.targetPattern} via ${c.audit.surface}`
+    );
+    say(`  effect: ${c.audit.expectedEffect}`);
+    say(JSON.stringify(c.patch, null, 2));
+  }
+
+  for (const n of notes) {
+    say(`note: ${n}`);
+  }
+
+  await Bun.write(
+    join(outDir, "dry-run.json"),
+    JSON.stringify({ bundle, candidates, notes }, null, 2)
+  );
+  say(`saved ${join(outDir, "dry-run.json")}`);
+  process.exit(0);
+}
+
+const lineage = await runSelfHarness({
+  model: entry.model,
+  rounds,
+  width,
+  splits,
+  provider,
+  evaluator,
+  log: say,
+});
+
+const report = emitReport(lineage);
+
+await Bun.write(join(outDir, "overlay.json"), report.overlayJson);
+await Bun.write(join(outDir, "report.md"), report.markdown);
+await Bun.write(join(outDir, "lineage.json"), JSON.stringify(lineage, null, 2));
+
+const acceptedTotal = lineage.rounds.reduce(
+  (acc, r) => acc + r.acceptedIds.length,
+  0
+);
+
+say("");
+say(
+  `done — ${String(acceptedTotal)} edit(s) accepted across ${String(lineage.rounds.length)} round(s)`
+);
+say(`  overlay:  ${join(outDir, "overlay.json")}`);
+say(`  report:   ${join(outDir, "report.md")}`);
+say(`  lineage:  ${join(outDir, "lineage.json")}`);
+say(
+  "review the report; installing the overlay is YOUR decision (see its install path inside)."
+);

--- a/packages/core/scripts/self-harness.ts
+++ b/packages/core/scripts/self-harness.ts
@@ -22,7 +22,9 @@ import {
   resolveSplits,
   runSelfHarness,
   emptyOverlay,
+  parseOverlay,
   type HarnessEvaluator,
+  type IHarnessOverlay,
   type ISplits,
 } from "../src/self-harness";
 import type { IProvider } from "../src/inference";
@@ -59,6 +61,34 @@ const width = Number(argValue("width") ?? "3");
 const repeats = Number(argValue("repeats") ?? "1");
 const dryRun = hasFlag("dry-run");
 const useJudge = !hasFlag("no-judge");
+const initialOverlayPath = argValue("initial-overlay");
+
+/** Continue a lineage: start from a previous session's accepted overlay so
+ *  improvements COMPOUND across sessions. Fails loudly on a bad path/file —
+ *  silently starting from the empty overlay would discard the lineage. */
+async function loadInitialOverlay(
+  path: string | undefined
+): Promise<IHarnessOverlay | undefined> {
+  if (path === undefined) {
+    return undefined;
+  }
+
+  const file = Bun.file(path);
+
+  if (!(await file.exists())) {
+    throw new Error(`--initial-overlay: no file at ${path}`);
+  }
+
+  const overlay = parseOverlay(JSON.parse(await file.text()));
+
+  if (overlay === null) {
+    throw new Error(`--initial-overlay: ${path} is not a valid overlay`);
+  }
+
+  return overlay;
+}
+
+const initialOverlay = await loadInitialOverlay(initialOverlayPath);
 
 const evalsRoot = join(import.meta.dir, "..", "..", "..", "evals");
 const corpusDir = join(evalsRoot, "corpus");
@@ -108,6 +138,11 @@ say(`  held-out: ${splits.heldOut.join(", ")}`);
 say(
   `  rounds=${String(rounds)} width=${String(width)} repeats=${String(repeats)} judge=${useJudge ? "on" : "off"}${dryRun ? " DRY-RUN" : ""}`
 );
+
+if (initialOverlayPath !== undefined) {
+  say(`  continuing lineage from: ${initialOverlayPath}`);
+}
+
 say(`  out: ${outDir}`);
 
 let evaluations = 0;
@@ -162,7 +197,7 @@ if (dryRun) {
     runsDir: join(outDir, "runs", "dry-run", "held-in"),
     provider,
     repeats,
-    overlay: null,
+    overlay: initialOverlay ?? null,
     log: say,
   });
   const bundle = mineWeaknesses(heldIn.runs);
@@ -181,7 +216,7 @@ if (dryRun) {
   const candidates = await propose(bundle, {
     provider,
     width,
-    current: emptyOverlay(),
+    current: initialOverlay ?? emptyOverlay(),
     idPrefix: "dry",
     notes,
   });
@@ -213,6 +248,7 @@ const lineage = await runSelfHarness({
   splits,
   provider,
   evaluator,
+  ...(initialOverlay === undefined ? {} : { initialOverlay }),
   log: say,
 });
 

--- a/packages/core/scripts/self-harness.ts
+++ b/packages/core/scripts/self-harness.ts
@@ -13,6 +13,7 @@ import { join } from "node:path";
 import { OpenAICompatibleProvider } from "../src/inference";
 import { resolveActiveModel, resolveApiKey } from "../src/models-config";
 import { providerConfig } from "../src/cli";
+import { BENCHMARK_CATALOG } from "./benchmark-catalog";
 import {
   emitReport,
   evaluateHarness,
@@ -117,7 +118,10 @@ const judgeProvider: IProvider | undefined = useJudge
 const splits: ISplits = await resolveSplits(
   corpusDir,
   csv(argValue("held-in")),
-  csv(argValue("held-out"))
+  csv(argValue("held-out")),
+  // `web:<slug>` tasks resolve against the benchmark catalog (script-side
+  // import; src/ never imports from scripts/).
+  BENCHMARK_CATALOG.map((a) => a.slug)
 );
 
 const outDir = join(

--- a/packages/core/scripts/self-harness.ts
+++ b/packages/core/scripts/self-harness.ts
@@ -25,7 +25,9 @@ import {
   emptyOverlay,
   parseOverlay,
   type HarnessEvaluator,
+  type IEvaluateOutcome,
   type IHarnessOverlay,
+  type ISplitScore,
   type ISplits,
 } from "../src/self-harness";
 import type { IProvider } from "../src/inference";
@@ -151,8 +153,102 @@ say(`  out: ${outDir}`);
 
 let evaluations = 0;
 
-/** The real corpus evaluator: one directory per (label, split); sequential —
- *  the primary endpoint is single-connection. */
+/** Per-task attempts before an errored task is given up (its errored count
+ *  then propagates so upstream logic reacts honestly). */
+const TASK_ATTEMPTS = 3;
+
+function meanOfSignaled(values: readonly number[]): number {
+  const signaled = values.filter((v) => v > 0);
+
+  return signaled.length === 0
+    ? 0
+    : signaled.reduce((a, b) => a + b, 0) / signaled.length;
+}
+
+/** Merge single-task outcomes into one split outcome. Counts sum; the
+ *  quality/concision means recompute over tasks that carry a signal —
+ *  identical semantics to evaluateHarness's own aggregation. */
+function mergeOutcomes(
+  outcomes: readonly IEvaluateOutcome[]
+): IEvaluateOutcome {
+  const records = outcomes.flatMap((o) => [...o.records]);
+  const runs = outcomes.flatMap((o) => [...o.runs]);
+  const perTask: ISplitScore["perTask"] = {};
+
+  for (const outcome of outcomes) {
+    for (const [task, summary] of Object.entries(outcome.score.perTask)) {
+      perTask[task] = summary;
+    }
+  }
+
+  return {
+    records,
+    runs,
+    score: {
+      passed: outcomes.reduce((a, o) => a + o.score.passed, 0),
+      runs: outcomes.reduce((a, o) => a + o.score.runs, 0),
+      errored: outcomes.reduce((a, o) => a + o.score.errored, 0),
+      avgQuality: meanOfSignaled(outcomes.map((o) => o.score.avgQuality)),
+      avgLoc: meanOfSignaled(outcomes.map((o) => o.score.avgLoc)),
+      perTask,
+    },
+  };
+}
+
+/** Evaluate one split TASK BY TASK: an errored task (endpoint outage) waits
+ *  out the weather and retries, so one flap costs one task's re-run — not the
+ *  whole evaluation. This is what lets a multi-hour session survive an
+ *  endpoint that drops every ~45–90 min. */
+async function evaluateSplitResilient(
+  taskIds: readonly string[],
+  runsDirBase: string,
+  overlay: Parameters<HarnessEvaluator>[0]
+): Promise<IEvaluateOutcome> {
+  const outcomes: IEvaluateOutcome[] = [];
+
+  for (const taskId of taskIds) {
+    let outcome: IEvaluateOutcome | undefined;
+
+    for (let attempt = 1; attempt <= TASK_ATTEMPTS; attempt += 1) {
+      outcome = await evaluateHarness([taskId], {
+        corpusDir,
+        runsDir: join(
+          runsDirBase,
+          attempt === 1 ? "." : `retry-${String(attempt)}`
+        ),
+        provider,
+        repeats,
+        overlay,
+        ...(judgeProvider === undefined ? {} : { judgeProvider }),
+        log: say,
+      });
+
+      if (outcome.score.errored === 0) {
+        break;
+      }
+
+      if (attempt < TASK_ATTEMPTS) {
+        say(
+          `  ${taskId}: errored (attempt ${String(attempt)}/${String(TASK_ATTEMPTS)}) — waiting for endpoint recovery, then retrying`
+        );
+        await waitHealthy();
+      } else {
+        say(
+          `  ${taskId}: still erroring after ${String(TASK_ATTEMPTS)} attempts — recorded as errored`
+        );
+      }
+    }
+
+    if (outcome !== undefined) {
+      outcomes.push(outcome);
+    }
+  }
+
+  return mergeOutcomes(outcomes);
+}
+
+/** The real corpus evaluator: one directory per (label, split, task);
+ *  sequential — the primary endpoint is single-connection. */
 const evaluator: HarnessEvaluator = async (overlay, s, label) => {
   evaluations += 1;
 
@@ -160,29 +256,21 @@ const evaluator: HarnessEvaluator = async (overlay, s, label) => {
     `  [eval ${String(evaluations)}] ${label}: held-in (${String(s.heldIn.length)} task(s) × ${String(repeats)})`
   );
 
-  const heldIn = await evaluateHarness(s.heldIn, {
-    corpusDir,
-    runsDir: join(outDir, "runs", label, "held-in"),
-    provider,
-    repeats,
-    overlay,
-    ...(judgeProvider === undefined ? {} : { judgeProvider }),
-    log: say,
-  });
+  const heldIn = await evaluateSplitResilient(
+    s.heldIn,
+    join(outDir, "runs", label, "held-in"),
+    overlay
+  );
 
   say(
     `  [eval ${String(evaluations)}] ${label}: held-out (${String(s.heldOut.length)} task(s) × ${String(repeats)})`
   );
 
-  const heldOut = await evaluateHarness(s.heldOut, {
-    corpusDir,
-    runsDir: join(outDir, "runs", label, "held-out"),
-    provider,
-    repeats,
-    overlay,
-    ...(judgeProvider === undefined ? {} : { judgeProvider }),
-    log: say,
-  });
+  const heldOut = await evaluateSplitResilient(
+    s.heldOut,
+    join(outDir, "runs", label, "held-out"),
+    overlay
+  );
 
   return {
     evaluation: { heldIn: heldIn.score, heldOut: heldOut.score },

--- a/packages/core/scripts/self-harness.ts
+++ b/packages/core/scripts/self-harness.ts
@@ -245,6 +245,45 @@ if (dryRun) {
   process.exit(0);
 }
 
+/** Endpoint-recovery wait for baseline retries: 3 consecutive small
+ *  completions, 60s apart — mirrors the campaign driver's health gate. */
+async function waitHealthy(): Promise<void> {
+  let ok = 0;
+
+  while (ok < 3) {
+    let healthy = false;
+
+    try {
+      const key = resolveApiKey(entry);
+      const res = await fetch(`${entry.baseUrl}/chat/completions`, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          ...(key === undefined ? {} : { Authorization: `Bearer ${key}` }),
+        },
+        body: JSON.stringify({
+          model: entry.model,
+          messages: [{ role: "user", content: "ok?" }],
+          max_tokens: 3,
+        }),
+        signal: AbortSignal.timeout(30_000),
+      });
+
+      healthy = res.ok;
+    } catch {
+      healthy = false;
+    }
+
+    ok = healthy ? ok + 1 : 0;
+
+    if (ok < 3) {
+      await Bun.sleep(60_000);
+    }
+  }
+
+  say("endpoint recovered (3 consecutive probes)");
+}
+
 const lineage = await runSelfHarness({
   model: entry.model,
   rounds,
@@ -253,6 +292,7 @@ const lineage = await runSelfHarness({
   provider,
   evaluator,
   ...(initialOverlay === undefined ? {} : { initialOverlay }),
+  waitHealthy,
   log: say,
 });
 

--- a/packages/core/scripts/self-harness.ts
+++ b/packages/core/scripts/self-harness.ts
@@ -248,11 +248,7 @@ if (dryRun) {
 /** Endpoint-recovery wait for baseline retries: 3 consecutive small
  *  completions, 60s apart — mirrors the campaign driver's health gate. */
 async function waitHealthy(): Promise<void> {
-  let ok = 0;
-
-  while (ok < 3) {
-    let healthy = false;
-
+  async function probe(): Promise<boolean> {
     try {
       const key = resolveApiKey(entry);
       const res = await fetch(`${entry.baseUrl}/chat/completions`, {
@@ -269,12 +265,16 @@ async function waitHealthy(): Promise<void> {
         signal: AbortSignal.timeout(30_000),
       });
 
-      healthy = res.ok;
+      return res.ok;
     } catch {
-      healthy = false;
+      return false;
     }
+  }
 
-    ok = healthy ? ok + 1 : 0;
+  let ok = 0;
+
+  while (ok < 3) {
+    ok = (await probe()) ? ok + 1 : 0;
 
     if (ok < 3) {
       await Bun.sleep(60_000);

--- a/packages/core/scripts/self-harness.ts
+++ b/packages/core/scripts/self-harness.ts
@@ -124,11 +124,11 @@ const splits: ISplits = await resolveSplits(
   BENCHMARK_CATALOG.map((a) => a.slug)
 );
 
-const outDir = join(
-  evalsRoot,
-  "self-harness",
-  `${modelSlug(entry.model)}-${stamp()}`
-);
+// `--out-dir <path>`: caller-chosen output location (the campaign driver's
+// contract for finding this session's lineage/overlay deterministically).
+const outDir =
+  argValue("out-dir") ??
+  join(evalsRoot, "self-harness", `${modelSlug(entry.model)}-${stamp()}`);
 
 await mkdir(outDir, { recursive: true });
 

--- a/packages/core/src/agent/agent-runner.ts
+++ b/packages/core/src/agent/agent-runner.ts
@@ -469,6 +469,7 @@ export class AgentRunner {
       edits: 0,
       regressions: 0,
       ttsrInterrupts: 0,
+      steerLevel: 0,
     };
     const maxTurns = spec.maxTurns ?? AGENT_LIMITS.maxTurns;
     const start = performance.now();

--- a/packages/core/src/agent/agent.constants.ts
+++ b/packages/core/src/agent/agent.constants.ts
@@ -28,6 +28,7 @@ export const TOOL_NAME = {
   addDependency: "add_dependency",
   packageInfo: "package_info",
   packageDocs: "package_docs",
+  pullConventions: "pull_conventions",
   webFetch: "web_fetch",
   webSearch: "web_search",
   webBrowse: "web_browse",
@@ -76,6 +77,7 @@ export const TOOL_SPECS: Readonly<Record<ToolName, IToolSpec>> = {
   [TOOL_NAME.addDependency]: { readOnly: false, scriptExposable: false },
   [TOOL_NAME.packageInfo]: { readOnly: true, scriptExposable: true },
   [TOOL_NAME.packageDocs]: { readOnly: true, scriptExposable: true },
+  [TOOL_NAME.pullConventions]: { readOnly: true, scriptExposable: true },
   // Web tools are read-only (no workspace mutation), so they're usable in plan
   // mode too — research while planning. Network egress here is structured and
   // opt-in (TSFORGE_WEB), unlike the raw `run` curl path plan mode blocks.
@@ -407,6 +409,35 @@ export const PACKAGE_INFO_TOOL = {
     },
   },
 };
+
+export const PULL_CONVENTIONS_TOOL = {
+  type: "function",
+  function: {
+    name: TOOL_NAME.pullConventions,
+    description:
+      "Pull the boringstack HOW-TO guide for a topic BEFORE you write that kind of code — so you write it right the first time instead of getting a gate error. Call it when you're about to create a component, write JSX, place state, add a route/form, or hit a rule you're unsure how to satisfy. Returns the exact pattern the gate enforces.",
+    parameters: {
+      type: "object",
+      properties: {
+        topic: {
+          type: "string",
+          enum: [
+            "component-anatomy",
+            "file-layout",
+            "jsx",
+            "state",
+            "no-casts",
+            "routing",
+            "forms",
+          ],
+          description:
+            "which guide: component-anatomy (where a component lives + one-per-file), file-layout (no inline types/constants/helpers), jsx (no computation in markup), state (hooks, not component body), no-casts (type guards instead of `as`/`!`), routing (thin route files), forms.",
+        },
+      },
+      required: ["topic"],
+    },
+  },
+} as const;
 
 export const PACKAGE_DOCS_TOOL = {
   type: "function",

--- a/packages/core/src/config/agent-specs.ts
+++ b/packages/core/src/config/agent-specs.ts
@@ -9,6 +9,7 @@ import { homedir } from "node:os";
 import { join } from "node:path";
 import { isRecord } from "../lib/guards";
 import { BUILTIN_SPECS } from "../agent/builtin-specs";
+import { activeOverlay } from "../self-harness/overlay";
 import type {
   AgentKind,
   AgentOutputMode,
@@ -186,6 +187,17 @@ export async function loadAgentSpecs(
 
   await loadDir(join(homeBase(), ".tsforge", "agents"), byId, report);
   await loadDir(join(cwd, ".tsforge", "agents"), byId, report);
+
+  // Self-harness overlay overrides: bounded (prompt/task/maxTurns only — the
+  // override type has no tools/model, so an edit can't grant capabilities) and
+  // only onto EXISTING specs; an override can never introduce a new agent.
+  for (const override of activeOverlay()?.agentSpecOverrides ?? []) {
+    const existing = byId.get(override.id);
+
+    if (existing !== undefined) {
+      byId.set(override.id, { ...existing, ...override });
+    }
+  }
 
   return [...byId.values()].sort((a, b) => a.id.localeCompare(b.id));
 }

--- a/packages/core/src/config/config.constants.ts
+++ b/packages/core/src/config/config.constants.ts
@@ -9,4 +9,5 @@ export const ENV_FLAG = {
   noGitTool: "TSFORGE_NO_GIT_TOOL",
   basicInput: "TSFORGE_BASIC_INPUT",
   noDelegation: "TSFORGE_NO_DELEGATION",
+  expertRescue: "TSFORGE_EXPERT_RESCUE",
 } as const;

--- a/packages/core/src/config/flags.ts
+++ b/packages/core/src/config/flags.ts
@@ -39,4 +39,11 @@ export const flags = {
    *  Default OFF — delegation is on. Set to "1" for the A/B control arm (measure
    *  the harness WITHOUT subagents) or to force a pure single-stream run. */
   noDelegation: (): boolean => isOn(ENV_FLAG.noDelegation),
+  /** Enable the EXPERT HANDOFF: when a build stalls after the full steering ladder,
+   *  hand the blocking file to the configured `capabilities.expert` model. Opt-in
+   *  (default OFF) because it makes a live, paid, non-deterministic API call — so
+   *  unit tests and eval sweeps that drive a run to a stall never hit it unless they
+   *  explicitly ask. Real autonomous builders (the headless web builder, interactive
+   *  sessions) turn it on. Without it, a stall parks with all work kept, as before. */
+  expertRescue: (): boolean => isOn(ENV_FLAG.expertRescue),
 };

--- a/packages/core/src/gate/web-gate.ts
+++ b/packages/core/src/gate/web-gate.ts
@@ -105,15 +105,25 @@ export function buildWebGate(
   // isn't silently skipped; see `webTestProbe`.
   const tests = webTestProbe();
 
-  // The SAME commands as the old `a && b && …` chain, run sequentially by the
-  // staged-gate runner so a failure names its stage ("✗ typecheck FAILED") instead
-  // of burying it in one opaque wall. Order is identical to the old chain, so the
-  // stop-on-first-failure behaviour is unchanged; the type-aware lint is its own
-  // stage (only when the scaffold has a tsconfig, as before).
+  // Run sequentially by the staged-gate runner (stop on first failure) so a
+  // failure names its stage ("✗ typecheck FAILED") instead of burying it in one
+  // opaque wall.
+  //
+  // ORDER MATTERS: plain `lint` runs FIRST. Many of the model's mistakes are
+  // caught by a rule with a CLEAR, actionable message (e.g. no-self-import:
+  // "'./index' resolves to THIS file"), but the SAME mistake also breaks the
+  // Rollup bundle with a CRYPTIC error ("X cannot be exported … reexports
+  // itself"). With `vite build` first, the gate stopped on the cryptic build
+  // error and the clean lint message never ran — the model was observed looping
+  // for 45+ turns unable to connect the two. Plain web lint is purely syntactic
+  // (no projectService — see strict.web.eslint.config.mjs), so it does NOT need
+  // the build's generated route tree and is safe to run first. `tsc` and the
+  // TYPE-AWARE lint still run AFTER `vite build`, because they DO need the
+  // generated routeTree.gen.ts the build emits.
   const stages = [
+    { label: "lint", command: lint },
     { label: "vite build", command: build },
     { label: "typecheck", command: tsc },
-    { label: "lint", command: lint },
     ...(typeAware === null
       ? []
       : [{ label: "type-aware lint", command: typeAware }]),

--- a/packages/core/src/loop/conventions.ts
+++ b/packages/core/src/loop/conventions.ts
@@ -1,0 +1,156 @@
+/**
+ * The boringstack CONVENTION library — the "how to write it right" knowledge the
+ * model needs AT write-time, distilled from boringstack's `docs/agents/*` and kept
+ * in lockstep with what the gate enforces. Two delivery paths use it:
+ *   • PUSH (primary) — the harness injects the relevant guide the moment the model
+ *     does the matching thing (e.g. creates its first component), so it writes
+ *     compliant code the FIRST time instead of writing wrong then refactoring.
+ *   • PULL (secondary) — the `pull_conventions` tool lets the model fetch a guide
+ *     on demand for the long tail the harness can't pre-anticipate.
+ * Concise on purpose: a local model absorbs a focused 8-line guide, not a 368-line
+ * wall. Each guide maps 1:1 to the rules that reject its violation.
+ */
+
+/** The convention topics the model can be handed or pull. Single source of truth:
+ *  the const tuple drives both the type and the runtime list (no `as` cast). */
+const TOPICS = [
+  "component-anatomy",
+  "file-layout",
+  "jsx",
+  "state",
+  "no-casts",
+  "routing",
+  "forms",
+] as const;
+
+export type ConventionTopic = (typeof TOPICS)[number];
+
+/** Membership set for the topic guard — a `Set<string>` so the check is a clean
+ *  `.has()` (no `as` cast, no `.some()` that unicorn flags). */
+const TOPIC_SET = new Set<string>(TOPICS);
+
+/** topic → the enforced-rule(s) it prevents, for cross-referencing gate errors. */
+export const TOPIC_RULES: Readonly<Record<ConventionTopic, readonly string[]>> =
+  {
+    "component-anatomy": [
+      "component-folder-structure",
+      "one-component-per-file",
+      "index-must-reexport-default",
+    ],
+    "file-layout": ["component-file-purity"],
+    jsx: ["no-jsx-computation", "no-inline-jsx-functions"],
+    state: ["no-state-in-component-body", "max-hooks-per-file"],
+    "no-casts": ["no-restricted-syntax", "no-non-null-assertion"],
+    routing: ["component-folder-structure"],
+    forms: [],
+  };
+
+const GUIDES: Readonly<Record<ConventionTopic, string>> = {
+  "component-anatomy":
+    "COMPONENT ANATOMY (boringstack). A component file `.tsx` renders props — it " +
+    "does NOT own state. Put each component in `src/views/<Feature>/`: the view root " +
+    "is `index.tsx`; extra components go in `components/<Name>.tsx`, ONE component per " +
+    "file. State/effects/memo live in `<feature>.hooks.ts`, never in the component " +
+    "body — the component imports the hook and consumes its return value. Types → " +
+    "`<feature>.types.ts`, constants → `<feature>.constants.ts`. NEVER place a " +
+    "component under `src/features/` (that's the data layer) — views live under " +
+    "`src/views/`. shadcn primitives in `src/components/ui/` are exempt.",
+  "file-layout":
+    "FILE PURITY (boringstack). A component `.tsx` holds ONLY imports + the component " +
+    "— nothing else atop it. Move each out and import it back: a type → " +
+    "`<feature>.types.ts`; a constant / label-map / column-spec → " +
+    "`<feature>.constants.ts` (`as const`); a pure helper (formatX, timeAgo) → " +
+    "`src/lib/<name>.ts`. Inline types/constants/helpers are a gate error " +
+    "(component-file-purity).",
+  jsx:
+    "JSX (boringstack). No COMPUTATION inside JSX — the markup only READS " +
+    "already-computed values. A derived value → a `useMemo` in `<feature>.hooks.ts`; " +
+    "a pure transform → a function in `src/lib`. A simple ternary is fine; a " +
+    "`.map()`/`.filter()`/arithmetic/`Object.entries()` in the markup is not (extract " +
+    "it). Every `<button>` needs an explicit `type`.",
+  state:
+    "STATE (boringstack). ALL `useState`/`useReducer`/`useEffect`/`useMemo`/" +
+    "`useCallback` live in `<feature>.hooks.ts`, never in a component body. Server " +
+    "data → a hook using react-query/fetch that narrows the response. A hooks file " +
+    "exporting too many hooks splits into focused modules (e.g. `*.queries.ts` + " +
+    "`*.mutations.ts`).",
+  "no-casts":
+    "NO CASTS (boringstack). Never write `x as T` or `x!`. To narrow a value (e.g. a " +
+    "`<select>` string to a union), use a TYPE GUARD: keep the allowed values in a " +
+    "const map (`as const` IS allowed) and guard with `in` — " +
+    "`const S = {open:1,closed:1} as const; type St = keyof typeof S; " +
+    "function isSt(v:string): v is St { return v in S; }` then `if (isSt(v)) {…}`. " +
+    "For a possibly-null DOM/query result, guard with `if (x === null) return` or " +
+    "`instanceof`, never `!`.",
+  routing:
+    "ROUTING (boringstack). A route file is THIN: it imports its view and renders it " +
+    "(e.g. `component: Dashboard` from `@/views/Dashboard`) — NO UI or logic of its " +
+    "own. Create ALL route files at once with `scaffold_routes` (list, detail with " +
+    "`$param` like `/accounts/$accountId`, create/edit), THEN fill each view. Never " +
+    "hand-write a route file or put a component's body in one.",
+  forms:
+    "FORMS (boringstack). Use react-hook-form's `useForm` inside `<Component>.hooks.ts` " +
+    "(not the component body). Map server/validation errors back onto the form fields; " +
+    "keep the component rendering the field state the hook returns.",
+};
+
+/** The guide for a topic (the exact string pushed or pulled). */
+export function conventionGuide(topic: ConventionTopic): string {
+  return GUIDES[topic];
+}
+
+/** Every topic name — for the pull tool's enum + listings. */
+export function conventionTopics(): ConventionTopic[] {
+  return [...TOPICS];
+}
+
+/** Narrow an arbitrary string to a ConventionTopic (for the pull tool's arg) —
+ *  membership test, no `as` cast. */
+export function isConventionTopic(s: string): s is ConventionTopic {
+  return TOPIC_SET.has(s);
+}
+
+/** The topic whose enforced rules include `rule` (bare or plugin-prefixed), or null.
+ *  Lets a gate error cross-reference the guide that prevents it. */
+export function topicForRule(rule: string): ConventionTopic | null {
+  const bare = rule.split("/").pop() ?? rule;
+
+  for (const topic of conventionTopics()) {
+    if (TOPIC_RULES[topic].includes(bare)) {
+      return topic;
+    }
+  }
+
+  return null;
+}
+
+/**
+ * PUSH helper: the convention guides for the gate errors whose rule maps to a topic
+ * NOT already shown this run (`seen` is mutated to dedupe). This is how the loop
+ * hands the model the boringstack how-to the FIRST time it trips a rule — right
+ * beside the error, not after the steering ladder escalates. One guide per topic
+ * per run: enough to teach, not a wall.
+ */
+export function unseenGuidesForErrors(
+  errors: readonly { readonly rule?: string }[],
+  seen: Set<string>
+): string[] {
+  const out: string[] = [];
+
+  for (const e of errors) {
+    if (e.rule === undefined) {
+      continue;
+    }
+
+    const topic = topicForRule(e.rule);
+
+    if (topic === null || seen.has(topic)) {
+      continue;
+    }
+
+    seen.add(topic);
+    out.push(conventionGuide(topic));
+  }
+
+  return out;
+}

--- a/packages/core/src/loop/expert-handoff.ts
+++ b/packages/core/src/loop/expert-handoff.ts
@@ -1,0 +1,227 @@
+/**
+ * EXPERT HANDOFF — the rung ABOVE the steering ladder. When escalating steers
+ * can't unblock the model on a stuck file, hand that single file + its exact gate
+ * error to a stronger "expert" model (configured via `capabilities.expert` in
+ * models.json, same routing as vision/imageGen). The expert returns the corrected
+ * file; the harness applies it and the PRIMARY model continues from there. Only if
+ * no expert is configured (or it can't help) does the run finally park — with all
+ * work kept, never discarded.
+ *
+ * The model call is injected (`ExpertAsk`) so the loop wires the real provider and
+ * tests stub it; the pure pieces (prompt, code extraction, apply) are unit-tested.
+ */
+import { stat } from "node:fs/promises";
+import { join, isAbsolute, relative } from "node:path";
+
+import { flags } from "../config";
+
+import { OpenAICompatibleProvider } from "../inference";
+import type { IOpenAICompatibleConfig } from "../inference";
+import { resolveCapabilityModel, resolveApiKey } from "../models-config";
+import type { IModelEntry } from "../models-config";
+
+/** What the expert is told about the stuck file. */
+export interface IExpertRequest {
+  /** The workspace-relative file that keeps failing. */
+  readonly file: string;
+  /** Its current full content. */
+  readonly content: string;
+  /** The exact gate error(s) for this file (message + rule), verbatim. */
+  readonly error: string;
+  /** A brief line of task context (what's being built). */
+  readonly goal: string;
+}
+
+/** The result of a handoff attempt, for the loop to log and act on. */
+export interface IExpertOutcome {
+  readonly applied: boolean;
+  readonly file?: string;
+  readonly note: string;
+}
+
+/** Ask an expert model to fix a stuck file; resolve to the corrected FULL file
+ *  content, or null if it can't/won't help. Injected for testability. */
+export type ExpertAsk = (req: IExpertRequest) => Promise<string | null>;
+
+const EXPERT_SYSTEM =
+  "You are a senior TypeScript engineer called in to unblock an automated agent " +
+  "that is STUCK on one file — it keeps failing the same gate check. Return the " +
+  "corrected file and nothing else. Obey the project's strict rules: no `as` type " +
+  "casts (narrow with a type guard), no `!` non-null assertions, no inline " +
+  "types/constants/helpers in a component file, no computation inside JSX.";
+
+/** The scoped fix request. Pure — unit-tested. */
+export function buildFixPrompt(req: IExpertRequest): string {
+  return (
+    `Project goal: ${req.goal}\n\n` +
+    `The file \`${req.file}\` fails the build gate with:\n${req.error}\n\n` +
+    `Current contents of \`${req.file}\`:\n\`\`\`tsx\n${req.content}\n\`\`\`\n\n` +
+    `Return ONLY the corrected FULL contents of \`${req.file}\` in a single \`\`\`tsx ` +
+    `code block. Fix the exact error above while keeping everything else working. ` +
+    `No explanation.`
+  );
+}
+
+/** The fenced code block from a model reply, or the raw reply when it's plainly a
+ *  file (has an import/export/statement). Null when there's nothing usable — so a
+ *  chatty "I can't help" reply doesn't get written to disk. Pure — unit-tested. */
+export function extractCode(reply: string): string | null {
+  const fenced = /```(?:tsx?|typescript|jsx?)?\n([\s\S]*?)```/u.exec(reply);
+
+  if (fenced?.[1] !== undefined) {
+    const body = fenced[1].trim();
+
+    return body.length > 0 ? body : null;
+  }
+
+  const raw = reply.trim();
+
+  return /\b(import|export|const|function|class)\b/u.test(raw) ? raw : null;
+}
+
+/** Attempt the handoff: ask the expert, and if it returns usable code, OVERWRITE the
+ *  stuck file with it. (This is the one place the harness rewrites a whole file — it
+ *  is the expert's deliberate repair, not the primary model flailing.) Returns what
+ *  happened, for the loop to log. Never throws — a handoff failure must not crash the
+ *  run; it just means the run parks instead. */
+export async function runExpertHandoff(
+  cwd: string,
+  req: IExpertRequest,
+  ask: ExpertAsk
+): Promise<IExpertOutcome> {
+  const reply = await ask(req).catch(() => null);
+  const code = reply === null ? null : extractCode(reply);
+
+  if (code === null) {
+    return {
+      applied: false,
+      note: "expert unavailable or produced no usable fix",
+    };
+  }
+
+  try {
+    await Bun.write(join(cwd, req.file), `${code}\n`);
+  } catch {
+    return {
+      applied: false,
+      note: `expert fix could not be written to ${req.file}`,
+    };
+  }
+
+  return {
+    applied: true,
+    file: req.file,
+    note: `expert model repaired ${req.file}`,
+  };
+}
+
+/** A file path parsed out of an error message, or undefined. Type-aware-lint names
+ *  the file in text (e.g. "views/Issues/index.tsx:215 …") but doesn't populate the
+ *  error's `.file`, so the expert would otherwise have nothing to hand over. */
+function fileInMessage(message: string): string | undefined {
+  const m = /\b([\w/.-]+\.[cm]?[jt]sx?)\b/u.exec(message);
+
+  return m?.[1];
+}
+
+/**
+ * Best-effort workspace-relative file for the stuck error — the target the expert
+ * repairs. Prefers a populated `.file`, else a path parsed from the error MESSAGES.
+ * Tries each candidate as-is and `src/`-prefixed (messages often drop the `src/`),
+ * and absolute→relative, returning the first that resolves to an EXISTING file.
+ * Null when nothing resolves (→ the caller logs a visible skip). This is what lets
+ * the expert fire on type-aware-lint failures, which killed a whole live run.
+ */
+export async function resolveStuckFile(
+  cwd: string,
+  errors: readonly { readonly file?: string; readonly message: string }[]
+): Promise<string | null> {
+  const raws = [
+    ...errors.flatMap((e) => (e.file === undefined ? [] : [e.file])),
+    ...errors.flatMap((e) => {
+      const f = fileInMessage(e.message);
+
+      return f === undefined ? [] : [f];
+    }),
+  ].map((raw) => (isAbsolute(raw) ? relative(cwd, raw) : raw));
+
+  // Exact location: as-is, or under src/ (messages often drop the prefix).
+  for (const rel of raws) {
+    for (const candidate of [rel, join("src", rel)]) {
+      if (await Bun.file(join(cwd, candidate)).exists()) {
+        return candidate;
+      }
+    }
+  }
+
+  // Basename only (e.g. stub-check names "dashboard.tsx" with no directory): find
+  // it anywhere under src/ — routes/, views/, components/, wherever it lives. Guard
+  // on src/ existing so a non-web build (no src/) resolves to null, not a throw.
+  const srcDir = join(cwd, "src");
+  const hasSrc = await stat(srcDir)
+    .then((s) => s.isDirectory())
+    .catch(() => false);
+
+  if (hasSrc) {
+    for (const rel of raws) {
+      const base = rel.split("/").at(-1);
+
+      if (base === undefined || base.length === 0) {
+        continue;
+      }
+
+      for await (const match of new Bun.Glob(`**/${base}`).scan({
+        cwd: srcDir,
+      })) {
+        return join("src", match);
+      }
+    }
+  }
+
+  return null;
+}
+
+/** Wire config for the expert entry (key resolved at use time). Mirrors the small
+ *  local builder in image-tools so this loop-layer module needn't import the CLI. */
+function entryConfig(entry: IModelEntry): IOpenAICompatibleConfig {
+  return {
+    baseUrl: entry.baseUrl,
+    model: entry.model,
+    apiKey: resolveApiKey(entry),
+    ...(entry.maxTokens === undefined ? {} : { maxTokens: entry.maxTokens }),
+    ...(entry.extraHeaders === undefined
+      ? {}
+      : { extraHeaders: entry.extraHeaders }),
+    ...(entry.extraBody === undefined ? {} : { extraBody: entry.extraBody }),
+  };
+}
+
+/** The real expert ask backed by the configured `capabilities.expert` model, or
+ *  null when the handoff is not explicitly enabled or no expert is configured (→ the
+ *  run parks as before; fully backward compatible). Gated on `flags.expertRescue()`
+ *  (opt-in) so a unit test or eval sweep that drives a run to a stall NEVER makes a
+ *  live, paid API call — only real autonomous builders opt in. Resolution failures
+ *  degrade to null (never break the loop). Tests that exercise the handoff inject
+ *  their own ExpertAsk into `tryExpertRescue`, bypassing this gate entirely. */
+export async function resolveExpertAsk(): Promise<ExpertAsk | null> {
+  if (!flags.expertRescue()) {
+    return null;
+  }
+
+  const resolved = await resolveCapabilityModel("expert").catch(() => null);
+
+  if (resolved === null) {
+    return null;
+  }
+
+  const provider = new OpenAICompatibleProvider(entryConfig(resolved.entry));
+
+  return async (req: IExpertRequest): Promise<string | null> => {
+    const res = await provider.complete([
+      { role: "system", content: EXPERT_SYSTEM },
+      { role: "user", content: buildFixPrompt(req) },
+    ]);
+
+    return res.content.length > 0 ? res.content : null;
+  };
+}

--- a/packages/core/src/loop/feedback/rule-docs.ts
+++ b/packages/core/src/loop/feedback/rule-docs.ts
@@ -1,5 +1,6 @@
 import type { ErrorSet } from "../../validate";
 import generatedJson from "./rule-docs.generated.json";
+import { activeOverlay } from "../../self-harness/overlay";
 
 export interface IRuleDoc {
   /** One-line statement of what the rule requires. */
@@ -464,6 +465,35 @@ export function ruleHelpFromOutput(output: string): string {
   return ruleHelp(errors);
 }
 
+/** Merge the active self-harness overlay's procedure-card edit (if any) for a
+ *  rule over its base doc. Returns the base doc unchanged when no edit exists,
+ *  and undefined when neither yields a renderable doc (no `what`). */
+function applyCardOverlay(
+  rule: string,
+  doc: IRuleDoc | undefined
+): IRuleDoc | undefined {
+  const edit = activeOverlay()?.procedureCards[rule];
+
+  if (edit === undefined) {
+    return doc;
+  }
+
+  const what = edit.what ?? doc?.what;
+
+  if (what === undefined || what.length === 0) {
+    return doc;
+  }
+
+  const merged: IRuleDoc = {
+    what,
+    bad: edit.bad ?? doc?.bad ?? "",
+    good: edit.good ?? doc?.good ?? "",
+  };
+  const procedure = edit.procedure ?? doc?.procedure;
+
+  return procedure === undefined ? merged : { ...merged, procedure };
+}
+
 /** Format the rule docs for whichever rules appear in the current error set. */
 export function ruleHelp(errors: ErrorSet): string {
   const seen = new Set<string>();
@@ -481,6 +511,11 @@ export function ruleHelp(errors: ErrorSet): string {
       // For tsforge pack rules, look up in generated docs
       doc = GENERATED[e.rule];
     }
+
+    // A self-harness procedure-card edit merges over the base doc field-wise;
+    // with no overlay the base doc passes through untouched. An edit with no
+    // base doc still needs a `what` to render a coherent block.
+    doc = applyCardOverlay(e.rule, doc);
 
     if (doc === undefined) {
       continue;

--- a/packages/core/src/loop/feedback/steer.ts
+++ b/packages/core/src/loop/feedback/steer.ts
@@ -1,0 +1,180 @@
+/**
+ * The STEERING LADDER. When the model stalls on the same error(s) — the gate
+ * isn't converging — the loop used to give up and kill the run. Instead it now
+ * escalates a STEER.
+ *
+ * Crucially, each rung escalates INTELLIGENCE, not more static rules. The gate has
+ * already told the model WHAT is wrong (the exact compiler/lint error) — repeating
+ * that louder won't unstick it. So the rungs ask the model to work DIFFERENTLY:
+ *   L1  STEP BACK — diagnose your own loop and pick a different approach.
+ *   L2  INVESTIGATE — use tools: read the imports, grep the codebase for a passing
+ *       example, web_search an unfamiliar error. Stop guessing.
+ *   L3  CHANGE STRATEGY — invert the failing approach, narrow to one error.
+ *   (above the ladder) EXPERT — hand off to a stronger model as the last resort.
+ * The harness supplies the nudge; the MODEL supplies the thinking. Rule-specific
+ * "playbooks" survive only as an optional reference at L2 for a few known walls —
+ * they are a convenience, not the mechanism. Pure/string-building; unit-tested.
+ */
+
+/** The essential HEAD of a conversation — the system prompt + the ORIGINAL task
+ *  request — used to RESET a context-poisoned run at the top steer rung: drop the
+ *  flailing middle (the dead-end attempts the model keeps re-reading and repeating),
+ *  keep only these, then the caller appends a fresh directive. Preserves order and
+ *  is a no-op-safe pure function (missing system/user → just omitted). */
+export function essentialMessages<T extends { readonly role: string }>(
+  messages: readonly T[]
+): T[] {
+  const head: T[] = [];
+  const system = messages.find((m) => m.role === "system");
+
+  if (system !== undefined) {
+    head.push(system);
+  }
+
+  const firstUser = messages.find((m) => m.role === "user");
+
+  if (firstUser !== undefined) {
+    head.push(firstUser);
+  }
+
+  return head;
+}
+
+/** A gate error, narrowed to what a steer needs (rule id, file, message). */
+export interface ISteerError {
+  readonly rule?: string;
+  readonly file?: string;
+  readonly message: string;
+}
+
+/** Steer escalations before a run parks. Level 1..MAX are steers; above MAX the
+ *  loop hands off to an expert model (then parks) — see the loop's stuck check. */
+export const STEER_LADDER_MAX = 3;
+
+/** Rule → a worked "here's how to actually satisfy me" recipe, for the handful of
+ *  strict rules the model repeatedly can't get past on a from-scratch build. Keyed
+ *  by the rule's BARE name (the segment after any `plugin/` prefix). */
+const PLAYBOOKS: Record<string, string> = {
+  "no-restricted-syntax":
+    "`as` cast rejected. Narrow with a TYPE GUARD, never a cast. Keep the allowed " +
+    "values in a const map (`as const` IS allowed) and guard with `in`:\n" +
+    "    const STATUS = { open: 1, closed: 1 } as const;\n" +
+    "    type Status = keyof typeof STATUS;\n" +
+    "    function isStatus(v: string): v is Status { return v in STATUS; }\n" +
+    "then `if (isStatus(v)) { /* v is Status here */ }`. Never write `x as T`.",
+  "no-jsx-computation":
+    "Computation inside JSX rejected. Move it OUT: a pure transform → a function in " +
+    "`src/lib/<name>.ts` (import and call it); derived state → a `useMemo` in your " +
+    "`<feature>.hooks.ts`. The JSX must only READ an already-computed value.",
+  "component-file-purity":
+    "A component file may hold ONLY imports + the component. Move the flagged " +
+    "declaration out and import it back: types → `<feature>.types.ts`, constants → " +
+    "`<feature>.constants.ts` (`as const`), pure helpers → `src/lib/`.",
+  "no-self-import":
+    "This file imports/re-exports from itself. If it's a barrel `index.ts` next to " +
+    "an `index.tsx`, DELETE the barrel — the `.tsx` is already the module entry " +
+    "(import the folder path). Otherwise define the binding directly here.",
+  "max-hooks-per-file":
+    "Too many hooks in one file. Split into focused modules — e.g. `<x>.queries.ts` " +
+    "(reads) + `<x>.mutations.ts` (writes) — each under the limit; update imports.",
+  "one-component-per-file":
+    "Two components in one file. Move the second into its own file and import it.",
+};
+
+/** The bare rule name — the segment after the last `/` (so `tsforge/no-jsx-computation`
+ *  and `no-jsx-computation` both resolve to the same playbook). */
+function bareRule(rule: string): string {
+  const parts = rule.split("/");
+
+  return parts[parts.length - 1] ?? rule;
+}
+
+/** The playbook for a rule id, or null when none is registered. */
+export function playbookFor(rule: string | undefined): string | null {
+  if (rule === undefined) {
+    return null;
+  }
+
+  return PLAYBOOKS[bareRule(rule)] ?? null;
+}
+
+/** The distinct playbooks for the rules present in `errors`, formatted as a list.
+ *  Empty string when none of the current errors has a registered playbook. */
+function playbooksFor(errors: readonly ISteerError[]): string {
+  const seen = new Set<string>();
+  const blocks: string[] = [];
+
+  for (const e of errors) {
+    const bare = e.rule === undefined ? "" : bareRule(e.rule);
+    const play = playbookFor(e.rule);
+
+    if (play !== null && !seen.has(bare)) {
+      seen.add(bare);
+      blocks.push(`• ${bare}: ${play}`);
+    }
+  }
+
+  return blocks.join("\n");
+}
+
+/**
+ * Build the steer message for an escalation `level` (1..MAX). Each rung escalates
+ * INTELLIGENCE (see the module comment):
+ *  1 — STEP BACK: diagnose your own loop, pick a different approach.
+ *  2 — INVESTIGATE with tools (read imports, grep for a passing example, web_search).
+ *  3 — CHANGE STRATEGY: invert the failing approach, one error / one file.
+ * `reason` is the convergence-guard diagnosis. `webEnabled` gates the `web_search`
+ * suggestion — never tell the model to use a tool the build doesn't have.
+ */
+export function buildSteerMessage(
+  level: number,
+  errors: readonly ISteerError[],
+  reason: string,
+  webEnabled = false
+): string {
+  const header = `⚠ STEER (escalation ${String(level)}/${String(STEER_LADDER_MAX)}) — you are NOT converging: ${reason}.`;
+
+  // The rungs escalate INTELLIGENCE, not more static rules. The gate already told
+  // the model WHAT is wrong (the compiler/lint error); repeating that won't unstick
+  // it. Each rung asks the model to work DIFFERENTLY — reflect, then investigate
+  // with tools, then change strategy — and only the rung ABOVE this ladder brings in
+  // the expert model. The harness supplies the nudge; the model supplies the thinking.
+  if (level <= 1) {
+    // STEP BACK — make the model diagnose its OWN loop instead of guessing again.
+    return (
+      `${header}\nSTEP BACK before you touch anything. In 1–2 sentences answer: ` +
+      `(a) what have you been repeatedly trying, (b) WHY does it keep failing, ` +
+      `(c) what fundamentally DIFFERENT approach will you take now? Then make ONE ` +
+      `small, targeted edit for that — no whole-file rewrites (they re-introduce ` +
+      `errors you already fixed).`
+    );
+  }
+
+  if (level === 2) {
+    // INVESTIGATE with tools — your mental model is wrong; go get the real cause.
+    const plays = playbooksFor(errors);
+    const ref =
+      plays.length > 0
+        ? `\n\nKnown-good pattern for what you're failing (use if it fits):\n${plays}`
+        : "";
+
+    const web = webEnabled
+      ? " if the error is unfamiliar, look it up with `web_search`;"
+      : "";
+
+    return (
+      `${header}\nStop guessing and INVESTIGATE. Use your tools: read the FULL ` +
+      `failing file and the files it imports; search the codebase for how this exact ` +
+      `pattern is done in code that ALREADY passes and copy that;${web} then report ` +
+      `the real root cause and fix it.${ref}`
+    );
+  }
+
+  // CHANGE STRATEGY — invert the failing approach and narrow to one thing.
+  return (
+    `${header}\nChange strategy completely. Pick the SINGLE most-blocking error and ` +
+    `fix ONLY it this turn; if your approach to it has already failed twice, do the ` +
+    `OPPOSITE of what you've been doing. Touch nothing that already passes. If it ` +
+    `still won't yield, a stronger expert model will be brought in to unblock you.`
+  );
+}

--- a/packages/core/src/loop/loop.constants.ts
+++ b/packages/core/src/loop/loop.constants.ts
@@ -58,6 +58,30 @@ export const LOOP_LIMITS = {
    */
   noProgressCycles: 12,
   /**
+   * Once STEERING has begun (a stall was detected and the first steer fired),
+   * escalate FAST: climb to the next, more directive rung after only this many
+   * non-improving gate cycles, instead of waiting another full `noProgressCycles`/
+   * `gateStuckRepeats` window. A live run reached only L1 by turn 105 because the
+   * coarse windows re-tripped too slowly over sparse forced-gates, so the L2 rule
+   * PLAYBOOK — the rung that actually hands the fix recipe — never arrived. Small,
+   * so L1→L2→L3→(expert/park) happens in a handful of gates once it's clear the
+   * model is stuck, not dozens.
+   */
+  steerRetrigger: 2,
+  /**
+   * PLATEAU (oscillation) backstop. The fine guards above reset on every intermittent
+   * success AND every error-SET rotation, so a model that OSCILLATES — fixes the stub
+   * stage, breaks lint; fixes lint, re-breaks a stub; never reaching green — crawls up
+   * the ladder over 150+ turns and the expert handoff at the top is effectively
+   * unreachable (observed live: 166 turns, only 3 escalations, expert fired 0×). This
+   * counts gate cycles since the last ALL-TIME-LOW error count (genuine convergence
+   * resets it; oscillation does not). Once the full ladder has deployed (L3 + context
+   * reset already tried) and this many further gate cycles pass with no new low, hand
+   * off to the expert NOW instead of waiting for the glacial natural escalation. This
+   * changes only WHEN the escape hatch opens — it relaxes no gate rule.
+   */
+  plateauGates: 4,
+  /**
    * Above this many chars of combined file content, the seed prompt sends a
    * navigable project MAP instead of full dumps. Below it, full dumps.
    */

--- a/packages/core/src/loop/prompt/prompt.ts
+++ b/packages/core/src/loop/prompt/prompt.ts
@@ -10,6 +10,22 @@ import {
   testLayoutPhrase,
 } from "../../infer-rules/guidance";
 import { renderFileSection } from "./project-map";
+import { activeOverlay } from "../../self-harness/overlay";
+import type { PromptBlockName } from "../../self-harness/self-harness.types";
+
+/** Apply the active self-harness overlay's edit (if any) to a NAMED editable
+ *  prompt block. With no overlay this returns `base` untouched, so the base
+ *  harness stays byte-identical. Only the named blocks route through here —
+ *  identity, tools, and the gate-rules sentence are not editable surfaces. */
+function overlayBlock(base: string, name: PromptBlockName): string {
+  const edit = activeOverlay()?.promptBlocks[name];
+
+  if (edit === undefined) {
+    return base;
+  }
+
+  return edit.mode === "replace" ? edit.text : `${base}\n${edit.text}`;
+}
 
 /** The strict-TS house-rules line, with the interface-naming clause tuned to the
  *  project's convention (omitted entirely when naming is "off"). The safety rules
@@ -28,10 +44,19 @@ export function buildSystem(conventions: IConventions): string {
   return [
     "You are an expert TypeScript engineer working inside tsforge, a harness specialized for STRICT TypeScript. Implement the task by editing code until the gate passes.",
     "Tools: `read` (inspect a file), `edit` (replace an exact, unique snippet), `create` (a new file), `run` (execute any shell command and see its output).",
-    "Lead with action: start writing code right away (one `create`/`edit`) — do NOT deliberate at length before writing any code. (In TDD mode the test comes first; see the test-first guidance below.)",
-    "After every edit the harness AUTOMATICALLY runs the gate and gives you the result (the errors + fix guidance for the failing rules). You do NOT need to run the acceptance command yourself — read that result and fix exactly what it reports, then edit again. Keep going until it reports green; the harness ends the task at that point.",
+    overlayBlock(
+      "Lead with action: start writing code right away (one `create`/`edit`) — do NOT deliberate at length before writing any code. (In TDD mode the test comes first; see the test-first guidance below.)",
+      "bootstrap"
+    ),
+    overlayBlock(
+      "After every edit the harness AUTOMATICALLY runs the gate and gives you the result (the errors + fix guidance for the failing rules). You do NOT need to run the acceptance command yourself — read that result and fix exactly what it reports, then edit again. Keep going until it reports green; the harness ends the task at that point.",
+      "execution"
+    ),
     "The harness also AUTO-FIXES mechanical formatting on every file you write — blank lines, braces, quotes, semicolons, import order, `prefer-template`. NEVER hand-fix or chase those, and do NOT run `tsc`/`eslint`/the gate yourself to look for them. Fix only what the gate explicitly hands back (`as`/`any`/`!`, real type errors), then stop.",
-    "Test hypotheses by RUNNING them, never by reasoning them out. Unsure about an edge case, rounding, or ordering (`Math.floor(100/3)`, largest-remainder ties)? `run` a quick `bun -e '…console.log(…)'`, or write a throwaway `scratch/check.ts` importing your impl and `run` it. `scratch/` is yours — the gate ignores it.",
+    overlayBlock(
+      "Test hypotheses by RUNNING them, never by reasoning them out. Unsure about an edge case, rounding, or ordering (`Math.floor(100/3)`, largest-remainder ties)? `run` a quick `bun -e '…console.log(…)'`, or write a throwaway `scratch/check.ts` importing your impl and `run` it. `scratch/` is yours — the gate ignores it.",
+      "verification"
+    ),
     gateRulesSentence(conventions),
     "Keep functions small: the gate caps cognitive complexity at 20 and nesting depth at 4. If a function grows long or deeply nested, extract named helpers instead of one sprawling block. Always `await` promises (or `void` them deliberately) — a floating promise is a gate error.",
   ].join("\n");
@@ -115,6 +140,14 @@ export function buildSystemPrompt(
 
   if (flags.tdd()) {
     blocks.push(buildTddGuidance(conventions));
+  }
+
+  // The self-harness `extra` block: a free append slot AFTER all built-in
+  // guidance (it has no base text, so append and replace are equivalent).
+  const extra = activeOverlay()?.promptBlocks.extra;
+
+  if (extra !== undefined) {
+    blocks.push(extra.text);
   }
 
   return blocks.join("\n\n");

--- a/packages/core/src/loop/run.ts
+++ b/packages/core/src/loop/run.ts
@@ -426,6 +426,7 @@ export async function runTask(
     edits: 0,
     regressions: 0,
     ttsrInterrupts: 0,
+    steerLevel: 0,
   };
   const taskStart = performance.now();
 

--- a/packages/core/src/loop/session.ts
+++ b/packages/core/src/loop/session.ts
@@ -62,6 +62,7 @@ import {
   runToolCalls,
   settleGate,
   toolsFor,
+  tryExpertRescue,
 } from "./turn";
 
 /**
@@ -569,6 +570,7 @@ export class Session {
       edits: 0,
       regressions: 0,
       ttsrInterrupts: 0,
+      steerLevel: 0,
     };
   }
 
@@ -1583,7 +1585,7 @@ export class Session {
     }
 
     const readonlyStreak = carry.readonlyStreak + 1;
-    const spin = this.readonlySpinStop(
+    const spin = await this.readonlySpinStop(
       readonlyStreak,
       carry.readonlyRecoveries,
       turn
@@ -1893,12 +1895,18 @@ export class Session {
       return "";
     }
 
+    // Show EVERY outstanding gate error — the model can't finish work it can't
+    // see. The ceiling is only a runaway backstop for a degenerate cascade, not
+    // a feedback limit (was 5, which hid most errors and caused whack-a-mole).
+    const MAX_GATE_ERRORS_SHOWN = 200;
     const lines = errs
-      .slice(0, 5)
+      .slice(0, MAX_GATE_ERRORS_SHOWN)
       .map((e) => `  - ${e.message}`)
       .join("\n");
     const more =
-      errs.length > 5 ? `\n  …and ${String(errs.length - 5)} more` : "";
+      errs.length > MAX_GATE_ERRORS_SHOWN
+        ? `\n  …and ${String(errs.length - MAX_GATE_ERRORS_SHOWN)} more`
+        : "";
 
     return (
       `\n\nA passing \`bun run build\` is NOT the gate. The gate is still RED — ` +
@@ -1906,16 +1914,28 @@ export class Session {
     );
   }
 
-  private readonlySpinStop(
+  private async readonlySpinStop(
     streak: number,
     recoveries: number,
     turn: number
-  ): ISendResult | "retry" | null {
+  ): Promise<ISendResult | "retry" | null> {
     if (streak < READONLY_STREAK_LIMIT) {
       return null;
     }
 
     if (recoveries >= MAX_READONLY_RECOVERIES) {
+      // This is a "stuck" exit too, so the EXPERT handoff gets its shot HERE before
+      // we give up — build v3 died on exactly this path (256 turns of read-only
+      // spinning) without ever reaching the expert, because the rescue was only
+      // wired to settleGate's stalled-park. If a stronger model repairs the blocking
+      // file, keep looping instead of stopping.
+      if (
+        this.hasGate &&
+        (await tryExpertRescue(this.ctx, this.state, this.state.prevGateErrors))
+      ) {
+        return "retry";
+      }
+
       this.report({
         kind: "stuck",
         task: SESSION_ID,

--- a/packages/core/src/loop/session.ts
+++ b/packages/core/src/loop/session.ts
@@ -1326,8 +1326,18 @@ export class Session {
     // scaffold_web emitted as text). The retry is a FORCED tool call, which is
     // grammar-constrained — so it always parses.
     const leaked = this.hasGate && leaksToolMarkup(content);
+    // An EMPTY no-tool reply mid-gated-build is never a valid conclusion — it
+    // is the signature of a degenerate/failed provider response (captured
+    // live: a 675ms "reply" during an endpoint flap ended a 180-turn build as
+    // "responded" with only the scaffold on disk). Nudge-with-cap, like the
+    // other mid-build non-answers.
+    const emptyMidBuild = this.hasGate && content.trim().length === 0;
 
-    if (!leaked && (!this.hasGate || !looksLikeCodeDump(content))) {
+    if (
+      !leaked &&
+      !emptyMidBuild &&
+      (!this.hasGate || !looksLikeCodeDump(content))
+    ) {
       return { result: { status: "responded", turns: turn } };
     }
 
@@ -1338,8 +1348,11 @@ export class Session {
         message: leaked
           ? "⚠ model kept emitting malformed tool-call text instead of real " +
             "calls — stopped. See malformed-toolcall-format (server parser)."
-          : "⚠ model kept writing files as chat messages instead of creating " +
-            "them — stopped. Try a smaller step (e.g. one file at a time).",
+          : emptyMidBuild
+            ? "⚠ model kept returning empty replies mid-build — stopped " +
+              "(endpoint likely degraded; the run is incomplete, not done)."
+            : "⚠ model kept writing files as chat messages instead of creating " +
+              "them — stopped. Try a smaller step (e.g. one file at a time).",
       });
 
       return { result: { status: "stuck", turns: turn } };
@@ -1350,7 +1363,9 @@ export class Session {
       task: SESSION_ID,
       message: leaked
         ? "↳ malformed tool-call text (no tool ran) — forcing a real call"
-        : "↳ no files written — nudging the model to build with tools",
+        : emptyMidBuild
+          ? "↳ empty reply during a gated build — asking the model to continue"
+          : "↳ no files written — nudging the model to build with tools",
     });
     this.ctx.messages.push({
       role: "user",

--- a/packages/core/src/loop/staged-build.ts
+++ b/packages/core/src/loop/staged-build.ts
@@ -105,6 +105,18 @@ export function isImplementationFile(path: string): boolean {
     return false; // scaffolded theme primitives, not app code
   }
 
+  // The web scaffold itself lays down __root.tsx + the placeholder index
+  // route in EVERY build — counting them made this check always-true, so a
+  // types-only phase 1 with a trivially-green scaffold gate could skip
+  // phase 2 and ship a hollow "done". A REAL app always has other route/view
+  // files, so excluding these two loses nothing.
+  if (
+    path.endsWith("src/routes/__root.tsx") ||
+    path.endsWith("src/routes/index.tsx")
+  ) {
+    return false;
+  }
+
   return base !== "main.ts" && base !== "main.tsx";
 }
 

--- a/packages/core/src/loop/tools/execute-tool.ts
+++ b/packages/core/src/loop/tools/execute-tool.ts
@@ -1,6 +1,7 @@
 import type { IToolCall } from "../../inference";
 import { TOOL_NAME, READ_ONLY_TOOL_NAMES, type ToolName } from "../../agent";
 import { readFile, runShell, doEdit, doCreate } from "./file-ops";
+import { doPullConventions } from "./pull-conventions";
 import { doHashlineEdit } from "./edit-hashline";
 import { doSearch, doLsp } from "./lsp-ops";
 import { doGit } from "./git-ops";
@@ -52,6 +53,7 @@ const HANDLERS: Record<ToolName, ToolHandler> = {
   [TOOL_NAME.addDependency]: doAddDependency,
   [TOOL_NAME.packageInfo]: doPackageInfo,
   [TOOL_NAME.packageDocs]: doPackageDocs,
+  [TOOL_NAME.pullConventions]: doPullConventions,
   [TOOL_NAME.webFetch]: doWebFetch,
   [TOOL_NAME.webSearch]: doWebSearch,
   [TOOL_NAME.webBrowse]: doWebBrowse,

--- a/packages/core/src/loop/tools/file-ops.ts
+++ b/packages/core/src/loop/tools/file-ops.ts
@@ -571,6 +571,73 @@ export async function runShell(
   return `exit ${res.exitCode}\n${output}${guidance}`;
 }
 
+/**
+ * True when `content` has a SYNTAX/parse error — it won't parse at all. Such a file
+ * CANNOT be surgically line-edited (line numbers / anchors are meaningless on broken
+ * syntax), so the guardrails that force targeted edits — the edit-size cap and
+ * `create`'s no-overwrite — must yield for it: rewriting an unparseable file loses
+ * nothing (it's already garbage) and is the only clean way to fix it. Without this
+ * the model deadlocks (observed live: 27 turns bouncing between "edit too large",
+ * "already exists", and "needs a hash anchor" on one broken file). Uses Bun's
+ * transpiler, which throws on a parse error but NOT on type errors — so this only
+ * frees genuinely-unparseable files, never a merely type-wrong one. Empty = fine.
+ */
+function isSyntacticallyBroken(content: string, file: string): boolean {
+  if (content.trim().length === 0) {
+    return false;
+  }
+
+  const loader = file.endsWith(".tsx")
+    ? "tsx"
+    : file.endsWith(".jsx")
+      ? "jsx"
+      : file.endsWith(".ts")
+        ? "ts"
+        : "js";
+
+  try {
+    new Bun.Transpiler({ loader }).transformSync(content);
+
+    return false;
+  } catch {
+    return true;
+  }
+}
+
+/** The edit-size guard: find the first replacement that rewrites a big span with
+ *  another big span (a lazy whole-function rewrite — the thing the cap exists to
+ *  block). Returns null when the batch is fine, OR when `brokenTarget` is true — a
+ *  syntactically-broken file legitimately needs a wholesale fix. */
+function oversizedEdit(
+  edits: readonly {
+    readonly oldString?: string;
+    readonly newString?: string;
+  }[],
+  brokenTarget: boolean
+): {
+  readonly index: number;
+  readonly oldSpan: number;
+  readonly newSpan: number;
+} | null {
+  if (brokenTarget) {
+    return null;
+  }
+
+  for (let i = 0; i < edits.length; i += 1) {
+    const oldSpan = (edits[i]?.oldString ?? "").split("\n").length;
+    const newSpan = (edits[i]?.newString ?? "").split("\n").length;
+
+    if (
+      oldSpan > LOOP_LIMITS.maxEditLines &&
+      newSpan > LOOP_LIMITS.maxEditLines
+    ) {
+      return { index: i + 1, oldSpan, newSpan };
+    }
+  }
+
+  return null;
+}
+
 export async function doEdit(
   args: Record<string, unknown>,
   ctx: IToolContext
@@ -595,19 +662,29 @@ export async function doEdit(
     );
   }
 
-  // The size cap is PER replacement — each piece must be surgical (no lazy
-  // whole-function rewrite) — but a batch may carry many pieces, so the model
-  // can fix the same issue at several spread-out sites in ONE turn.
-  for (let i = 0; i < edit.edits.length; i += 1) {
-    const span = (edit.edits[i]?.oldString ?? "").split("\n").length;
+  // The size cap targets lazy whole-function REWRITES — a big old span replaced by
+  // a big new span. A big old span → an EMPTY/small new span is a DELETION or a
+  // shrink (clearing broken/orphaned code), which is exactly what we want to allow:
+  // blocking it traps the model into shell-`mv` gymnastics and read-only spinning
+  // (observed live — a run died at 256 turns unable to delete 60 orphaned lines).
+  // So reject only when BOTH sides are large. A batch may carry many pieces.
+  // EXCEPTION: if the file on disk currently has a SYNTAX error it can't be surgically
+  // edited (line anchors are meaningless), so a large rewrite is the legitimate fix —
+  // skip the cap. Otherwise the model deadlocks (can't edit big, can't recreate).
+  const currentContent = await Bun.file(join(ctx.cwd, edit.file))
+    .text()
+    .catch(() => "");
+  const oversized = oversizedEdit(
+    edit.edits,
+    isSyntacticallyBroken(currentContent, edit.file)
+  );
 
-    if (span > LOOP_LIMITS.maxEditLines) {
-      return reject(
-        ctx,
-        "edit",
-        `edit ${edit.file} REJECTED: replacement #${i + 1} is too large (${span} lines). Change ONLY the broken lines — make small, targeted replacements (the gate names the exact lines). To fix several spots, pass each as its own entry in \`edits\`; don't rewrite a whole function.`
-      );
-    }
+  if (oversized !== null) {
+    return reject(
+      ctx,
+      "edit",
+      `edit ${edit.file} REJECTED: replacement #${String(oversized.index)} rewrites a large span (${String(oversized.oldSpan)}→${String(oversized.newSpan)} lines). Change ONLY the broken lines — make small, targeted replacements (the gate names the exact lines); pass several as separate entries in \`edits\`. (DELETING or shrinking a broken span IS allowed. And if the file has a SYNTAX error so it can't be surgically edited, use \`create\` to rewrite it wholesale — that's allowed for a broken file.)`
+    );
   }
 
   const result = await applyEdits(ctx.cwd, edit.file, edit.edits);
@@ -637,8 +714,7 @@ export async function doEdit(
   const where =
     edit.edits.length > 1 ? ` (replacement #${result.index + 1})` : "";
 
-  const authored = ctx.touched?.has(edit.file.replaceAll("\\", "/")) ?? false;
-  let help = editFailHelp(edit.file, result, authored);
+  let help = editFailHelp(edit.file, result);
 
   // A not-found edit is almost always a STALE ANCHOR — the auto-formatter rewrote
   // the file after the model's last write, so its oldString no longer matches. The
@@ -706,8 +782,7 @@ async function currentFileView(
  */
 function editFailHelp(
   file: string,
-  result: { reason: string; matches?: number },
-  authored: boolean
+  result: { reason: string; matches?: number }
 ): string {
   if (result.reason === EDIT_FAIL_REASON.ambiguous) {
     return `oldString matched ${result.matches ?? 0} places — include more surrounding lines to make it unique`;
@@ -718,15 +793,12 @@ function editFailHelp(
   }
 
   if (result.reason === EDIT_FAIL_REASON.notFound) {
-    // A file the model AUTHORED this session can be fully rewritten via `create`
-    // (the overwrite escape hatch) — so when it's painted into a corner with stale
-    // anchors or a too-large edit, offer that rather than steering it away from the
-    // one clean exit (observed: ~20 turns thrashing edit↔read on its own service file).
-    const rewrite = authored
-      ? ` Since you created ${file} this session, you may also \`create\` it again to fully rewrite it.`
-      : " Do NOT use `create` (it already exists).";
-
-    return `the file ${file} EXISTS, but your oldString text was not found in it (it was likely auto-reformatted after your last write — imports reordered, quotes/commas normalized).${rewrite}`;
+    // Stale anchor: the file was auto-reformatted after the model's last write
+    // (imports reordered, quotes/commas normalized), so its oldString no longer
+    // matches. Steer it to re-anchor on the CURRENT content (the caller inlines it)
+    // and make a TARGETED edit — never to rewrite the whole file via `create`
+    // (that re-introduces already-fixed errors, and `create` now rejects it).
+    return `the file ${file} EXISTS, but your oldString was not found in it (it was auto-reformatted after your last write — imports reordered, quotes/commas normalized). Do NOT recreate or rewrite the file — copy a fresh oldString verbatim from its CURRENT content and make a targeted \`edit\`.`;
   }
 
   return result.reason;
@@ -761,37 +833,51 @@ export async function doCreate(
     );
   }
 
-  // A file the model AUTHORED this session (in the write-only change-set) may be
-  // fully rewritten via `create` — it's the model's own work, already rewritable
-  // via `edit`, so this grants no new power; it just provides the whole-file-rewrite
-  // path the model otherwise lacks. Without it, a model that wrote a file badly (e.g.
-  // seed data with `as` casts) thrashes edit(too-large)↔create(exists)↔edit_lines to
-  // the turn cap. A file the model did NOT author (pre-existing/scaffold code) still
-  // can't be clobbered by `create`.
-  const authored = ctx.touched?.has(create.file.replaceAll("\\", "/")) ?? false;
-  const result = await applyCreate(ctx.cwd, create, authored);
+  // `create` normally NEVER overwrites an existing file — rewriting WORKING code
+  // re-introduces the very errors just fixed (runs looped 45+ turns undoing their own
+  // progress). The ONE exception: a file that currently has a SYNTAX error can't be
+  // surgically edited at all (line anchors are meaningless), so forbidding overwrite
+  // there DEADLOCKS the model between "edit too large" / "already exists" / "needs a
+  // hash anchor" (observed live, 27 turns). So allow overwrite IFF the existing file
+  // is unparseable — rewriting garbage loses nothing and is the only clean fix.
+  const createPath = join(ctx.cwd, create.file);
+  const exists = await Bun.file(createPath).exists();
+
+  if (exists) {
+    const current = await Bun.file(createPath)
+      .text()
+      .catch(() => "");
+
+    if (!isSyntacticallyBroken(current, create.file)) {
+      return reject(
+        ctx,
+        "create:exists",
+        `create ${create.file} REJECTED: it already EXISTS and parses fine. Do NOT rewrite a working file — a full rewrite re-introduces errors you already fixed. Use \`edit\`/\`edit_lines\` to change ONLY the specific lines the gate flagged.`
+      );
+    }
+  }
+
+  const result = await applyCreate(ctx.cwd, create, exists);
 
   if (result.ok) {
-    const overwrote = authored;
-
     ctx.report({
       kind: "create",
       task: ctx.task,
       file: create.file,
-      message: overwrote
-        ? `create ${create.file} (overwrote your earlier version)`
+      message: exists
+        ? `create ${create.file} (rewrote a syntactically-broken file)`
         : `create ${create.file}`,
       content: create.content,
     });
 
-    return overwrote
-      ? `overwrote ${create.file} — full rewrite of the file you created earlier this session.`
+    return exists
+      ? `created ${create.file} — rewrote a file that had a syntax error; it parses now, keep it green.`
       : `created ${create.file}`;
   }
 
   return reject(
     ctx,
-    "create:exists",
-    `create ${create.file} REJECTED: already exists and you didn't create it this session — use \`edit\` to change it.`
+    "create",
+    `create ${create.file} could not be written (${result.reason}).`
   );
 }

--- a/packages/core/src/loop/tools/pull-conventions.ts
+++ b/packages/core/src/loop/tools/pull-conventions.ts
@@ -1,0 +1,25 @@
+import { str } from "./tool-context";
+import {
+  conventionGuide,
+  conventionTopics,
+  isConventionTopic,
+} from "../conventions";
+
+/**
+ * The `pull_conventions` tool handler — the PULL half of the convention layer. The
+ * model fetches the boringstack how-to for a topic ON DEMAND (before writing that
+ * kind of code), the complement to the harness PUSHing guides on first violation.
+ * Pure lookup; no ctx needed (fewer params is assignable to ToolHandler).
+ */
+export function doPullConventions(args: Record<string, unknown>): string {
+  const topic = str(args, "topic");
+
+  if (!isConventionTopic(topic)) {
+    return (
+      `pull_conventions: unknown topic "${topic}". ` +
+      `Valid topics: ${conventionTopics().join(", ")}.`
+    );
+  }
+
+  return conventionGuide(topic);
+}

--- a/packages/core/src/loop/ttsr-init.ts
+++ b/packages/core/src/loop/ttsr-init.ts
@@ -5,6 +5,7 @@ import type { ILoopState } from "./turn";
 import type { IChatMessage } from "../inference";
 import { TtsrManager, parseProjectRules, type ITtsrRule } from "./ttsr";
 import { DEFAULT_TTSR_RULES } from "./ttsr-defaults";
+import { activeOverlay } from "../self-harness/overlay";
 
 /** Global backstop across ALL rules. Individual noisy rules are silenced
  *  per-rule (TtsrManager.recordInterrupt, cap 2) well before this trips; the
@@ -66,6 +67,25 @@ export async function initTtsrManager(
       kind: "ttsr",
       task: taskId,
       message: `loaded ${added} project/learned TTSR rule(s) from .tsforge/`,
+    });
+  }
+
+  // Self-harness overlay rules (already schema-validated by parseOverlay) —
+  // last so an overlay rule never displaces a same-named built-in/project rule
+  // silently; addRule's first-wins dedup keeps the base harness authoritative.
+  let overlayAdded = 0;
+
+  for (const rule of activeOverlay()?.ttsrRules ?? []) {
+    if (manager.addRule(rule)) {
+      overlayAdded += 1;
+    }
+  }
+
+  if (overlayAdded > 0) {
+    report({
+      kind: "ttsr",
+      task: taskId,
+      message: `loaded ${overlayAdded} self-harness overlay TTSR rule(s)`,
     });
   }
 

--- a/packages/core/src/loop/turn.ts
+++ b/packages/core/src/loop/turn.ts
@@ -19,6 +19,18 @@ import type { IRunResult, Reporter } from "./loop.types";
 import { flags } from "../config";
 import type { IStackProfile } from "../stack-detection";
 import { gateFeedback } from "./feedback";
+import { unseenGuidesForErrors } from "./conventions";
+import {
+  buildSteerMessage,
+  essentialMessages,
+  STEER_LADDER_MAX,
+} from "./feedback/steer";
+import {
+  runExpertHandoff,
+  resolveExpertAsk,
+  resolveStuckFile,
+  type ExpertAsk,
+} from "./expert-handoff";
 import {
   executeTool,
   type SetupWebFn,
@@ -42,6 +54,7 @@ import {
   WEB_BROWSE_TOOL,
   PACKAGE_INFO_TOOL,
   PACKAGE_DOCS_TOOL,
+  PULL_CONVENTIONS_TOOL,
   SCRIPT_TOOL,
   GIT_CONTEXT_TOOL,
   READ_IMAGE_TOOL,
@@ -93,6 +106,7 @@ type AdvertisedTool =
   | typeof WEB_BROWSE_TOOL
   | typeof PACKAGE_INFO_TOOL
   | typeof PACKAGE_DOCS_TOOL
+  | typeof PULL_CONVENTIONS_TOOL
   | typeof SCRIPT_TOOL
   | typeof GIT_CONTEXT_TOOL
   | typeof READ_IMAGE_TOOL
@@ -154,10 +168,20 @@ export function toolsFor(
   const script = scriptTools();
   const image = imageTools(caps);
 
+  // pull_conventions — a read-only knowledge tool the model calls to fetch the
+  // boringstack how-to BEFORE writing that kind of code (the PULL complement to the
+  // harness PUSHing guides on first violation). Web-gated: the guides are React/web
+  // conventions, so it belongs to web runs only — advertising it on every scratch/
+  // logic task would dilute the deliberately minimal base tool set (tools-gating).
+  const conventions: AdvertisedTool[] = flags.webTools()
+    ? [PULL_CONVENTIONS_TOOL]
+    : [];
+
   if (flags.noLspTools() || !hasExistingCode) {
     return [
       ...BASE_TOOLS,
       ...HASHLINE_TOOLS,
+      ...conventions,
       ...web,
       ...git,
       ...script,
@@ -169,6 +193,7 @@ export function toolsFor(
   return [
     ...BASE_TOOLS,
     ...HASHLINE_TOOLS,
+    ...conventions,
     ...LSP_TOOLS,
     ...web,
     ...git,
@@ -281,6 +306,33 @@ export interface ILoopState {
   regressions: number;
   /** Count of TTSR rule interrupts this task. Hard cap at 3 to prevent loops. */
   ttsrInterrupts: number;
+  /** Steering ladder: how many times a convergence guard has tripped and escalated
+   *  a steer this run (0 = never stalled). Each escalation resets the guards so the
+   *  model gets fresh cycles at a more directive steer; a run only parks once this
+   *  exceeds the ladder (see checkStuck). */
+  steerLevel: number;
+  /** The steer message to inject on the NEXT feedback push (set when a guard trips,
+   *  cleared once injected). Undefined when no steer is pending. */
+  pendingSteer?: string;
+  /** How many times the EXPERT handoff (the rung above the ladder) has fired this
+   *  run. Capped so a strong-model rescue is a few-shot escape, not a loop. */
+  expertUses?: number;
+  /** Set at the top steer rung: the NEXT feedback push first PRUNES the flailing
+   *  conversation to its essentials (system + original task), so the model's new
+   *  strategy isn't anchored to the dead-end transcript. Cleared once applied. */
+  resetContext?: boolean;
+  /** Convention topics already PUSHED this run (dedupe): the boringstack how-to for
+   *  a rule is attached the FIRST time it's tripped, once per topic — see
+   *  `unseenGuidesForErrors`. */
+  pushedGuides?: Set<string>;
+  /** PLATEAU backstop (oscillation detector): consecutive gate cycles since the error
+   *  count last hit a new ALL-TIME low. Unlike the fine guards it does NOT reset on an
+   *  error-set rotation or a non-improving re-visit — only genuine progress (a new low)
+   *  clears it — so an oscillating model can't hide from it. See `LOOP_LIMITS.plateauGates`. */
+  redGates?: number;
+  /** Lowest gate-error count seen this run, NEVER reset on escalation (unlike
+   *  `bestErrorCount`) — the stable baseline the plateau backstop measures against. */
+  plateauBest?: number;
 }
 
 /** Build the in-process TS LanguageService if the project has a tsconfig. Guarded
@@ -883,54 +935,238 @@ function stuckResult(
   };
 }
 
+/** Cap on expert-handoff attempts per run — the expert is a strong-model call, not
+ *  free; a couple of rescues is plenty before a genuine park. */
+const EXPERT_MAX_USES = 2;
+
+/** Before accepting a stalled PARK, try the expert handoff (the rung ABOVE the
+ *  steering ladder): hand the single most-blocking failing FILE to the configured
+ *  `capabilities.expert` model, apply its fix, and let the primary model continue.
+ *  Returns true when a fix was applied (→ keep looping). No expert configured, no
+ *  failing file, the cap reached, or the expert declining all fall through to false
+ *  (→ park as before). Never throws — a handoff hiccup must not crash the run. */
+export async function tryExpertRescue(
+  ctx: ILoopCtx,
+  state: ILoopState,
+  gateErrors: IErrorItem[],
+  resolveAsk: () => Promise<ExpertAsk | null> = resolveExpertAsk
+): Promise<boolean> {
+  // Every bail is REPORTED — a silent skip here is what hid, for a whole run, WHY
+  // the expert never fired (it turned out to be one of these branches). Now the log
+  // always says why we parked instead of calling the expert.
+  const skip = (why: string): false => {
+    ctx.report({
+      kind: "tool",
+      task: ctx.task.id,
+      message: `expert handoff skipped — ${why}; parking`,
+    });
+
+    return false;
+  };
+
+  if ((state.expertUses ?? 0) >= EXPERT_MAX_USES) {
+    return skip(`already used ${String(EXPERT_MAX_USES)}× this run`);
+  }
+
+  // Resolve the file to repair: prefer a populated `.file`, else parse it from the
+  // error MESSAGE (type-aware-lint names the file in text but doesn't set `.file` —
+  // which skipped the expert on a whole live run). See resolveStuckFile.
+  const targetFile = await resolveStuckFile(ctx.cwd, gateErrors);
+
+  if (targetFile === null) {
+    return skip("no file could be resolved from the failing error(s)");
+  }
+
+  const ask = await resolveAsk();
+
+  if (ask === null) {
+    return skip(
+      "no expert model configured (set capabilities.expert in models.json)"
+    );
+  }
+
+  const content = await Bun.file(join(ctx.cwd, targetFile))
+    .text()
+    .catch(() => "");
+  // All error messages: file-less errors (type-aware-lint) can't be filtered by
+  // file, and the extra context doesn't hurt the expert's single-file fix.
+  const errorText = gateErrors.map((e) => e.message).join("\n");
+
+  ctx.report({
+    kind: "tool",
+    task: ctx.task.id,
+    message: `🆘 expert handoff: ${targetFile}`,
+  });
+
+  const outcome = await runExpertHandoff(
+    ctx.cwd,
+    { file: targetFile, content, error: errorText, goal: ctx.task.id },
+    ask
+  );
+
+  ctx.report({ kind: "tool", task: ctx.task.id, message: outcome.note });
+
+  if (!outcome.applied) {
+    return false;
+  }
+
+  // The expert fixed it — give the primary model a fresh run at the ladder to
+  // verify and finish (reset guards + steer level; count the rescue against the cap).
+  state.expertUses = (state.expertUses ?? 0) + 1;
+  state.steerLevel = 0;
+  resetConvergenceGuards(state, gateErrors.length);
+  // Rebase the plateau backstop too (fresh baseline after the expert's fix). This is
+  // ONE of only two places it resets (here + a new all-time low) — deliberately NOT in
+  // resetConvergenceGuards, or a steer escalation would reset the oscillation detector.
+  state.redGates = 0;
+  state.plateauBest = gateErrors.length;
+  ctx.messages.push({
+    role: "user",
+    content: `An expert engineer just repaired \`${targetFile}\` for you. Run the gate to verify, then finish the remaining work.`,
+  });
+
+  return true;
+}
+
+/** Reset the convergence guards so the model gets fresh cycles after a steer
+ *  escalation — else a guard that just tripped would trip again next cycle and
+ *  race up the ladder in a few turns. Ages clear, the whole-set counter zeroes,
+ *  and the net-progress watermark rebases to the current count (so any real drop
+ *  from here counts as progress). */
+function resetConvergenceGuards(state: ILoopState, errorCount: number): void {
+  state.errorAge = new Map();
+  state.gateNoProgress = 0;
+  state.noNewLow = 0;
+  state.bestErrorCount = errorCount;
+}
+
 /** STEP 4 — the three convergence guards, in escalating coarseness: a single
  *  (file,rule) persisting `samePersist` cycles; the WHOLE error set unchanged
  *  `gateStuckRepeats` cycles; and no new error-count low in `noProgressCycles`
- *  cycles. Returns the terminal STUCK result, or null to keep looping. Exported
- *  for unit tests (feed crafted states + error sets → stuck vs continue). */
+ *  cycles. When one trips, the model has STALLED — but instead of killing the run
+ *  (the old behaviour, which discarded hours of work on a wall it could climb with
+ *  a nudge), we ESCALATE A STEER: a more directive message telling it to stop
+ *  flailing and HOW to fix the rule it keeps failing. Only once the steer ladder is
+ *  exhausted (`STEER_LADDER_MAX`) does the run park. Returns the terminal (park)
+ *  result, or null to keep looping — with `state.pendingSteer` set when a steer
+ *  should be injected this cycle. Exported for unit tests. */
 export function checkStuck(
   ctx: ILoopCtx,
   state: ILoopState,
   gateErrors: IErrorItem[],
   turn: number
 ): IRunResult | null {
-  // PRIMARY no-progress stop: the model keeps failing at the SAME (file,rule)
-  // for `samePersist` cycles running — even if other errors churn. Hand back a
-  // concrete blocker rather than spinning to a raw turn cap.
+  // Advance ALL three trackers every cycle (they mutate state), then decide which,
+  // if any, tripped — the coarsest-first order preserves the old diagnosis text.
   const persisted = trackErrorAges(state, gateErrors);
 
-  if (persisted !== null) {
-    return stuckResult(ctx, turn, persistDetail(persisted), "");
-  }
-
-  // Coarser secondary net: the WHOLE error set unchanged this many cycles.
   state.gateNoProgress = sameErrorSet(state.prevGateErrors, gateErrors)
     ? state.gateNoProgress + 1
     : 0;
   state.prevGateErrors = gateErrors;
 
-  if (state.gateNoProgress >= LOOP_LIMITS.gateStuckRepeats) {
-    const detail = `gate unchanged ${String(LOOP_LIMITS.gateStuckRepeats)} cycles (${String(gateErrors.length)} error(s) not converging)`;
+  // Update the net-progress watermark (mutates noNewLow / bestErrorCount).
+  trackNetProgress(state, gateErrors.length);
 
-    return stuckResult(ctx, turn, detail, "stuck — ");
+  // PLATEAU tracker: count gate cycles since the last ALL-TIME-low error count. A new
+  // low is genuine progress (reset); anything else — an error-set rotation, or a return
+  // to a count already seen — is oscillation (climb). `plateauBest` is NEVER rebased on
+  // escalation (unlike the fine guards' `bestErrorCount`), so re-reaching a count the
+  // model already hit doesn't look like progress — which is exactly how a flailing model
+  // evades the fine guards and crawls the ladder over 150+ turns. `redGates` DOES reset
+  // on each escalation (below) so escalations stay spaced, but it climbs right back under
+  // oscillation because no new all-time low arrives — driving the ladder to the expert in
+  // a handful of gates instead of ~150 turns (observed live: v8 still L2 at turn 153).
+  if (gateErrors.length < (state.plateauBest ?? Number.POSITIVE_INFINITY)) {
+    state.plateauBest = gateErrors.length;
+    state.redGates = 0;
+  } else {
+    state.redGates = (state.redGates ?? 0) + 1;
   }
 
-  // NET-PROGRESS stop (the convergence guard, not a turn count): big apps run as
-  // long as the error count keeps dropping; we stop when it churns without getting
-  // closer to green — the through-12 failure mode that evaded both guards above.
-  if (trackNetProgress(state, gateErrors.length)) {
-    const detail = `no net progress: ${String(gateErrors.length)} error(s) open, none cleared in ${String(LOOP_LIMITS.noProgressCycles)} cycles (best ${String(state.bestErrorCount)}) — not converging`;
+  // Once steering has begun, the two coarse guards re-trip on a MUCH smaller window
+  // (`steerRetrigger`) so the ladder actually climbs L1→L2→L3 within a few gates —
+  // otherwise, over sparse forced-gates, the useful rungs (esp. the L2 playbook)
+  // never arrive (observed live: only L1 by turn 105). The finer per-error guard
+  // keeps its own threshold (it resets fully each escalation).
+  const stalling = state.steerLevel > 0;
+  const setCap = stalling
+    ? LOOP_LIMITS.steerRetrigger
+    : LOOP_LIMITS.gateStuckRepeats;
+  const progressCap = stalling
+    ? LOOP_LIMITS.steerRetrigger
+    : LOOP_LIMITS.noProgressCycles;
+  const wholeSetStuck = state.gateNoProgress >= setCap;
+  const noNetProgress = state.noNewLow >= progressCap;
+  // The plateau: no NEW ALL-TIME low for `plateauGates` gate cycles. This is the guard
+  // the others miss — it drives escalation under oscillation (rotating error sets + a
+  // count that bounces but never actually improves), so the ladder reaches the expert
+  // fast instead of crawling. Checked LAST so the finer diagnoses win when they apply.
+  const plateaued = (state.redGates ?? 0) >= LOOP_LIMITS.plateauGates;
 
-    return stuckResult(ctx, turn, detail, "stuck — ");
+  const reason =
+    persisted !== null
+      ? persistDetail(persisted)
+      : wholeSetStuck
+        ? `gate unchanged ${String(setCap)} cycles (${String(gateErrors.length)} error(s) not converging)`
+        : noNetProgress
+          ? `no net progress: ${String(gateErrors.length)} error(s) open, none cleared in ${String(progressCap)} cycles (best ${String(state.bestErrorCount)})`
+          : plateaued
+            ? `oscillating: ${String(gateErrors.length)} error(s) open, no NEW low in ${String(state.redGates ?? 0)} gate cycles (best ever ${String(state.plateauBest ?? 0)})`
+            : null;
+
+  if (reason === null) {
+    return null; // still converging — keep looping normally
   }
 
-  return null;
+  // Stalled. Escalate a steer and give the model fresh cycles at the new level. Reset the
+  // plateau COUNTER too (spacing — one escalation per plateau window) but NOT plateauBest,
+  // so oscillation keeps re-tripping it and the ladder climbs to the expert.
+  state.steerLevel += 1;
+  state.redGates = 0;
+  resetConvergenceGuards(state, gateErrors.length);
+
+  if (state.steerLevel > STEER_LADDER_MAX) {
+    // Ladder exhausted — the run parks (an expert-model handoff slots in here).
+    return stuckResult(
+      ctx,
+      turn,
+      `${reason} — steering exhausted after ${String(STEER_LADDER_MAX)} escalations`,
+      "parked — "
+    );
+  }
+
+  state.pendingSteer = buildSteerMessage(
+    state.steerLevel,
+    gateErrors,
+    reason,
+    flags.webTools()
+  );
+
+  // At the TOP rung (change-strategy), also RESET the conversation: the flailing
+  // history anchors the model to the dead-end approach it's been repeating. Pruning
+  // to the essentials + a fresh directive breaks that "context poisoning" so the new
+  // strategy isn't fighting the old transcript. injectFeedback does the actual prune.
+  if (state.steerLevel >= STEER_LADDER_MAX) {
+    state.resetContext = true;
+  }
+
+  ctx.report({
+    kind: "tool",
+    task: ctx.task.id,
+    message: `⤴ steer L${String(state.steerLevel)}/${String(STEER_LADDER_MAX)}: ${reason}`,
+  });
+
+  return null; // keep looping, with the steer injected this cycle
 }
 
 /** STEP 5 — inject the red-gate feedback (rule docs + the auto-fix notice) into
- *  the conversation as the next user message, so the model fixes in-context. */
-async function injectFeedback(
+ *  the conversation as the next user message, so the model fixes in-context.
+ *  Exported for unit testing (like checkStuck/autoFixStep) — the convention PUSH
+ *  delivery is a seam we need to assert actually reaches the model's messages. */
+export async function injectFeedback(
   ctx: ILoopCtx,
+  state: ILoopState,
   gateErrors: IErrorItem[],
   metaViolations: IMetaRuleViolation[],
   autoFixed: string[]
@@ -942,8 +1178,59 @@ async function injectFeedback(
     metaViolations
   );
   const notice = autoFixed.length > 0 ? `${autoFixNotice(autoFixed)}\n\n` : "";
+  // A pending steer (the model stalled) leads the feedback so it can't be missed,
+  // then is cleared — it's a one-shot escalation for THIS cycle.
+  const steer =
+    state.pendingSteer !== undefined ? `${state.pendingSteer}\n\n` : "";
 
-  ctx.messages.push({ role: "user", content: `${notice}${feedback}` });
+  state.pendingSteer = undefined;
+
+  // Context reset (top steer rung): prune the poisoned transcript to its essentials
+  // IN PLACE (keep the array reference the loop holds), so the fresh directive lands
+  // on a clean slate instead of after dozens of dead-end turns.
+  if (state.resetContext === true) {
+    const before = ctx.messages.length;
+
+    ctx.messages.splice(
+      0,
+      ctx.messages.length,
+      ...essentialMessages(ctx.messages)
+    );
+    state.resetContext = false;
+    // Observable (the reset used to be silent — the same blindness that hid the
+    // expert bug): log that the poisoned transcript was pruned.
+    ctx.report({
+      kind: "tool",
+      task: ctx.task.id,
+      message: `↺ context reset — pruned ${String(before)} messages to ${String(ctx.messages.length)} (fresh start for the change-strategy rung)`,
+    });
+  }
+
+  // PUSH the boringstack HOW-TO the first time a gate error maps to a convention —
+  // right beside the error, not after the steering ladder escalates. Deduped per
+  // run (once per topic), so it teaches without becoming a wall.
+  state.pushedGuides ??= new Set<string>();
+  const guides = unseenGuidesForErrors(gateErrors, state.pushedGuides);
+  const how =
+    guides.length > 0
+      ? `\n\nHOW TO WRITE THIS RIGHT (boringstack):\n${guides.join("\n\n")}`
+      : "";
+
+  // Observable (was silent — the same blindness that hid the expert bug and made it
+  // impossible to tell from a build log whether the model was ever taught a
+  // convention). Log which topics were pushed this cycle so adoption is measurable.
+  if (guides.length > 0) {
+    ctx.report({
+      kind: "tool",
+      task: ctx.task.id,
+      message: `📐 pushed ${String(guides.length)} convention guide(s) beside the gate errors`,
+    });
+  }
+
+  ctx.messages.push({
+    role: "user",
+    content: `${steer}${notice}${feedback}${how}`,
+  });
 }
 
 /** Settle a turn against the gate: auto-fix → gate → meta-rules → (green? done :
@@ -1024,10 +1311,21 @@ export async function settleGate(
   const stuck = checkStuck(ctx, state, gateErrors, turn);
 
   if (stuck !== null) {
+    // A stalled park is the rung where the EXPERT handoff gets a shot before we give
+    // up: if a stronger model repairs the blocking file, keep looping instead of
+    // parking. No expert configured → this is a no-op and the run parks as before.
+    if (
+      stuck.status === RUN_STATUS.stuck &&
+      stuck.reason === STUCK_REASON.stalled &&
+      (await tryExpertRescue(ctx, state, gateErrors))
+    ) {
+      return null;
+    }
+
     return stuck;
   }
 
-  await injectFeedback(ctx, gateErrors, metaViolations, autoFixed);
+  await injectFeedback(ctx, state, gateErrors, metaViolations, autoFixed);
 
   return null;
 }

--- a/packages/core/src/loop/write-guard.ts
+++ b/packages/core/src/loop/write-guard.ts
@@ -85,8 +85,14 @@ function isTransientDiag(d: { code: number; message: string }): boolean {
   return TRANSIENT_DIAG_CODES.has(d.code) || isPhantomRouteError(d.message);
 }
 
-/** Max diagnostics surfaced per write — keep the in-band feedback tight. */
-const MAX_WRITE_GUARD_DIAGS = 5;
+/** Upper bound on diagnostics surfaced per write. This is a RUNAWAY BACKSTOP,
+ *  not a feedback-shaping limit: the model must see EVERY real error so it can
+ *  fix them all in one pass. Capping this low (it was 5) caused whack-a-mole —
+ *  a file with 14 violations showed 5 + "…and 9 more", so the model fixed 5,
+ *  the hidden 9 resurfaced next turn, and it never converged. Set high enough
+ *  that a normal file shows all of its errors; the cap only trims a degenerate
+ *  cascade (one syntax error fanning out to hundreds) from blowing the context. */
+const MAX_WRITE_GUARD_DIAGS = 200;
 
 /** Render the per-issue lines (type errors + lint problems), capped + ordered. */
 function writeGuardLines(
@@ -105,8 +111,8 @@ function writeGuardLines(
 
   const lineOf = (offset: number): number =>
     text.slice(0, offset).split("\n").length;
-  // Slice to the cap BEFORE mapping: lineOf does O(offset) string work per diag,
-  // so mapping every error in a large file (then discarding all but 5) is wasteful.
+  // Slice to the backstop BEFORE mapping: lineOf does O(offset) string work per
+  // diag, so mapping past the ceiling in a degenerate cascade would be wasteful.
   // Output is identical to map-all-then-slice (type errors fill the budget first).
   const total = typeErrors.length + lintProblems.length;
   const capped = typeErrors.slice(0, MAX_WRITE_GUARD_DIAGS);

--- a/packages/core/src/models-config.ts
+++ b/packages/core/src/models-config.ts
@@ -59,7 +59,7 @@ export type ImageApi = "chat-modalities" | "images-generations";
  *  the primary chat model can't do them. Each value NAMES an entry in `models`,
  *  so a capability reuses the same endpoint config (key resolution, headers) as
  *  any chat model. Absent → the capability (and its tool/UX) stays off. */
-export type CapabilityName = "vision" | "imageGen";
+export type CapabilityName = "vision" | "imageGen" | "expert";
 
 export interface IModelsConfig {
   /** Name of the active entry — always a key of `models`. */
@@ -197,9 +197,9 @@ function parseCapabilities(
   const out: Partial<Record<CapabilityName, string>> = {};
 
   for (const [cap, target] of Object.entries(raw)) {
-    if (cap !== "vision" && cap !== "imageGen") {
+    if (cap !== "vision" && cap !== "imageGen" && cap !== "expert") {
       throw new Error(
-        `models.json: unknown capability "${cap}" — expected vision, imageGen`
+        `models.json: unknown capability "${cap}" — expected vision, imageGen, expert`
       );
     }
 
@@ -356,7 +356,12 @@ export async function resolveModelByName(
 export async function resolveCapabilityModel(
   cap: CapabilityName
 ): Promise<{ name: string; entry: IModelEntry } | null> {
-  const prefix = cap === "vision" ? "TSFORGE_VISION" : "TSFORGE_IMAGE";
+  const prefixByCap: Record<CapabilityName, string> = {
+    vision: "TSFORGE_VISION",
+    imageGen: "TSFORGE_IMAGE",
+    expert: "TSFORGE_EXPERT",
+  };
+  const prefix = prefixByCap[cap];
   const envBase = process.env[`${prefix}_BASE_URL`];
   const envModel = process.env[`${prefix}_MODEL`];
 

--- a/packages/core/src/rule-packs/typescript-core/rules/no-self-import.ts
+++ b/packages/core/src/rule-packs/typescript-core/rules/no-self-import.ts
@@ -33,7 +33,7 @@ export const noSelfImportRule = createRule<[], MessageIds>({
     schema: [],
     messages: {
       selfImport:
-        "'{{source}}' resolves to THIS file — a module cannot import from itself. Define the binding here instead of importing it from the same file.",
+        "'{{source}}' resolves to THIS file — a module cannot import or re-export from itself (it bundles to a circular self-reference that breaks the build). Fix: define/keep the binding directly in this file. If this is a barrel `index.ts` sitting beside an `index.tsx` of the same folder, DELETE this file — the `.tsx` component is already the module entry (import it via the folder path, e.g. `@/views/Foo`).",
     },
   },
   defaultOptions: [],

--- a/packages/core/src/self-harness/evaluate-web.ts
+++ b/packages/core/src/self-harness/evaluate-web.ts
@@ -1,0 +1,170 @@
+/**
+ * Web-build evaluation for the Self-Harness loop: run benchmark-catalog apps
+ * as verifiable tasks. Each app builds in a SUBPROCESS of headless-build.ts
+ * (web-sweep precedent) — the overlay under test rides the inherited
+ * TSFORGE_SELF_HARNESS_OVERLAY env; pass/fail is the exit code (the real web
+ * gate + entity coverage decide it); the JSONL event log (via the script's
+ * --log-file contract) feeds mining and the cycle/efficiency metrics.
+ *
+ * Subprocess isolation is a feature: each build gets a fresh provider and
+ * session, and a driver crash is an *errored* run, never a fake verdict.
+ */
+import { mkdir } from "node:fs/promises";
+import { join } from "node:path";
+import { parseEventLog } from "../eval";
+import type { IRunRecord } from "../eval";
+import { cycleCount, type IMinedRun } from "./mine";
+import { classifyRun } from "../eval/failure-class";
+import { resolveActiveModel, resolveApiKey } from "../models-config";
+import type { ILoopEvent } from "../loop/loop.types";
+
+/** Web builds legitimately run long (multi-entity apps, 180-turn cap); only a
+ *  true crawl toward that cap mines as slow-green. */
+export const WEB_SLOW_THRESHOLD = 100;
+
+/** Default hard wall-clock cap per app build. */
+export const WEB_RUN_TIMEOUT_MS = 90 * 60 * 1000;
+
+export interface IWebEvaluateOptions {
+  /** Directory for this evaluation's run dirs (one per app × repeat). */
+  readonly runsDir: string;
+  readonly repeats: number;
+  /** Per-run wall-clock cap; a healthy-endpoint kill records as FAILED
+   *  (timeout — minable), an unhealthy-endpoint kill as ERRORED. */
+  readonly timeoutMs?: number;
+  /** Probe the endpoint after a timeout/nonzero exit to decide failed vs
+   *  errored. Injectable for tests; default probes the active model. */
+  readonly probeHealthy?: () => Promise<boolean>;
+  readonly log?: (line: string) => void;
+}
+
+export interface IWebRunOutcome {
+  readonly record: IRunRecord;
+  readonly run?: IMinedRun;
+  readonly errored: boolean;
+}
+
+const HEADLESS_BUILD = join(
+  import.meta.dir,
+  "..",
+  "..",
+  "scripts",
+  "headless-build.ts"
+);
+
+async function defaultProbe(): Promise<boolean> {
+  const { entry } = await resolveActiveModel();
+
+  try {
+    const key = resolveApiKey(entry);
+    const res = await fetch(`${entry.baseUrl}/chat/completions`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        ...(key === undefined ? {} : { Authorization: `Bearer ${key}` }),
+      },
+      body: JSON.stringify({
+        model: entry.model,
+        messages: [{ role: "user", content: "ok?" }],
+        max_tokens: 1,
+      }),
+      signal: AbortSignal.timeout(30_000),
+    });
+
+    return res.ok;
+  } catch {
+    return false;
+  }
+}
+
+async function readEvents(logFile: string): Promise<ILoopEvent[]> {
+  try {
+    return parseEventLog(await Bun.file(logFile).text());
+  } catch {
+    return [];
+  }
+}
+
+/** Run ONE catalog app once. Sequential caller-side — never parallelize
+ *  (single-connection endpoint). */
+export async function runWebTaskOnce(
+  slug: string,
+  runDir: string,
+  opts: IWebEvaluateOptions
+): Promise<IWebRunOutcome> {
+  await mkdir(runDir, { recursive: true });
+
+  const logFile = join(runDir, "events.jsonl");
+  const proc = Bun.spawn(
+    [
+      "bun",
+      HEADLESS_BUILD,
+      "--app",
+      slug,
+      "react",
+      runDir,
+      "--log-file",
+      logFile,
+    ],
+    {
+      env: { ...process.env },
+      stdout: Bun.file(join(runDir, "driver.log")),
+      stderr: Bun.file(join(runDir, "driver.err.log")),
+    }
+  );
+
+  const timeoutMs = opts.timeoutMs ?? WEB_RUN_TIMEOUT_MS;
+  // Object property (not a bare let): the timer mutates it from a callback,
+  // which TS flow analysis can't see — a boolean local would narrow to
+  // `false` and read as an always-truthy conditional below.
+  const state = { timedOut: false };
+  const timer = setTimeout(() => {
+    state.timedOut = true;
+    proc.kill();
+  }, timeoutMs);
+  const exitCode = await proc.exited;
+
+  clearTimeout(timer);
+
+  const events = await readEvents(logFile);
+  const passed = !state.timedOut && exitCode === 0;
+  const taskId = `web:${slug}`;
+  const cycles = cycleCount(events);
+
+  if (passed) {
+    return {
+      errored: false,
+      record: { label: taskId, passed: true, cycles, ms: 0 },
+      run: { taskId, passed: true, events, slowThreshold: WEB_SLOW_THRESHOLD },
+    };
+  }
+
+  // Not green. Blame allocation mirrors the spec path's hardening: only a
+  // healthy endpoint makes this a real task failure the miner may learn from;
+  // a sick endpoint makes it an errored run (no valid result — never a
+  // verdict, in either direction).
+  const healthy = await (opts.probeHealthy ?? defaultProbe)();
+
+  if (!healthy) {
+    return {
+      errored: true,
+      record: { label: taskId, passed: false, cycles: 0, ms: 0 },
+    };
+  }
+
+  const failureClass = state.timedOut
+    ? "timeout"
+    : classifyRun(events).failureClass;
+
+  return {
+    errored: false,
+    record: {
+      label: taskId,
+      passed: false,
+      cycles,
+      ms: 0,
+      failureClass,
+    },
+    run: { taskId, passed: false, events, slowThreshold: WEB_SLOW_THRESHOLD },
+  };
+}

--- a/packages/core/src/self-harness/evaluate-web.ts
+++ b/packages/core/src/self-harness/evaluate-web.ts
@@ -52,7 +52,7 @@ const HEADLESS_BUILD = join(
   "headless-build.ts"
 );
 
-async function defaultProbe(): Promise<boolean> {
+async function probeAttempt(): Promise<boolean> {
   const { entry } = await resolveActiveModel();
 
   try {
@@ -75,6 +75,22 @@ async function defaultProbe(): Promise<boolean> {
   } catch {
     return false;
   }
+}
+
+/** A single probe right after a 500K-context build request is unreliable (the
+ *  server may still be draining); one flaky probe must not reclassify a REAL
+ *  task failure as infrastructure noise — that discards minable signal. Three
+ *  attempts, 10s apart; any success = healthy. */
+async function defaultProbe(): Promise<boolean> {
+  for (let attempt = 0; attempt < 3; attempt += 1) {
+    if (await probeAttempt()) {
+      return true;
+    }
+
+    await Bun.sleep(10_000);
+  }
+
+  return false;
 }
 
 async function readEvents(logFile: string): Promise<ILoopEvent[]> {

--- a/packages/core/src/self-harness/evaluate-web.ts
+++ b/packages/core/src/self-harness/evaluate-web.ts
@@ -9,7 +9,7 @@
  * Subprocess isolation is a feature: each build gets a fresh provider and
  * session, and a driver crash is an *errored* run, never a fake verdict.
  */
-import { mkdir } from "node:fs/promises";
+import { mkdir, rm } from "node:fs/promises";
 import { join } from "node:path";
 import { parseEventLog } from "../eval";
 import type { IRunRecord } from "../eval";
@@ -111,6 +111,11 @@ export async function runWebTaskOnce(
   await mkdir(runDir, { recursive: true });
 
   const logFile = join(runDir, "events.jsonl");
+
+  // headless-build APPENDS to the log; a reused run dir (campaign restart)
+  // would mix the old run's events into this run's stream — inflating cycle
+  // counts past the turn cap and mis-classifying failures. Start clean.
+  await rm(logFile, { force: true });
   const proc = Bun.spawn(
     [
       "bun",

--- a/packages/core/src/self-harness/evaluate.ts
+++ b/packages/core/src/self-harness/evaluate.ts
@@ -36,8 +36,16 @@ export interface IEvaluateOptions {
    *  is skipped for evals produced without it. */
   readonly judgeProvider?: IProvider;
   readonly temperature?: number;
+  /** Cycle count at which a PASSED run still mines as `slow-green` (the
+   *  efficiency signal). Default {@link SPEC_SLOW_THRESHOLD}; web builds pass
+   *  a much higher value. */
+  readonly slowThreshold?: number;
   readonly log?: (line: string) => void;
 }
+
+/** Healthy spec-corpus runs green in 1–7 cycles; ≥8 is friction worth mining
+ *  (query's measured 15–17-cycle crawls are the motivating case). */
+export const SPEC_SLOW_THRESHOLD = 8;
 
 export interface IEvaluateOutcome {
   readonly score: ISplitScore;
@@ -202,7 +210,12 @@ async function runTaskOnce(
       ...(loc === undefined ? {} : { loc }),
       ...(failureClass === undefined ? {} : { failureClass }),
     },
-    run: { taskId, passed, events },
+    run: {
+      taskId,
+      passed,
+      events,
+      slowThreshold: opts.slowThreshold ?? SPEC_SLOW_THRESHOLD,
+    },
   };
 }
 

--- a/packages/core/src/self-harness/evaluate.ts
+++ b/packages/core/src/self-harness/evaluate.ts
@@ -20,6 +20,7 @@ import { classifyRun, countTaskLoc, judge, summarize } from "../eval";
 import type { IRunRecord } from "../eval";
 import { renderEvent } from "../render";
 import { resetOverlayCache } from "./overlay";
+import { runWebTaskOnce } from "./evaluate-web";
 import type { IHarnessOverlay, ISplitScore } from "./self-harness.types";
 import type { IMinedRun } from "./mine";
 
@@ -40,6 +41,8 @@ export interface IEvaluateOptions {
    *  efficiency signal). Default {@link SPEC_SLOW_THRESHOLD}; web builds pass
    *  a much higher value. */
   readonly slowThreshold?: number;
+  /** Hard wall-clock cap per `web:` task build (forwarded to evaluate-web). */
+  readonly webTimeoutMs?: number;
   readonly log?: (line: string) => void;
 }
 
@@ -262,46 +265,110 @@ function meanOfSignaled(values: readonly number[]): number {
     : signaled.reduce((a, b) => a + b, 0) / signaled.length;
 }
 
+interface IRunSink {
+  readonly records: IRunRecord[];
+  readonly runs: IMinedRun[];
+  readonly log: (line: string) => void;
+  erroredCount: number;
+}
+
+function verdictLine(taskId: string, attempt: number, r: IRunRecord): string {
+  return `    ${taskId} #${String(attempt)}: ${r.passed ? "green" : `red[${r.failureClass ?? "unknown"}]`} (${String(r.cycles)} cyc)`;
+}
+
+/** One `web:<slug>` run via the headless-build subprocess — the real web gate
+ *  + entity coverage decide pass/fail; the overlay under test rides the
+ *  inherited env. */
+async function runOneWeb(
+  taskId: string,
+  attempt: number,
+  runDir: string,
+  opts: IEvaluateOptions,
+  sink: IRunSink
+): Promise<void> {
+  const outcome = await runWebTaskOnce(taskId.slice(4), runDir, {
+    runsDir: opts.runsDir,
+    repeats: 1,
+    ...(opts.webTimeoutMs === undefined
+      ? {}
+      : { timeoutMs: opts.webTimeoutMs }),
+    log: sink.log,
+  });
+
+  sink.records.push(outcome.record);
+
+  if (outcome.errored) {
+    sink.erroredCount += 1;
+    sink.log(`    ${taskId} #${String(attempt)}: ERRORED (endpoint unhealthy)`);
+
+    return;
+  }
+
+  if (outcome.run !== undefined) {
+    sink.runs.push(outcome.run);
+  }
+
+  sink.log(verdictLine(taskId, attempt, outcome.record));
+}
+
+/** One spec-corpus run. A crash (endpoint timeout, connection failure) must
+ *  not abort the evaluation — but it is NOT a task failure either: it counts
+ *  as `errored` so the acceptance rule can refuse to blame/credit the edit
+ *  for infrastructure weather. */
+async function runOneSpec(
+  taskId: string,
+  attempt: number,
+  runDir: string,
+  opts: IEvaluateOptions,
+  sink: IRunSink
+): Promise<void> {
+  try {
+    const { record, run } = await runTaskOnce(taskId, runDir, opts);
+
+    sink.records.push(record);
+    sink.runs.push(run);
+    sink.log(verdictLine(taskId, attempt, record));
+  } catch (err) {
+    sink.erroredCount += 1;
+    sink.records.push({ label: taskId, passed: false, cycles: 0, ms: 0 });
+    sink.log(
+      `    ${taskId} #${String(attempt)}: ERRORED (${err instanceof Error ? err.message : String(err)})`
+    );
+  }
+}
+
 /**
- * Evaluate one harness variant on a task list. Sequential by design: the
- * primary endpoint is a single-connection local server, and sequential runs
- * keep per-run wall-clock comparable across candidates.
+ * Evaluate one harness variant on a task list (spec ids and `web:<slug>` ids
+ * dispatch to their runners). Sequential by design: the primary endpoint is a
+ * single-connection local server, and sequential runs keep per-run wall-clock
+ * comparable across candidates.
  */
 export async function evaluateHarness(
   taskIds: readonly string[],
   opts: IEvaluateOptions
 ): Promise<IEvaluateOutcome> {
   return withOverlayEnv(opts.overlay, opts.runsDir, async () => {
-    const records: IRunRecord[] = [];
-    const runs: IMinedRun[] = [];
-    const log = opts.log ?? ((): void => undefined);
-    let errored = 0;
+    const sink: IRunSink = {
+      records: [],
+      runs: [],
+      log: opts.log ?? ((): void => undefined),
+      erroredCount: 0,
+    };
 
     for (const taskId of taskIds) {
       for (let i = 0; i < opts.repeats; i += 1) {
-        const runDir = join(opts.runsDir, `${taskId}-${i + 1}`);
+        const runDir = join(
+          opts.runsDir,
+          `${taskId.replace(":", "-")}-${i + 1}`
+        );
 
-        // One run's crash (endpoint timeout, connection failure) must not
-        // abort the evaluation — but it is NOT a task failure either. It is
-        // counted separately (`errored`) so the acceptance rule can refuse to
-        // blame/credit the edit for infrastructure weather.
-        try {
-          const { record, run } = await runTaskOnce(taskId, runDir, opts);
-
-          records.push(record);
-          runs.push(run);
-          log(
-            `    ${taskId} #${i + 1}: ${record.passed ? "green" : `red[${record.failureClass ?? "unknown"}]`} (${record.cycles} cyc)`
-          );
-        } catch (err) {
-          errored += 1;
-          records.push({ label: taskId, passed: false, cycles: 0, ms: 0 });
-          log(
-            `    ${taskId} #${i + 1}: ERRORED (${err instanceof Error ? err.message : String(err)})`
-          );
-        }
+        await (taskId.startsWith("web:")
+          ? runOneWeb(taskId, i + 1, runDir, opts, sink)
+          : runOneSpec(taskId, i + 1, runDir, opts, sink));
       }
     }
+
+    const { records, runs, erroredCount: errored } = sink;
 
     const summaries = summarize(records);
     const perTask: Record<string, (typeof summaries)[number]> = {};

--- a/packages/core/src/self-harness/evaluate.ts
+++ b/packages/core/src/self-harness/evaluate.ts
@@ -250,14 +250,16 @@ export async function evaluateHarness(
     const records: IRunRecord[] = [];
     const runs: IMinedRun[] = [];
     const log = opts.log ?? ((): void => undefined);
+    let errored = 0;
 
     for (const taskId of taskIds) {
       for (let i = 0; i < opts.repeats; i += 1) {
         const runDir = join(opts.runsDir, `${taskId}-${i + 1}`);
 
-        // One run's crash (endpoint timeout, spawn failure) records as a
-        // failed run and the evaluation carries on — same resilience stance
-        // as the sweep. Its events are empty, so mining skips it gracefully.
+        // One run's crash (endpoint timeout, connection failure) must not
+        // abort the evaluation — but it is NOT a task failure either. It is
+        // counted separately (`errored`) so the acceptance rule can refuse to
+        // blame/credit the edit for infrastructure weather.
         try {
           const { record, run } = await runTaskOnce(taskId, runDir, opts);
 
@@ -267,8 +269,8 @@ export async function evaluateHarness(
             `    ${taskId} #${i + 1}: ${record.passed ? "green" : `red[${record.failureClass ?? "unknown"}]`} (${record.cycles} cyc)`
           );
         } catch (err) {
+          errored += 1;
           records.push({ label: taskId, passed: false, cycles: 0, ms: 0 });
-          runs.push({ taskId, passed: false, events: [] });
           log(
             `    ${taskId} #${i + 1}: ERRORED (${err instanceof Error ? err.message : String(err)})`
           );
@@ -286,6 +288,7 @@ export async function evaluateHarness(
     const score: ISplitScore = {
       passed: records.filter((r) => r.passed).length,
       runs: records.length,
+      errored,
       avgQuality: meanOfSignaled(summaries.map((s) => s.avgQuality)),
       avgLoc: meanOfSignaled(summaries.map((s) => s.avgLoc)),
       perTask,

--- a/packages/core/src/self-harness/evaluate.ts
+++ b/packages/core/src/self-harness/evaluate.ts
@@ -55,6 +55,10 @@ export interface IEvaluateOutcome {
   /** Per-run event streams, for weakness mining (held-in only is mined, but
    *  returning them is cheap and keeps evaluate split-agnostic). */
   readonly runs: readonly IMinedRun[];
+  /** Raw per-run records (labelled by task id) — the substrate for the proof
+   *  protocol's Wilson-CI/z-test comparison (relabel per variant, then
+   *  buildSweepReport). */
+  readonly records: readonly IRunRecord[];
 }
 
 /** Copy the seed's files into a fresh run dir. */
@@ -386,6 +390,6 @@ export async function evaluateHarness(
       perTask,
     };
 
-    return { score, runs };
+    return { score, runs, records };
   });
 }

--- a/packages/core/src/self-harness/evaluate.ts
+++ b/packages/core/src/self-harness/evaluate.ts
@@ -1,0 +1,297 @@
+/**
+ * EVALUATE (paper §3.1/§3.4): run a harness variant over corpus tasks and
+ * score it. Drives the SAME implement path the eval sweep uses — parseSpec →
+ * strict-floor gating (buildGate) → runSpec — with the variant's overlay
+ * activated via TSFORGE_SELF_HARNESS_OVERLAY for the duration of the runs,
+ * so the injection points resolve it exactly the way a real run would.
+ *
+ * Quality is a MEASUREMENT here (a single judge() call on green runs), never
+ * sweep's qualityRepair improve-loop — an evaluator that edits the solution
+ * would contaminate the very comparison the acceptance rule depends on.
+ */
+import { mkdir, readdir, rm, stat } from "node:fs/promises";
+import { join } from "node:path";
+import { parseSpec } from "../spec";
+import { buildGate, buildCoreFix } from "../gate";
+import { runSpec } from "../loop";
+import type { ILoopEvent } from "../loop";
+import type { IProvider } from "../inference";
+import { classifyRun, countTaskLoc, judge, summarize } from "../eval";
+import type { IRunRecord } from "../eval";
+import { renderEvent } from "../render";
+import { resetOverlayCache } from "./overlay";
+import type { IHarnessOverlay, ISplitScore } from "./self-harness.types";
+import type { IMinedRun } from "./mine";
+
+export interface IEvaluateOptions {
+  readonly corpusDir: string;
+  /** Parent directory for this evaluation's run dirs (one per task × repeat). */
+  readonly runsDir: string;
+  readonly provider: IProvider;
+  readonly repeats: number;
+  /** The harness variant under test; null = base harness (no overlay). */
+  readonly overlay: IHarnessOverlay | null;
+  /** Judge green runs for quality (adds one model call per green run). When
+   *  absent, quality stays unsignaled and the acceptance rule's quality guard
+   *  is skipped for evals produced without it. */
+  readonly judgeProvider?: IProvider;
+  readonly temperature?: number;
+  readonly log?: (line: string) => void;
+}
+
+export interface IEvaluateOutcome {
+  readonly score: ISplitScore;
+  /** Per-run event streams, for weakness mining (held-in only is mined, but
+   *  returning them is cheap and keeps evaluate split-agnostic). */
+  readonly runs: readonly IMinedRun[];
+}
+
+/** Copy the seed's files into a fresh run dir. */
+async function setupRunDir(dir: string, seedDir: string): Promise<void> {
+  await mkdir(dir, { recursive: true });
+
+  for (const file of await readdir(seedDir, { recursive: true })) {
+    const src = join(seedDir, file);
+
+    if (!(await stat(src)).isDirectory()) {
+      await Bun.write(join(dir, file), Bun.file(src));
+    }
+  }
+}
+
+/** Delete task files for scratch-mode seeds (brownfield keeps them RED). */
+async function startRed(
+  dir: string,
+  spec: ReturnType<typeof parseSpec>
+): Promise<void> {
+  if (spec.mode !== "existing") {
+    for (const task of spec.tasks) {
+      for (const f of task.files) {
+        await rm(join(dir, f), { force: true });
+      }
+    }
+  }
+}
+
+/** Run a seed's optional setup.sh (brownfield git history). Trusted: the
+ *  corpus is our own code — same stance as the eval sweep. */
+async function runSeedSetup(dir: string): Promise<void> {
+  if (!(await Bun.file(join(dir, "setup.sh")).exists())) {
+    return;
+  }
+
+  await Bun.spawn(["sh", "setup.sh"], {
+    cwd: dir,
+    stdout: "ignore",
+    stderr: "ignore",
+  }).exited;
+}
+
+/** Gate every task and the whole-spec verify behind tsforge's strict floor —
+ *  identical composition to the eval sweep, so scores are comparable. */
+async function gateSpec(
+  runDir: string,
+  spec: ReturnType<typeof parseSpec>
+): Promise<ReturnType<typeof parseSpec>> {
+  const gateCommand = (await buildGate(runDir)).command;
+  const fixCommand = buildCoreFix();
+
+  return {
+    ...spec,
+    tasks: spec.tasks.map((t) => ({
+      ...t,
+      fix: fixCommand,
+      accept: `${gateCommand} && ${t.accept}`,
+    })),
+    verify:
+      spec.verify.length > 0 ? `${gateCommand} && ${spec.verify}` : gateCommand,
+  };
+}
+
+interface ITaskRunOutput {
+  readonly record: IRunRecord;
+  readonly run: IMinedRun;
+}
+
+async function runTaskOnce(
+  taskId: string,
+  runDir: string,
+  opts: IEvaluateOptions
+): Promise<ITaskRunOutput> {
+  const seedDir = join(opts.corpusDir, taskId);
+
+  await setupRunDir(runDir, seedDir);
+
+  const spec = parseSpec(
+    await Bun.file(join(runDir, `${taskId}.spec.md`)).text()
+  );
+
+  await startRed(runDir, spec);
+  await runSeedSetup(runDir);
+
+  const gated = await gateSpec(runDir, spec);
+  const logFile = Bun.file(join(runDir, "run.log")).writer();
+  const events: ILoopEvent[] = [];
+  const onEvent = (e: ILoopEvent): void => {
+    events.push(e);
+    void logFile.write(renderEvent(e, { color: false }));
+    void logFile.flush();
+  };
+
+  const result = await runSpec(gated, runDir, opts.provider, {
+    onEvent,
+    temperature: opts.temperature ?? 0,
+  });
+
+  await logFile.end();
+
+  const passed = result.status === "done";
+  const cycles = result.results.reduce((acc, r) => acc + r.cycles, 0);
+  let loc: number | undefined;
+  let quality: number | undefined;
+
+  if (passed) {
+    loc = (
+      await countTaskLoc(
+        runDir,
+        spec.tasks.flatMap((t) => t.files)
+      )
+    ).totalLoc;
+
+    const firstTask = spec.tasks[0];
+
+    if (opts.judgeProvider !== undefined && firstTask !== undefined) {
+      const specText = await Bun.file(
+        join(runDir, `${taskId}.spec.md`)
+      ).text();
+      const code = (
+        await Promise.all(
+          firstTask.files.map((f) => Bun.file(join(runDir, f)).text())
+        )
+      ).join("\n\n");
+      const score = await judge(opts.judgeProvider, {
+        goal: spec.title,
+        criteria: specText,
+        code,
+      });
+
+      quality = score.scored ? score.overall : undefined;
+    }
+  }
+
+  const failureClass = passed ? undefined : classifyRun(events).failureClass;
+
+  return {
+    record: {
+      label: taskId,
+      passed,
+      cycles,
+      ms: 0,
+      ...(quality === undefined ? {} : { quality }),
+      ...(loc === undefined ? {} : { loc }),
+      ...(failureClass === undefined ? {} : { failureClass }),
+    },
+    run: { taskId, passed, events },
+  };
+}
+
+/** Write the overlay under test (if any) and point the injection points at it
+ *  for the duration of `body`. Restores the previous env + cache after. */
+async function withOverlayEnv<T>(
+  overlay: IHarnessOverlay | null,
+  runsDir: string,
+  body: () => Promise<T>
+): Promise<T> {
+  const saved = process.env.TSFORGE_SELF_HARNESS_OVERLAY;
+
+  if (overlay === null) {
+    delete process.env.TSFORGE_SELF_HARNESS_OVERLAY;
+  } else {
+    const path = join(runsDir, "overlay.json");
+
+    await mkdir(runsDir, { recursive: true });
+    await Bun.write(path, JSON.stringify(overlay, null, 2));
+    process.env.TSFORGE_SELF_HARNESS_OVERLAY = path;
+  }
+
+  resetOverlayCache();
+
+  try {
+    return await body();
+  } finally {
+    if (saved === undefined) {
+      delete process.env.TSFORGE_SELF_HARNESS_OVERLAY;
+    } else {
+      process.env.TSFORGE_SELF_HARNESS_OVERLAY = saved;
+    }
+
+    resetOverlayCache();
+  }
+}
+
+/** Mean over per-task values that carry a real signal (>0), or 0 when none. */
+function meanOfSignaled(values: readonly number[]): number {
+  const signaled = values.filter((v) => v > 0);
+
+  return signaled.length === 0
+    ? 0
+    : signaled.reduce((a, b) => a + b, 0) / signaled.length;
+}
+
+/**
+ * Evaluate one harness variant on a task list. Sequential by design: the
+ * primary endpoint is a single-connection local server, and sequential runs
+ * keep per-run wall-clock comparable across candidates.
+ */
+export async function evaluateHarness(
+  taskIds: readonly string[],
+  opts: IEvaluateOptions
+): Promise<IEvaluateOutcome> {
+  return withOverlayEnv(opts.overlay, opts.runsDir, async () => {
+    const records: IRunRecord[] = [];
+    const runs: IMinedRun[] = [];
+    const log = opts.log ?? ((): void => undefined);
+
+    for (const taskId of taskIds) {
+      for (let i = 0; i < opts.repeats; i += 1) {
+        const runDir = join(opts.runsDir, `${taskId}-${i + 1}`);
+
+        // One run's crash (endpoint timeout, spawn failure) records as a
+        // failed run and the evaluation carries on — same resilience stance
+        // as the sweep. Its events are empty, so mining skips it gracefully.
+        try {
+          const { record, run } = await runTaskOnce(taskId, runDir, opts);
+
+          records.push(record);
+          runs.push(run);
+          log(
+            `    ${taskId} #${i + 1}: ${record.passed ? "green" : `red[${record.failureClass ?? "unknown"}]`} (${record.cycles} cyc)`
+          );
+        } catch (err) {
+          records.push({ label: taskId, passed: false, cycles: 0, ms: 0 });
+          runs.push({ taskId, passed: false, events: [] });
+          log(
+            `    ${taskId} #${i + 1}: ERRORED (${err instanceof Error ? err.message : String(err)})`
+          );
+        }
+      }
+    }
+
+    const summaries = summarize(records);
+    const perTask: Record<string, (typeof summaries)[number]> = {};
+
+    for (const summary of summaries) {
+      perTask[summary.label] = summary;
+    }
+
+    const score: ISplitScore = {
+      passed: records.filter((r) => r.passed).length,
+      runs: records.length,
+      avgQuality: meanOfSignaled(summaries.map((s) => s.avgQuality)),
+      avgLoc: meanOfSignaled(summaries.map((s) => s.avgLoc)),
+      perTask,
+    };
+
+    return { score, runs };
+  });
+}

--- a/packages/core/src/self-harness/evaluate.ts
+++ b/packages/core/src/self-harness/evaluate.ts
@@ -132,6 +132,7 @@ async function runTaskOnce(
   const gated = await gateSpec(runDir, spec);
   const logFile = Bun.file(join(runDir, "run.log")).writer();
   const events: ILoopEvent[] = [];
+
   const onEvent = (e: ILoopEvent): void => {
     events.push(e);
     void logFile.write(renderEvent(e, { color: false }));
@@ -161,9 +162,7 @@ async function runTaskOnce(
     const firstTask = spec.tasks[0];
 
     if (opts.judgeProvider !== undefined && firstTask !== undefined) {
-      const specText = await Bun.file(
-        join(runDir, `${taskId}.spec.md`)
-      ).text();
+      const specText = await Bun.file(join(runDir, `${taskId}.spec.md`)).text();
       const code = (
         await Promise.all(
           firstTask.files.map((f) => Bun.file(join(runDir, f)).text())

--- a/packages/core/src/self-harness/evaluate.ts
+++ b/packages/core/src/self-harness/evaluate.ts
@@ -74,17 +74,29 @@ async function startRed(
 }
 
 /** Run a seed's optional setup.sh (brownfield git history). Trusted: the
- *  corpus is our own code — same stance as the eval sweep. */
+ *  corpus is our own code — same stance as the eval sweep. A FAILED setup
+ *  throws: it leaves the seed in the wrong starting state (e.g. green instead
+ *  of the brownfield RED), which would silently invalidate the run's verdict —
+ *  the caller records it as an errored run, never a task result. */
 async function runSeedSetup(dir: string): Promise<void> {
   if (!(await Bun.file(join(dir, "setup.sh")).exists())) {
     return;
   }
 
-  await Bun.spawn(["sh", "setup.sh"], {
+  const proc = Bun.spawn(["sh", "setup.sh"], {
     cwd: dir,
     stdout: "ignore",
-    stderr: "ignore",
-  }).exited;
+    stderr: "pipe",
+  });
+  const exitCode = await proc.exited;
+
+  if (exitCode !== 0) {
+    const stderr = await new Response(proc.stderr).text();
+
+    throw new Error(
+      `seed setup.sh exited ${String(exitCode)}: ${stderr.slice(0, 200)}`
+    );
+  }
 }
 
 /** Gate every task and the whole-spec verify behind tsforge's strict floor —

--- a/packages/core/src/self-harness/evaluate.ts
+++ b/packages/core/src/self-harness/evaluate.ts
@@ -366,6 +366,15 @@ export async function evaluateHarness(
           `${taskId.replace(":", "-")}-${i + 1}`
         );
 
+        // Every run starts from an empty directory. Run dir names are
+        // deterministic (taskId-repeat) and get reused across campaign
+        // launches and baseline retries, so without this a fresh run would
+        // write ON TOP of the previous run's artifacts — leaving a mix of new
+        // and stale files (logs from two different attempts in one dir, a
+        // half-overwritten build) that is impossible to read honestly. Wipe
+        // first so what's on disk is always exactly one run.
+        await rm(runDir, { recursive: true, force: true });
+
         await (taskId.startsWith("web:")
           ? runOneWeb(taskId, i + 1, runDir, opts, sink)
           : runOneSpec(taskId, i + 1, runDir, opts, sink));

--- a/packages/core/src/self-harness/index.ts
+++ b/packages/core/src/self-harness/index.ts
@@ -18,9 +18,17 @@ export {
 export { mineWeaknesses, dominantSignal, type IMinedRun } from "./mine";
 export {
   evaluateHarness,
+  SPEC_SLOW_THRESHOLD,
   type IEvaluateOptions,
   type IEvaluateOutcome,
 } from "./evaluate";
+export {
+  runWebTaskOnce,
+  WEB_SLOW_THRESHOLD,
+  WEB_RUN_TIMEOUT_MS,
+  type IWebEvaluateOptions,
+  type IWebRunOutcome,
+} from "./evaluate-web";
 export { propose, type IProposeOptions } from "./propose";
 export {
   acceptanceDecision,

--- a/packages/core/src/self-harness/index.ts
+++ b/packages/core/src/self-harness/index.ts
@@ -1,0 +1,24 @@
+export * from "./self-harness.types";
+export {
+  activeOverlay,
+  emptyOverlay,
+  isEmptyPatch,
+  mergeOverlay,
+  modelSlug,
+  overlayPathFor,
+  parseOverlay,
+  resetOverlayCache,
+} from "./overlay";
+export { resolveSplits, listCorpusTasks, DEFAULT_HELD_IN, DEFAULT_HELD_OUT } from "./split";
+export { mineWeaknesses, dominantSignal, type IMinedRun } from "./mine";
+export { evaluateHarness, type IEvaluateOptions, type IEvaluateOutcome } from "./evaluate";
+export { propose, type IProposeOptions } from "./propose";
+export {
+  acceptanceDecision,
+  validateCandidate,
+  type HarnessEvaluator,
+  type IEvaluationOutput,
+  type IAcceptanceDecision,
+} from "./validate";
+export { runSelfHarness, type ISelfHarnessOptions } from "./loop";
+export { emitReport, type IReport } from "./report";

--- a/packages/core/src/self-harness/index.ts
+++ b/packages/core/src/self-harness/index.ts
@@ -9,9 +9,18 @@ export {
   parseOverlay,
   resetOverlayCache,
 } from "./overlay";
-export { resolveSplits, listCorpusTasks, DEFAULT_HELD_IN, DEFAULT_HELD_OUT } from "./split";
+export {
+  resolveSplits,
+  listCorpusTasks,
+  DEFAULT_HELD_IN,
+  DEFAULT_HELD_OUT,
+} from "./split";
 export { mineWeaknesses, dominantSignal, type IMinedRun } from "./mine";
-export { evaluateHarness, type IEvaluateOptions, type IEvaluateOutcome } from "./evaluate";
+export {
+  evaluateHarness,
+  type IEvaluateOptions,
+  type IEvaluateOutcome,
+} from "./evaluate";
 export { propose, type IProposeOptions } from "./propose";
 export {
   acceptanceDecision,

--- a/packages/core/src/self-harness/loop.ts
+++ b/packages/core/src/self-harness/loop.ts
@@ -39,6 +39,12 @@ export interface ISelfHarnessOptions {
   readonly log?: (line: string) => void;
 }
 
+function baselineErrored(output: {
+  evaluation: { heldIn: { errored: number }; heldOut: { errored: number } };
+}): number {
+  return output.evaluation.heldIn.errored + output.evaluation.heldOut.errored;
+}
+
 function attemptSummary(result: IValidationResult): string {
   const { candidate } = result;
 
@@ -57,11 +63,35 @@ export async function runSelfHarness(
   for (let t = 0; t < opts.rounds; t += 1) {
     log(`round ${String(t)}: evaluating h_${String(t)} on both splits…`);
 
-    const base = await opts.evaluator(
+    let base = await opts.evaluator(
       isEmptyPatch(overlay) ? null : overlay,
       opts.splits,
       `r${String(t)}-baseline`
     );
+
+    // An errored BASELINE would corrupt every delta this round (an endpoint
+    // flake could make a bogus candidate look like an improvement). Retry the
+    // baseline once; if the infrastructure is still failing, stop the loop —
+    // no verdict is trustworthy without a clean baseline.
+    if (baselineErrored(base) > 0) {
+      notes.push(
+        `round ${String(t)}: baseline had ${String(baselineErrored(base))} infrastructure-errored run(s) — retrying once`
+      );
+      log(`round ${String(t)}: baseline hit infrastructure errors — retrying…`);
+      base = await opts.evaluator(
+        isEmptyPatch(overlay) ? null : overlay,
+        opts.splits,
+        `r${String(t)}-baseline-retry`
+      );
+
+      if (baselineErrored(base) > 0) {
+        notes.push(
+          `round ${String(t)}: baseline retry ALSO errored — endpoint unhealthy, loop stopped (no verdict is trustworthy without a clean baseline)`
+        );
+        log(`round ${String(t)}: endpoint unhealthy — stopping the loop`);
+        break;
+      }
+    }
 
     log(
       `round ${String(t)}: baseline pass held-in ${String(base.evaluation.heldIn.passed)}/${String(base.evaluation.heldIn.runs)}, held-out ${String(base.evaluation.heldOut.passed)}/${String(base.evaluation.heldOut.runs)}`

--- a/packages/core/src/self-harness/loop.ts
+++ b/packages/core/src/self-harness/loop.ts
@@ -1,0 +1,145 @@
+/**
+ * The Self-Harness loop (paper Algorithm 1), tsforge-native. Per round t:
+ *   1. EVALUATE h_t on both splits (baseline for this round's deltas).
+ *   2. MINE the held-in failures into an evidence bundle (deterministic).
+ *   3. PROPOSE K minimal candidate edits (the same fixed model, proposer role).
+ *   4. VALIDATE each candidate; ACCEPT iff non-regressive with strict gain.
+ *   5. MERGE accepted edits → h_{t+1}; rejected ones are logged, not applied.
+ *
+ * The loop only ever *builds* an overlay lineage — installation of the final
+ * overlay is a human decision on the emitted PR diff (report.ts), never
+ * automatic.
+ */
+import { emptyOverlay, isEmptyPatch, mergeOverlay } from "./overlay";
+import { mineWeaknesses } from "./mine";
+import { propose } from "./propose";
+import { validateCandidate, type HarnessEvaluator } from "./validate";
+import type { IProvider } from "../inference";
+import type {
+  IHarnessOverlay,
+  ILineage,
+  IRoundRecord,
+  ISplits,
+  IValidationResult,
+} from "./self-harness.types";
+
+export interface ISelfHarnessOptions {
+  /** Model id, for the per-model lineage (a DeepSeek harness ≠ a Qwen one). */
+  readonly model: string;
+  readonly rounds: number;
+  readonly width: number;
+  readonly splits: ISplits;
+  /** The proposer — the SAME fixed model the harness runs under. */
+  readonly provider: IProvider;
+  /** Evaluates one harness variant on the splits. Injected: the CLI wires the
+   *  real corpus evaluator; tests wire a deterministic fake. */
+  readonly evaluator: HarnessEvaluator;
+  /** Start from an already-promoted overlay to continue a lineage. */
+  readonly initialOverlay?: IHarnessOverlay;
+  readonly log?: (line: string) => void;
+}
+
+function attemptSummary(result: IValidationResult): string {
+  const { candidate } = result;
+
+  return `${candidate.id} (${result.accepted ? "ACCEPTED" : "rejected"}): targets ${candidate.audit.targetPattern} via ${candidate.audit.surface} — ${candidate.audit.expectedEffect} [Δin=${String(result.deltaIn)}, Δho=${String(result.deltaOut)}: ${result.reason}]`;
+}
+
+export async function runSelfHarness(
+  opts: ISelfHarnessOptions
+): Promise<ILineage> {
+  const log = opts.log ?? ((): void => undefined);
+  const notes: string[] = [];
+  const priorAttempts: string[] = [];
+  const rounds: IRoundRecord[] = [];
+  let overlay = opts.initialOverlay ?? emptyOverlay();
+
+  for (let t = 0; t < opts.rounds; t += 1) {
+    log(`round ${String(t)}: evaluating h_${String(t)} on both splits…`);
+
+    const base = await opts.evaluator(
+      isEmptyPatch(overlay) ? null : overlay,
+      opts.splits,
+      `r${String(t)}-baseline`
+    );
+
+    log(
+      `round ${String(t)}: baseline pass held-in ${String(base.evaluation.heldIn.passed)}/${String(base.evaluation.heldIn.runs)}, held-out ${String(base.evaluation.heldOut.passed)}/${String(base.evaluation.heldOut.runs)}`
+    );
+
+    const evidence = mineWeaknesses(base.heldInRuns);
+
+    if (evidence.patterns.length === 0) {
+      notes.push(
+        `round ${String(t)}: no held-in failures to mine — loop stops early`
+      );
+      rounds.push({
+        round: t,
+        baseline: base.evaluation,
+        evidence,
+        candidates: [],
+        acceptedIds: [],
+      });
+      log(`round ${String(t)}: held-in fully green — nothing to improve`);
+      break;
+    }
+
+    log(
+      `round ${String(t)}: mined ${String(evidence.patterns.length)} failure pattern(s); proposing ${String(opts.width)} candidate(s)…`
+    );
+
+    const candidates = await propose(evidence, {
+      provider: opts.provider,
+      width: opts.width,
+      current: overlay,
+      priorAttempts,
+      idPrefix: `r${String(t)}`,
+      notes,
+    });
+
+    const results: IValidationResult[] = [];
+
+    // Sequential: candidate evaluations share the single-connection endpoint.
+    for (const candidate of candidates) {
+      log(`round ${String(t)}: validating ${candidate.id}…`);
+
+      const result = await validateCandidate(
+        candidate,
+        overlay,
+        base.evaluation,
+        opts.splits,
+        opts.evaluator
+      );
+
+      results.push(result);
+      priorAttempts.push(attemptSummary(result));
+      log(
+        `round ${String(t)}: ${candidate.id} ${result.accepted ? "ACCEPTED" : "rejected"} — ${result.reason}`
+      );
+    }
+
+    const accepted = results.filter((r) => r.accepted);
+
+    // MergeAccepted: compatible accepted edits merge in proposal order
+    // (paper §3.4); when none pass, h_{t+1} = h_t.
+    for (const result of accepted) {
+      overlay = mergeOverlay(overlay, result.candidate.patch);
+    }
+
+    rounds.push({
+      round: t,
+      baseline: base.evaluation,
+      evidence,
+      candidates: results,
+      acceptedIds: accepted.map((r) => r.candidate.id),
+    });
+  }
+
+  return {
+    model: opts.model,
+    splits: opts.splits,
+    rounds,
+    finalOverlay: overlay,
+    notes,
+  };
+}

--- a/packages/core/src/self-harness/loop.ts
+++ b/packages/core/src/self-harness/loop.ts
@@ -36,6 +36,10 @@ export interface ISelfHarnessOptions {
   readonly evaluator: HarnessEvaluator;
   /** Start from an already-promoted overlay to continue a lineage. */
   readonly initialOverlay?: IHarnessOverlay;
+  /** Await endpoint recovery before retrying an errored baseline — without
+   *  this the retry fires straight into the same outage and the session
+   *  aborts for weather it could have waited out. */
+  readonly waitHealthy?: () => Promise<void>;
   readonly log?: (line: string) => void;
 }
 
@@ -78,6 +82,7 @@ export async function runSelfHarness(
         `round ${String(t)}: baseline had ${String(baselineErrored(base))} infrastructure-errored run(s) — retrying once`
       );
       log(`round ${String(t)}: baseline hit infrastructure errors — retrying…`);
+      await opts.waitHealthy?.();
       base = await opts.evaluator(
         isEmptyPatch(overlay) ? null : overlay,
         opts.splits,

--- a/packages/core/src/self-harness/mine.ts
+++ b/packages/core/src/self-harness/mine.ts
@@ -154,7 +154,9 @@ export function mineWeaknesses(runs: readonly IMinedRun[]): IEvidenceBundle {
       }
 
       // Keep the bundle bounded: at most 4 snippets per cluster.
-      existing.snippets.push(...snippets.slice(0, 4 - existing.snippets.length));
+      existing.snippets.push(
+        ...snippets.slice(0, 4 - existing.snippets.length)
+      );
     }
   }
 
@@ -170,8 +172,10 @@ export function mineWeaknesses(runs: readonly IMinedRun[]): IEvidenceBundle {
       traceSnippets: draft.snippets,
       mechanism: MECHANISMS[draft.signal] ?? MECHANISMS.none ?? "",
     }))
-    .sort(
-      (a, b) => b.support - a.support || a.signature.localeCompare(b.signature)
+    .sort((a, b) =>
+      a.support === b.support
+        ? a.signature.localeCompare(b.signature)
+        : b.support - a.support
     );
 
   return { totalRuns: runs.length, failedRuns, patterns };

--- a/packages/core/src/self-harness/mine.ts
+++ b/packages/core/src/self-harness/mine.ts
@@ -127,6 +127,50 @@ interface IClusterDraft {
   slowGreen: boolean;
 }
 
+interface IMinableRun {
+  readonly signature: string;
+  readonly failureClass: string;
+  readonly signal: string;
+  readonly detail?: string;
+  readonly snippets: string[];
+  readonly slowGreen: boolean;
+}
+
+/** Classify one run for mining, or null when it isn't minable (green and not
+ *  over its slow-green threshold). classifyRun tallies behavioral signals
+ *  BEFORE the green early-return, so a slow-green run still exposes its
+ *  friction (edit-rejects, salvages, repair churn). */
+function minableRun(run: IMinedRun): IMinableRun | null {
+  const cycles = run.passed ? cycleCount(run.events) : 0;
+  const slowGreen =
+    run.passed &&
+    run.slowThreshold !== undefined &&
+    cycles >= run.slowThreshold;
+
+  if (run.passed && !slowGreen) {
+    return null;
+  }
+
+  const summary = classifyRun(run.events);
+  const signal = dominantSignal(summary.signals);
+  const failureClass = slowGreen ? "slow-green" : summary.failureClass;
+  const snippets = slowGreen
+    ? [
+        `slow-green: ${run.taskId} reached green in ${String(cycles)} cycles (threshold ${String(run.slowThreshold)})`,
+        ...traceSnippets(run.events).slice(0, 2),
+      ]
+    : traceSnippets(run.events);
+
+  return {
+    signature: `${failureClass}|${signal}|${summary.detail ?? "-"}`,
+    failureClass,
+    signal,
+    ...(summary.detail === undefined ? {} : { detail: summary.detail }),
+    snippets,
+    slowGreen,
+  };
+}
+
 /** Cluster failed held-in runs by exact signature agreement and rank by
  *  support (paper: recurring mechanisms first — they most plausibly map to a
  *  high-value harness modification). Ties break lexicographically so the
@@ -137,48 +181,29 @@ export function mineWeaknesses(runs: readonly IMinedRun[]): IEvidenceBundle {
   let slowGreenRuns = 0;
 
   for (const run of runs) {
-    // A green run is minable ONLY as an efficiency pattern: it must carry a
-    // slow-green threshold and have crossed it. Everything else green skips.
-    const cycles = run.passed ? cycleCount(run.events) : 0;
-    const slowGreen =
-      run.passed &&
-      run.slowThreshold !== undefined &&
-      cycles >= run.slowThreshold;
+    const minable = minableRun(run);
 
-    if (run.passed && !slowGreen) {
+    if (minable === null) {
       continue;
     }
 
-    if (slowGreen) {
+    if (minable.slowGreen) {
       slowGreenRuns += 1;
     } else {
       failedRuns += 1;
     }
 
-    // classifyRun tallies behavioral signals BEFORE the green early-return, so
-    // a slow-green run still exposes its friction (edit-rejects, salvages,
-    // repair churn) — the mechanism the proposer needs to target.
-    const summary = classifyRun(run.events);
-    const signal = dominantSignal(summary.signals);
-    const failureClass = slowGreen ? "slow-green" : summary.failureClass;
-    const signature = `${failureClass}|${signal}|${summary.detail ?? "-"}`;
-    const existing = clusters.get(signature);
-    const snippets = slowGreen
-      ? [
-          `slow-green: ${run.taskId} reached green in ${String(cycles)} cycles (threshold ${String(run.slowThreshold)})`,
-          ...traceSnippets(run.events).slice(0, 2),
-        ]
-      : traceSnippets(run.events);
+    const existing = clusters.get(minable.signature);
 
     if (existing === undefined) {
-      clusters.set(signature, {
-        failureClass,
-        signal,
-        ...(summary.detail === undefined ? {} : { detail: summary.detail }),
+      clusters.set(minable.signature, {
+        failureClass: minable.failureClass,
+        signal: minable.signal,
+        ...(minable.detail === undefined ? {} : { detail: minable.detail }),
         taskIds: [run.taskId],
         evidence: new Set(verifierEvidence(run.events)),
-        snippets,
-        slowGreen,
+        snippets: minable.snippets,
+        slowGreen: minable.slowGreen,
       });
     } else {
       existing.taskIds.push(run.taskId);
@@ -189,7 +214,7 @@ export function mineWeaknesses(runs: readonly IMinedRun[]): IEvidenceBundle {
 
       // Keep the bundle bounded: at most 4 snippets per cluster.
       existing.snippets.push(
-        ...snippets.slice(0, 4 - existing.snippets.length)
+        ...minable.snippets.slice(0, 4 - existing.snippets.length)
       );
     }
   }

--- a/packages/core/src/self-harness/mine.ts
+++ b/packages/core/src/self-harness/mine.ts
@@ -1,0 +1,178 @@
+/**
+ * Weakness Mining (paper §3.2): turn held-in, verifier-grounded FAILURES into
+ * clustered failure patterns. Deterministic — no model call. Each failed run
+ * gets a signature φ = (verifier cause, dominant agent-side signal, dominant
+ * rule code); exact agreement on φ clusters runs, so two failures group only
+ * when they plausibly admit the SAME harness-level intervention.
+ */
+import { classifyRun } from "../eval/failure-class";
+import type { IFailureSignals } from "../eval/failure-class";
+import type { ILoopEvent } from "../loop/loop.types";
+import type { IEvidenceBundle, IFailurePattern } from "./self-harness.types";
+
+/** One evaluated run, as mine consumes it. */
+export interface IMinedRun {
+  readonly taskId: string;
+  readonly passed: boolean;
+  readonly events: readonly ILoopEvent[];
+}
+
+/** Precedence-ordered detection of the dominant AGENT-side behavior in a
+ *  failed run. Terminal booleans first (they end the run outright), then the
+ *  largest behavioral tally. "none" = the failure lives in the final gate
+ *  output, not in any recurrent agent behavior. */
+export function dominantSignal(signals: IFailureSignals): string {
+  if (signals.degenerated) {
+    return "degenerated";
+  }
+
+  if (signals.timedOut) {
+    return "timed-out";
+  }
+
+  if (signals.toolUseFailed) {
+    return "tool-use-failed";
+  }
+
+  const tallies: readonly [string, number][] = [
+    ["edit-rejects", signals.editRejects],
+    ["tool-salvages", signals.salvages],
+    ["repair-loop", signals.repairs >= 3 ? signals.repairs : 0],
+  ];
+  let best: [string, number] = ["none", 0];
+
+  for (const [name, count] of tallies) {
+    if (count > best[1]) {
+      best = [name, count];
+    }
+  }
+
+  return best[0];
+}
+
+/** Deterministic one-line description of the agent mechanism behind a
+ *  signature — the "inferred agent mechanism" field of the paper's evidence
+ *  bundle, phrased so the proposer can target it with a bounded edit. */
+const MECHANISMS: Record<string, string> = {
+  degenerated:
+    "The model degenerated into a repetition loop and the stream guard ended the run.",
+  "timed-out":
+    "Model calls timed out repeatedly; the run ended before producing a green gate.",
+  "tool-use-failed":
+    "The model never produced usable tool calls (malformed calls or narrated code instead of creating files).",
+  "edit-rejects":
+    "The model repeatedly targeted edit snippets/files that don't match the working tree (stale reads or hallucinated targets).",
+  "tool-salvages":
+    "The model emitted malformed tool calls the parser had to salvage, burning turns on re-asks.",
+  "repair-loop":
+    "Gate errors persisted across many repair cycles without converging on green.",
+  none: "No recurrent agent-side behavior — the failure is characterized by the final gate errors.",
+};
+
+function truncate(text: string, max: number): string {
+  return text.length <= max ? text : `${text.slice(0, max - 1)}…`;
+}
+
+/** Short representative event lines: the last failing gate verdict plus the
+ *  last couple of tool/repair messages — evidence, not a transcript dump. */
+function traceSnippets(events: readonly ILoopEvent[]): string[] {
+  const snippets: string[] = [];
+  const lastRedGate = [...events]
+    .reverse()
+    .find((e) => e.kind === "validated" && e.passed === false);
+
+  if (lastRedGate !== undefined) {
+    snippets.push(truncate(`gate: ${lastRedGate.message}`, 160));
+  }
+
+  const behavioral = events
+    .filter(
+      (e) =>
+        (e.kind === "tool" || e.kind === "repair" || e.kind === "stuck") &&
+        e.message.length > 0
+    )
+    .slice(-2)
+    .map((e) => truncate(`${e.kind}: ${e.message}`, 160));
+
+  return [...snippets, ...behavioral];
+}
+
+/** The failing rules on the LAST red gate — the verifier evidence backing the
+ *  cluster. */
+function verifierEvidence(events: readonly ILoopEvent[]): string[] {
+  const lastRedGate = [...events]
+    .reverse()
+    .find((e) => e.kind === "validated" && e.passed === false);
+
+  return [...new Set(lastRedGate?.rules ?? [])];
+}
+
+interface IClusterDraft {
+  failureClass: string;
+  signal: string;
+  detail?: string;
+  taskIds: string[];
+  evidence: Set<string>;
+  snippets: string[];
+}
+
+/** Cluster failed held-in runs by exact signature agreement and rank by
+ *  support (paper: recurring mechanisms first — they most plausibly map to a
+ *  high-value harness modification). Ties break lexicographically so the
+ *  bundle is fully deterministic. */
+export function mineWeaknesses(runs: readonly IMinedRun[]): IEvidenceBundle {
+  const clusters = new Map<string, IClusterDraft>();
+  let failedRuns = 0;
+
+  for (const run of runs) {
+    if (run.passed) {
+      continue;
+    }
+
+    failedRuns += 1;
+
+    const summary = classifyRun(run.events);
+    const signal = dominantSignal(summary.signals);
+    const signature = `${summary.failureClass}|${signal}|${summary.detail ?? "-"}`;
+    const existing = clusters.get(signature);
+    const snippets = traceSnippets(run.events);
+
+    if (existing === undefined) {
+      clusters.set(signature, {
+        failureClass: summary.failureClass,
+        signal,
+        ...(summary.detail === undefined ? {} : { detail: summary.detail }),
+        taskIds: [run.taskId],
+        evidence: new Set(verifierEvidence(run.events)),
+        snippets,
+      });
+    } else {
+      existing.taskIds.push(run.taskId);
+
+      for (const rule of verifierEvidence(run.events)) {
+        existing.evidence.add(rule);
+      }
+
+      // Keep the bundle bounded: at most 4 snippets per cluster.
+      existing.snippets.push(...snippets.slice(0, 4 - existing.snippets.length));
+    }
+  }
+
+  const patterns: IFailurePattern[] = [...clusters.entries()]
+    .map(([signature, draft]) => ({
+      signature,
+      failureClass: draft.failureClass,
+      dominantSignal: draft.signal,
+      ...(draft.detail === undefined ? {} : { detail: draft.detail }),
+      support: draft.taskIds.length,
+      taskIds: draft.taskIds,
+      verifierEvidence: [...draft.evidence].sort((a, b) => a.localeCompare(b)),
+      traceSnippets: draft.snippets,
+      mechanism: MECHANISMS[draft.signal] ?? MECHANISMS.none ?? "",
+    }))
+    .sort(
+      (a, b) => b.support - a.support || a.signature.localeCompare(b.signature)
+    );
+
+  return { totalRuns: runs.length, failedRuns, patterns };
+}

--- a/packages/core/src/self-harness/mine.ts
+++ b/packages/core/src/self-harness/mine.ts
@@ -15,6 +15,16 @@ export interface IMinedRun {
   readonly taskId: string;
   readonly passed: boolean;
   readonly events: readonly ILoopEvent[];
+  /** When set, a PASSED run with at least this many cycles is still mined —
+   *  as a `slow-green` pattern (efficiency signal). The threshold travels with
+   *  the run so the evaluator can scale it per task kind (spec vs web build);
+   *  absent = green runs are never mined. */
+  readonly slowThreshold?: number;
+}
+
+/** Model turns a run consumed (one `cycle` event per loop iteration). */
+export function cycleCount(events: readonly ILoopEvent[]): number {
+  return events.filter((e) => e.kind === "cycle").length;
 }
 
 /** Precedence-ordered detection of the dominant AGENT-side behavior in a
@@ -114,6 +124,7 @@ interface IClusterDraft {
   taskIds: string[];
   evidence: Set<string>;
   snippets: string[];
+  slowGreen: boolean;
 }
 
 /** Cluster failed held-in runs by exact signature agreement and rank by
@@ -123,28 +134,51 @@ interface IClusterDraft {
 export function mineWeaknesses(runs: readonly IMinedRun[]): IEvidenceBundle {
   const clusters = new Map<string, IClusterDraft>();
   let failedRuns = 0;
+  let slowGreenRuns = 0;
 
   for (const run of runs) {
-    if (run.passed) {
+    // A green run is minable ONLY as an efficiency pattern: it must carry a
+    // slow-green threshold and have crossed it. Everything else green skips.
+    const cycles = run.passed ? cycleCount(run.events) : 0;
+    const slowGreen =
+      run.passed &&
+      run.slowThreshold !== undefined &&
+      cycles >= run.slowThreshold;
+
+    if (run.passed && !slowGreen) {
       continue;
     }
 
-    failedRuns += 1;
+    if (slowGreen) {
+      slowGreenRuns += 1;
+    } else {
+      failedRuns += 1;
+    }
 
+    // classifyRun tallies behavioral signals BEFORE the green early-return, so
+    // a slow-green run still exposes its friction (edit-rejects, salvages,
+    // repair churn) — the mechanism the proposer needs to target.
     const summary = classifyRun(run.events);
     const signal = dominantSignal(summary.signals);
-    const signature = `${summary.failureClass}|${signal}|${summary.detail ?? "-"}`;
+    const failureClass = slowGreen ? "slow-green" : summary.failureClass;
+    const signature = `${failureClass}|${signal}|${summary.detail ?? "-"}`;
     const existing = clusters.get(signature);
-    const snippets = traceSnippets(run.events);
+    const snippets = slowGreen
+      ? [
+          `slow-green: ${run.taskId} reached green in ${String(cycles)} cycles (threshold ${String(run.slowThreshold)})`,
+          ...traceSnippets(run.events).slice(0, 2),
+        ]
+      : traceSnippets(run.events);
 
     if (existing === undefined) {
       clusters.set(signature, {
-        failureClass: summary.failureClass,
+        failureClass,
         signal,
         ...(summary.detail === undefined ? {} : { detail: summary.detail }),
         taskIds: [run.taskId],
         evidence: new Set(verifierEvidence(run.events)),
         snippets,
+        slowGreen,
       });
     } else {
       existing.taskIds.push(run.taskId);
@@ -170,7 +204,9 @@ export function mineWeaknesses(runs: readonly IMinedRun[]): IEvidenceBundle {
       taskIds: draft.taskIds,
       verifierEvidence: [...draft.evidence].sort((a, b) => a.localeCompare(b)),
       traceSnippets: draft.snippets,
-      mechanism: MECHANISMS[draft.signal] ?? MECHANISMS.none ?? "",
+      mechanism: draft.slowGreen
+        ? `Reaches green but burns an outsized cycle budget — recurring friction: ${MECHANISMS[draft.signal] ?? MECHANISMS.none ?? ""}`
+        : (MECHANISMS[draft.signal] ?? MECHANISMS.none ?? ""),
     }))
     .sort((a, b) =>
       a.support === b.support
@@ -178,5 +214,5 @@ export function mineWeaknesses(runs: readonly IMinedRun[]): IEvidenceBundle {
         : b.support - a.support
     );
 
-  return { totalRuns: runs.length, failedRuns, patterns };
+  return { totalRuns: runs.length, failedRuns, slowGreenRuns, patterns };
 }

--- a/packages/core/src/self-harness/overlay.ts
+++ b/packages/core/src/self-harness/overlay.ts
@@ -1,0 +1,327 @@
+/**
+ * The harness overlay — the unit of change for the Self-Harness loop.
+ * h_t = base harness + overlay; a candidate edit is one more JSON patch.
+ *
+ * Runtime resolution (sync, cached — the injection points in prompt/ttsr/agent
+ * loading are hot paths on the base harness and must stay byte-identical when
+ * no overlay is active):
+ *   1. `TSFORGE_SELF_HARNESS_OVERLAY=<path>` — explicit, used by the validator
+ *      to test a candidate. Wins.
+ *   2. `~/.tsforge/self-harness/<model-slug>/overlay.json` — the promoted
+ *      per-model overlay a human installed by merging the PR diff.
+ *   3. Neither → null (base harness, unchanged behavior).
+ */
+import { readFileSync } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
+import { isRecord } from "../lib/guards";
+import { parseProjectRules } from "../loop/ttsr";
+import { parseModelsConfig } from "../models-config";
+import {
+  PROMPT_BLOCK_NAMES,
+  type IAgentSpecOverride,
+  type IHarnessOverlay,
+  type IOverlayPatch,
+  type IProcedureCardEdit,
+  type IPromptBlockEdit,
+  type PromptBlockName,
+} from "./self-harness.types";
+
+export function emptyOverlay(): IHarnessOverlay {
+  return {
+    version: 1,
+    ttsrRules: [],
+    agentSpecOverrides: [],
+    promptBlocks: {},
+    procedureCards: {},
+  };
+}
+
+function parseAgentOverride(value: unknown): IAgentSpecOverride | null {
+  if (!isRecord(value) || typeof value.id !== "string") {
+    return null;
+  }
+
+  const override: {
+    id: string;
+    systemPrompt?: string;
+    task?: string;
+    maxTurns?: number;
+  } = { id: value.id };
+
+  if (typeof value.systemPrompt === "string") {
+    override.systemPrompt = value.systemPrompt;
+  }
+
+  if (typeof value.task === "string") {
+    override.task = value.task;
+  }
+
+  if (
+    typeof value.maxTurns === "number" &&
+    Number.isInteger(value.maxTurns) &&
+    value.maxTurns > 0
+  ) {
+    override.maxTurns = value.maxTurns;
+  }
+
+  return override;
+}
+
+function isBlockName(value: string): value is PromptBlockName {
+  return (PROMPT_BLOCK_NAMES as readonly string[]).includes(value);
+}
+
+function parseBlockEdit(value: unknown): IPromptBlockEdit | null {
+  if (
+    !isRecord(value) ||
+    (value.mode !== "append" && value.mode !== "replace") ||
+    typeof value.text !== "string" ||
+    value.text.length === 0
+  ) {
+    return null;
+  }
+
+  return { mode: value.mode, text: value.text };
+}
+
+function parsePromptBlocks(
+  value: unknown
+): Partial<Record<PromptBlockName, IPromptBlockEdit>> {
+  const blocks: Partial<Record<PromptBlockName, IPromptBlockEdit>> = {};
+
+  if (!isRecord(value)) {
+    return blocks;
+  }
+
+  for (const [name, raw] of Object.entries(value)) {
+    const edit = parseBlockEdit(raw);
+
+    if (isBlockName(name) && edit !== null) {
+      blocks[name] = edit;
+    }
+  }
+
+  return blocks;
+}
+
+const CARD_FIELDS = ["what", "bad", "good", "procedure"] as const;
+
+function parseCardEdit(value: unknown): IProcedureCardEdit | null {
+  if (!isRecord(value)) {
+    return null;
+  }
+
+  const card: { what?: string; bad?: string; good?: string; procedure?: string } =
+    {};
+
+  for (const field of CARD_FIELDS) {
+    const raw = value[field];
+
+    if (typeof raw === "string" && raw.length > 0) {
+      card[field] = raw;
+    }
+  }
+
+  return Object.keys(card).length > 0 ? card : null;
+}
+
+function parseProcedureCards(value: unknown): Record<string, IProcedureCardEdit> {
+  const cards: Record<string, IProcedureCardEdit> = {};
+
+  if (!isRecord(value)) {
+    return cards;
+  }
+
+  for (const [rule, raw] of Object.entries(value)) {
+    const card = parseCardEdit(raw);
+
+    if (card !== null) {
+      cards[rule] = card;
+    }
+  }
+
+  return cards;
+}
+
+/** Validate one parsed JSON value into an overlay. Invalid entries drop
+ *  (warn-and-drop is the house loader style — a malformed overlay degrades to
+ *  "less overlay", never a crash); a non-object degrades to null. */
+export function parseOverlay(value: unknown): IHarnessOverlay | null {
+  if (!isRecord(value)) {
+    return null;
+  }
+
+  return {
+    version: 1,
+    // Reuse the project-rules validator so overlay TTSR rules obey exactly the
+    // same schema as hand-authored .tsforge/rules.json ones.
+    ttsrRules: parseProjectRules(JSON.stringify(value.ttsrRules ?? [])),
+    agentSpecOverrides: Array.isArray(value.agentSpecOverrides)
+      ? value.agentSpecOverrides
+          .map(parseAgentOverride)
+          .filter((o): o is IAgentSpecOverride => o !== null)
+      : [],
+    promptBlocks: parsePromptBlocks(value.promptBlocks),
+    procedureCards: parseProcedureCards(value.procedureCards),
+  };
+}
+
+/** Compose two edits to the same prompt block: a replace supersedes what came
+ *  before it; an append stacks below the existing edit. */
+function composeBlockEdit(
+  base: IPromptBlockEdit | undefined,
+  patch: IPromptBlockEdit
+): IPromptBlockEdit {
+  if (patch.mode === "replace" || base === undefined) {
+    return patch;
+  }
+
+  return { mode: base.mode, text: `${base.text}\n${patch.text}` };
+}
+
+/** Merge a candidate patch onto an overlay (both already validated). TTSR
+ *  rules dedupe by name with the patch winning; agent overrides merge by id
+ *  field-wise; prompt blocks compose (see composeBlockEdit); procedure cards
+ *  merge field-wise per rule. */
+export function mergeOverlay(
+  base: IHarnessOverlay,
+  patch: IOverlayPatch
+): IHarnessOverlay {
+  const patchRuleNames = new Set((patch.ttsrRules ?? []).map((r) => r.name));
+  const ttsrRules = [
+    ...base.ttsrRules.filter((r) => !patchRuleNames.has(r.name)),
+    ...(patch.ttsrRules ?? []),
+  ];
+
+  const overridesById = new Map(base.agentSpecOverrides.map((o) => [o.id, o]));
+
+  for (const o of patch.agentSpecOverrides ?? []) {
+    overridesById.set(o.id, { ...overridesById.get(o.id), ...o });
+  }
+
+  const promptBlocks = { ...base.promptBlocks };
+
+  for (const [name, edit] of Object.entries(patch.promptBlocks ?? {})) {
+    if (isBlockName(name) && edit !== undefined) {
+      promptBlocks[name] = composeBlockEdit(promptBlocks[name], edit);
+    }
+  }
+
+  const procedureCards = { ...base.procedureCards };
+
+  for (const [rule, card] of Object.entries(patch.procedureCards ?? {})) {
+    procedureCards[rule] = { ...procedureCards[rule], ...card };
+  }
+
+  return {
+    version: 1,
+    ttsrRules,
+    agentSpecOverrides: [...overridesById.values()],
+    promptBlocks,
+    procedureCards,
+  };
+}
+
+/** True when a patch changes no editable surface — such a candidate is
+ *  rejected outright (paper §3.4: validation rejects proposals that modify no
+ *  editable surface). */
+export function isEmptyPatch(patch: IOverlayPatch): boolean {
+  return (
+    (patch.ttsrRules ?? []).length === 0 &&
+    (patch.agentSpecOverrides ?? []).length === 0 &&
+    Object.keys(patch.promptBlocks ?? {}).length === 0 &&
+    Object.keys(patch.procedureCards ?? {}).length === 0
+  );
+}
+
+/** Filesystem-safe slug of a model id ("deepseek-ai/DeepSeek-V4-Flash" →
+ *  "deepseek-ai-deepseek-v4-flash"). */
+export function modelSlug(modelId: string): string {
+  return (
+    modelId
+      .toLowerCase()
+      .replaceAll(/[^a-z0-9]+/gu, "-")
+      .replaceAll(/^-+|-+$/gu, "") || "model"
+  );
+}
+
+function homeBase(): string {
+  return process.env.TSFORGE_HOME ?? homedir();
+}
+
+/** The promoted-overlay path for a model id. */
+export function overlayPathFor(modelId: string): string {
+  return join(
+    homeBase(),
+    ".tsforge",
+    "self-harness",
+    modelSlug(modelId),
+    "overlay.json"
+  );
+}
+
+/** The active model's id, resolved synchronously (env escape hatch first,
+ *  then the registry's active entry) — mirrors resolveActiveModel() without
+ *  the async file API so the hot-path injection points can call it. */
+function activeModelIdSync(): string | null {
+  const envModel = process.env.TSFORGE_MODEL;
+
+  if (envModel !== undefined && envModel.length > 0) {
+    return envModel;
+  }
+
+  try {
+    const raw: unknown = JSON.parse(
+      readFileSync(join(homeBase(), ".tsforge", "models.json"), "utf8")
+    );
+    const cfg = parseModelsConfig(raw);
+
+    return cfg.models[cfg.active]?.model ?? null;
+  } catch {
+    return null;
+  }
+}
+
+function readOverlayFile(path: string): IHarnessOverlay | null {
+  try {
+    const raw: unknown = JSON.parse(readFileSync(path, "utf8"));
+
+    return parseOverlay(raw);
+  } catch {
+    return null;
+  }
+}
+
+let cached: IHarnessOverlay | null = null;
+let cacheKey: string | null = null;
+
+/** The overlay in effect for this process, or null (base harness). Cached per
+ *  resolved source so repeated prompt builds don't re-read disk; the cache
+ *  key includes the env override so tests and the validator can flip it. */
+export function activeOverlay(): IHarnessOverlay | null {
+  const envPath = process.env.TSFORGE_SELF_HARNESS_OVERLAY;
+  const key = envPath ?? `model:${process.env.TSFORGE_MODEL ?? "registry"}`;
+
+  if (cacheKey === key) {
+    return cached;
+  }
+
+  if (envPath !== undefined && envPath.length > 0) {
+    cached = readOverlayFile(envPath);
+  } else {
+    const modelId = activeModelIdSync();
+
+    cached = modelId === null ? null : readOverlayFile(overlayPathFor(modelId));
+  }
+
+  cacheKey = key;
+
+  return cached;
+}
+
+/** Drop the cached overlay (tests, and the validator between candidates). */
+export function resetOverlayCache(): void {
+  cached = null;
+  cacheKey = null;
+}

--- a/packages/core/src/self-harness/overlay.ts
+++ b/packages/core/src/self-harness/overlay.ts
@@ -68,8 +68,10 @@ function parseAgentOverride(value: unknown): IAgentSpecOverride | null {
   return override;
 }
 
+const BLOCK_NAMES: ReadonlySet<string> = new Set(PROMPT_BLOCK_NAMES);
+
 function isBlockName(value: string): value is PromptBlockName {
-  return (PROMPT_BLOCK_NAMES as readonly string[]).includes(value);
+  return BLOCK_NAMES.has(value);
 }
 
 function parseBlockEdit(value: unknown): IPromptBlockEdit | null {
@@ -112,8 +114,12 @@ function parseCardEdit(value: unknown): IProcedureCardEdit | null {
     return null;
   }
 
-  const card: { what?: string; bad?: string; good?: string; procedure?: string } =
-    {};
+  const card: {
+    what?: string;
+    bad?: string;
+    good?: string;
+    procedure?: string;
+  } = {};
 
   for (const field of CARD_FIELDS) {
     const raw = value[field];
@@ -126,7 +132,9 @@ function parseCardEdit(value: unknown): IProcedureCardEdit | null {
   return Object.keys(card).length > 0 ? card : null;
 }
 
-function parseProcedureCards(value: unknown): Record<string, IProcedureCardEdit> {
+function parseProcedureCards(
+  value: unknown
+): Record<string, IProcedureCardEdit> {
   const cards: Record<string, IProcedureCardEdit> = {};
 
   if (!isRecord(value)) {
@@ -203,7 +211,7 @@ export function mergeOverlay(
   const promptBlocks = { ...base.promptBlocks };
 
   for (const [name, edit] of Object.entries(patch.promptBlocks ?? {})) {
-    if (isBlockName(name) && edit !== undefined) {
+    if (isBlockName(name)) {
       promptBlocks[name] = composeBlockEdit(promptBlocks[name], edit);
     }
   }
@@ -238,12 +246,12 @@ export function isEmptyPatch(patch: IOverlayPatch): boolean {
 /** Filesystem-safe slug of a model id ("deepseek-ai/DeepSeek-V4-Flash" →
  *  "deepseek-ai-deepseek-v4-flash"). */
 export function modelSlug(modelId: string): string {
-  return (
-    modelId
-      .toLowerCase()
-      .replaceAll(/[^a-z0-9]+/gu, "-")
-      .replaceAll(/^-+|-+$/gu, "") || "model"
-  );
+  const slug = modelId
+    .toLowerCase()
+    .replaceAll(/[^a-z0-9]+/gu, "-")
+    .replaceAll(/^-+|-+$/gu, "");
+
+  return slug.length === 0 ? "model" : slug;
 }
 
 function homeBase(): string {

--- a/packages/core/src/self-harness/propose.ts
+++ b/packages/core/src/self-harness/propose.ts
@@ -84,7 +84,7 @@ function renderContext(
 ): string {
   const parts = [
     SURFACE_CATALOG,
-    `## Failure patterns (held-in split, ${String(bundle.failedRuns)}/${String(bundle.totalRuns)} runs failed)\n${renderBundle(bundle, notes)}`,
+    `## Failure patterns (held-in split, ${String(bundle.failedRuns)}/${String(bundle.totalRuns)} runs failed${bundle.slowGreenRuns > 0 ? `, ${String(bundle.slowGreenRuns)} passed but pathologically slow` : ""})\n${renderBundle(bundle, notes)}`,
     `## Current overlay (already-promoted edits — preserve their behavior)\n${JSON.stringify(current, null, 2)}`,
   ];
 

--- a/packages/core/src/self-harness/propose.ts
+++ b/packages/core/src/self-harness/propose.ts
@@ -144,11 +144,21 @@ function parseCandidate(
     return { reason: "patch is not an object" };
   }
 
+  // Only the surfaces the edit actually touches — empty arrays/objects in the
+  // patch would read as "this edit touches everything" in the report diff.
   const patch: IOverlayPatch = {
-    ttsrRules: validated.ttsrRules,
-    agentSpecOverrides: validated.agentSpecOverrides,
-    promptBlocks: validated.promptBlocks,
-    procedureCards: validated.procedureCards,
+    ...(validated.ttsrRules.length > 0
+      ? { ttsrRules: validated.ttsrRules }
+      : {}),
+    ...(validated.agentSpecOverrides.length > 0
+      ? { agentSpecOverrides: validated.agentSpecOverrides }
+      : {}),
+    ...(Object.keys(validated.promptBlocks).length > 0
+      ? { promptBlocks: validated.promptBlocks }
+      : {}),
+    ...(Object.keys(validated.procedureCards).length > 0
+      ? { procedureCards: validated.procedureCards }
+      : {}),
   };
 
   if (isEmptyPatch(patch)) {

--- a/packages/core/src/self-harness/propose.ts
+++ b/packages/core/src/self-harness/propose.ts
@@ -1,0 +1,255 @@
+/**
+ * Harness Proposal (paper §3.3): the SAME fixed model, in a proposer role,
+ * turns the mined evidence bundle into K diverse-but-minimal candidate edits.
+ * The proposer sees a bounded context — the editable-surface catalog, the
+ * evidence bundle, the current overlay (behaviors already promoted), and
+ * summaries of prior attempts — never raw execution logs or the held-out
+ * split. Each candidate must ground itself in ONE failure pattern and edit a
+ * declared surface; anything else drops with an explicit note (no silent caps).
+ */
+import type { IProvider } from "../inference";
+import { extractJson } from "../lib/json";
+import { isRecord } from "../lib/guards";
+import { isEmptyPatch, parseOverlay } from "./overlay";
+import type {
+  ICandidate,
+  IEvidenceBundle,
+  IHarnessOverlay,
+  IOverlayPatch,
+} from "./self-harness.types";
+
+/** Patterns shown to the proposer per round; the rest are noted as dropped. */
+const MAX_PATTERNS = 5;
+/** A candidate may touch at most this many individual edits — the paper's
+ *  minimality constraint, enforced mechanically. */
+const MAX_EDITS_PER_CANDIDATE = 3;
+
+const SURFACE_CATALOG = `You may edit ONLY these declared harness surfaces, expressed as a JSON "patch" object (all fields optional):
+
+1. "ttsrRules": array of stream-time rules. Each rule aborts generation when a regex matches the live output and injects corrective guidance on retry.
+   Shape: {"name": "kebab-case", "condition": ["regex source", ...], "scope": "content"|"tool-args"|"both", "fileGlobs": ["src/**/*.ts"]?, "guidance": "<=300 chars", "repeatMode": "once"|"cooldown", "repeatGap": number?}
+
+2. "promptBlocks": edits to NAMED system-prompt blocks. Names: "bootstrap" (the lead-with-action instruction), "execution" (the gate-feedback-loop instruction), "verification" (the run-your-hypotheses instruction), "extra" (a free block appended after all built-in guidance).
+   Shape: {"<name>": {"mode": "append"|"replace", "text": "..."}}
+
+3. "procedureCards": per-gate-rule repair guidance shown when that rule fails, keyed by the exact rule id (e.g. "TS2307", "no-as").
+   Shape: {"<ruleId>": {"what": "...", "bad": "...", "good": "...", "procedure": "step-by-step fix workflow"}}
+
+4. "agentSpecOverrides": bounded overrides of existing subagents (explore, research, verify, review-lens). Only systemPrompt, task, and maxTurns — tools and model are NOT editable.
+   Shape: [{"id": "explore", "systemPrompt": "..."?, "task": "..."?, "maxTurns": number?}]
+
+NOT editable (do not attempt): the gate/verifier, its strictness or rules, tool availability, model routing, the control loop.`;
+
+const PROPOSER_SYSTEM = `You are the harness-improvement proposer inside tsforge (Self-Harness loop). A fixed model — you — runs coding tasks under a harness; the harness is the object of improvement, not the model or the verifier.
+
+You receive verifier-grounded failure patterns mined from held-in execution traces. Propose exactly ONE minimal candidate edit that targets ONE pattern's mechanism. Requirements:
+- MINIMAL: change only the surface needed for the chosen mechanism (at most ${String(MAX_EDITS_PER_CANDIDATE)} individual edits); preserve unrelated harness behavior.
+- GROUNDED: pick a pattern that is concrete, recurrent, and plausibly mitigated by a narrow change to instructions/rules — not one reflecting task difficulty or model capability limits.
+- DISTINCT: materially different from the other candidates listed (different pattern, surface, or hypothesis — not a rewording).
+
+Respond with ONLY a JSON object:
+{"targetPattern": "<signature of the pattern you target>", "surface": "ttsrRules|promptBlocks|procedureCards|agentSpecOverrides", "expectedEffect": "<one sentence>", "risks": "<one sentence>", "patch": {<the patch object>}}`;
+
+function renderBundle(bundle: IEvidenceBundle, notes: string[]): string {
+  const shown = bundle.patterns.slice(0, MAX_PATTERNS);
+
+  if (bundle.patterns.length > shown.length) {
+    notes.push(
+      `proposer context: dropped ${String(bundle.patterns.length - shown.length)} low-support pattern(s) beyond the top ${String(MAX_PATTERNS)}`
+    );
+  }
+
+  const blocks = shown.map((p, i) =>
+    [
+      `Pattern ${String(i + 1)} — signature: ${p.signature} (${String(p.support)} failed run(s): ${p.taskIds.join(", ")})`,
+      `  mechanism: ${p.mechanism}`,
+      p.verifierEvidence.length > 0
+        ? `  verifier evidence (failing gate rules): ${p.verifierEvidence.join(", ")}`
+        : "",
+      ...p.traceSnippets.map((s) => `  trace: ${s}`),
+    ]
+      .filter((line) => line.length > 0)
+      .join("\n")
+  );
+
+  return blocks.join("\n\n");
+}
+
+function renderContext(
+  bundle: IEvidenceBundle,
+  current: IHarnessOverlay,
+  priorAttempts: readonly string[],
+  soFar: readonly ICandidate[],
+  notes: string[]
+): string {
+  const parts = [
+    SURFACE_CATALOG,
+    `## Failure patterns (held-in split, ${String(bundle.failedRuns)}/${String(bundle.totalRuns)} runs failed)\n${renderBundle(bundle, notes)}`,
+    `## Current overlay (already-promoted edits — preserve their behavior)\n${JSON.stringify(current, null, 2)}`,
+  ];
+
+  if (priorAttempts.length > 0) {
+    parts.push(
+      `## Previously attempted edits (do not repeat)\n${priorAttempts.map((a) => `- ${a}`).join("\n")}`
+    );
+  }
+
+  if (soFar.length > 0) {
+    parts.push(
+      `## Candidates already proposed THIS round (be materially distinct)\n${soFar
+        .map(
+          (c) =>
+            `- targets ${c.audit.targetPattern} via ${c.audit.surface}: ${c.audit.expectedEffect}`
+        )
+        .join("\n")}`
+    );
+  }
+
+  return parts.join("\n\n");
+}
+
+/** Total individual edits in a patch — the minimality metric. */
+function editCount(patch: IOverlayPatch): number {
+  return (
+    (patch.ttsrRules?.length ?? 0) +
+    (patch.agentSpecOverrides?.length ?? 0) +
+    Object.keys(patch.promptBlocks ?? {}).length +
+    Object.keys(patch.procedureCards ?? {}).length
+  );
+}
+
+/** Validate one raw proposer response into a candidate, or a rejection reason. */
+function parseCandidate(
+  raw: string,
+  id: string
+): { candidate?: ICandidate; reason?: string } {
+  let data: unknown;
+
+  try {
+    data = JSON.parse(extractJson(raw));
+  } catch {
+    return { reason: "unparseable proposer response" };
+  }
+
+  if (!isRecord(data) || !isRecord(data.patch)) {
+    return { reason: "response lacks a patch object" };
+  }
+
+  // Route the raw patch through the overlay validator so a proposed edit obeys
+  // exactly the runtime schema; invalid entries drop, and a patch that
+  // validates to nothing is rejected (paper: must modify an editable surface).
+  const validated = parseOverlay(data.patch);
+
+  if (validated === null) {
+    return { reason: "patch is not an object" };
+  }
+
+  const patch: IOverlayPatch = {
+    ttsrRules: validated.ttsrRules,
+    agentSpecOverrides: validated.agentSpecOverrides,
+    promptBlocks: validated.promptBlocks,
+    procedureCards: validated.procedureCards,
+  };
+
+  if (isEmptyPatch(patch)) {
+    return { reason: "patch modifies no editable surface after validation" };
+  }
+
+  if (editCount(patch) > MAX_EDITS_PER_CANDIDATE) {
+    return {
+      reason: `patch exceeds the minimality cap (${String(editCount(patch))} edits > ${String(MAX_EDITS_PER_CANDIDATE)})`,
+    };
+  }
+
+  return {
+    candidate: {
+      id,
+      patch,
+      audit: {
+        targetPattern:
+          typeof data.targetPattern === "string" ? data.targetPattern : "",
+        surface: typeof data.surface === "string" ? data.surface : "",
+        expectedEffect:
+          typeof data.expectedEffect === "string" ? data.expectedEffect : "",
+        risks: typeof data.risks === "string" ? data.risks : "",
+      },
+    },
+  };
+}
+
+export interface IProposeOptions {
+  readonly provider: IProvider;
+  readonly width: number;
+  readonly current: IHarnessOverlay;
+  /** One-line summaries of previously rejected/accepted edits across rounds. */
+  readonly priorAttempts?: readonly string[];
+  /** Candidate id prefix, e.g. "r2" → r2-c1, r2-c2… */
+  readonly idPrefix?: string;
+  /** No-silent-caps sink: dropped candidates / truncated context. */
+  readonly notes?: string[];
+}
+
+/**
+ * Generate up to `width` validated candidates. Sequential calls (the primary
+ * endpoint is single-connection); each later call sees the earlier candidates
+ * so diversity is prompted, not hoped for. A round with zero mineable
+ * patterns short-circuits to no candidates.
+ */
+export async function propose(
+  bundle: IEvidenceBundle,
+  opts: IProposeOptions
+): Promise<ICandidate[]> {
+  const notes = opts.notes ?? [];
+
+  if (bundle.patterns.length === 0) {
+    notes.push("propose: no failure patterns — nothing to target");
+
+    return [];
+  }
+
+  const candidates: ICandidate[] = [];
+
+  for (let i = 0; i < opts.width; i += 1) {
+    const id = `${opts.idPrefix ?? "r0"}-c${String(i + 1)}`;
+    let content: string;
+
+    try {
+      const res = await opts.provider.complete(
+        [
+          { role: "system", content: PROPOSER_SYSTEM },
+          {
+            role: "user",
+            content: renderContext(
+              bundle,
+              opts.current,
+              opts.priorAttempts ?? [],
+              candidates,
+              notes
+            ),
+          },
+        ],
+        // Mild temperature: K identical greedy calls would defeat the
+        // parallel-proposal diversity the paper relies on.
+        { temperature: 0.7 }
+      );
+
+      content = res.content;
+    } catch (err) {
+      notes.push(
+        `propose ${id}: call failed (${err instanceof Error ? err.message : String(err)})`
+      );
+      continue;
+    }
+
+    const { candidate, reason } = parseCandidate(content, id);
+
+    if (candidate === undefined) {
+      notes.push(`propose ${id}: dropped — ${reason ?? "invalid"}`);
+      continue;
+    }
+
+    candidates.push(candidate);
+  }
+
+  return candidates;
+}

--- a/packages/core/src/self-harness/propose.ts
+++ b/packages/core/src/self-harness/propose.ts
@@ -251,10 +251,48 @@ export async function propose(
       continue;
     }
 
-    const { candidate, reason } = parseCandidate(content, id);
+    let { candidate, reason } = parseCandidate(content, id);
+
+    // One salvage re-ask on a malformed proposal: show the model exactly why
+    // its response was unusable and demand a corrected JSON object. Wasting a
+    // full validation slot on a JSON formatting slip starves the loop of
+    // measured attempts (observed: 2 of 3 proposals dropped unparsed).
+    if (candidate === undefined) {
+      try {
+        const retry = await opts.provider.complete(
+          [
+            { role: "system", content: PROPOSER_SYSTEM },
+            {
+              role: "user",
+              content: renderContext(
+                bundle,
+                opts.current,
+                opts.priorAttempts ?? [],
+                candidates,
+                notes
+              ),
+            },
+            { role: "assistant", content },
+            {
+              role: "user",
+              content: `Your response was unusable: ${reason ?? "invalid"}. Reply again with ONLY the corrected JSON object — same schema, no prose, no code fences.`,
+            },
+          ],
+          { temperature: 0 }
+        );
+
+        ({ candidate, reason } = parseCandidate(retry.content, id));
+      } catch (err) {
+        notes.push(
+          `propose ${id}: salvage re-ask failed (${err instanceof Error ? err.message : String(err)})`
+        );
+      }
+    }
 
     if (candidate === undefined) {
-      notes.push(`propose ${id}: dropped — ${reason ?? "invalid"}`);
+      notes.push(
+        `propose ${id}: dropped after salvage re-ask — ${reason ?? "invalid"}`
+      );
       continue;
     }
 

--- a/packages/core/src/self-harness/report.ts
+++ b/packages/core/src/self-harness/report.ts
@@ -1,0 +1,111 @@
+/**
+ * The human gate: render a self-harness lineage into (a) the final overlay
+ * JSON — the PR-able artifact a human reviews and installs — and (b) a
+ * markdown evidence report making every transition auditable (paper §3.4:
+ * "changed surfaces, split-wise outcomes, proposal summary, and accept/reject
+ * decision"). This module never writes to the promoted overlay path itself.
+ */
+import { isEmptyPatch, overlayPathFor } from "./overlay";
+import type {
+  IHarnessEval,
+  ILineage,
+  IRoundRecord,
+  IValidationResult,
+} from "./self-harness.types";
+
+function passLine(label: string, evaluation: IHarnessEval): string {
+  const { heldIn, heldOut } = evaluation;
+
+  return `| ${label} | ${String(heldIn.passed)}/${String(heldIn.runs)} | ${String(heldOut.passed)}/${String(heldOut.runs)} | ${heldIn.avgQuality > 0 ? heldIn.avgQuality.toFixed(1) : "—"} | ${heldOut.avgQuality > 0 ? heldOut.avgQuality.toFixed(1) : "—"} |`;
+}
+
+function renderCandidate(result: IValidationResult): string {
+  const { candidate } = result;
+  const verdict = result.accepted ? "✅ ACCEPTED" : "❌ rejected";
+  const lines = [
+    `#### ${candidate.id} — ${verdict}`,
+    `- **targets:** \`${candidate.audit.targetPattern}\` via **${candidate.audit.surface}**`,
+    `- **expected effect:** ${candidate.audit.expectedEffect}`,
+    `- **risks:** ${candidate.audit.risks}`,
+    `- **outcome:** Δin=${String(result.deltaIn)}, Δho=${String(result.deltaOut)} — ${result.reason}`,
+    "```json",
+    JSON.stringify(candidate.patch, null, 2),
+    "```",
+  ];
+
+  return lines.join("\n");
+}
+
+function renderRound(round: IRoundRecord): string {
+  const parts = [
+    `### Round ${String(round.round)}`,
+    "",
+    "| harness | held-in pass | held-out pass | Q(in) | Q(ho) |",
+    "|---|---|---|---|---|",
+    passLine(`h_${String(round.round)}`, round.baseline),
+    "",
+    `**Mined patterns (${String(round.evidence.failedRuns)}/${String(round.evidence.totalRuns)} held-in runs failed):**`,
+    ...round.evidence.patterns.map(
+      (p) =>
+        `- \`${p.signature}\` ×${String(p.support)} (${p.taskIds.join(", ")}) — ${p.mechanism}`
+    ),
+    "",
+  ];
+
+  if (round.candidates.length === 0) {
+    parts.push("_No candidates this round._");
+  } else {
+    parts.push(...round.candidates.map(renderCandidate));
+  }
+
+  return parts.join("\n");
+}
+
+export interface IReport {
+  /** The final overlay as JSON — the artifact a human reviews and installs. */
+  readonly overlayJson: string;
+  readonly markdown: string;
+}
+
+export function emitReport(lineage: ILineage): IReport {
+  const overlayJson = `${JSON.stringify(lineage.finalOverlay, null, 2)}\n`;
+  const acceptedTotal = lineage.rounds.reduce(
+    (acc, r) => acc + r.acceptedIds.length,
+    0
+  );
+  const rejectedTotal = lineage.rounds.reduce(
+    (acc, r) => acc + (r.candidates.length - r.acceptedIds.length),
+    0
+  );
+  const installPath = overlayPathFor(lineage.model);
+
+  const md = [
+    `# Self-Harness report — ${lineage.model}`,
+    "",
+    `Held-in: ${lineage.splits.heldIn.join(", ")}`,
+    `Held-out: ${lineage.splits.heldOut.join(", ")} _(never shown to the proposer)_`,
+    "",
+    `Rounds: ${String(lineage.rounds.length)} · accepted: ${String(acceptedTotal)} · rejected: ${String(rejectedTotal)}`,
+    "",
+    ...lineage.rounds.map(renderRound),
+    "",
+    "## Final overlay",
+    "",
+    isEmptyPatch(lineage.finalOverlay)
+      ? "_Empty — no edit survived validation. The base harness stands._"
+      : [
+          "```json",
+          overlayJson.trimEnd(),
+          "```",
+          "",
+          `**To install (human decision):** review the overlay above, then write it to \`${installPath}\`. Remove that file to revert to the base harness.`,
+        ].join("\n"),
+    "",
+    ...(lineage.notes.length > 0
+      ? ["## Notes (dropped/skipped/truncated — nothing is silent)", "", ...lineage.notes.map((n) => `- ${n}`)]
+      : []),
+    "",
+  ].join("\n");
+
+  return { overlayJson, markdown: md };
+}

--- a/packages/core/src/self-harness/report.ts
+++ b/packages/core/src/self-harness/report.ts
@@ -102,7 +102,11 @@ export function emitReport(lineage: ILineage): IReport {
         ].join("\n"),
     "",
     ...(lineage.notes.length > 0
-      ? ["## Notes (dropped/skipped/truncated — nothing is silent)", "", ...lineage.notes.map((n) => `- ${n}`)]
+      ? [
+          "## Notes (dropped/skipped/truncated — nothing is silent)",
+          "",
+          ...lineage.notes.map((n) => `- ${n}`),
+        ]
       : []),
     "",
   ].join("\n");

--- a/packages/core/src/self-harness/report.ts
+++ b/packages/core/src/self-harness/report.ts
@@ -44,7 +44,7 @@ function renderRound(round: IRoundRecord): string {
     "|---|---|---|---|---|",
     passLine(`h_${String(round.round)}`, round.baseline),
     "",
-    `**Mined patterns (${String(round.evidence.failedRuns)}/${String(round.evidence.totalRuns)} held-in runs failed):**`,
+    `**Mined patterns (${String(round.evidence.failedRuns)}/${String(round.evidence.totalRuns)} held-in runs failed${round.evidence.slowGreenRuns > 0 ? `, ${String(round.evidence.slowGreenRuns)} slow-green` : ""}):**`,
     ...round.evidence.patterns.map(
       (p) =>
         `- \`${p.signature}\` ×${String(p.support)} (${p.taskIds.join(", ")}) — ${p.mechanism}`

--- a/packages/core/src/self-harness/self-harness.types.ts
+++ b/packages/core/src/self-harness/self-harness.types.ts
@@ -1,0 +1,162 @@
+/**
+ * Shared types for the Self-Harness loop (arXiv 2606.09498): a fixed model
+ * improves the declarative harness around itself via a regression-gated
+ * hill-climb — evaluate → mine weaknesses → propose minimal edits → validate
+ * with a non-regression acceptance rule → merge into a per-model overlay.
+ */
+import type { ITtsrRule } from "../loop/ttsr";
+import type { IVariantSummary } from "../eval/eval.types";
+
+/** The named, editable system-prompt anchor points. `bootstrap` = the
+ *  lead-with-action instruction, `execution` = the gate-feedback loop
+ *  instruction, `verification` = the run-your-hypotheses instruction, and
+ *  `extra` = a free slot appended after all built-in blocks (starts empty, so
+ *  it is effectively append-only). Everything else in the system prompt —
+ *  identity, tool list, gate-rules sentence — is deliberately NOT editable:
+ *  the proposer must not be able to redescribe the verifier. */
+export const PROMPT_BLOCK_NAMES = [
+  "bootstrap",
+  "execution",
+  "verification",
+  "extra",
+] as const;
+
+export type PromptBlockName = (typeof PROMPT_BLOCK_NAMES)[number];
+
+/** One edit to a named prompt block: append below it or replace it. */
+export interface IPromptBlockEdit {
+  readonly mode: "append" | "replace";
+  readonly text: string;
+}
+
+/** A bounded override of one agent spec — prompt/task/turn-budget only.
+ *  `tools` and `model` are deliberately not overridable: an edit must not be
+ *  able to grant a subagent new capabilities or reroute it to another model. */
+export interface IAgentSpecOverride {
+  readonly id: string;
+  readonly systemPrompt?: string;
+  readonly task?: string;
+  readonly maxTurns?: number;
+}
+
+/** A procedure-card override for one gate rule id — merged over the curated /
+ *  generated doc at `ruleHelp()` time, field-wise. */
+export interface IProcedureCardEdit {
+  readonly what?: string;
+  readonly bad?: string;
+  readonly good?: string;
+  readonly procedure?: string;
+}
+
+/**
+ * The per-model harness overlay: h_t = base harness + overlay. Every field is
+ * declarative data, so applying an edit is a JSON merge and reverting is
+ * dropping it. There is intentionally NO gate-strictness field — the verifier
+ * is not a proposable surface (reward-hacking guard).
+ */
+export interface IHarnessOverlay {
+  readonly version: 1;
+  /** Extra TTSR rules (JSON shape: string regex sources). */
+  readonly ttsrRules: readonly ITtsrRule[];
+  readonly agentSpecOverrides: readonly IAgentSpecOverride[];
+  readonly promptBlocks: Partial<Record<PromptBlockName, IPromptBlockEdit>>;
+  /** Keyed by the exact rule id the validators emit (e.g. "TS2307"). */
+  readonly procedureCards: Record<string, IProcedureCardEdit>;
+}
+
+/** A candidate edit Δj: a partial overlay to merge onto h_t. */
+export type IOverlayPatch = Partial<Omit<IHarnessOverlay, "version">>;
+
+/** One verifier-grounded failure pattern C_φ mined from held-in traces. */
+export interface IFailurePattern {
+  /** Exact-agreement clustering key: `failureClass|dominantSignal|detail`. */
+  readonly signature: string;
+  readonly failureClass: string;
+  /** The dominant IFailureSignals key (e.g. "editRejects", "tsErrors"). */
+  readonly dominantSignal: string;
+  /** Dominant rule code when the gate failed (e.g. "TS2307", "no-as"). */
+  readonly detail?: string;
+  /** Cluster size — how many failed runs share this signature. */
+  readonly support: number;
+  readonly taskIds: readonly string[];
+  /** Gate rule ids / verifier outcomes backing the cluster. */
+  readonly verifierEvidence: readonly string[];
+  /** Short representative event lines from the ledger. */
+  readonly traceSnippets: readonly string[];
+  /** Deterministic one-line description of the agent-side mechanism. */
+  readonly mechanism: string;
+}
+
+/** The evidence bundle B_t handed to the proposer. */
+export interface IEvidenceBundle {
+  readonly totalRuns: number;
+  readonly failedRuns: number;
+  /** Ranked by support, descending. */
+  readonly patterns: readonly IFailurePattern[];
+}
+
+/** Audit record a_j accompanying each candidate edit. */
+export interface ICandidateAudit {
+  readonly targetPattern: string;
+  readonly surface: string;
+  readonly expectedEffect: string;
+  readonly risks: string;
+}
+
+export interface ICandidate {
+  readonly id: string;
+  readonly patch: IOverlayPatch;
+  readonly audit: ICandidateAudit;
+}
+
+/** Held-in / held-out task-id splits. Held-out is never shown to the proposer. */
+export interface ISplits {
+  readonly heldIn: readonly string[];
+  readonly heldOut: readonly string[];
+}
+
+/** Aggregate score of one harness variant on one split. */
+export interface ISplitScore {
+  /** Total passed runs across all tasks × repeats. */
+  readonly passed: number;
+  readonly runs: number;
+  /** Mean of per-task avgQuality over tasks that recorded one (0 if none). */
+  readonly avgQuality: number;
+  /** Mean of per-task avgLoc over tasks that recorded one (0 if none). */
+  readonly avgLoc: number;
+  readonly perTask: Record<string, IVariantSummary>;
+}
+
+export interface IHarnessEval {
+  readonly heldIn: ISplitScore;
+  readonly heldOut: ISplitScore;
+}
+
+/** Outcome of validating one candidate against the acceptance rule. */
+export interface IValidationResult {
+  readonly candidate: ICandidate;
+  readonly accepted: boolean;
+  readonly reason: string;
+  readonly deltaIn: number;
+  readonly deltaOut: number;
+  readonly candidateEval?: IHarnessEval;
+}
+
+/** One round t of the loop, fully auditable. */
+export interface IRoundRecord {
+  readonly round: number;
+  readonly baseline: IHarnessEval;
+  readonly evidence: IEvidenceBundle;
+  readonly candidates: readonly IValidationResult[];
+  readonly acceptedIds: readonly string[];
+}
+
+/** The full harness lineage h_0 → h_T produced by one self-harness run. */
+export interface ILineage {
+  readonly model: string;
+  readonly splits: ISplits;
+  readonly rounds: readonly IRoundRecord[];
+  readonly finalOverlay: IHarnessOverlay;
+  /** No-silent-caps log: every dropped candidate / skipped task / truncation. */
+  readonly notes: readonly string[];
+}

--- a/packages/core/src/self-harness/self-harness.types.ts
+++ b/packages/core/src/self-harness/self-harness.types.ts
@@ -120,6 +120,11 @@ export interface ISplitScore {
   /** Total passed runs across all tasks × repeats. */
   readonly passed: number;
   readonly runs: number;
+  /** Runs that crashed before producing a valid result (endpoint timeout /
+   *  connection failure) — counted as not-passed but flagged so a verdict is
+   *  never blamed on the edit when the infrastructure failed (paper §3.4:
+   *  "fail execution before a valid evaluation result"). */
+  readonly errored: number;
   /** Mean of per-task avgQuality over tasks that recorded one (0 if none). */
   readonly avgQuality: number;
   /** Mean of per-task avgLoc over tasks that recorded one (0 if none). */

--- a/packages/core/src/self-harness/self-harness.types.ts
+++ b/packages/core/src/self-harness/self-harness.types.ts
@@ -91,6 +91,9 @@ export interface IFailurePattern {
 export interface IEvidenceBundle {
   readonly totalRuns: number;
   readonly failedRuns: number;
+  /** Passed runs that crossed their slow-green threshold — green, but at a
+   *  cycle cost worth improving (the efficiency signal the pass bit hides). */
+  readonly slowGreenRuns: number;
   /** Ranked by support, descending. */
   readonly patterns: readonly IFailurePattern[];
 }

--- a/packages/core/src/self-harness/split.ts
+++ b/packages/core/src/self-harness/split.ts
@@ -64,7 +64,9 @@ export async function resolveSplits(
   heldOut?: readonly string[]
 ): Promise<ISplits> {
   const available = new Set(await listCorpusTasks(corpusDir));
-  const inIds = [...(heldIn ?? DEFAULT_HELD_IN.filter((t) => available.has(t)))];
+  const inIds = [
+    ...(heldIn ?? DEFAULT_HELD_IN.filter((t) => available.has(t))),
+  ];
   const outIds = [
     ...(heldOut ?? DEFAULT_HELD_OUT.filter((t) => available.has(t))),
   ];

--- a/packages/core/src/self-harness/split.ts
+++ b/packages/core/src/self-harness/split.ts
@@ -1,0 +1,93 @@
+/**
+ * Held-in / held-out task splits over `evals/corpus/*`. The held-in split
+ * supplies failure evidence to the proposer; the held-out split is NEVER shown
+ * to it and gates every promotion (the paper's overfitting guard). Assignment
+ * is fixed and deterministic — never derived from run outcomes.
+ */
+import { readdir } from "node:fs/promises";
+import { join } from "node:path";
+import type { ISplits } from "./self-harness.types";
+
+/** Fixed default assignment over the 12 corpus tasks. Held-out mixes a
+ *  multi-file greenfield task (auth), the only brownfield task
+ *  (fix-regression), and two single-module tasks — so a promoted edit must
+ *  generalize across task shapes it never saw evidence from. */
+export const DEFAULT_HELD_IN = [
+  "checkout",
+  "debounce",
+  "fixtures",
+  "handlers",
+  "math",
+  "migrate",
+  "slugify",
+  "validators",
+] as const;
+
+export const DEFAULT_HELD_OUT = [
+  "auth",
+  "fix-regression",
+  "query",
+  "rate-limit",
+] as const;
+
+/** All corpus task ids (directories containing `<id>.spec.md`). */
+export async function listCorpusTasks(corpusDir: string): Promise<string[]> {
+  const entries = await readdir(corpusDir, { withFileTypes: true });
+  const ids: string[] = [];
+
+  for (const entry of entries) {
+    if (!entry.isDirectory()) {
+      continue;
+    }
+
+    if (
+      await Bun.file(
+        join(corpusDir, entry.name, `${entry.name}.spec.md`)
+      ).exists()
+    ) {
+      ids.push(entry.name);
+    }
+  }
+
+  return ids.sort((a, b) => a.localeCompare(b));
+}
+
+/**
+ * Resolve the splits: explicit lists win (validated against the corpus),
+ * otherwise the fixed defaults filtered to tasks that exist. Throws on an
+ * unknown task id, an overlapping assignment, or an empty split — a silent
+ * misassignment would invalidate every acceptance decision downstream.
+ */
+export async function resolveSplits(
+  corpusDir: string,
+  heldIn?: readonly string[],
+  heldOut?: readonly string[]
+): Promise<ISplits> {
+  const available = new Set(await listCorpusTasks(corpusDir));
+  const inIds = [...(heldIn ?? DEFAULT_HELD_IN.filter((t) => available.has(t)))];
+  const outIds = [
+    ...(heldOut ?? DEFAULT_HELD_OUT.filter((t) => available.has(t))),
+  ];
+
+  for (const id of [...inIds, ...outIds]) {
+    if (!available.has(id)) {
+      throw new Error(
+        `unknown corpus task "${id}" — available: ${[...available].join(", ")}`
+      );
+    }
+  }
+
+  const overlap = inIds.filter((id) => outIds.includes(id));
+
+  if (overlap.length > 0) {
+    throw new Error(
+      `task(s) in BOTH splits: ${overlap.join(", ")} — splits must be disjoint`
+    );
+  }
+
+  if (inIds.length === 0 || outIds.length === 0) {
+    throw new Error("both splits must be non-empty");
+  }
+
+  return { heldIn: inIds, heldOut: outIds };
+}

--- a/packages/core/src/self-harness/split.ts
+++ b/packages/core/src/self-harness/split.ts
@@ -53,17 +53,24 @@ export async function listCorpusTasks(corpusDir: string): Promise<string[]> {
 }
 
 /**
- * Resolve the splits: explicit lists win (validated against the corpus),
- * otherwise the fixed defaults filtered to tasks that exist. Throws on an
- * unknown task id, an overlapping assignment, or an empty split — a silent
- * misassignment would invalidate every acceptance decision downstream.
+ * Resolve the splits: explicit lists win (validated against the corpus and,
+ * for `web:<slug>` ids, against the provided catalog slugs), otherwise the
+ * fixed defaults filtered to tasks that exist. Throws on an unknown task id,
+ * an overlapping assignment, or an empty split — a silent misassignment would
+ * invalidate every acceptance decision downstream.
+ *
+ * `webSlugs` is injected by the CLI (which may import the benchmark catalog);
+ * src/ deliberately never imports from scripts/. No slugs provided = no
+ * `web:` tasks allowed.
  */
 export async function resolveSplits(
   corpusDir: string,
   heldIn?: readonly string[],
-  heldOut?: readonly string[]
+  heldOut?: readonly string[],
+  webSlugs?: readonly string[]
 ): Promise<ISplits> {
   const available = new Set(await listCorpusTasks(corpusDir));
+  const webAvailable = new Set((webSlugs ?? []).map((s) => `web:${s}`));
   const inIds = [
     ...(heldIn ?? DEFAULT_HELD_IN.filter((t) => available.has(t))),
   ];
@@ -72,6 +79,18 @@ export async function resolveSplits(
   ];
 
   for (const id of [...inIds, ...outIds]) {
+    if (id.startsWith("web:")) {
+      if (!webAvailable.has(id)) {
+        const listed = [...webAvailable].join(", ");
+
+        throw new Error(
+          `unknown web task "${id}" — available: ${listed.length > 0 ? listed : "(none — pass catalog slugs)"}`
+        );
+      }
+
+      continue;
+    }
+
     if (!available.has(id)) {
       throw new Error(
         `unknown corpus task "${id}" — available: ${[...available].join(", ")}`

--- a/packages/core/src/self-harness/validate.ts
+++ b/packages/core/src/self-harness/validate.ts
@@ -1,0 +1,149 @@
+/**
+ * Proposal Validation (paper §3.4): a candidate edit is promoted ONLY if it
+ * improves at least one split without degrading the other:
+ *
+ *   Δin ≥ 0  ∧  Δho ≥ 0  ∧  max(Δin, Δho) > 0     (on pass counts)
+ *
+ * plus two held-out quality guards the paper's pass-count rule can't see
+ * (tsforge's gate is code-quality-blind past green): an edit must not buy
+ * pass-rate with materially worse judged quality or materially more code.
+ */
+import { isEmptyPatch, mergeOverlay } from "./overlay";
+import type { IMinedRun } from "./mine";
+import type {
+  ICandidate,
+  IHarnessEval,
+  IHarnessOverlay,
+  ISplits,
+  IValidationResult,
+} from "./self-harness.types";
+
+/** Judge scores are 1–5 and noisy; only a drop beyond this is a regression. */
+const QUALITY_TOLERANCE = 0.5;
+/** Held-out solutions may grow at most this factor before the edit reads as
+ *  buying passes with slop. */
+const LOC_TOLERANCE_FACTOR = 1.25;
+
+/** What one full evaluation of a harness variant yields: the per-split score
+ *  plus the held-in run traces (the mining substrate). Injectable so the loop
+ *  is testable without a live model. */
+export interface IEvaluationOutput {
+  readonly evaluation: IHarnessEval;
+  readonly heldInRuns: readonly IMinedRun[];
+}
+
+export type HarnessEvaluator = (
+  overlay: IHarnessOverlay | null,
+  splits: ISplits,
+  label: string
+) => Promise<IEvaluationOutput>;
+
+export interface IAcceptanceDecision {
+  readonly accepted: boolean;
+  readonly reason: string;
+  readonly deltaIn: number;
+  readonly deltaOut: number;
+}
+
+/** The pure acceptance rule over a baseline and a candidate evaluation. */
+export function acceptanceDecision(
+  baseline: IHarnessEval,
+  candidate: IHarnessEval
+): IAcceptanceDecision {
+  const deltaIn = candidate.heldIn.passed - baseline.heldIn.passed;
+  const deltaOut = candidate.heldOut.passed - baseline.heldOut.passed;
+
+  if (deltaIn < 0 || deltaOut < 0) {
+    return {
+      accepted: false,
+      deltaIn,
+      deltaOut,
+      reason: `regresses ${deltaIn < 0 ? "held-in" : "held-out"} pass count (Δin=${String(deltaIn)}, Δho=${String(deltaOut)})`,
+    };
+  }
+
+  if (deltaIn === 0 && deltaOut === 0) {
+    return {
+      accepted: false,
+      deltaIn,
+      deltaOut,
+      reason: "no strict gain on either split (Δin=0, Δho=0)",
+    };
+  }
+
+  // Quality guard: only when BOTH sides carry a judge signal.
+  const bq = baseline.heldOut.avgQuality;
+  const cq = candidate.heldOut.avgQuality;
+
+  if (bq > 0 && cq > 0 && cq < bq - QUALITY_TOLERANCE) {
+    return {
+      accepted: false,
+      deltaIn,
+      deltaOut,
+      reason: `held-out quality regressed (${cq.toFixed(1)} < ${bq.toFixed(1)} − ${String(QUALITY_TOLERANCE)})`,
+    };
+  }
+
+  // Concision guard: only when BOTH sides measured green solutions.
+  const bl = baseline.heldOut.avgLoc;
+  const cl = candidate.heldOut.avgLoc;
+
+  if (bl > 0 && cl > 0 && cl > bl * LOC_TOLERANCE_FACTOR) {
+    return {
+      accepted: false,
+      deltaIn,
+      deltaOut,
+      reason: `held-out solutions grew past the concision guard (${cl.toFixed(0)} loc > ${bl.toFixed(0)} × ${String(LOC_TOLERANCE_FACTOR)})`,
+    };
+  }
+
+  return {
+    accepted: true,
+    deltaIn,
+    deltaOut,
+    reason: `non-regressive with strict gain (Δin=${String(deltaIn)}, Δho=${String(deltaOut)})`,
+  };
+}
+
+/**
+ * Validate one candidate: apply its patch to the current overlay, evaluate the
+ * resulting harness on both splits, and apply the acceptance rule. A candidate
+ * that edits nothing or whose evaluation errors out is rejected — never
+ * promoted on a missing result.
+ */
+export async function validateCandidate(
+  candidate: ICandidate,
+  current: IHarnessOverlay,
+  baseline: IHarnessEval,
+  splits: ISplits,
+  evaluator: HarnessEvaluator
+): Promise<IValidationResult> {
+  if (isEmptyPatch(candidate.patch)) {
+    return {
+      candidate,
+      accepted: false,
+      reason: "patch modifies no editable surface",
+      deltaIn: 0,
+      deltaOut: 0,
+    };
+  }
+
+  const merged = mergeOverlay(current, candidate.patch);
+  let output: IEvaluationOutput;
+
+  try {
+    output = await evaluator(merged, splits, candidate.id);
+  } catch (err) {
+    return {
+      candidate,
+      accepted: false,
+      reason: `evaluation errored before a valid result (${err instanceof Error ? err.message : String(err)})`,
+      deltaIn: 0,
+      deltaOut: 0,
+    };
+  }
+
+  const decision = acceptanceDecision(baseline, output.evaluation);
+
+  return { candidate, ...decision, candidateEval: output.evaluation };
+}

--- a/packages/core/src/self-harness/validate.ts
+++ b/packages/core/src/self-harness/validate.ts
@@ -14,6 +14,7 @@ import type {
   ICandidate,
   IHarnessEval,
   IHarnessOverlay,
+  ISplitScore,
   ISplits,
   IValidationResult,
 } from "./self-harness.types";
@@ -23,6 +24,13 @@ const QUALITY_TOLERANCE = 0.5;
 /** Held-out solutions may grow at most this factor before the edit reads as
  *  buying passes with slop. */
 const LOC_TOLERANCE_FACTOR = 1.25;
+/** Efficiency tie-break (pass counts identical on BOTH splits): held-in
+ *  commonly-green cycles must improve by at least this fraction AND this many
+ *  absolute cycles (noise floor at repeats=1)… */
+const EFFICIENCY_MIN_REL = 0.2;
+const EFFICIENCY_MIN_ABS = 2;
+/** …while held-out commonly-green cycles may grow at most this fraction. */
+const EFFICIENCY_HO_TOLERANCE = 0.1;
 
 /** What one full evaluation of a harness variant yields: the per-split score
  *  plus the held-in run traces (the mining substrate). Injectable so the loop
@@ -45,32 +53,41 @@ export interface IAcceptanceDecision {
   readonly deltaOut: number;
 }
 
-/** The pure acceptance rule over a baseline and a candidate evaluation. */
-export function acceptanceDecision(
+/** Summed avgTurnsToGreen over tasks green in BOTH evaluations of one split —
+ *  the only apples-to-apples efficiency comparison (a task green on one side
+ *  only would smuggle a pass delta into a cycle delta). */
+function commonGreenCycles(
+  base: ISplitScore,
+  cand: ISplitScore
+): { base: number; cand: number; tasks: number } {
+  let baseSum = 0;
+  let candSum = 0;
+  let tasks = 0;
+
+  for (const [task, summary] of Object.entries(base.perTask)) {
+    const candTurns = cand.perTask[task]?.avgTurnsToGreen;
+
+    if (
+      summary.avgTurnsToGreen !== null &&
+      candTurns !== null &&
+      candTurns !== undefined
+    ) {
+      baseSum += summary.avgTurnsToGreen;
+      candSum += candTurns;
+      tasks += 1;
+    }
+  }
+
+  return { base: baseSum, cand: candSum, tasks };
+}
+
+/** Held-out quality + concision guards; null = no objection. */
+function heldOutGuards(
   baseline: IHarnessEval,
-  candidate: IHarnessEval
-): IAcceptanceDecision {
-  const deltaIn = candidate.heldIn.passed - baseline.heldIn.passed;
-  const deltaOut = candidate.heldOut.passed - baseline.heldOut.passed;
-
-  if (deltaIn < 0 || deltaOut < 0) {
-    return {
-      accepted: false,
-      deltaIn,
-      deltaOut,
-      reason: `regresses ${deltaIn < 0 ? "held-in" : "held-out"} pass count (Δin=${String(deltaIn)}, Δho=${String(deltaOut)})`,
-    };
-  }
-
-  if (deltaIn === 0 && deltaOut === 0) {
-    return {
-      accepted: false,
-      deltaIn,
-      deltaOut,
-      reason: "no strict gain on either split (Δin=0, Δho=0)",
-    };
-  }
-
+  candidate: IHarnessEval,
+  deltaIn: number,
+  deltaOut: number
+): IAcceptanceDecision | null {
   // Quality guard: only when BOTH sides carry a judge signal.
   const bq = baseline.heldOut.avgQuality;
   const cq = candidate.heldOut.avgQuality;
@@ -95,6 +112,90 @@ export function acceptanceDecision(
       deltaOut,
       reason: `held-out solutions grew past the concision guard (${cl.toFixed(0)} loc > ${bl.toFixed(0)} × ${String(LOC_TOLERANCE_FACTOR)})`,
     };
+  }
+
+  return null;
+}
+
+/** The efficiency tie-break, reached ONLY at Δin=0 ∧ Δho=0: equal pass counts
+ *  may still promote an edit that makes the harness materially FASTER to green
+ *  — the signal the paper's pass-only metric can't see. Pass regression never
+ *  reaches here; nothing about the pass rule is loosened. */
+function efficiencyDecision(
+  baseline: IHarnessEval,
+  candidate: IHarnessEval,
+  guard: IAcceptanceDecision | null
+): IAcceptanceDecision {
+  const heldIn = commonGreenCycles(baseline.heldIn, candidate.heldIn);
+  const heldOut = commonGreenCycles(baseline.heldOut, candidate.heldOut);
+  const gain = heldIn.base - heldIn.cand;
+  const material =
+    heldIn.tasks > 0 &&
+    heldIn.base > 0 &&
+    gain >= EFFICIENCY_MIN_ABS &&
+    gain / heldIn.base >= EFFICIENCY_MIN_REL;
+
+  if (!material) {
+    return {
+      accepted: false,
+      deltaIn: 0,
+      deltaOut: 0,
+      reason:
+        "no strict gain on either split (Δin=0, Δho=0) and no material efficiency gain",
+    };
+  }
+
+  if (
+    heldOut.tasks > 0 &&
+    heldOut.cand > heldOut.base * (1 + EFFICIENCY_HO_TOLERANCE)
+  ) {
+    return {
+      accepted: false,
+      deltaIn: 0,
+      deltaOut: 0,
+      reason: `held-out efficiency regressed (${heldOut.cand.toFixed(1)} > ${heldOut.base.toFixed(1)} cycles × ${String(1 + EFFICIENCY_HO_TOLERANCE)})`,
+    };
+  }
+
+  if (guard !== null) {
+    return guard;
+  }
+
+  const rel = Math.round((gain / heldIn.base) * 100);
+
+  return {
+    accepted: true,
+    deltaIn: 0,
+    deltaOut: 0,
+    reason: `efficiency gain: held-in ${heldIn.base.toFixed(1)}→${heldIn.cand.toFixed(1)} cycles (−${String(rel)}%), held-out ${heldOut.base.toFixed(1)}→${heldOut.cand.toFixed(1)}`,
+  };
+}
+
+/** The pure acceptance rule over a baseline and a candidate evaluation. */
+export function acceptanceDecision(
+  baseline: IHarnessEval,
+  candidate: IHarnessEval
+): IAcceptanceDecision {
+  const deltaIn = candidate.heldIn.passed - baseline.heldIn.passed;
+  const deltaOut = candidate.heldOut.passed - baseline.heldOut.passed;
+
+  if (deltaIn < 0 || deltaOut < 0) {
+    return {
+      accepted: false,
+      deltaIn,
+      deltaOut,
+      reason: `regresses ${deltaIn < 0 ? "held-in" : "held-out"} pass count (Δin=${String(deltaIn)}, Δho=${String(deltaOut)})`,
+    };
+  }
+
+  const guard = heldOutGuards(baseline, candidate, deltaIn, deltaOut);
+
+  if (deltaIn === 0 && deltaOut === 0) {
+    return efficiencyDecision(baseline, candidate, guard);
+  }
+
+  if (guard !== null) {
+    return guard;
   }
 
   return {

--- a/packages/core/src/self-harness/validate.ts
+++ b/packages/core/src/self-harness/validate.ts
@@ -143,6 +143,23 @@ export async function validateCandidate(
     };
   }
 
+  // Runs that crashed on infrastructure (endpoint timeout/unreachable) make
+  // the deltas meaningless — reject on the honest ground that no valid result
+  // was obtained, never as a phantom "regression" blamed on the edit.
+  const erroredRuns =
+    output.evaluation.heldIn.errored + output.evaluation.heldOut.errored;
+
+  if (erroredRuns > 0) {
+    return {
+      candidate,
+      accepted: false,
+      reason: `no valid evaluation result — ${String(erroredRuns)} run(s) hit infrastructure errors (endpoint timeout/unreachable)`,
+      deltaIn: 0,
+      deltaOut: 0,
+      candidateEval: output.evaluation,
+    };
+  }
+
   const decision = acceptanceDecision(baseline, output.evaluation);
 
   return { candidate, ...decision, candidateEval: output.evaluation };

--- a/packages/core/tests/boringstack-conventions.test.ts
+++ b/packages/core/tests/boringstack-conventions.test.ts
@@ -1,0 +1,164 @@
+import { test, expect, describe } from "bun:test";
+import { tmpdir } from "node:os";
+import {
+  conventionGuide,
+  conventionTopics,
+  topicForRule,
+  unseenGuidesForErrors,
+} from "../src/loop/conventions";
+import { injectFeedback, type ILoopCtx } from "../src/loop/turn";
+import type { ILoopState, ILoopEvent } from "../src/loop";
+import type { IErrorItem } from "../src/validate";
+
+describe("convention registry", () => {
+  test("every topic has a non-empty guide", () => {
+    for (const topic of conventionTopics()) {
+      expect(conventionGuide(topic).length).toBeGreaterThan(40);
+    }
+  });
+
+  test("the no-casts guide teaches a type guard, never a cast", () => {
+    const g = conventionGuide("no-casts");
+
+    expect(g).toContain("TYPE GUARD");
+    expect(g).toContain("v is St");
+  });
+
+  test("component-anatomy points views to src/views, not src/features", () => {
+    const g = conventionGuide("component-anatomy");
+
+    expect(g).toContain("src/views/");
+    expect(g).toContain("NEVER place a component under `src/features/`");
+  });
+});
+
+describe("topicForRule", () => {
+  test("maps enforced rule ids (bare and plugin-prefixed) to their topic", () => {
+    expect(topicForRule("component-file-purity")).toBe("file-layout");
+    expect(topicForRule("tsforge/no-jsx-computation")).toBe("jsx");
+    expect(topicForRule("no-restricted-syntax")).toBe("no-casts");
+    expect(topicForRule("component-folder-structure")).toBe(
+      "component-anatomy"
+    );
+  });
+
+  test("an unknown rule maps to nothing", () => {
+    expect(topicForRule("some-random-rule")).toBeNull();
+  });
+});
+
+describe("unseenGuidesForErrors (the PUSH dedup)", () => {
+  test("returns the guide the FIRST time a rule is hit, then never again", () => {
+    const seen = new Set<string>();
+    const errors = [{ rule: "tsforge/component-file-purity" }];
+
+    const first = unseenGuidesForErrors(errors, seen);
+
+    expect(first).toHaveLength(1);
+    expect(first[0]).toContain("FILE PURITY");
+
+    // Same rule next cycle → already pushed → nothing (no wall of repeats).
+    expect(unseenGuidesForErrors(errors, seen)).toHaveLength(0);
+  });
+
+  test("one guide per TOPIC even across many errors of that topic", () => {
+    const seen = new Set<string>();
+    const errors = [
+      { rule: "component-folder-structure" },
+      { rule: "one-component-per-file" }, // same topic (component-anatomy)
+      { rule: "no-restricted-syntax" }, // different topic (no-casts)
+    ];
+
+    const guides = unseenGuidesForErrors(errors, seen);
+
+    expect(guides).toHaveLength(2); // component-anatomy + no-casts, not 3
+  });
+
+  test("errors with no rule, or unknown rules, contribute nothing", () => {
+    const seen = new Set<string>();
+
+    expect(
+      unseenGuidesForErrors([{ rule: undefined }, { rule: "unknown" }], seen)
+    ).toEqual([]);
+  });
+});
+
+describe("convention PUSH delivery (the guide actually reaches the model + is observable)", () => {
+  function makeCtx(events: ILoopEvent[]): ILoopCtx {
+    return {
+      task: {
+        id: "t",
+        intent: "build",
+        accept: "true",
+        files: [],
+        context: [],
+      },
+      cwd: tmpdir(),
+      tsService: null,
+      report: (e) => {
+        events.push(e);
+      },
+      messages: [],
+      tool: {},
+      gate: { parse: undefined },
+    };
+  }
+
+  function freshState(): ILoopState {
+    return {
+      prevGateErrors: [],
+      gateNoProgress: 0,
+      bestErrorCount: Number.POSITIVE_INFINITY,
+      noNewLow: 0,
+      errorAge: new Map(),
+      lastGateCount: -1,
+      edits: 0,
+      regressions: 0,
+      ttsrInterrupts: 0,
+      steerLevel: 0,
+    };
+  }
+
+  const asCastError: IErrorItem = {
+    key: "src/x.tsx:1:no-restricted-syntax",
+    file: "src/x.tsx",
+    rule: "no-restricted-syntax", // → no-casts guide
+    message: "L1: No `as` type casts (no-restricted-syntax)",
+  };
+
+  test("a gate error maps to a guide that lands in the message SENT to the model", async () => {
+    const events: ILoopEvent[] = [];
+    const ctx = makeCtx(events);
+    const state = freshState();
+
+    await injectFeedback(ctx, state, [asCastError], [], []);
+
+    // The guide is in the actual user message the model will receive next.
+    const sent = ctx.messages.at(-1)?.content ?? "";
+
+    expect(sent).toContain("HOW TO WRITE THIS RIGHT (boringstack)");
+    expect(sent).toContain("TYPE GUARD"); // the no-casts guide's teaching
+    // …and the push is OBSERVABLE (was silent — you couldn't tell it fired).
+    expect(
+      events.some((e) => e.kind === "tool" && e.message.includes("📐 pushed"))
+    ).toBe(true);
+  });
+
+  test("the same topic is pushed only ONCE per run (deduped, not a wall)", async () => {
+    const events: ILoopEvent[] = [];
+    const ctx = makeCtx(events);
+    const state = freshState();
+
+    await injectFeedback(ctx, state, [asCastError], [], []);
+    await injectFeedback(ctx, state, [asCastError], [], []);
+
+    const pushes = events.filter(
+      (e) => e.kind === "tool" && e.message.includes("📐 pushed")
+    );
+
+    expect(pushes).toHaveLength(1); // second cycle: already taught, no re-push
+    expect(ctx.messages.at(-1)?.content ?? "").not.toContain(
+      "HOW TO WRITE THIS RIGHT"
+    );
+  });
+});

--- a/packages/core/tests/execute-tool.test.ts
+++ b/packages/core/tests/execute-tool.test.ts
@@ -46,24 +46,52 @@ test("scratch/ files are writable even when not in scope — for experiments", a
   }
 });
 
-test("rejects an oversized edit — forces surgical changes, not whole-function rewrites", async () => {
+test("rejects an oversized REWRITE — big span replaced by ANOTHER big span", async () => {
   const dir = await mkdtemp(join(tmpdir(), "tsforge-exec-"));
 
   try {
     const big = Array.from({ length: 60 }, (_, i) => `line${i}`).join("\n");
+    const bigNew = Array.from({ length: 60 }, (_, i) => `new${i}`).join("\n");
 
     await Bun.write(join(dir, "impl.ts"), big);
 
     const r = await executeTool(
       {
         name: "edit",
-        arguments: { file: "impl.ts", oldString: big, newString: "tiny" },
+        // big → big = a lazy whole-function rewrite → still rejected.
+        arguments: { file: "impl.ts", oldString: big, newString: bigNew },
       },
       ctx(dir, ["impl.ts"])
     );
 
-    expect(r).toContain("too large");
+    expect(r).toContain("rewrites a large span");
     expect(await Bun.file(join(dir, "impl.ts")).text()).toBe(big); // unchanged
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test("ALLOWS deleting a large broken span (big old → empty new) — the cleanup escape", async () => {
+  const dir = await mkdtemp(join(tmpdir(), "tsforge-exec-"));
+
+  try {
+    // The exact trap from the live run: 60 orphaned lines the model must DELETE.
+    const orphaned = Array.from({ length: 60 }, (_, i) => `orphan${i}`).join(
+      "\n"
+    );
+
+    await Bun.write(join(dir, "impl.ts"), orphaned);
+
+    const r = await executeTool(
+      {
+        name: "edit",
+        arguments: { file: "impl.ts", oldString: orphaned, newString: "" },
+      },
+      ctx(dir, ["impl.ts"])
+    );
+
+    expect(r).not.toContain("REJECTED");
+    expect(await Bun.file(join(dir, "impl.ts")).text()).toBe(""); // deleted
   } finally {
     await rm(dir, { recursive: true, force: true });
   }
@@ -112,6 +140,7 @@ test("the size cap is per-replacement — a huge single replacement is still rej
 
   try {
     const big = Array.from({ length: 60 }, (_, i) => `line${i}`).join("\n");
+    const bigNew = Array.from({ length: 60 }, (_, i) => `new${i}`).join("\n");
 
     await Bun.write(join(dir, "impl.ts"), big);
 
@@ -120,13 +149,13 @@ test("the size cap is per-replacement — a huge single replacement is still rej
         name: "edit",
         arguments: {
           file: "impl.ts",
-          edits: [{ oldString: big, newString: "tiny" }],
+          edits: [{ oldString: big, newString: bigNew }],
         },
       },
       ctx(dir, ["impl.ts"])
     );
 
-    expect(r).toContain("too large");
+    expect(r).toContain("rewrites a large span");
     expect(await Bun.file(join(dir, "impl.ts")).text()).toBe(big); // unchanged
   } finally {
     await rm(dir, { recursive: true, force: true });
@@ -156,17 +185,21 @@ test("edit on an EXISTING file with an unmatched oldString says the file exists 
 
     expect(r).toContain("REJECTED");
     expect(r).toContain("EXISTS");
-    expect(r).toContain("Do NOT use `create`");
-    expect(r).toContain("read");
+    // Steer to a targeted edit on the current content — NOT to recreate/rewrite.
+    expect(r).toContain("Do NOT recreate or rewrite");
+    expect(r).toContain("targeted `edit`");
   } finally {
     await rm(dir, { recursive: true, force: true });
   }
 });
 
-test("create OVERWRITES a file the model authored this session (in `touched`)", async () => {
-  // The whole-file-rewrite escape hatch: a file the model created earlier (so it's
-  // in the session change-set) can be fully rewritten via `create`, instead of
-  // thrashing edit(too-large)↔create(exists) on its own seed-data file.
+test("create does NOT overwrite an existing file that PARSES — even one the model authored", async () => {
+  // The whole-file-rewrite escape hatch is GONE for WORKING files. Rewriting a file
+  // the model authored re-introduced errors it had already fixed (runs looped 45+
+  // turns undoing their own progress). `create` rejects an existing PARSEABLE file
+  // and steers to a surgical `edit` (a syntactically-BROKEN file is the exception —
+  // see the next test); the file's current content is left untouched. `1 as any`
+  // parses fine (it's a type error, not a syntax error), so this stays protected.
   const dir = await mkdtemp(join(tmpdir(), "tsforge-exec-"));
 
   try {
@@ -187,8 +220,37 @@ test("create OVERWRITES a file the model authored this session (in `touched`)", 
       }
     );
 
-    expect(r).toContain("overwrote");
+    expect(r).toContain("REJECTED");
+    expect(r).toContain("edit");
+    // Untouched — no whole-file rewrite happened.
     expect(await Bun.file(join(dir, "store.ts")).text()).toBe(
+      "export const x = 1 as any;\n"
+    );
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test("create OVERWRITES a syntactically-BROKEN file (the deadlock escape)", async () => {
+  // A file that won't parse can't be surgically edited (line anchors are meaningless),
+  // so create MUST be allowed to rewrite it — else the model deadlocks between "edit
+  // too large" / "already exists" / "needs a hash anchor" (observed live, 27 turns).
+  const dir = await mkdtemp(join(tmpdir(), "tsforge-exec-"));
+
+  try {
+    await Bun.write(join(dir, "broken.ts"), "export const x = ;\nfunction (\n");
+
+    const r = await executeTool(
+      {
+        name: "create",
+        arguments: { file: "broken.ts", content: "export const x = 1;\n" },
+      },
+      ctx(dir, ["broken.ts"])
+    );
+
+    expect(r).not.toContain("REJECTED");
+    expect(r).toContain("rewrote");
+    expect(await Bun.file(join(dir, "broken.ts")).text()).toBe(
       "export const x = 1;\n"
     );
   } finally {
@@ -650,11 +712,11 @@ test("package and browser research tools are permitted in plan mode", async () =
   expect(`${info}\n${docs}\n${browse}`).not.toContain("plan mode");
 });
 
-test("edit not-found on a file the model AUTHORED offers the create-rewrite escape hatch", async () => {
-  // F24: the model painted its own service file into a corner (stale anchors +
-  // too-large edits) and thrashed ~20 turns because the not-found message said
-  // "Do NOT use create". For a file it authored this session, create-overwrite IS
-  // the clean full-rewrite path — so the message must offer it.
+test("edit not-found steers to a surgical edit on current content, never a rewrite", async () => {
+  // The old escape hatch (offer create-rewrite for an authored file) is gone: a
+  // full rewrite re-introduces already-fixed errors. On a stale anchor the message
+  // re-feeds the file's CURRENT content and asks for a targeted edit — even for a
+  // file the model authored this session.
   const dir = await mkdtemp(join(tmpdir(), "tsforge-exec-"));
 
   try {
@@ -679,8 +741,11 @@ test("edit not-found on a file the model AUTHORED offers the create-rewrite esca
     );
 
     expect(r).toContain("REJECTED");
-    expect(r).toMatch(/you may also `create` it again|fully rewrite/u);
-    expect(r).not.toContain("Do NOT use `create`"); // authored → not steered away
+    expect(r).toContain("Do NOT recreate or rewrite");
+    expect(r).toContain("targeted `edit`");
+    // The current content is re-fed so it can re-anchor without a `read`.
+    expect(r).toContain("CURRENT content");
+    expect(r).not.toMatch(/you may also `create`|fully rewrite/u);
   } finally {
     await rm(dir, { recursive: true, force: true });
   }

--- a/packages/core/tests/expert-handoff.test.ts
+++ b/packages/core/tests/expert-handoff.test.ts
@@ -1,0 +1,195 @@
+import { test, expect, describe } from "bun:test";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  buildFixPrompt,
+  extractCode,
+  runExpertHandoff,
+  resolveStuckFile,
+  resolveExpertAsk,
+  type IExpertRequest,
+  type ExpertAsk,
+} from "../src/loop/expert-handoff";
+
+const REQ: IExpertRequest = {
+  file: "src/views/Foo/index.tsx",
+  content: "export const Foo = () => <div/>;\n",
+  error: "L3: No `as` type casts (no-restricted-syntax)",
+  goal: "build the Foo view",
+};
+
+describe("buildFixPrompt", () => {
+  test("names the file, the exact error, the goal, and the current content", () => {
+    const p = buildFixPrompt(REQ);
+
+    expect(p).toContain("src/views/Foo/index.tsx");
+    expect(p).toContain("No `as` type casts");
+    expect(p).toContain("build the Foo view");
+    expect(p).toContain("export const Foo");
+    expect(p).toContain("ONLY the corrected FULL contents");
+  });
+});
+
+describe("extractCode", () => {
+  test("pulls the body out of a ```tsx fence", () => {
+    const code = extractCode(
+      "Here you go:\n```tsx\nexport const X = 1;\n```\nDone."
+    );
+
+    expect(code).toBe("export const X = 1;");
+  });
+
+  test("accepts a raw code reply with no fence", () => {
+    expect(extractCode("export const Y = 2;\n")).toBe("export const Y = 2;");
+  });
+
+  test("returns null for a chatty non-code reply (never written to disk)", () => {
+    expect(extractCode("Sorry, I can't help with that.")).toBeNull();
+  });
+
+  test("returns null for an empty fence", () => {
+    expect(extractCode("```tsx\n\n```")).toBeNull();
+  });
+});
+
+describe("runExpertHandoff", () => {
+  test("applies a usable fix by overwriting the file", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "expert-"));
+
+    try {
+      await Bun.write(join(dir, "a.ts"), "export const bad = 1 as any;\n");
+      const ask: ExpertAsk = async () => "```ts\nexport const good = 1;\n```";
+
+      const out = await runExpertHandoff(
+        dir,
+        { file: "a.ts", content: "x", error: "e", goal: "g" },
+        ask
+      );
+
+      expect(out.applied).toBe(true);
+      expect(await Bun.file(join(dir, "a.ts")).text()).toBe(
+        "export const good = 1;\n"
+      );
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  test("does NOT touch the file when the expert declines (no usable code)", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "expert-"));
+
+    try {
+      await Bun.write(join(dir, "a.ts"), "original\n");
+      const ask: ExpertAsk = async () => "I cannot fix this.";
+
+      const out = await runExpertHandoff(
+        dir,
+        { file: "a.ts", content: "x", error: "e", goal: "g" },
+        ask
+      );
+
+      expect(out.applied).toBe(false);
+      expect(await Bun.file(join(dir, "a.ts")).text()).toBe("original\n");
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  test("a throwing ask degrades to not-applied (never crashes the run)", async () => {
+    const ask: ExpertAsk = async () => {
+      throw new Error("network down");
+    };
+
+    const out = await runExpertHandoff(
+      "/nonexistent",
+      { file: "a.ts", content: "x", error: "e", goal: "g" },
+      ask
+    );
+
+    expect(out.applied).toBe(false);
+  });
+});
+
+describe("resolveExpertAsk gating (no surprise live/paid API call in tests or evals)", () => {
+  test("returns null when the expert-rescue flag is OFF — even if a capability is configured", async () => {
+    // The exact leak this guards: a stalled run in a unit test / eval sweep would call
+    // the real configured expert model. Opt-in only — OFF by default, so it can't.
+    const prev = process.env.TSFORGE_EXPERT_RESCUE;
+
+    delete process.env.TSFORGE_EXPERT_RESCUE;
+
+    try {
+      expect(await resolveExpertAsk()).toBeNull();
+    } finally {
+      if (prev !== undefined) {
+        process.env.TSFORGE_EXPERT_RESCUE = prev;
+      }
+    }
+  });
+});
+
+describe("resolveStuckFile (the v5 fix — expert can target file-less errors)", () => {
+  test("prefers a populated .file", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "stuck-"));
+
+    try {
+      await Bun.write(join(dir, "a.ts"), "x");
+
+      expect(
+        await resolveStuckFile(dir, [{ file: "a.ts", message: "boom" }])
+      ).toBe("a.ts");
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  test("parses the file from the MESSAGE + adds the dropped src/ prefix (type-aware-lint)", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "stuck-"));
+
+    try {
+      await Bun.write(join(dir, "src/views/Issues/index.tsx"), "x");
+      // The exact v5 shape: no `.file`, but the message names "views/Issues/..."
+      // WITHOUT the src/ prefix. resolveStuckFile must still find it.
+      const f = await resolveStuckFile(dir, [
+        {
+          message: "views/Issues/index.tsx:215 tsforge/no-inline-jsx-functions",
+        },
+      ]);
+
+      expect(f).toBe("src/views/Issues/index.tsx");
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  test("finds a basename-only file under src/ (stub-check names 'dashboard.tsx', lives in src/routes/)", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "stuck-"));
+
+    try {
+      await Bun.write(join(dir, "src/routes/dashboard.tsx"), "x");
+      const f = await resolveStuckFile(dir, [
+        {
+          message:
+            "stub-check: 1 route(s) are still empty scaffold STUBS — Unfilled: dashboard.tsx",
+        },
+      ]);
+
+      expect(f).toBe("src/routes/dashboard.tsx");
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  test("null when no field/message resolves to an existing file", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "stuck-"));
+
+    try {
+      expect(
+        await resolveStuckFile(dir, [{ message: "some prose, no path" }])
+      ).toBeNull();
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+});

--- a/packages/core/tests/expert-rescue.test.ts
+++ b/packages/core/tests/expert-rescue.test.ts
@@ -1,0 +1,143 @@
+import { test, expect, describe } from "bun:test";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { tryExpertRescue, type ILoopCtx } from "../src/loop/turn";
+import type { ILoopState, ILoopEvent } from "../src/loop";
+import type { IErrorItem } from "../src/validate";
+import type { ExpertAsk } from "../src/loop/expert-handoff";
+
+function freshState(): ILoopState {
+  return {
+    prevGateErrors: [],
+    gateNoProgress: 0,
+    bestErrorCount: Number.POSITIVE_INFINITY,
+    noNewLow: 0,
+    errorAge: new Map(),
+    lastGateCount: -1,
+    edits: 0,
+    regressions: 0,
+    ttsrInterrupts: 0,
+    steerLevel: 4,
+  };
+}
+
+function makeCtx(events: ILoopEvent[], cwd: string): ILoopCtx {
+  return {
+    task: { id: "t", intent: "test", accept: "true", files: [], context: [] },
+    cwd,
+    tsService: null,
+    report: (event) => {
+      events.push(event);
+    },
+    messages: [],
+    tool: {},
+    gate: { parse: undefined },
+  };
+}
+
+const fileErr = (file: string): IErrorItem => ({
+  key: `${file}:1:no-restricted-syntax`,
+  file,
+  rule: "no-restricted-syntax",
+  message: "L1: No `as` type casts",
+});
+
+const toolMsgs = (events: ILoopEvent[]): string[] =>
+  events.filter((e) => e.kind === "tool").map((e) => e.message);
+
+describe("tryExpertRescue", () => {
+  test("HAPPY PATH: expert returns a fix → file overwritten, run continues", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "expert-rescue-"));
+
+    try {
+      await Bun.write(join(dir, "x.ts"), "export const s = v as any;\n");
+      const events: ILoopEvent[] = [];
+      const ctx = makeCtx(events, dir);
+      const state = freshState();
+      const ask: ExpertAsk = async () =>
+        "```ts\nexport const s = String(v);\n```";
+
+      const rescued = await tryExpertRescue(
+        ctx,
+        state,
+        [fileErr("x.ts")],
+        async () => ask
+      );
+
+      expect(rescued).toBe(true);
+      // The stuck file was repaired by the expert.
+      expect(await Bun.file(join(dir, "x.ts")).text()).toBe(
+        "export const s = String(v);\n"
+      );
+      // Guards + steer level reset so the primary model gets a fresh run; use counted.
+      expect(state.expertUses).toBe(1);
+      expect(state.steerLevel).toBe(0);
+      // The model was told to verify + continue.
+      expect(ctx.messages.at(-1)?.content).toContain("expert engineer");
+      // The handoff was VISIBLE in the log (not silent).
+      expect(toolMsgs(events).some((m) => m.includes("expert handoff"))).toBe(
+        true
+      );
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  test("no expert configured → returns false AND logs why (never silent)", async () => {
+    const events: ILoopEvent[] = [];
+    const ctx = makeCtx(events, "/tmp");
+    const state = freshState();
+
+    const rescued = await tryExpertRescue(
+      ctx,
+      state,
+      [fileErr("x.ts")],
+      async () => null
+    );
+
+    expect(rescued).toBe(false);
+    // The exact bug that hid for a whole run: this MUST be logged now.
+    expect(
+      toolMsgs(events).some(
+        (m) => m.includes("skipped") && m.includes("expert")
+      )
+    ).toBe(true);
+  });
+
+  test("cap reached → skips with a visible reason", async () => {
+    const events: ILoopEvent[] = [];
+    const ctx = makeCtx(events, "/tmp");
+    const state = { ...freshState(), expertUses: 2 };
+    const ask: ExpertAsk = async () => "```ts\nx\n```";
+
+    const rescued = await tryExpertRescue(
+      ctx,
+      state,
+      [fileErr("x.ts")],
+      async () => ask
+    );
+
+    expect(rescued).toBe(false);
+    expect(toolMsgs(events).some((m) => m.includes("already used"))).toBe(true);
+  });
+
+  test("no file-scoped error → skips with a visible reason", async () => {
+    const events: ILoopEvent[] = [];
+    const ctx = makeCtx(events, "/tmp");
+    const state = freshState();
+    const ask: ExpertAsk = async () => "```ts\nx\n```";
+
+    const rescued = await tryExpertRescue(
+      ctx,
+      state,
+      [{ key: "k", rule: "r", message: "no file here" }],
+      async () => ask
+    );
+
+    expect(rescued).toBe(false);
+    expect(
+      toolMsgs(events).some((m) => m.includes("no file could be resolved"))
+    ).toBe(true);
+  });
+});

--- a/packages/core/tests/pull-conventions.test.ts
+++ b/packages/core/tests/pull-conventions.test.ts
@@ -1,0 +1,19 @@
+import { test, expect, describe } from "bun:test";
+import { doPullConventions } from "../src/loop/tools/pull-conventions";
+
+describe("pull_conventions tool", () => {
+  test("returns the guide for a valid topic", () => {
+    expect(doPullConventions({ topic: "no-casts" })).toContain("TYPE GUARD");
+    expect(doPullConventions({ topic: "component-anatomy" })).toContain(
+      "src/views/"
+    );
+  });
+
+  test("an unknown/empty topic lists the valid ones (never a bare failure)", () => {
+    const r = doPullConventions({ topic: "styling" });
+
+    expect(r).toContain("unknown topic");
+    expect(r).toContain("component-anatomy");
+    expect(r).toContain("no-casts");
+  });
+});

--- a/packages/core/tests/repair-loop.test.ts
+++ b/packages/core/tests/repair-loop.test.ts
@@ -3,6 +3,7 @@ import { mkdtemp, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { runTask, LOOP_LIMITS } from "../src/loop";
+import { STEER_LADDER_MAX } from "../src/loop/feedback/steer";
 import { scripted, runStep, STOP } from "./stub-provider";
 
 async function tmp(): Promise<string> {
@@ -74,9 +75,12 @@ test("stuck when it claims done but the gate stays red, unchanged", async () => 
   const dir = await tmp();
 
   try {
-    // Always stops without fixing → gate red with the SAME error every time, so
-    // the per-(file,rule) persistence guard trips at `samePersist` cycles (the
-    // primary no-progress stop), well before any raw turn cap.
+    // Always stops without fixing → gate red with the SAME error every time. The
+    // per-(file,rule) guard trips every `samePersist` cycles, but instead of an
+    // instant kill the loop now ESCALATES a steer each time and resets — so it only
+    // PARKS after the ladder is exhausted, at `samePersist × (STEER_LADDER_MAX + 1)`
+    // cycles. Still bounded, well before any raw turn cap; the model just gets more
+    // (escalating) chances first.
     const r = await runTask(
       { id: "1", accept: "test -f never.txt", files: [] },
       dir,
@@ -85,7 +89,14 @@ test("stuck when it claims done but the gate stays red, unchanged", async () => 
 
     expect(r.status).toBe("stuck");
     expect(r.reason).toBe("stalled");
-    expect(r.cycles).toBe(LOOP_LIMITS.samePersist);
+    // Parked at the top of the ladder: the first stall is detected patiently
+    // (samePersist), then steering escalates fast (steerRetrigger) to the park — so
+    // it stops in a handful of cycles, well before any raw turn cap.
+    expect(r.cycles).toBeGreaterThanOrEqual(LOOP_LIMITS.samePersist);
+    expect(r.cycles).toBeLessThanOrEqual(
+      LOOP_LIMITS.samePersist +
+        LOOP_LIMITS.steerRetrigger * (STEER_LADDER_MAX + 1)
+    );
   } finally {
     await rm(dir, { recursive: true, force: true });
   }

--- a/packages/core/tests/rule-packs.test.ts
+++ b/packages/core/tests/rule-packs.test.ts
@@ -3933,4 +3933,21 @@ describe("typescript-core: no-self-import", () => {
 
     expect(messages.map((m) => m.messageId)).not.toContain("selfImport");
   });
+
+  // The exact shape that stalled the hospital-scheduling web build: a barrel
+  // `index.ts` re-exporting from "./index" — which resolves to the barrel ITSELF
+  // (the real component sat beside it in `index.tsx`). tsc resolves `./index` to
+  // the .tsx and typechecks fine, but Rollup resolves it to the .ts and fails
+  // with a cryptic "reexports itself" — a contradiction the model couldn't fix.
+  // Lint must catch it up front with the actionable message.
+  test("FLAGS a barrel index.ts re-exporting from './index' (self)", () => {
+    const messages = lint(
+      "typescript-core",
+      "no-self-import",
+      'export { AppointmentsList } from "./index";\n',
+      "src/views/Appointments/index.ts"
+    );
+
+    expect(messages.map((m) => m.messageId)).toContain("selfImport");
+  });
 });

--- a/packages/core/tests/same-persist-guard.test.ts
+++ b/packages/core/tests/same-persist-guard.test.ts
@@ -20,6 +20,7 @@ function freshState(): ILoopState {
     edits: 0,
     regressions: 0,
     ttsrInterrupts: 0,
+    steerLevel: 0,
   };
 }
 

--- a/packages/core/tests/self-harness-injection.test.ts
+++ b/packages/core/tests/self-harness-injection.test.ts
@@ -17,21 +17,21 @@ import { DEFAULT_CONVENTIONS } from "../src/infer-rules/conventions";
 import type { IHarnessOverlay } from "../src/self-harness/self-harness.types";
 
 let dir: string;
-const SAVED_VARS = [
-  "TSFORGE_SELF_HARNESS_OVERLAY",
-  "TSFORGE_MODEL",
-  "TSFORGE_HOME",
-] as const;
-const savedEnv = new Map<string, string | undefined>();
+const savedEnv = {
+  overlay: process.env.TSFORGE_SELF_HARNESS_OVERLAY,
+  model: process.env.TSFORGE_MODEL,
+  home: process.env.TSFORGE_HOME,
+};
+
+function clearEnv(): void {
+  delete process.env.TSFORGE_SELF_HARNESS_OVERLAY;
+  delete process.env.TSFORGE_MODEL;
+  delete process.env.TSFORGE_HOME;
+}
 
 beforeEach(async () => {
   dir = await mkdtemp(join(tmpdir(), "sh-inject-"));
-
-  for (const name of SAVED_VARS) {
-    savedEnv.set(name, process.env[name]);
-    delete process.env[name];
-  }
-
+  clearEnv();
   // Hermetic: the registry-fallback path must look in the tmp dir, never the
   // developer's real ~/.tsforge (which may hold a promoted overlay).
   process.env.TSFORGE_HOME = dir;
@@ -40,21 +40,26 @@ beforeEach(async () => {
 
 afterEach(async () => {
   await rm(dir, { recursive: true, force: true });
+  clearEnv();
 
-  for (const name of SAVED_VARS) {
-    const value = savedEnv.get(name);
+  if (savedEnv.overlay !== undefined) {
+    process.env.TSFORGE_SELF_HARNESS_OVERLAY = savedEnv.overlay;
+  }
 
-    if (value === undefined) {
-      delete process.env[name];
-    } else {
-      process.env[name] = value;
-    }
+  if (savedEnv.model !== undefined) {
+    process.env.TSFORGE_MODEL = savedEnv.model;
+  }
+
+  if (savedEnv.home !== undefined) {
+    process.env.TSFORGE_HOME = savedEnv.home;
   }
 
   resetOverlayCache();
 });
 
-async function activateOverlay(overlay: Partial<IHarnessOverlay>): Promise<void> {
+async function activateOverlay(
+  overlay: Partial<IHarnessOverlay>
+): Promise<void> {
   const path = join(dir, "overlay.json");
 
   await writeFile(path, JSON.stringify(overlay));

--- a/packages/core/tests/self-harness-injection.test.ts
+++ b/packages/core/tests/self-harness-injection.test.ts
@@ -1,0 +1,228 @@
+/**
+ * Injection-point safety: with NO overlay active, every editable surface must
+ * behave byte-identically to the base harness; with an overlay active, each
+ * of the four surfaces (prompt blocks, procedure cards, TTSR rules, agent
+ * specs) must reflect exactly the declared edit.
+ */
+import { test, expect, describe, beforeEach, afterEach } from "bun:test";
+import { mkdtemp, writeFile, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { buildSystem, buildSystemPrompt } from "../src/loop/prompt/prompt";
+import { ruleHelp } from "../src/loop/feedback/rule-docs";
+import { initTtsrManager } from "../src/loop/ttsr-init";
+import { loadAgentSpecs } from "../src/config/agent-specs";
+import { resetOverlayCache } from "../src/self-harness/overlay";
+import { DEFAULT_CONVENTIONS } from "../src/infer-rules/conventions";
+import type { IHarnessOverlay } from "../src/self-harness/self-harness.types";
+
+let dir: string;
+const SAVED_VARS = [
+  "TSFORGE_SELF_HARNESS_OVERLAY",
+  "TSFORGE_MODEL",
+  "TSFORGE_HOME",
+] as const;
+const savedEnv = new Map<string, string | undefined>();
+
+beforeEach(async () => {
+  dir = await mkdtemp(join(tmpdir(), "sh-inject-"));
+
+  for (const name of SAVED_VARS) {
+    savedEnv.set(name, process.env[name]);
+    delete process.env[name];
+  }
+
+  // Hermetic: the registry-fallback path must look in the tmp dir, never the
+  // developer's real ~/.tsforge (which may hold a promoted overlay).
+  process.env.TSFORGE_HOME = dir;
+  resetOverlayCache();
+});
+
+afterEach(async () => {
+  await rm(dir, { recursive: true, force: true });
+
+  for (const name of SAVED_VARS) {
+    const value = savedEnv.get(name);
+
+    if (value === undefined) {
+      delete process.env[name];
+    } else {
+      process.env[name] = value;
+    }
+  }
+
+  resetOverlayCache();
+});
+
+async function activateOverlay(overlay: Partial<IHarnessOverlay>): Promise<void> {
+  const path = join(dir, "overlay.json");
+
+  await writeFile(path, JSON.stringify(overlay));
+  process.env.TSFORGE_SELF_HARNESS_OVERLAY = path;
+  resetOverlayCache();
+}
+
+describe("no overlay → base harness byte-identical", () => {
+  test("system prompt, rule help, agent specs, and TTSR are unchanged by the wiring", async () => {
+    // Snapshot outputs with the overlay machinery in place but inactive.
+    const system = buildSystem(DEFAULT_CONVENTIONS);
+    const full = buildSystemPrompt(false, undefined);
+    const help = ruleHelp([{ key: "TS2307", rule: "TS2307", message: "" }]);
+    const specs = await loadAgentSpecs(dir);
+
+    // The known base content is present and no overlay text can be (none exists).
+    expect(system).toContain("Lead with action");
+    expect(system).toContain("After every edit the harness AUTOMATICALLY");
+    expect(system).toContain("Test hypotheses by RUNNING them");
+    expect(full.startsWith(system)).toBe(true);
+    expect(help).toContain("TS2307");
+
+    const explore = specs.find((s) => s.id === "explore");
+
+    expect(explore).toBeDefined();
+
+    // Determinism: a second call produces the identical bytes.
+    expect(buildSystem(DEFAULT_CONVENTIONS)).toBe(system);
+    expect(buildSystemPrompt(false, undefined)).toBe(full);
+    expect(ruleHelp([{ key: "TS2307", rule: "TS2307", message: "" }])).toBe(
+      help
+    );
+  });
+});
+
+describe("prompt-block injection", () => {
+  test("append stacks below the named block; replace substitutes it", async () => {
+    const base = buildSystem(DEFAULT_CONVENTIONS);
+
+    await activateOverlay({
+      promptBlocks: {
+        bootstrap: {
+          mode: "append",
+          text: "Create the required output artifact as early as possible.",
+        },
+        verification: {
+          mode: "replace",
+          text: "Always read the artifact back before concluding.",
+        },
+      },
+    });
+
+    const edited = buildSystem(DEFAULT_CONVENTIONS);
+
+    expect(edited).not.toBe(base);
+    // append: base line retained, new text directly after it
+    expect(edited).toContain(
+      "writing any code. (In TDD mode the test comes first; see the test-first guidance below.)\nCreate the required output artifact as early as possible."
+    );
+    // replace: base verification line gone, replacement present
+    expect(edited).not.toContain("Test hypotheses by RUNNING them");
+    expect(edited).toContain("read the artifact back before concluding");
+    // non-edited blocks untouched
+    expect(edited).toContain("After every edit the harness AUTOMATICALLY");
+  });
+
+  test("the extra block lands at the end of the full system prompt", async () => {
+    await activateOverlay({
+      promptBlocks: {
+        extra: { mode: "append", text: "EXTRA-BLOCK-SENTINEL" },
+      },
+    });
+
+    const full = buildSystemPrompt(false, undefined);
+
+    expect(full.endsWith("EXTRA-BLOCK-SENTINEL")).toBe(true);
+  });
+});
+
+describe("procedure-card injection", () => {
+  test("card edit merges over the base doc; unknown rule without `what` stays absent", async () => {
+    await activateOverlay({
+      procedureCards: {
+        TS2307: { procedure: "OVERLAY-PROCEDURE: verify the file exists." },
+        "made-up-rule": { procedure: "no what, no base doc → not rendered" },
+      },
+    });
+
+    const help = ruleHelp([
+      { key: "TS2307", rule: "TS2307", message: "" },
+      { key: "made-up-rule", rule: "made-up-rule", message: "" },
+    ]);
+
+    expect(help).toContain("OVERLAY-PROCEDURE: verify the file exists.");
+    expect(help).not.toContain("made-up-rule");
+  });
+
+  test("a card with `what` can document a rule that has no base doc", async () => {
+    await activateOverlay({
+      procedureCards: {
+        "brand-new-rule": {
+          what: "OVERLAY-WHAT for a rule with no curated doc.",
+        },
+      },
+    });
+
+    const help = ruleHelp([
+      { key: "brand-new-rule", rule: "brand-new-rule", message: "" },
+    ]);
+
+    expect(help).toContain("brand-new-rule: OVERLAY-WHAT");
+  });
+});
+
+describe("TTSR injection", () => {
+  test("overlay rules register; base rules keep priority on name collision", async () => {
+    await activateOverlay({
+      ttsrRules: [
+        {
+          name: "overlay-loop-breaker",
+          condition: ["let me try a completely different"],
+          scope: "content",
+          guidance: "Stop exploring; produce the required artifact now.",
+          repeatMode: "once",
+        },
+        {
+          // Collides with a built-in default rule name — must NOT displace it.
+          name: "no-as-any",
+          condition: ["zzz"],
+          scope: "content",
+          guidance: "hijacked",
+          repeatMode: "once",
+        },
+      ],
+    });
+
+    const events: string[] = [];
+    const manager = await initTtsrManager(
+      dir,
+      (e) => {
+        events.push(e.message);
+      },
+      "t1"
+    );
+
+    expect(manager).not.toBeNull();
+    expect(
+      events.some((m) => m.includes("1 self-harness overlay TTSR rule"))
+    ).toBe(true);
+  });
+});
+
+describe("agent-spec injection", () => {
+  test("override merges onto an existing spec; unknown id creates nothing", async () => {
+    await activateOverlay({
+      agentSpecOverrides: [
+        { id: "explore", maxTurns: 99, systemPrompt: "OVERLAY-PROMPT" },
+        { id: "not-a-real-agent", systemPrompt: "must not appear" },
+      ],
+    });
+
+    const specs = await loadAgentSpecs(dir);
+    const explore = specs.find((s) => s.id === "explore");
+
+    expect(explore?.maxTurns).toBe(99);
+    expect(explore?.systemPrompt).toBe("OVERLAY-PROMPT");
+    // untouched fields survive the merge
+    expect(explore?.tools).toBeDefined();
+    expect(specs.find((s) => s.id === "not-a-real-agent")).toBeUndefined();
+  });
+});

--- a/packages/core/tests/self-harness-loop.test.ts
+++ b/packages/core/tests/self-harness-loop.test.ts
@@ -1,0 +1,366 @@
+/**
+ * Acceptance-rule unit tests + a deterministic end-to-end run of the full
+ * Self-Harness loop with a scripted proposer and a programmed fake evaluator
+ * — Algorithm 1's control flow proven without a live model.
+ */
+import { test, expect, describe } from "bun:test";
+import {
+  acceptanceDecision,
+  validateCandidate,
+  type HarnessEvaluator,
+} from "../src/self-harness/validate";
+import { runSelfHarness } from "../src/self-harness/loop";
+import { emitReport } from "../src/self-harness/report";
+import { emptyOverlay } from "../src/self-harness/overlay";
+import type {
+  ICandidate,
+  IHarnessEval,
+  ISplitScore,
+  ISplits,
+} from "../src/self-harness/self-harness.types";
+import type { IMinedRun } from "../src/self-harness/mine";
+import type {
+  IChatMessage,
+  IModelResponse,
+  IProvider,
+} from "../src/inference";
+import type { ILoopEvent } from "../src/loop/loop.types";
+
+function score(partial: Partial<ISplitScore>): ISplitScore {
+  return {
+    passed: 0,
+    runs: 8,
+    avgQuality: 0,
+    avgLoc: 0,
+    perTask: {},
+    ...partial,
+  };
+}
+
+function evalOf(
+  heldIn: Partial<ISplitScore>,
+  heldOut: Partial<ISplitScore>
+): IHarnessEval {
+  return { heldIn: score(heldIn), heldOut: score({ runs: 4, ...heldOut }) };
+}
+
+describe("acceptanceDecision — the paper's rule, exactly", () => {
+  const baseline = evalOf({ passed: 4 }, { passed: 2 });
+
+  test("accepts strict gain on one split with no regression on the other", () => {
+    const d = acceptanceDecision(baseline, evalOf({ passed: 5 }, { passed: 2 }));
+
+    expect(d.accepted).toBe(true);
+    expect(d.deltaIn).toBe(1);
+    expect(d.deltaOut).toBe(0);
+  });
+
+  test("rejects Δin=0 ∧ Δho=0 (no strict gain)", () => {
+    const d = acceptanceDecision(baseline, evalOf({ passed: 4 }, { passed: 2 }));
+
+    expect(d.accepted).toBe(false);
+    expect(d.reason).toContain("no strict gain");
+  });
+
+  test("rejects any regression, even when the total improves", () => {
+    // +3 held-in, -1 held-out: total is up, but the rule is conservative
+    const d = acceptanceDecision(baseline, evalOf({ passed: 7 }, { passed: 1 }));
+
+    expect(d.accepted).toBe(false);
+    expect(d.reason).toContain("held-out");
+  });
+
+  test("quality guard: pass-rate gain bought with worse held-out quality is rejected", () => {
+    const withQuality = evalOf({ passed: 4 }, { passed: 2, avgQuality: 4.0 });
+    const d = acceptanceDecision(
+      withQuality,
+      evalOf({ passed: 6 }, { passed: 2, avgQuality: 3.0 })
+    );
+
+    expect(d.accepted).toBe(false);
+    expect(d.reason).toContain("quality regressed");
+
+    // within tolerance (0.5) → accepted
+    const ok = acceptanceDecision(
+      withQuality,
+      evalOf({ passed: 6 }, { passed: 2, avgQuality: 3.6 })
+    );
+
+    expect(ok.accepted).toBe(true);
+  });
+
+  test("quality guard is skipped when either side lacks a judge signal", () => {
+    const noSignal = acceptanceDecision(
+      evalOf({ passed: 4 }, { passed: 2, avgQuality: 0 }),
+      evalOf({ passed: 6 }, { passed: 2, avgQuality: 1.0 })
+    );
+
+    expect(noSignal.accepted).toBe(true);
+  });
+
+  test("concision guard: held-out solutions ballooning past 1.25× is rejected", () => {
+    const d = acceptanceDecision(
+      evalOf({ passed: 4 }, { passed: 2, avgLoc: 100 }),
+      evalOf({ passed: 6 }, { passed: 2, avgLoc: 130 })
+    );
+
+    expect(d.accepted).toBe(false);
+    expect(d.reason).toContain("concision guard");
+  });
+});
+
+const CANDIDATE: ICandidate = {
+  id: "r0-c1",
+  patch: {
+    promptBlocks: {
+      bootstrap: { mode: "append", text: "Create the artifact early." },
+    },
+  },
+  audit: {
+    targetPattern: "no-progress|edit-rejects|-",
+    surface: "promptBlocks",
+    expectedEffect: "Earlier artifact creation.",
+    risks: "None expected.",
+  },
+};
+
+const SPLITS: ISplits = { heldIn: ["math", "slugify"], heldOut: ["auth"] };
+
+describe("validateCandidate", () => {
+  test("rejects an empty patch without ever calling the evaluator", async () => {
+    let called = 0;
+    const evaluator: HarnessEvaluator = () => {
+      called += 1;
+
+      return Promise.resolve({
+        evaluation: evalOf({}, {}),
+        heldInRuns: [],
+      });
+    };
+    const result = await validateCandidate(
+      { ...CANDIDATE, patch: {} },
+      emptyOverlay(),
+      evalOf({ passed: 4 }, { passed: 2 }),
+      SPLITS,
+      evaluator
+    );
+
+    expect(result.accepted).toBe(false);
+    expect(result.reason).toContain("no editable surface");
+    expect(called).toBe(0);
+  });
+
+  test("an erroring evaluation rejects — a candidate is never promoted on a missing result", async () => {
+    const evaluator: HarnessEvaluator = () =>
+      Promise.reject(new Error("endpoint down"));
+    const result = await validateCandidate(
+      CANDIDATE,
+      emptyOverlay(),
+      evalOf({ passed: 4 }, { passed: 2 }),
+      SPLITS,
+      evaluator
+    );
+
+    expect(result.accepted).toBe(false);
+    expect(result.reason).toContain("endpoint down");
+  });
+});
+
+/** A failed held-in run with enough signal to mine (edit rejections). */
+function failedRun(taskId: string): IMinedRun {
+  const ev = (partial: Partial<ILoopEvent> & { kind: ILoopEvent["kind"] }): ILoopEvent => ({
+    task: taskId,
+    message: "",
+    ...partial,
+  });
+
+  return {
+    taskId,
+    passed: false,
+    events: [
+      ev({ kind: "start" }),
+      ev({ kind: "tool", message: "tool_rejected: edit target not found" }),
+      ev({ kind: "tool", message: "tool_rejected: edit target not found" }),
+      ev({ kind: "stuck", message: "no progress" }),
+    ],
+  };
+}
+
+function passedRun(taskId: string): IMinedRun {
+  return {
+    taskId,
+    passed: true,
+    events: [
+      { kind: "validated", task: taskId, message: "GREEN", passed: true },
+      { kind: "done", task: taskId, message: "done" },
+    ],
+  };
+}
+
+const PROPOSAL = JSON.stringify({
+  targetPattern: "no-progress|edit-rejects|-",
+  surface: "promptBlocks",
+  expectedEffect: "Re-read the file before every edit.",
+  risks: "Slightly more read turns.",
+  patch: {
+    promptBlocks: {
+      execution: {
+        mode: "append",
+        text: "Before each edit, re-read the target region so the snippet matches.",
+      },
+    },
+  },
+});
+
+function proposerOf(responses: string[]): IProvider {
+  let i = 0;
+
+  return {
+    complete: (_messages: IChatMessage[]): Promise<IModelResponse> => {
+      const content = responses[i] ?? responses[responses.length - 1] ?? "{}";
+
+      i += 1;
+
+      return Promise.resolve({ content, toolCalls: [] });
+    },
+  };
+}
+
+describe("runSelfHarness — Algorithm 1 end-to-end (deterministic)", () => {
+  test("accepted edit merges into h_1 and the loop stops when held-in goes green", async () => {
+    // Programmed world: the base harness fails slugify; any overlay containing
+    // the proposed execution-block edit fixes it without hurting held-out.
+    const evaluator: HarnessEvaluator = (overlay) => {
+      const fixed =
+        overlay?.promptBlocks.execution?.text.includes("re-read the target") ??
+        false;
+
+      return Promise.resolve({
+        evaluation: evalOf(
+          { passed: fixed ? 2 : 1, runs: 2 },
+          { passed: 1, runs: 1 }
+        ),
+        heldInRuns: fixed
+          ? [passedRun("math"), passedRun("slugify")]
+          : [passedRun("math"), failedRun("slugify")],
+      });
+    };
+
+    const lineage = await runSelfHarness({
+      model: "acme/test-model",
+      rounds: 3,
+      width: 2,
+      splits: SPLITS,
+      provider: proposerOf([PROPOSAL]),
+      evaluator,
+    });
+
+    // Round 0: mined, proposed, accepted, merged.
+    expect(lineage.rounds[0]?.acceptedIds).toContain("r0-c1");
+    expect(
+      lineage.finalOverlay.promptBlocks.execution?.text
+    ).toContain("re-read the target");
+
+    // Round 1: h_1 is fully green held-in → early stop (not 3 full rounds).
+    expect(lineage.rounds).toHaveLength(2);
+    expect(lineage.rounds[1]?.candidates).toEqual([]);
+    expect(
+      lineage.notes.some((n) => n.includes("no held-in failures"))
+    ).toBe(true);
+  });
+
+  test("a regressive candidate is rejected and h_{t+1} = h_t", async () => {
+    // Programmed world: the edit LOWERS held-out passes — must not merge.
+    const evaluator: HarnessEvaluator = (overlay) => {
+      const edited = overlay?.promptBlocks.execution !== undefined;
+
+      return Promise.resolve({
+        evaluation: evalOf(
+          { passed: edited ? 2 : 1, runs: 2 },
+          { passed: edited ? 0 : 1, runs: 1 }
+        ),
+        heldInRuns: [passedRun("math"), failedRun("slugify")],
+      });
+    };
+
+    const lineage = await runSelfHarness({
+      model: "acme/test-model",
+      rounds: 1,
+      width: 1,
+      splits: SPLITS,
+      provider: proposerOf([PROPOSAL]),
+      evaluator,
+    });
+
+    expect(lineage.rounds[0]?.acceptedIds).toEqual([]);
+    expect(lineage.finalOverlay.promptBlocks.execution).toBeUndefined();
+
+    const rejected = lineage.rounds[0]?.candidates[0];
+
+    expect(rejected?.accepted).toBe(false);
+    expect(rejected?.reason).toContain("held-out");
+  });
+
+  test("prior attempts flow into the next round's proposer context", async () => {
+    const prompts: IChatMessage[][] = [];
+    const provider: IProvider = {
+      complete: (messages): Promise<IModelResponse> => {
+        prompts.push(messages);
+
+        return Promise.resolve({ content: PROPOSAL, toolCalls: [] });
+      },
+    };
+    // Never improves → every candidate rejected → 2 rounds of proposals.
+    const evaluator: HarnessEvaluator = () =>
+      Promise.resolve({
+        evaluation: evalOf({ passed: 1, runs: 2 }, { passed: 1, runs: 1 }),
+        heldInRuns: [passedRun("math"), failedRun("slugify")],
+      });
+
+    const lineage = await runSelfHarness({
+      model: "acme/test-model",
+      rounds: 2,
+      width: 1,
+      splits: SPLITS,
+      provider,
+      evaluator,
+    });
+
+    expect(lineage.rounds).toHaveLength(2);
+
+    const round1User =
+      prompts[1]?.find((m) => m.role === "user")?.content ?? "";
+
+    expect(round1User).toContain("Previously attempted edits");
+    expect(round1User).toContain("r0-c1 (rejected)");
+  });
+
+  test("the report renders the lineage with verdicts, deltas, and install path", async () => {
+    const evaluator: HarnessEvaluator = (overlay) =>
+      Promise.resolve({
+        evaluation: evalOf(
+          { passed: overlay === null ? 1 : 2, runs: 2 },
+          { passed: 1, runs: 1 }
+        ),
+        heldInRuns: [passedRun("math"), failedRun("slugify")],
+      });
+    const lineage = await runSelfHarness({
+      model: "acme/test-model",
+      rounds: 1,
+      width: 1,
+      splits: SPLITS,
+      provider: proposerOf([PROPOSAL]),
+      evaluator,
+    });
+    const report = emitReport(lineage);
+
+    expect(report.markdown).toContain("Self-Harness report — acme/test-model");
+    expect(report.markdown).toContain("✅ ACCEPTED");
+    expect(report.markdown).toContain("Δin=1");
+    expect(report.markdown).toContain("never shown to the proposer");
+    expect(report.markdown).toContain("self-harness/acme-test-model/overlay.json");
+    expect(report.overlayJson).toContain("re-read the target");
+    // rejected-vs-accepted accounting shows in the header
+    expect(report.markdown).toContain("accepted: 1");
+  });
+});

--- a/packages/core/tests/self-harness-loop.test.ts
+++ b/packages/core/tests/self-harness-loop.test.ts
@@ -26,6 +26,7 @@ function score(partial: Partial<ISplitScore>): ISplitScore {
   return {
     passed: 0,
     runs: 8,
+    errored: 0,
     avgQuality: 0,
     avgLoc: 0,
     perTask: {},
@@ -170,6 +171,27 @@ describe("validateCandidate", () => {
 
     expect(result.accepted).toBe(false);
     expect(result.reason).toContain("endpoint down");
+  });
+
+  test("infrastructure-errored runs reject with an infra reason, never a phantom regression", async () => {
+    // The candidate eval "lost" 3 held-in passes — but they ERRORED, they
+    // didn't fail. The verdict must say so instead of blaming the edit.
+    const evaluator: HarnessEvaluator = () =>
+      Promise.resolve({
+        evaluation: evalOf({ passed: 1, errored: 3 }, { passed: 2 }),
+        heldInRuns: [],
+      });
+    const result = await validateCandidate(
+      CANDIDATE,
+      emptyOverlay(),
+      evalOf({ passed: 4 }, { passed: 2 }),
+      SPLITS,
+      evaluator
+    );
+
+    expect(result.accepted).toBe(false);
+    expect(result.reason).toContain("infrastructure errors");
+    expect(result.reason).not.toContain("regresses");
   });
 });
 
@@ -342,6 +364,36 @@ describe("runSelfHarness — Algorithm 1 end-to-end (deterministic)", () => {
 
     expect(round1User).toContain("Previously attempted edits");
     expect(round1User).toContain("r0-c1 (rejected)");
+  });
+
+  test("an errored baseline retries once, then stops the loop — no verdict without a clean baseline", async () => {
+    let calls = 0;
+
+    const evaluator: HarnessEvaluator = () => {
+      calls += 1;
+
+      return Promise.resolve({
+        evaluation: evalOf({ passed: 1, errored: 2, runs: 2 }, { passed: 1 }),
+        heldInRuns: [passedRun("math"), failedRun("slugify")],
+      });
+    };
+
+    const lineage = await runSelfHarness({
+      model: "acme/test-model",
+      rounds: 3,
+      width: 2,
+      splits: SPLITS,
+      provider: proposerOf([PROPOSAL]),
+      evaluator,
+    });
+
+    // baseline + one retry, then stop — no proposals, no further rounds
+    expect(calls).toBe(2);
+    expect(lineage.rounds).toEqual([]);
+    expect(lineage.notes.some((n) => n.includes("retrying once"))).toBe(true);
+    expect(lineage.notes.some((n) => n.includes("endpoint unhealthy"))).toBe(
+      true
+    );
   });
 
   test("the report renders the lineage with verdicts, deltas, and install path", async () => {

--- a/packages/core/tests/self-harness-loop.test.ts
+++ b/packages/core/tests/self-harness-loop.test.ts
@@ -19,6 +19,7 @@ import type {
   ISplits,
 } from "../src/self-harness/self-harness.types";
 import type { IMinedRun } from "../src/self-harness/mine";
+import type { IVariantSummary } from "../src/eval/eval.types";
 import type { IChatMessage, IModelResponse, IProvider } from "../src/inference";
 import type { ILoopEvent } from "../src/loop/loop.types";
 
@@ -112,6 +113,139 @@ describe("acceptanceDecision — the paper's rule, exactly", () => {
 
     expect(d.accepted).toBe(false);
     expect(d.reason).toContain("concision guard");
+  });
+});
+
+/** Per-task summary carrying only what the efficiency comparison reads. */
+function taskSummary(turnsToGreen: number | null): IVariantSummary {
+  return {
+    label: "t",
+    runs: 1,
+    passed: turnsToGreen === null ? 0 : 1,
+    passRate: turnsToGreen === null ? 0 : 1,
+    avgCycles: turnsToGreen ?? 0,
+    avgTurnsToGreen: turnsToGreen,
+    avgMs: 0,
+    avgQuality: 0,
+    avgLoc: 0,
+    failureClasses: {},
+  };
+}
+
+function withTurns(
+  base: IHarnessEval,
+  heldIn: Record<string, number | null>,
+  heldOut: Record<string, number | null>
+): IHarnessEval {
+  const toPerTask = (
+    turns: Record<string, number | null>
+  ): Record<string, IVariantSummary> =>
+    Object.fromEntries(
+      Object.entries(turns).map(([task, t]) => [task, taskSummary(t)])
+    );
+
+  return {
+    heldIn: { ...base.heldIn, perTask: toPerTask(heldIn) },
+    heldOut: { ...base.heldOut, perTask: toPerTask(heldOut) },
+  };
+}
+
+describe("acceptanceDecision — efficiency tie-break (Δin=0 ∧ Δho=0)", () => {
+  const passes = { in: { passed: 4 }, out: { passed: 2 } };
+  const baseline = withTurns(
+    evalOf(passes.in, passes.out),
+    { query: 15, math: 2, slugify: 1 },
+    { auth: 4, checkout: 2 }
+  );
+
+  test("material held-in cycle gain with stable held-out is accepted with an efficiency reason", () => {
+    const candidate = withTurns(
+      evalOf(passes.in, passes.out),
+      { query: 8, math: 2, slugify: 1 },
+      { auth: 4, checkout: 2 }
+    );
+    const d = acceptanceDecision(baseline, candidate);
+
+    expect(d.accepted).toBe(true);
+    expect(d.reason).toContain("efficiency gain");
+    expect(d.reason).toContain("18.0→11.0");
+  });
+
+  test("a below-floor gain still rejects (noise is not signal)", () => {
+    // 18→17 total: above neither the 20% relative nor... below 2-cycle floor
+    const candidate = withTurns(
+      evalOf(passes.in, passes.out),
+      { query: 14, math: 2, slugify: 1 },
+      { auth: 4, checkout: 2 }
+    );
+    const d = acceptanceDecision(baseline, candidate);
+
+    expect(d.accepted).toBe(false);
+    expect(d.reason).toContain("no material efficiency gain");
+  });
+
+  test("held-in gain bought with a held-out cycle blowup is rejected", () => {
+    const candidate = withTurns(
+      evalOf(passes.in, passes.out),
+      { query: 8, math: 2, slugify: 1 },
+      { auth: 7, checkout: 2 } // 6 → 9 cycles: +50%
+    );
+    const d = acceptanceDecision(baseline, candidate);
+
+    expect(d.accepted).toBe(false);
+    expect(d.reason).toContain("held-out efficiency regressed");
+  });
+
+  test("pass regression rejects before any efficiency math (pass rule dominates)", () => {
+    const candidate = withTurns(
+      evalOf({ passed: 4 }, { passed: 1 }),
+      { query: 4, math: 1, slugify: 1 },
+      { auth: 1, checkout: 1 }
+    );
+    const d = acceptanceDecision(baseline, candidate);
+
+    expect(d.accepted).toBe(false);
+    expect(d.reason).toContain("regresses held-out");
+  });
+
+  test("tasks green on only one side are excluded from the comparison", () => {
+    // query green only in candidate — its 3 cycles must not count as a gain;
+    // remaining common tasks are unchanged → no material gain → reject.
+    const lopsidedBaseline = withTurns(
+      evalOf(passes.in, passes.out),
+      { query: null, math: 2, slugify: 1 },
+      { auth: 4 }
+    );
+    const candidate = withTurns(
+      evalOf(passes.in, passes.out),
+      { query: 3, math: 2, slugify: 1 },
+      { auth: 4 }
+    );
+    const d = acceptanceDecision(lopsidedBaseline, candidate);
+
+    expect(d.accepted).toBe(false);
+    expect(d.reason).toContain("no material efficiency gain");
+  });
+
+  test("efficiency acceptance still honors the quality guard", () => {
+    const withQuality = (e: IHarnessEval, q: number): IHarnessEval => ({
+      ...e,
+      heldOut: { ...e.heldOut, avgQuality: q },
+    });
+    const d = acceptanceDecision(
+      withQuality(baseline, 4.0),
+      withQuality(
+        withTurns(
+          evalOf(passes.in, passes.out),
+          { query: 8, math: 2, slugify: 1 },
+          { auth: 4, checkout: 2 }
+        ),
+        3.0
+      )
+    );
+
+    expect(d.accepted).toBe(false);
+    expect(d.reason).toContain("quality regressed");
   });
 });
 

--- a/packages/core/tests/self-harness-loop.test.ts
+++ b/packages/core/tests/self-harness-loop.test.ts
@@ -19,11 +19,7 @@ import type {
   ISplits,
 } from "../src/self-harness/self-harness.types";
 import type { IMinedRun } from "../src/self-harness/mine";
-import type {
-  IChatMessage,
-  IModelResponse,
-  IProvider,
-} from "../src/inference";
+import type { IChatMessage, IModelResponse, IProvider } from "../src/inference";
 import type { ILoopEvent } from "../src/loop/loop.types";
 
 function score(partial: Partial<ISplitScore>): ISplitScore {
@@ -48,7 +44,10 @@ describe("acceptanceDecision — the paper's rule, exactly", () => {
   const baseline = evalOf({ passed: 4 }, { passed: 2 });
 
   test("accepts strict gain on one split with no regression on the other", () => {
-    const d = acceptanceDecision(baseline, evalOf({ passed: 5 }, { passed: 2 }));
+    const d = acceptanceDecision(
+      baseline,
+      evalOf({ passed: 5 }, { passed: 2 })
+    );
 
     expect(d.accepted).toBe(true);
     expect(d.deltaIn).toBe(1);
@@ -56,7 +55,10 @@ describe("acceptanceDecision — the paper's rule, exactly", () => {
   });
 
   test("rejects Δin=0 ∧ Δho=0 (no strict gain)", () => {
-    const d = acceptanceDecision(baseline, evalOf({ passed: 4 }, { passed: 2 }));
+    const d = acceptanceDecision(
+      baseline,
+      evalOf({ passed: 4 }, { passed: 2 })
+    );
 
     expect(d.accepted).toBe(false);
     expect(d.reason).toContain("no strict gain");
@@ -64,7 +66,10 @@ describe("acceptanceDecision — the paper's rule, exactly", () => {
 
   test("rejects any regression, even when the total improves", () => {
     // +3 held-in, -1 held-out: total is up, but the rule is conservative
-    const d = acceptanceDecision(baseline, evalOf({ passed: 7 }, { passed: 1 }));
+    const d = acceptanceDecision(
+      baseline,
+      evalOf({ passed: 7 }, { passed: 1 })
+    );
 
     expect(d.accepted).toBe(false);
     expect(d.reason).toContain("held-out");
@@ -129,6 +134,7 @@ const SPLITS: ISplits = { heldIn: ["math", "slugify"], heldOut: ["auth"] };
 describe("validateCandidate", () => {
   test("rejects an empty patch without ever calling the evaluator", async () => {
     let called = 0;
+
     const evaluator: HarnessEvaluator = () => {
       called += 1;
 
@@ -137,6 +143,7 @@ describe("validateCandidate", () => {
         heldInRuns: [],
       });
     };
+
     const result = await validateCandidate(
       { ...CANDIDATE, patch: {} },
       emptyOverlay(),
@@ -168,7 +175,9 @@ describe("validateCandidate", () => {
 
 /** A failed held-in run with enough signal to mine (edit rejections). */
 function failedRun(taskId: string): IMinedRun {
-  const ev = (partial: Partial<ILoopEvent> & { kind: ILoopEvent["kind"] }): ILoopEvent => ({
+  const ev = (
+    partial: Partial<ILoopEvent> & { kind: ILoopEvent["kind"] }
+  ): ILoopEvent => ({
     task: taskId,
     message: "",
     ...partial,
@@ -257,16 +266,16 @@ describe("runSelfHarness — Algorithm 1 end-to-end (deterministic)", () => {
 
     // Round 0: mined, proposed, accepted, merged.
     expect(lineage.rounds[0]?.acceptedIds).toContain("r0-c1");
-    expect(
-      lineage.finalOverlay.promptBlocks.execution?.text
-    ).toContain("re-read the target");
+    expect(lineage.finalOverlay.promptBlocks.execution?.text).toContain(
+      "re-read the target"
+    );
 
     // Round 1: h_1 is fully green held-in → early stop (not 3 full rounds).
     expect(lineage.rounds).toHaveLength(2);
     expect(lineage.rounds[1]?.candidates).toEqual([]);
-    expect(
-      lineage.notes.some((n) => n.includes("no held-in failures"))
-    ).toBe(true);
+    expect(lineage.notes.some((n) => n.includes("no held-in failures"))).toBe(
+      true
+    );
   });
 
   test("a regressive candidate is rejected and h_{t+1} = h_t", async () => {
@@ -358,7 +367,9 @@ describe("runSelfHarness — Algorithm 1 end-to-end (deterministic)", () => {
     expect(report.markdown).toContain("✅ ACCEPTED");
     expect(report.markdown).toContain("Δin=1");
     expect(report.markdown).toContain("never shown to the proposer");
-    expect(report.markdown).toContain("self-harness/acme-test-model/overlay.json");
+    expect(report.markdown).toContain(
+      "self-harness/acme-test-model/overlay.json"
+    );
     expect(report.overlayJson).toContain("re-read the target");
     // rejected-vs-accepted accounting shows in the header
     expect(report.markdown).toContain("accepted: 1");

--- a/packages/core/tests/self-harness-mine.test.ts
+++ b/packages/core/tests/self-harness-mine.test.ts
@@ -15,7 +15,9 @@ import type { ILoopEvent } from "../src/loop/loop.types";
 
 const CORPUS = join(import.meta.dir, "..", "..", "..", "evals", "corpus");
 
-function ev(partial: Partial<ILoopEvent> & { kind: ILoopEvent["kind"] }): ILoopEvent {
+function ev(
+  partial: Partial<ILoopEvent> & { kind: ILoopEvent["kind"] }
+): ILoopEvent {
   return { task: "t", message: "", ...partial };
 }
 
@@ -179,9 +181,9 @@ describe("resolveSplits", () => {
   });
 
   test("explicit lists are validated: unknown id and overlap both throw", async () => {
-    await expect(resolveSplits(CORPUS, ["nonexistent"], ["math"])).rejects.toThrow(
-      /unknown corpus task/
-    );
+    await expect(
+      resolveSplits(CORPUS, ["nonexistent"], ["math"])
+    ).rejects.toThrow(/unknown corpus task/);
     await expect(resolveSplits(CORPUS, ["math"], ["math"])).rejects.toThrow(
       /disjoint/
     );

--- a/packages/core/tests/self-harness-mine.test.ts
+++ b/packages/core/tests/self-harness-mine.test.ts
@@ -147,6 +147,66 @@ describe("mineWeaknesses", () => {
     );
   });
 
+  test("slow-green: a passed run at/over its threshold mines as an efficiency pattern", () => {
+    const cycles = Array.from({ length: 15 }, (_, i) =>
+      ev({ kind: "cycle", message: `cycle ${String(i + 1)}` })
+    );
+    const slowRun: IMinedRun = {
+      taskId: "query",
+      passed: true,
+      slowThreshold: 8,
+      events: [
+        ev({ kind: "start" }),
+        ...cycles,
+        ev({
+          kind: "validated",
+          passed: false,
+          rules: ["no-non-null-assertion"],
+          message: "task query · turn 9: red (2 error(s))",
+        }),
+        ev({ kind: "validated", passed: true, message: "GREEN" }),
+        ev({ kind: "done", message: "done" }),
+      ],
+    };
+    const bundle = mineWeaknesses([slowRun, passedRun("math")]);
+
+    expect(bundle.slowGreenRuns).toBe(1);
+    expect(bundle.failedRuns).toBe(0);
+    expect(bundle.patterns).toHaveLength(1);
+
+    const pattern = bundle.patterns[0];
+
+    expect(pattern?.signature.startsWith("slow-green|")).toBe(true);
+    expect(pattern?.mechanism).toContain("Reaches green but burns");
+    // mid-run red-gate rules become the verifier evidence
+    expect(pattern?.verifierEvidence).toContain("no-non-null-assertion");
+    expect(pattern?.traceSnippets.some((s) => s.includes("15 cycles"))).toBe(
+      true
+    );
+  });
+
+  test("slow-green: below-threshold and threshold-less green runs never mine", () => {
+    const fastRun: IMinedRun = {
+      taskId: "math",
+      passed: true,
+      slowThreshold: 8,
+      events: [
+        ev({ kind: "cycle", message: "1" }),
+        ev({ kind: "validated", passed: true, message: "GREEN" }),
+        ev({ kind: "done", message: "done" }),
+      ],
+    };
+    const noThreshold: IMinedRun = {
+      taskId: "slugify",
+      passed: true,
+      events: Array.from({ length: 30 }, () => ev({ kind: "cycle" })),
+    };
+    const bundle = mineWeaknesses([fastRun, noThreshold]);
+
+    expect(bundle.slowGreenRuns).toBe(0);
+    expect(bundle.patterns).toEqual([]);
+  });
+
   test("trace snippets carry the failing gate line, truncated", () => {
     const bundle = mineWeaknesses([failedGateRun("slugify", ["TS2532"])]);
     const snippets = bundle.patterns[0]?.traceSnippets ?? [];

--- a/packages/core/tests/self-harness-mine.test.ts
+++ b/packages/core/tests/self-harness-mine.test.ts
@@ -1,0 +1,192 @@
+import { test, expect, describe } from "bun:test";
+import { join } from "node:path";
+import {
+  mineWeaknesses,
+  dominantSignal,
+  type IMinedRun,
+} from "../src/self-harness/mine";
+import {
+  resolveSplits,
+  listCorpusTasks,
+  DEFAULT_HELD_IN,
+  DEFAULT_HELD_OUT,
+} from "../src/self-harness/split";
+import type { ILoopEvent } from "../src/loop/loop.types";
+
+const CORPUS = join(import.meta.dir, "..", "..", "..", "evals", "corpus");
+
+function ev(partial: Partial<ILoopEvent> & { kind: ILoopEvent["kind"] }): ILoopEvent {
+  return { task: "t", message: "", ...partial };
+}
+
+/** A run that ends stuck with a red gate dominated by the given rules. */
+function failedGateRun(taskId: string, rules: string[]): IMinedRun {
+  return {
+    taskId,
+    passed: false,
+    events: [
+      ev({ kind: "start", message: "start" }),
+      ev({ kind: "cycle", message: "cycle 1" }),
+      ev({
+        kind: "validated",
+        passed: false,
+        errors: rules.length,
+        rules,
+        message: `task ${taskId} · turn 1: red (${rules.length} error(s))`,
+      }),
+      ev({ kind: "stuck", message: "turn cap reached" }),
+    ],
+  };
+}
+
+/** A run that fails via repeated edit rejections. */
+function editRejectRun(taskId: string): IMinedRun {
+  const rejects = Array.from({ length: 4 }, (_, i) =>
+    ev({
+      kind: "tool",
+      message: `tool_rejected: edit target not found (attempt ${i + 1})`,
+    })
+  );
+
+  return {
+    taskId,
+    passed: false,
+    events: [
+      ev({ kind: "start", message: "start" }),
+      ...rejects,
+      ev({ kind: "stuck", message: "no progress" }),
+    ],
+  };
+}
+
+function passedRun(taskId: string): IMinedRun {
+  return {
+    taskId,
+    passed: true,
+    events: [
+      ev({ kind: "start", message: "start" }),
+      ev({ kind: "validated", passed: true, message: "GREEN" }),
+      ev({ kind: "done", message: "done" }),
+    ],
+  };
+}
+
+describe("dominantSignal", () => {
+  test("terminal booleans outrank tallies; largest tally wins otherwise", () => {
+    const base = {
+      repairs: 0,
+      salvages: 0,
+      editRejects: 0,
+      degenerated: false,
+      timedOut: false,
+      toolUseFailed: false,
+      tsErrors: 0,
+      lintErrors: 0,
+      missingModule: 0,
+      browser: 0,
+      build: 0,
+    };
+
+    expect(dominantSignal({ ...base, degenerated: true, editRejects: 9 })).toBe(
+      "degenerated"
+    );
+    expect(dominantSignal({ ...base, editRejects: 3, salvages: 1 })).toBe(
+      "edit-rejects"
+    );
+    // repairs only dominate as a LOOP (≥3) — two repair rounds are normal
+    expect(dominantSignal({ ...base, repairs: 2 })).toBe("none");
+    expect(dominantSignal({ ...base, repairs: 5 })).toBe("repair-loop");
+    expect(dominantSignal(base)).toBe("none");
+  });
+});
+
+describe("mineWeaknesses", () => {
+  test("clusters failures by exact signature and ranks by support", () => {
+    const bundle = mineWeaknesses([
+      passedRun("math"),
+      failedGateRun("slugify", ["TS2307", "TS2307"]),
+      failedGateRun("debounce", ["TS2307"]),
+      editRejectRun("checkout"),
+    ]);
+
+    expect(bundle.totalRuns).toBe(4);
+    expect(bundle.failedRuns).toBe(3);
+    expect(bundle.patterns).toHaveLength(2);
+
+    // The 2-run hallucinated-import cluster ranks first (support desc)
+    const [first, second] = bundle.patterns;
+
+    expect(first?.support).toBe(2);
+    expect(first?.failureClass).toBe("hallucinated-import");
+    expect(first?.taskIds).toEqual(["slugify", "debounce"]);
+    expect(first?.verifierEvidence).toContain("TS2307");
+    expect(first?.mechanism.length).toBeGreaterThan(0);
+
+    expect(second?.support).toBe(1);
+    expect(second?.dominantSignal).toBe("edit-rejects");
+    expect(second?.mechanism).toContain("don't match the working tree");
+  });
+
+  test("a fully green round yields an empty pattern list, not an error", () => {
+    const bundle = mineWeaknesses([passedRun("math"), passedRun("slugify")]);
+
+    expect(bundle.failedRuns).toBe(0);
+    expect(bundle.patterns).toEqual([]);
+  });
+
+  test("is deterministic: same input, same bundle", () => {
+    const runs = [
+      failedGateRun("slugify", ["no-as"]),
+      editRejectRun("checkout"),
+    ];
+
+    expect(JSON.stringify(mineWeaknesses(runs))).toBe(
+      JSON.stringify(mineWeaknesses(runs))
+    );
+  });
+
+  test("trace snippets carry the failing gate line, truncated", () => {
+    const bundle = mineWeaknesses([failedGateRun("slugify", ["TS2532"])]);
+    const snippets = bundle.patterns[0]?.traceSnippets ?? [];
+
+    expect(snippets.some((s) => s.startsWith("gate: task slugify"))).toBe(true);
+
+    for (const s of snippets) {
+      expect(s.length).toBeLessThanOrEqual(160);
+    }
+  });
+});
+
+describe("resolveSplits", () => {
+  test("defaults are disjoint, non-empty, and exist in the corpus", async () => {
+    const splits = await resolveSplits(CORPUS);
+
+    expect(splits.heldIn.length).toBeGreaterThan(0);
+    expect(splits.heldOut.length).toBeGreaterThan(0);
+
+    const all = await listCorpusTasks(CORPUS);
+
+    for (const id of [...splits.heldIn, ...splits.heldOut]) {
+      expect(all).toContain(id);
+    }
+
+    expect(splits.heldIn.filter((id) => splits.heldOut.includes(id))).toEqual(
+      []
+    );
+    // pinned defaults (update if the corpus changes)
+    expect(splits.heldIn).toEqual([...DEFAULT_HELD_IN]);
+    expect(splits.heldOut).toEqual([...DEFAULT_HELD_OUT]);
+  });
+
+  test("explicit lists are validated: unknown id and overlap both throw", async () => {
+    await expect(resolveSplits(CORPUS, ["nonexistent"], ["math"])).rejects.toThrow(
+      /unknown corpus task/
+    );
+    await expect(resolveSplits(CORPUS, ["math"], ["math"])).rejects.toThrow(
+      /disjoint/
+    );
+    await expect(resolveSplits(CORPUS, ["math"], [])).rejects.toThrow(
+      /non-empty/
+    );
+  });
+});

--- a/packages/core/tests/self-harness-overlay.test.ts
+++ b/packages/core/tests/self-harness-overlay.test.ts
@@ -20,21 +20,27 @@ const SAVED_ENV = {
   model: process.env.TSFORGE_MODEL,
 };
 
-function restoreEnv(): void {
-  for (const [key, envVar] of [
-    ["overlay", "TSFORGE_SELF_HARNESS_OVERLAY"],
-    ["home", "TSFORGE_HOME"],
-    ["model", "TSFORGE_MODEL"],
-  ] as const) {
-    const value = SAVED_ENV[key];
+function restoreVar(name: "overlay" | "home" | "model"): void {
+  const value = SAVED_ENV[name];
 
-    if (value === undefined) {
-      delete process.env[envVar];
+  if (value !== undefined) {
+    if (name === "overlay") {
+      process.env.TSFORGE_SELF_HARNESS_OVERLAY = value;
+    } else if (name === "home") {
+      process.env.TSFORGE_HOME = value;
     } else {
-      process.env[envVar] = value;
+      process.env.TSFORGE_MODEL = value;
     }
   }
+}
 
+function restoreEnv(): void {
+  delete process.env.TSFORGE_SELF_HARNESS_OVERLAY;
+  delete process.env.TSFORGE_HOME;
+  delete process.env.TSFORGE_MODEL;
+  restoreVar("overlay");
+  restoreVar("home");
+  restoreVar("model");
   resetOverlayCache();
 }
 
@@ -176,9 +182,9 @@ describe("isEmptyPatch", () => {
   test("true only when no surface is touched", () => {
     expect(isEmptyPatch({})).toBe(true);
     expect(isEmptyPatch({ ttsrRules: [], promptBlocks: {} })).toBe(true);
-    expect(
-      isEmptyPatch({ procedureCards: { TS2307: { what: "x" } } })
-    ).toBe(false);
+    expect(isEmptyPatch({ procedureCards: { TS2307: { what: "x" } } })).toBe(
+      false
+    );
   });
 });
 

--- a/packages/core/tests/self-harness-overlay.test.ts
+++ b/packages/core/tests/self-harness-overlay.test.ts
@@ -1,0 +1,297 @@
+import { test, expect, describe, afterEach } from "bun:test";
+import { mkdtemp, mkdir, writeFile, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  emptyOverlay,
+  parseOverlay,
+  mergeOverlay,
+  isEmptyPatch,
+  modelSlug,
+  overlayPathFor,
+  activeOverlay,
+  resetOverlayCache,
+} from "../src/self-harness/overlay";
+import type { IOverlayPatch } from "../src/self-harness/self-harness.types";
+
+const SAVED_ENV = {
+  overlay: process.env.TSFORGE_SELF_HARNESS_OVERLAY,
+  home: process.env.TSFORGE_HOME,
+  model: process.env.TSFORGE_MODEL,
+};
+
+function restoreEnv(): void {
+  for (const [key, envVar] of [
+    ["overlay", "TSFORGE_SELF_HARNESS_OVERLAY"],
+    ["home", "TSFORGE_HOME"],
+    ["model", "TSFORGE_MODEL"],
+  ] as const) {
+    const value = SAVED_ENV[key];
+
+    if (value === undefined) {
+      delete process.env[envVar];
+    } else {
+      process.env[envVar] = value;
+    }
+  }
+
+  resetOverlayCache();
+}
+
+afterEach(restoreEnv);
+
+describe("parseOverlay", () => {
+  test("accepts a well-formed overlay and validates every surface", () => {
+    const overlay = parseOverlay({
+      version: 1,
+      ttsrRules: [
+        {
+          name: "loop-breaker",
+          condition: ["stuck in a loop"],
+          scope: "content",
+          guidance: "Stop repeating; pick the smallest next step.",
+          repeatMode: "cooldown",
+          repeatGap: 5,
+        },
+      ],
+      agentSpecOverrides: [{ id: "explore", maxTurns: 20 }],
+      promptBlocks: {
+        bootstrap: { mode: "append", text: "Create the output file early." },
+      },
+      procedureCards: {
+        TS2307: { procedure: "1) Check the import path exists on disk." },
+      },
+    });
+
+    expect(overlay).not.toBeNull();
+    expect(overlay?.ttsrRules).toHaveLength(1);
+    expect(overlay?.ttsrRules[0]?.name).toBe("loop-breaker");
+    expect(overlay?.agentSpecOverrides).toEqual([
+      { id: "explore", maxTurns: 20 },
+    ]);
+    expect(overlay?.promptBlocks.bootstrap?.mode).toBe("append");
+    expect(overlay?.procedureCards.TS2307?.procedure).toContain("import path");
+  });
+
+  test("drops invalid entries per-surface instead of failing the overlay", () => {
+    const overlay = parseOverlay({
+      ttsrRules: [{ name: "no-guidance", condition: ["x"] }], // missing guidance
+      agentSpecOverrides: [{ maxTurns: 5 }, { id: "verify", maxTurns: -1 }],
+      promptBlocks: {
+        "not-a-block": { mode: "append", text: "hi" },
+        execution: { mode: "sideways", text: "hi" },
+        verification: { mode: "replace", text: "" },
+      },
+      procedureCards: { TS2532: { what: 42 }, "no-as": "not-an-object" },
+    });
+
+    expect(overlay).not.toBeNull();
+    expect(overlay?.ttsrRules).toEqual([]);
+    // the id-less override drops entirely; the bad maxTurns drops field-wise
+    expect(overlay?.agentSpecOverrides).toEqual([{ id: "verify" }]);
+    expect(overlay?.promptBlocks).toEqual({});
+    expect(overlay?.procedureCards).toEqual({});
+  });
+
+  test("rejects a non-object and tolerates missing fields", () => {
+    expect(parseOverlay("nope")).toBeNull();
+    expect(parseOverlay(null)).toBeNull();
+    expect(parseOverlay({})).toEqual(emptyOverlay());
+  });
+});
+
+describe("mergeOverlay", () => {
+  test("append edits to the same block compose; replace supersedes", () => {
+    const base = mergeOverlay(emptyOverlay(), {
+      promptBlocks: { bootstrap: { mode: "append", text: "A" } },
+    });
+    const appended = mergeOverlay(base, {
+      promptBlocks: { bootstrap: { mode: "append", text: "B" } },
+    });
+
+    expect(appended.promptBlocks.bootstrap).toEqual({
+      mode: "append",
+      text: "A\nB",
+    });
+
+    const replaced = mergeOverlay(appended, {
+      promptBlocks: { bootstrap: { mode: "replace", text: "C" } },
+    });
+
+    expect(replaced.promptBlocks.bootstrap).toEqual({
+      mode: "replace",
+      text: "C",
+    });
+  });
+
+  test("ttsr rules dedupe by name with the patch winning", () => {
+    const base = mergeOverlay(emptyOverlay(), {
+      ttsrRules: [
+        {
+          name: "r1",
+          condition: ["old"],
+          scope: "content",
+          guidance: "old guidance",
+          repeatMode: "once",
+        },
+      ],
+    });
+    const merged = mergeOverlay(base, {
+      ttsrRules: [
+        {
+          name: "r1",
+          condition: ["new"],
+          scope: "content",
+          guidance: "new guidance",
+          repeatMode: "once",
+        },
+      ],
+    });
+
+    expect(merged.ttsrRules).toHaveLength(1);
+    expect(merged.ttsrRules[0]?.guidance).toBe("new guidance");
+  });
+
+  test("agent overrides merge field-wise by id; cards merge per rule", () => {
+    const base = mergeOverlay(emptyOverlay(), {
+      agentSpecOverrides: [{ id: "explore", maxTurns: 10 }],
+      procedureCards: { TS2307: { what: "module missing" } },
+    });
+    const merged = mergeOverlay(base, {
+      agentSpecOverrides: [{ id: "explore", systemPrompt: "Be brief." }],
+      procedureCards: { TS2307: { procedure: "check the path" } },
+    });
+
+    expect(merged.agentSpecOverrides).toEqual([
+      { id: "explore", maxTurns: 10, systemPrompt: "Be brief." },
+    ]);
+    expect(merged.procedureCards.TS2307).toEqual({
+      what: "module missing",
+      procedure: "check the path",
+    });
+  });
+});
+
+describe("isEmptyPatch", () => {
+  test("true only when no surface is touched", () => {
+    expect(isEmptyPatch({})).toBe(true);
+    expect(isEmptyPatch({ ttsrRules: [], promptBlocks: {} })).toBe(true);
+    expect(
+      isEmptyPatch({ procedureCards: { TS2307: { what: "x" } } })
+    ).toBe(false);
+  });
+});
+
+describe("modelSlug / overlayPathFor", () => {
+  test("slugs a model id to a safe directory name", () => {
+    expect(modelSlug("deepseek-ai/DeepSeek-V4-Flash")).toBe(
+      "deepseek-ai-deepseek-v4-flash"
+    );
+    expect(modelSlug("///")).toBe("model");
+  });
+
+  test("path honors TSFORGE_HOME", () => {
+    process.env.TSFORGE_HOME = "/custom/home";
+    expect(overlayPathFor("m1")).toBe(
+      "/custom/home/.tsforge/self-harness/m1/overlay.json"
+    );
+  });
+});
+
+describe("activeOverlay resolution", () => {
+  test("env path wins and the cache resets when it changes", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "sh-overlay-"));
+
+    try {
+      const path = join(dir, "candidate.json");
+
+      await writeFile(
+        path,
+        JSON.stringify({
+          promptBlocks: { extra: { mode: "append", text: "candidate edit" } },
+        })
+      );
+      process.env.TSFORGE_SELF_HARNESS_OVERLAY = path;
+      resetOverlayCache();
+
+      expect(activeOverlay()?.promptBlocks.extra?.text).toBe("candidate edit");
+
+      delete process.env.TSFORGE_SELF_HARNESS_OVERLAY;
+      delete process.env.TSFORGE_MODEL;
+      process.env.TSFORGE_HOME = dir; // no models.json here → no overlay
+      resetOverlayCache();
+
+      expect(activeOverlay()).toBeNull();
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  test("falls back to the per-model promoted overlay", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "sh-overlay-"));
+
+    try {
+      process.env.TSFORGE_HOME = dir;
+      process.env.TSFORGE_MODEL = "acme/Model-X";
+      delete process.env.TSFORGE_SELF_HARNESS_OVERLAY;
+
+      const promoted = overlayPathFor("acme/Model-X");
+
+      await mkdir(join(dir, ".tsforge", "self-harness", "acme-model-x"), {
+        recursive: true,
+      });
+      await writeFile(
+        promoted,
+        JSON.stringify({
+          promptBlocks: { extra: { mode: "append", text: "promoted" } },
+        })
+      );
+      resetOverlayCache();
+
+      expect(activeOverlay()?.promptBlocks.extra?.text).toBe("promoted");
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  test("a malformed overlay file degrades to null, never a crash", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "sh-overlay-"));
+
+    try {
+      const path = join(dir, "broken.json");
+
+      await writeFile(path, "{not json");
+      process.env.TSFORGE_SELF_HARNESS_OVERLAY = path;
+      resetOverlayCache();
+
+      expect(activeOverlay()).toBeNull();
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+});
+
+describe("merge patch typing", () => {
+  test("a full-surface patch merges onto the empty overlay", () => {
+    const patch: IOverlayPatch = {
+      ttsrRules: [
+        {
+          name: "verify-artifact",
+          condition: ["task is complete"],
+          scope: "content",
+          guidance: "Verify the required artifact exists before concluding.",
+          repeatMode: "once",
+        },
+      ],
+      agentSpecOverrides: [{ id: "verify", task: "Check outputs exist." }],
+      promptBlocks: { verification: { mode: "append", text: "Read it back." } },
+      procedureCards: { "no-as": { procedure: "Type the parameter instead." } },
+    };
+    const merged = mergeOverlay(emptyOverlay(), patch);
+
+    expect(merged.ttsrRules).toHaveLength(1);
+    expect(merged.agentSpecOverrides).toHaveLength(1);
+    expect(Object.keys(merged.promptBlocks)).toEqual(["verification"]);
+    expect(Object.keys(merged.procedureCards)).toEqual(["no-as"]);
+  });
+});

--- a/packages/core/tests/self-harness-propose.test.ts
+++ b/packages/core/tests/self-harness-propose.test.ts
@@ -5,11 +5,7 @@ import type {
   IEvidenceBundle,
   IFailurePattern,
 } from "../src/self-harness/self-harness.types";
-import type {
-  IChatMessage,
-  IModelResponse,
-  IProvider,
-} from "../src/inference";
+import type { IChatMessage, IModelResponse, IProvider } from "../src/inference";
 
 function pattern(partial: Partial<IFailurePattern>): IFailurePattern {
   return {

--- a/packages/core/tests/self-harness-propose.test.ts
+++ b/packages/core/tests/self-harness-propose.test.ts
@@ -89,7 +89,32 @@ describe("propose", () => {
     expect(notes).toEqual([]);
   });
 
-  test("drops garbage, empty patches, and oversize patches with notes — never throws", async () => {
+  test("a malformed proposal is salvaged by one re-ask showing the parse error", async () => {
+    const { provider, prompts } = scriptedProvider([
+      "not json at all", // first attempt: garbage
+      VALID_RESPONSE, // salvage re-ask: corrected
+    ]);
+    const notes: string[] = [];
+    const candidates = await propose(bundle([pattern({})]), {
+      provider,
+      width: 1,
+      current: emptyOverlay(),
+      notes,
+    });
+
+    expect(candidates).toHaveLength(1);
+    expect(notes).toEqual([]);
+
+    // the re-ask shows the model its own reply + the reason it was unusable
+    const salvage = prompts[1] ?? [];
+
+    expect(salvage.some((m) => m.role === "assistant")).toBe(true);
+    expect(
+      salvage.some((m) => m.role === "user" && m.content.includes("unusable"))
+    ).toBe(true);
+  });
+
+  test("persistently malformed proposals drop with a salvage note — never throw", async () => {
     const oversize = JSON.stringify({
       targetPattern: "x",
       surface: "promptBlocks",
@@ -106,23 +131,23 @@ describe("propose", () => {
     });
     const { provider } = scriptedProvider([
       "not json at all",
-      JSON.stringify({ targetPattern: "x", patch: { ttsrRules: [] } }),
+      "still not json", // salvage also fails
       oversize,
-      VALID_RESPONSE,
+      oversize, // salvage repeats the oversize patch
     ]);
     const notes: string[] = [];
     const candidates = await propose(bundle([pattern({})]), {
       provider,
-      width: 4,
+      width: 2,
       current: emptyOverlay(),
       notes,
     });
 
-    expect(candidates).toHaveLength(1);
-    expect(notes).toHaveLength(3);
+    expect(candidates).toHaveLength(0);
+    expect(notes).toHaveLength(2);
+    expect(notes[0]).toContain("after salvage re-ask");
     expect(notes[0]).toContain("unparseable");
-    expect(notes[1]).toContain("no editable surface");
-    expect(notes[2]).toContain("minimality cap");
+    expect(notes[1]).toContain("minimality cap");
   });
 
   test("an invalid patch entry drops at validation, not at runtime", async () => {
@@ -136,7 +161,7 @@ describe("propose", () => {
         ttsrRules: [{ name: "bad-rule", condition: ["x"] }],
       },
     });
-    const { provider } = scriptedProvider([sneaky]);
+    const { provider } = scriptedProvider([sneaky, sneaky]);
     const notes: string[] = [];
     const candidates = await propose(bundle([pattern({})]), {
       provider,

--- a/packages/core/tests/self-harness-propose.test.ts
+++ b/packages/core/tests/self-harness-propose.test.ts
@@ -47,7 +47,7 @@ function scriptedProvider(responses: string[]): {
 
         i += 1;
 
-        return Promise.resolve({ content });
+        return Promise.resolve({ content, toolCalls: [] });
       },
     },
   };

--- a/packages/core/tests/self-harness-propose.test.ts
+++ b/packages/core/tests/self-harness-propose.test.ts
@@ -1,0 +1,217 @@
+import { test, expect, describe } from "bun:test";
+import { propose } from "../src/self-harness/propose";
+import { emptyOverlay } from "../src/self-harness/overlay";
+import type {
+  IEvidenceBundle,
+  IFailurePattern,
+} from "../src/self-harness/self-harness.types";
+import type {
+  IChatMessage,
+  IModelResponse,
+  IProvider,
+} from "../src/inference";
+
+function pattern(partial: Partial<IFailurePattern>): IFailurePattern {
+  return {
+    signature: "type-error|none|TS2532",
+    failureClass: "type-error",
+    dominantSignal: "none",
+    support: 2,
+    taskIds: ["slugify", "math"],
+    verifierEvidence: ["TS2532"],
+    traceSnippets: ["gate: red (2 errors)"],
+    mechanism: "Gate errors persisted.",
+    ...partial,
+  };
+}
+
+function bundle(patterns: IFailurePattern[]): IEvidenceBundle {
+  return { totalRuns: 8, failedRuns: patterns.length, patterns };
+}
+
+/** A provider that replays canned responses and records what it was asked. */
+function scriptedProvider(responses: string[]): {
+  provider: IProvider;
+  prompts: IChatMessage[][];
+} {
+  const prompts: IChatMessage[][] = [];
+  let i = 0;
+
+  return {
+    prompts,
+    provider: {
+      complete: (messages: IChatMessage[]): Promise<IModelResponse> => {
+        prompts.push(messages);
+
+        const content = responses[i] ?? "{}";
+
+        i += 1;
+
+        return Promise.resolve({ content });
+      },
+    },
+  };
+}
+
+const VALID_RESPONSE = JSON.stringify({
+  targetPattern: "type-error|none|TS2532",
+  surface: "procedureCards",
+  expectedEffect: "Guides the model to guard index access before use.",
+  risks: "Slightly longer repair feedback.",
+  patch: {
+    procedureCards: {
+      TS2532: {
+        procedure: "1) Bind the access to a const. 2) Guard for undefined.",
+      },
+    },
+  },
+});
+
+describe("propose", () => {
+  test("parses a valid response into a candidate with audit record", async () => {
+    const { provider } = scriptedProvider([VALID_RESPONSE]);
+    const notes: string[] = [];
+    const candidates = await propose(bundle([pattern({})]), {
+      provider,
+      width: 1,
+      current: emptyOverlay(),
+      idPrefix: "r1",
+      notes,
+    });
+
+    expect(candidates).toHaveLength(1);
+    expect(candidates[0]?.id).toBe("r1-c1");
+    expect(candidates[0]?.audit.targetPattern).toBe("type-error|none|TS2532");
+    expect(candidates[0]?.patch.procedureCards?.TS2532?.procedure).toContain(
+      "Guard for undefined"
+    );
+    expect(notes).toEqual([]);
+  });
+
+  test("drops garbage, empty patches, and oversize patches with notes — never throws", async () => {
+    const oversize = JSON.stringify({
+      targetPattern: "x",
+      surface: "promptBlocks",
+      expectedEffect: "too much",
+      risks: "sprawl",
+      patch: {
+        promptBlocks: {
+          bootstrap: { mode: "append", text: "a" },
+          execution: { mode: "append", text: "b" },
+          verification: { mode: "append", text: "c" },
+          extra: { mode: "append", text: "d" },
+        },
+      },
+    });
+    const { provider } = scriptedProvider([
+      "not json at all",
+      JSON.stringify({ targetPattern: "x", patch: { ttsrRules: [] } }),
+      oversize,
+      VALID_RESPONSE,
+    ]);
+    const notes: string[] = [];
+    const candidates = await propose(bundle([pattern({})]), {
+      provider,
+      width: 4,
+      current: emptyOverlay(),
+      notes,
+    });
+
+    expect(candidates).toHaveLength(1);
+    expect(notes).toHaveLength(3);
+    expect(notes[0]).toContain("unparseable");
+    expect(notes[1]).toContain("no editable surface");
+    expect(notes[2]).toContain("minimality cap");
+  });
+
+  test("an invalid patch entry drops at validation, not at runtime", async () => {
+    const sneaky = JSON.stringify({
+      targetPattern: "x",
+      surface: "ttsrRules",
+      expectedEffect: "hijack",
+      risks: "none",
+      patch: {
+        // missing guidance → rule drops → patch becomes empty → rejected
+        ttsrRules: [{ name: "bad-rule", condition: ["x"] }],
+      },
+    });
+    const { provider } = scriptedProvider([sneaky]);
+    const notes: string[] = [];
+    const candidates = await propose(bundle([pattern({})]), {
+      provider,
+      width: 1,
+      current: emptyOverlay(),
+      notes,
+    });
+
+    expect(candidates).toEqual([]);
+    expect(notes[0]).toContain("no editable surface");
+  });
+
+  test("later calls see earlier candidates (diversity context)", async () => {
+    const { provider, prompts } = scriptedProvider([
+      VALID_RESPONSE,
+      VALID_RESPONSE,
+    ]);
+
+    await propose(bundle([pattern({})]), {
+      provider,
+      width: 2,
+      current: emptyOverlay(),
+    });
+
+    const secondUser = prompts[1]?.find((m) => m.role === "user")?.content;
+
+    expect(secondUser).toContain("already proposed THIS round");
+    expect(secondUser).toContain("procedureCards");
+  });
+
+  test("empty bundle short-circuits; overflow patterns are noted, not silent", async () => {
+    const notes: string[] = [];
+    const { provider, prompts } = scriptedProvider([]);
+
+    expect(
+      await propose(bundle([]), {
+        provider,
+        width: 3,
+        current: emptyOverlay(),
+        notes,
+      })
+    ).toEqual([]);
+    expect(prompts).toHaveLength(0);
+    expect(notes[0]).toContain("no failure patterns");
+
+    const many = Array.from({ length: 7 }, (_, i) =>
+      pattern({ signature: `sig-${String(i)}` })
+    );
+    const scripted = scriptedProvider([VALID_RESPONSE]);
+    const overflowNotes: string[] = [];
+
+    await propose(bundle(many), {
+      provider: scripted.provider,
+      width: 1,
+      current: emptyOverlay(),
+      notes: overflowNotes,
+    });
+
+    expect(overflowNotes.some((n) => n.includes("dropped 2 low-support"))).toBe(
+      true
+    );
+  });
+
+  test("held-out task ids never appear in the proposer context", async () => {
+    const { provider, prompts } = scriptedProvider([VALID_RESPONSE]);
+
+    await propose(bundle([pattern({ taskIds: ["slugify"] })]), {
+      provider,
+      width: 1,
+      current: emptyOverlay(),
+    });
+
+    const user = prompts[0]?.find((m) => m.role === "user")?.content ?? "";
+
+    // The context contains only what the bundle carries — held-in evidence.
+    expect(user).toContain("slugify");
+    expect(user).not.toContain("held-out");
+  });
+});

--- a/packages/core/tests/self-harness-propose.test.ts
+++ b/packages/core/tests/self-harness-propose.test.ts
@@ -22,7 +22,12 @@ function pattern(partial: Partial<IFailurePattern>): IFailurePattern {
 }
 
 function bundle(patterns: IFailurePattern[]): IEvidenceBundle {
-  return { totalRuns: 8, failedRuns: patterns.length, patterns };
+  return {
+    totalRuns: 8,
+    failedRuns: patterns.length,
+    slowGreenRuns: 0,
+    patterns,
+  };
 }
 
 /** A provider that replays canned responses and records what it was asked. */

--- a/packages/core/tests/self-harness-web.test.ts
+++ b/packages/core/tests/self-harness-web.test.ts
@@ -1,0 +1,90 @@
+/**
+ * Web-task evaluation: split validation for the `web:` namespace and the
+ * blame-allocation logic of runWebTaskOnce (pass / fail-healthy / errored-sick
+ * / timeout), driven against a STUB headless-build subprocess so no model or
+ * real web gate is involved.
+ */
+import { test, expect, describe } from "bun:test";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { resolveSplits } from "../src/self-harness/split";
+import { runWebTaskOnce } from "../src/self-harness/evaluate-web";
+
+const CORPUS = join(import.meta.dir, "..", "..", "..", "evals", "corpus");
+
+describe("resolveSplits — web: namespace", () => {
+  test("accepts web:<slug> ids only when the slug is in the provided catalog", async () => {
+    const splits = await resolveSplits(
+      CORPUS,
+      ["math", "web:saas-crm"],
+      ["slugify", "web:udemy"],
+      ["saas-crm", "udemy"]
+    );
+
+    expect(splits.heldIn).toEqual(["math", "web:saas-crm"]);
+    expect(splits.heldOut).toEqual(["slugify", "web:udemy"]);
+  });
+
+  test("rejects unknown web slugs, and any web id when no catalog is provided", async () => {
+    await expect(
+      resolveSplits(CORPUS, ["web:not-an-app"], ["math"], ["saas-crm"])
+    ).rejects.toThrow(/unknown web task/);
+    await expect(
+      resolveSplits(CORPUS, ["web:saas-crm"], ["math"])
+    ).rejects.toThrow(/unknown web task/);
+  });
+
+  test("web ids participate in the disjointness check", async () => {
+    await expect(
+      resolveSplits(CORPUS, ["web:udemy"], ["web:udemy"], ["udemy"])
+    ).rejects.toThrow(/disjoint/);
+  });
+});
+
+/** A real (but instant, model-free) subprocess: an UNKNOWN app slug makes
+ *  headless-build print its catalog and exit 2 immediately — the deterministic
+ *  fail path, exercising the genuine spawn + blame-allocation contract. */
+async function inTmpDir(
+  body: (runDir: string) => Promise<void>
+): Promise<void> {
+  const dir = await mkdtemp(join(tmpdir(), "sh-web-"));
+
+  try {
+    await body(dir);
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+}
+
+describe("runWebTaskOnce — blame allocation (real spawn, instant exit)", () => {
+  test("a failing build with a HEALTHY endpoint records a minable failure", async () => {
+    await inTmpDir(async (runDir) => {
+      const outcome = await runWebTaskOnce("definitely-not-an-app", runDir, {
+        runsDir: runDir,
+        repeats: 1,
+        probeHealthy: () => Promise.resolve(true),
+      });
+
+      expect(outcome.errored).toBe(false);
+      expect(outcome.record.passed).toBe(false);
+      expect(outcome.record.label).toBe("web:definitely-not-an-app");
+      expect(outcome.run?.passed).toBe(false);
+      expect(outcome.run?.slowThreshold).toBeGreaterThan(50);
+    });
+  });
+
+  test("the same failure with a SICK endpoint records an errored run — no verdict", async () => {
+    await inTmpDir(async (runDir) => {
+      const outcome = await runWebTaskOnce("definitely-not-an-app", runDir, {
+        runsDir: runDir,
+        repeats: 1,
+        probeHealthy: () => Promise.resolve(false),
+      });
+
+      expect(outcome.errored).toBe(true);
+      expect(outcome.record.passed).toBe(false);
+      expect(outcome.run).toBeUndefined();
+    });
+  });
+});

--- a/packages/core/tests/session-e2e.test.ts
+++ b/packages/core/tests/session-e2e.test.ts
@@ -44,6 +44,33 @@ describe("session e2e — full agent loop via a scripted model", () => {
     expect(creates[0]?.file).toContain("hello.ts");
   });
 
+  test("an EMPTY no-tool reply mid-gated-build nudges and continues, never ends as 'responded'", async () => {
+    // Captured live (pm-platform, 2026-07-10): a degenerate 675ms empty reply
+    // during an endpoint flap ended a 180-turn build as "responded". The fix
+    // routes empty mid-build replies through the nudge-with-cap path.
+    const s = await runScriptedSession({
+      task: "build the thing",
+      accept: 'node -e "process.exit(0)"',
+      turns: [
+        { content: "" }, // degenerate empty reply (provider glitch)
+        {
+          toolCalls: [
+            call("create", { file: "b.ts", content: "export const b = 1;\n" }),
+          ],
+        },
+        { content: "done" },
+      ],
+    });
+
+    expect(s.fileExists("b.ts")).toBe(true);
+    expect(s.status).toBe("done");
+    expect(
+      s
+        .eventsOfKind("tool")
+        .some((e) => e.message.includes("empty reply during a gated build"))
+    ).toBe(true);
+  });
+
   test("a passing gate (accept) confirms the change as done", async () => {
     const s = await runScriptedSession({
       task: "create a file then finish",

--- a/packages/core/tests/session.test.ts
+++ b/packages/core/tests/session.test.ts
@@ -1221,29 +1221,46 @@ test("a never-yielding edit loop is bounded: a gate is FORCED and the guards sto
 
   try {
     const gateLog = join(dir, "gate-runs.log");
-    // The model NEVER yields — it overwrites one file it authored, with new content,
-    // every single turn (the index.css churn pathology). Before the fix the full
-    // gate only ran on yield, so it never ran → the no-progress guards never ticked
-    // → it churned to the maxTurns backstop. Now a gate is FORCED after
+    // The model NEVER yields — it churns one file it authored every single turn
+    // (creates it once, then EDITs it with new content forever). Before the fix the
+    // full gate only ran on yield, so it never ran → the no-progress guards never
+    // ticked → it churned to the maxTurns backstop. Now a gate is FORCED after
     // FULL_GATE_EVERY edits, surfacing the failure AND advancing the guards.
+    // (The churn is via `edit`, not create-overwrite — `create` no longer overwrites
+    // an existing file; that whole-file-rewrite escape hatch was removed.)
     let n = 0;
     const provider: IProvider = {
       async complete() {
         n += 1;
 
-        return {
-          content: "",
-          toolCalls: [
-            {
-              id: String(n),
-              name: "create",
-              arguments: {
-                file: "churn.ts",
-                content: `export const x = ${n};\n`,
-              },
-            },
-          ],
-        };
+        return n === 1
+          ? {
+              content: "",
+              toolCalls: [
+                {
+                  id: "1",
+                  name: "create",
+                  arguments: {
+                    file: "churn.ts",
+                    content: "export const x = 0;\n",
+                  },
+                },
+              ],
+            }
+          : {
+              content: "",
+              toolCalls: [
+                {
+                  id: String(n),
+                  name: "edit",
+                  arguments: {
+                    file: "churn.ts",
+                    oldString: `export const x = ${n - 2};`,
+                    newString: `export const x = ${n - 1};`,
+                  },
+                },
+              ],
+            };
       },
     };
     const session = await Session.create({
@@ -1260,8 +1277,11 @@ test("a never-yielding edit loop is bounded: a gate is FORCED and the guards sto
       : 0;
 
     expect(ran).toBeGreaterThan(0); // a gate was forced despite the model never yielding
-    expect(result.status).toBe("stuck"); // the no-progress guards stopped it
-    expect(result.turns).toBeLessThan(120); // before the runaway backstop
+    expect(result.status).toBe("stuck"); // the run terminated (steered, then stopped)
+    // Steering keeps a stalled run alive with escalating nudges, so a genuinely
+    // hopeless churn rides the ladder and may use the full turn budget — but it is
+    // STILL bounded (never an infinite loop); maxTurns is the ultimate backstop.
+    expect(result.turns).toBeLessThanOrEqual(120);
   } finally {
     await rm(dir, { recursive: true, force: true });
   }

--- a/packages/core/tests/settle-steps.test.ts
+++ b/packages/core/tests/settle-steps.test.ts
@@ -5,6 +5,7 @@ import { join } from "node:path";
 import { checkStuck, autoFixStep, type ILoopCtx } from "../src/loop/turn";
 import type { ILoopState, ILoopEvent } from "../src/loop";
 import { LOOP_LIMITS, RUN_STATUS } from "../src/loop";
+import { STEER_LADDER_MAX } from "../src/loop/feedback/steer";
 import type { IErrorItem } from "../src/validate";
 
 /** The settleGate steps extracted for unit testing (review item 4): checkStuck
@@ -23,6 +24,7 @@ function freshState(): ILoopState {
     edits: 0,
     regressions: 0,
     ttsrInterrupts: 0,
+    steerLevel: 0,
   };
 }
 
@@ -56,50 +58,57 @@ describe("checkStuck (the composed convergence guards)", () => {
     expect(events.filter((e) => e.kind === "stuck")).toHaveLength(0);
   });
 
-  test("persistent single error → STUCK with the samePersist detail", () => {
+  test("a persisting error ESCALATES steers, then parks once the ladder is exhausted", () => {
     const events: ILoopEvent[] = [];
     const ctx = makeCtx(events);
     const state = freshState();
-    let result: ReturnType<typeof checkStuck> = null;
 
-    // The same (file,rule) key every cycle, with a churn error so ONLY the
-    // primary per-error guard can fire (the whole-set guard sees a new set).
-    for (let i = 0; i < LOOP_LIMITS.samePersist; i += 1) {
-      result = checkStuck(
-        ctx,
-        state,
-        [err("src/a.ts:any"), err(`churn:${String(i)}`, `rule-${String(i)}`)],
-        i + 1
-      );
+    // The same (file,rule) every cycle: the first stall is detected patiently
+    // (samePersist), then steering ESCALATES fast (steerRetrigger) up the ladder.
+    // Drive cycles until the FIRST terminal, then assert the whole ladder was climbed
+    // exactly once — robust to the precise cadence (a generous bound can't loop).
+    let result: ReturnType<typeof checkStuck> = null;
+    const bound =
+      LOOP_LIMITS.samePersist +
+      LOOP_LIMITS.steerRetrigger * (STEER_LADDER_MAX + 2);
+
+    for (let i = 0; i < bound && result === null; i += 1) {
+      result = checkStuck(ctx, state, [err("src/a.ts:any")], i + 1);
     }
 
+    // It parked at the top of the ladder (not an instant kill).
     expect(result?.status).toBe(RUN_STATUS.stuck);
-    // The stuck event was reported exactly once, with a concrete detail.
-    const stuckEvents = events.filter((e) => e.kind === "stuck");
+    expect(result?.detail).toContain("steering exhausted");
+    expect(state.steerLevel).toBe(STEER_LADDER_MAX + 1);
 
-    expect(stuckEvents).toHaveLength(1);
+    // MAX steers were injected (L1..LMAX) before the single park event.
+    const steers = events.filter(
+      (e) => e.kind === "tool" && e.message.includes("steer")
+    );
+
+    expect(steers).toHaveLength(STEER_LADDER_MAX);
+    expect(events.filter((e) => e.kind === "stuck")).toHaveLength(1);
   });
 
-  test("identical whole error set repeating → STUCK via the set guard", () => {
+  test("an unchanging error set steers, then parks (never loops forever)", () => {
     const events: ILoopEvent[] = [];
     const ctx = makeCtx(events);
     const state = freshState();
     let result: ReturnType<typeof checkStuck> = null;
 
-    // Two errors, identical every cycle. The per-error guard is primary and has
-    // the tighter threshold, so a stuck verdict from EITHER guard is fine — what
-    // this pins is that an unchanging set terminates instead of looping forever.
-    const cycles = Math.max(
-      LOOP_LIMITS.gateStuckRepeats,
-      LOOP_LIMITS.samePersist
-    );
+    // Two errors, identical every cycle. Steering keeps the run alive through the
+    // ladder, but an unchanging set must EVENTUALLY park — never loop forever. Give
+    // it well past the ladder's height and assert it lands on a terminal park.
+    const cap =
+      LOOP_LIMITS.samePersist * (STEER_LADDER_MAX + 1) +
+      LOOP_LIMITS.gateStuckRepeats;
 
-    for (let i = 0; i < cycles && result === null; i += 1) {
+    for (let i = 0; i < cap && result?.status !== RUN_STATUS.stuck; i += 1) {
       result = checkStuck(ctx, state, [err("a:1"), err("b:2")], i + 1);
     }
 
     expect(result?.status).toBe(RUN_STATUS.stuck);
-    expect(result?.detail).toBeDefined();
+    expect(result?.detail).toContain("steering exhausted");
   });
 
   test("a shrinking error count never trips any guard (converging run)", () => {
@@ -115,6 +124,47 @@ describe("checkStuck (the composed convergence guards)", () => {
 
       expect(checkStuck(ctx, state, set, 6 - n)).toBeNull();
     }
+  });
+
+  test("the plateau ESCALATES the ladder even when no fine guard trips (fixes the slow climb)", () => {
+    const events: ILoopEvent[] = [];
+    const ctx = makeCtx(events);
+    // Fresh state (all fine-guard counters at 0, so none can trip on a single call), but
+    // one gate short of the plateau, with the all-time low (1) already hit. THIS gate is
+    // pure oscillation. If it escalates, the PLATEAU is the only possible trigger — this
+    // is the guard v6/v8 lacked, which let them crawl 150+ turns without reaching L3.
+    const state: ILoopState = {
+      ...freshState(),
+      redGates: LOOP_LIMITS.plateauGates - 1,
+      plateauBest: 1,
+    };
+
+    const result = checkStuck(ctx, state, [err("x:1")], 5);
+
+    expect(result).toBeNull(); // escalated + keep looping (not parked, not ignored)
+    expect(state.steerLevel).toBe(1); // climbed a rung on the plateau alone
+    expect(
+      events.some((e) => e.kind === "tool" && e.message.includes("oscillating"))
+    ).toBe(true);
+  });
+
+  test("sustained oscillation climbs the WHOLE ladder to the expert-park FAST (not 150 turns)", () => {
+    const events: ILoopEvent[] = [];
+    const ctx = makeCtx(events);
+    const state = freshState();
+    let result: ReturnType<typeof checkStuck> = null;
+
+    // Every cycle: a DIFFERENT error key (set rotates → the whole-set/persist guards keep
+    // resetting) but the count never drops below the all-time low → only the plateau sees
+    // it. It must reach the terminal park within a tight bound — the whole point of the fix.
+    const bound = LOOP_LIMITS.plateauGates * (STEER_LADDER_MAX + 1) + 5;
+
+    for (let i = 0; i < bound && result?.status !== RUN_STATUS.stuck; i += 1) {
+      result = checkStuck(ctx, state, [err(`k${String(i)}:1`)], i + 1);
+    }
+
+    expect(result?.status).toBe(RUN_STATUS.stuck); // reached the expert-park
+    expect(result?.detail).toContain("steering exhausted");
   });
 });
 

--- a/packages/core/tests/staged-build.test.ts
+++ b/packages/core/tests/staged-build.test.ts
@@ -139,6 +139,10 @@ describe("isImplementationFile / hasImplementation", () => {
       "src/components/ui/button.tsx",
       "src/main.ts",
       "src/main.tsx",
+      // laid down by scaffoldWeb in EVERY build — counting them made the
+      // phase-2 skip check always-true (hollow-app bug)
+      "src/routes/__root.tsx",
+      "src/routes/index.tsx",
     ]) {
       expect(isImplementationFile(p)).toBe(false);
     }
@@ -150,6 +154,9 @@ describe("isImplementationFile / hasImplementation", () => {
       "src/store/store.ts",
       "src/views/Home/home.hooks.ts",
       "src/game/game.ts",
+      // real route files beyond the scaffold pair still count
+      "src/routes/projects.tsx",
+      "src/routes/projects.$projectId.tsx",
     ]) {
       expect(isImplementationFile(p)).toBe(true);
     }

--- a/packages/core/tests/steer.test.ts
+++ b/packages/core/tests/steer.test.ts
@@ -1,0 +1,122 @@
+import { test, expect, describe } from "bun:test";
+import {
+  buildSteerMessage,
+  essentialMessages,
+  playbookFor,
+  STEER_LADDER_MAX,
+  type ISteerError,
+} from "../src/loop/feedback/steer";
+
+const err = (rule: string): ISteerError => ({
+  rule,
+  file: "src/views/Foo/index.tsx",
+  message: `${rule} violated`,
+});
+
+describe("playbookFor", () => {
+  test("resolves a bare rule name to its recipe", () => {
+    expect(playbookFor("no-jsx-computation")).toContain("src/lib");
+  });
+
+  test("resolves a plugin-prefixed rule to the same recipe", () => {
+    expect(playbookFor("tsforge/no-jsx-computation")).toBe(
+      playbookFor("no-jsx-computation")
+    );
+  });
+
+  test("the as-cast playbook teaches a type guard, never a cast", () => {
+    const play = playbookFor("no-restricted-syntax");
+
+    expect(play).toContain("TYPE GUARD");
+    expect(play).toContain("v is Status");
+  });
+
+  test("unknown / undefined rules have no playbook", () => {
+    expect(playbookFor("some-unknown-rule")).toBeNull();
+    expect(playbookFor(undefined)).toBeNull();
+  });
+});
+
+describe("buildSteerMessage escalation", () => {
+  const errors = [
+    err("tsforge/no-jsx-computation"),
+    err("no-restricted-syntax"),
+  ];
+
+  test("level 1 makes the model STEP BACK and diagnose its own loop", () => {
+    const msg = buildSteerMessage(1, errors, "same error 5×");
+
+    expect(msg).toContain("escalation 1");
+    expect(msg).toContain("STEP BACK");
+    expect(msg).toContain("DIFFERENT approach"); // reflect, don't feed a rule
+    expect(msg.toLowerCase()).toContain("whole-file");
+  });
+
+  test("level 2 tells the model to INVESTIGATE with tools (+ pattern for known rules)", () => {
+    const msg = buildSteerMessage(2, errors, "same error", true);
+
+    expect(msg).toContain("INVESTIGATE");
+    expect(msg).toContain("search the codebase");
+    // The known-good pattern is still offered as a reference when it fits.
+    expect(msg).toContain("no-jsx-computation");
+    expect(msg).toContain("TYPE GUARD");
+  });
+
+  test("web_search is suggested ONLY when web tools are enabled", () => {
+    expect(buildSteerMessage(2, errors, "s", true)).toContain("web_search");
+    expect(buildSteerMessage(2, errors, "s", false)).not.toContain(
+      "web_search"
+    );
+  });
+
+  test("level 2 with no known-rule errors still says INVESTIGATE (no static rule)", () => {
+    const msg = buildSteerMessage(2, [err("some-unknown-rule")], "stuck");
+
+    expect(msg).toContain("INVESTIGATE");
+    expect(msg).toContain("search the codebase");
+  });
+
+  test("level 3 changes strategy: invert, one error one file, then expert", () => {
+    const msg = buildSteerMessage(3, errors, "not converging");
+
+    expect(msg).toContain("SINGLE");
+    expect(msg).toContain("OPPOSITE");
+    expect(msg).toContain("already pass");
+    expect(msg).toContain("expert"); // the last resort is the stronger model
+  });
+
+  test("every level names the escalation out of the ladder max", () => {
+    for (let lvl = 1; lvl <= STEER_LADDER_MAX; lvl += 1) {
+      expect(buildSteerMessage(lvl, errors, "r")).toContain(
+        `/${String(STEER_LADDER_MAX)}`
+      );
+    }
+  });
+});
+
+describe("essentialMessages (context reset)", () => {
+  const msgs = [
+    { role: "system", content: "sys" },
+    { role: "user", content: "build the app" },
+    { role: "assistant", content: "attempt 1" },
+    { role: "user", content: "error: X" },
+    { role: "assistant", content: "attempt 2 (dead end)" },
+    { role: "user", content: "error: X still" },
+  ];
+
+  test("keeps ONLY the system prompt + the original task (drops the flailing middle)", () => {
+    const head = essentialMessages(msgs);
+
+    expect(head).toEqual([
+      { role: "system", content: "sys" },
+      { role: "user", content: "build the app" },
+    ]);
+  });
+
+  test("preserves order and omits a missing system/user cleanly", () => {
+    expect(essentialMessages([{ role: "user", content: "task" }])).toEqual([
+      { role: "user", content: "task" },
+    ]);
+    expect(essentialMessages([])).toEqual([]);
+  });
+});

--- a/packages/core/tests/tdd-enforcement.test.ts
+++ b/packages/core/tests/tdd-enforcement.test.ts
@@ -48,7 +48,9 @@ test("a created .ts logic file WITHOUT a test stays red in a non-git project", a
   } finally {
     rmSync(dir, { recursive: true, force: true });
   }
-});
+  // Steering keeps a stalled run alive through the ladder before parking (~4× the
+  // old cycle count), so allow more wall-clock than the 5s default.
+}, 20000);
 
 test("adding the test makes the same non-git project go green", async () => {
   const dir = project();

--- a/packages/core/tests/tool-accounting.test.ts
+++ b/packages/core/tests/tool-accounting.test.ts
@@ -92,6 +92,7 @@ function freshState(): ILoopState {
     edits: 0,
     regressions: 0,
     ttsrInterrupts: 0,
+    steerLevel: 0,
   };
 }
 


### PR DESCRIPTION
## What

Banks the general harness work from the last few days. The UI-only web-greenfield scaffold that was also on this branch has been **removed** — it's superseded by the BoringStack full-stack pivot (spec: `docs/superpowers/specs/2026-07-12-boringstack-fullstack-build-pivot-design.md`).

### Committed earlier on this branch (24 commits)
- **Self-harness (Algorithm-1)**: overlay layer + injection points, weakness mining, harness evaluator, model proposer, acceptance rule, 24/7 campaign driver with PROOF.md (Wilson CI + z-test), efficiency signal.

### This commit — general improvements
- **Steering ladder**: escalating STEER (L1 surgical / L2 rule-playbook / L3 one-file) + plateau backstop that escalates off an all-time-low gate count.
- **Expert rescue** (opt-in `TSFORGE_EXPERT_RESCUE`): hands a genuinely-stuck file to a stronger model; resolves the target from file-less (type-aware-lint) errors.
- **BoringStack conventions**: concise write-time guides (distilled from boringstack `docs/agents/*`), delivered PUSH (beside the matching gate error) + PULL (`pull_conventions` tool); each maps 1:1 to an enforced rule.
- **Harness fixes**:
  1. broken-file edit/create **deadlock** — a syntactically-broken file can be overwritten/big-edited so the model can escape;
  2. model error-feedback **diag cap 5→200** so it sees all errors;
  3. web gate runs cheap actionable **lint before the cryptic vite build** so a clear rule message isn't buried by a Rollup error.

## Why not the UI-only web scaffold
Live builds proved the model can produce kind-appropriate, gate-clean pages but hits a hard wall on persistence — because a UI-only app has no backend. Decision: for web apps, the harness scaffolds **BoringStack** (full-stack: Elysia + React + Postgres + Drizzle) and nothing else. The tsforge↔BoringStack scaffold integration (clone + manifest + boot + gate) is already built; the next work connects the AI build loop to it. See the spec.

## Test
`bun run validate` green — **2228 pass / 0 fail / 15 skip**, all e2e ALL PASS.