### PR TITLE
fix(memory): stop learned rules from self-poisoning the build that mines them

### DIFF
--- a/packages/core/src/loop/session.ts
+++ b/packages/core/src/loop/session.ts
@@ -50,7 +50,11 @@ import type { Reporter, ILoopEvent, IHandoff } from "./loop.types";
 import type { TtsrManager } from "./ttsr";
 import { initTtsrManager, applyTtsrInterrupt } from "./ttsr-init";
 import { selectThinking, offeredToolsFor } from "./model-call";
-import { mineLessons, consolidate as consolidateMemory } from "./memory";
+import {
+  mineLessons,
+  consolidate as consolidateMemory,
+  type ICandidateLesson,
+} from "./memory";
 import {
   buildChatSystem,
   buildDriveToGreenSystem,
@@ -76,6 +80,14 @@ import {
   tryExpertRescue,
 } from "./turn";
 
+/** Signature of the memory-consolidation step, injectable for tests so they can
+ *  capture the per-build source id each send passes. */
+export type ConsolidateLessonsFn = (
+  cwd: string,
+  candidates: readonly ICandidateLesson[],
+  source: string
+) => Promise<number>;
+
 /**
  * A persistent, tool-using conversation against a working directory — the engine
  * behind the interactive CLI. Unlike `runTask` (one RED-first task driven to
@@ -99,6 +111,10 @@ export interface ISessionConfig {
   context?: string[];
   parse?: ErrorParser;
   report?: Reporter;
+  /** Test seam: override the memory-consolidation step (defaults to the real
+   *  cross-build learned-rule pipeline). Lets a test observe the stable per-build
+   *  source id passed on every send. */
+  consolidateLessons?: ConsolidateLessonsFn;
   temperature?: number;
   enableThinking?: boolean;
   thinkingTokenBudget?: number;
@@ -190,6 +206,20 @@ export interface ISendOptions {
 }
 
 const SESSION_ID = "session";
+
+/** ONE stable memory-source id for this whole PROCESS (= one build; the nightly
+ *  loop spawns a fresh headless-build process per domain, and all of a build's
+ *  features / revisit attempts / Sessions run inside it). Memory's recurrence
+ *  gate (MIN_HITS_TO_ACTIVATE) treats a distinct `source` as a distinct session,
+ *  so this MUST be stable across the build — a per-send/per-Session id makes a
+ *  lesson mined twice within ONE build look like a cross-session recurrence,
+ *  activate mid-build, and trap the model with notes about its own in-progress
+ *  code (the learned-rule self-poisoning bug). Cross-build learning still works:
+ *  a separate invocation is a new process with a new id, so a genuinely
+ *  recurring lesson still bumps hits and activates on the next build. The pid
+ *  disambiguates two builds started in the same millisecond (Date.now alone can
+ *  collide), so genuine cross-build recurrence is never misread as same-build. */
+export const MEMORY_RUN_ID = `${SESSION_ID}-${Date.now().toString(36)}-${process.pid.toString(36)}`;
 
 /** A gate-output sink that also carries `flush()` — call it when the stream
  *  ends to emit any trailing line the process printed without a newline. */
@@ -1943,8 +1973,8 @@ export class Session {
   private async consolidateLessons(): Promise<void> {
     try {
       const candidates = mineLessons(this.sendEvents);
-      const runId = `${SESSION_ID}-${Date.now().toString(36)}`;
-      const active = await consolidateMemory(this.ctx.cwd, candidates, runId);
+      const consolidate = this.cfg.consolidateLessons ?? consolidateMemory;
+      const active = await consolidate(this.ctx.cwd, candidates, MEMORY_RUN_ID);
 
       if (active > 0) {
         this.report({

--- a/packages/core/tests/session-memory.test.ts
+++ b/packages/core/tests/session-memory.test.ts
@@ -1,0 +1,47 @@
+import { test, expect, describe } from "bun:test";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { IProvider } from "../src/inference";
+import { Session } from "../src/loop";
+import { MEMORY_RUN_ID } from "../src/loop/session";
+
+describe("Session memory source id (learned-rule self-poisoning guard)", () => {
+  test("every send in one build consolidates under the SAME stable source id", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "tsforge-sess-mem-"));
+
+    try {
+      // A provider that just yields — enough to drive a send to completion so the
+      // post-send memory hook runs.
+      const provider: IProvider = {
+        complete: () => Promise.resolve({ content: "done", toolCalls: [] }),
+      };
+
+      // Capture the source id passed to consolidation on each send (the seam
+      // defaults to the real memory pipeline in production).
+      const sources: string[] = [];
+      const session = await Session.create({
+        provider,
+        cwd: dir,
+        files: ["**/*"],
+        consolidateLessons: (_cwd, _cands, source) => {
+          sources.push(source);
+
+          return Promise.resolve(0);
+        },
+      });
+
+      await session.send("first send");
+      await session.send("second send");
+
+      // The whole point of the fix: two sends of ONE build share ONE source id.
+      // The old code recomputed `session-${Date.now()}` per send, so reverting
+      // it pushes two DIFFERENT ids here — this asserts the shared constant.
+      expect(sources).toHaveLength(2);
+      expect(sources[0]).toBe(MEMORY_RUN_ID);
+      expect(sources[1]).toBe(MEMORY_RUN_ID);
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+});


### PR DESCRIPTION
### The bug (observed live: expense[114] oscillated 141 turns, then parked)
tsforge's learned-rule memory records "this snippet failed check X → here's the fix," and interrupts the model (TTSR) when it re-types a recorded-bad pattern. During a build it turned on the model itself:

- The per-send memory hook recomputed its **source id** as `session-${Date.now()}` on **every** model send.
- Memory's recurrence gate (`MIN_HITS_TO_ACTIVATE = 2`) treats a distinct source as a distinct session — so a lesson mined on two sends of the **same build** looked like a cross-session recurrence, hit the threshold, and **activated mid-build**.
- The build had recorded **contradictory** lessons (both `f(this: void, …)` *and* `f(…)` as "failed"), so every form the model tried was blocked → unwinnable.

### The fix
One stable **per-process** source id (`MEMORY_RUN_ID = session-<time>-<pid>`). A build is one `headless-build` process (its features / revisit attempts / Sessions all share it), so nothing it mines can reach the activation threshold **within that build** → `learned-rules.json` stays empty during the build → no self-poisoning.

Cross-build learning is preserved: a separate invocation is a new process (new id), so a genuinely recurring lesson still bumps hits and activates on the next build. `pid` disambiguates two builds started in the same millisecond.

### Test
`session-memory.test.ts` drives **two real `Session.send`s** and asserts both consolidate under the one shared `MEMORY_RUN_ID` — reverting the per-send id breaks it deterministically (exercises the real session path, not `consolidate()` with hand-picked ids). Full `bun run validate` green; independent panel PASS (4/4) after a round that correctly rejected an earlier fake test.

Follow-up (not in this PR): the miner also over-records (coarse rule→edit attribution; non-rule tokens like `"expected"`; transient cascade TS codes). Those no longer bite within a build, but are worth tightening for persistent projects.