### PR TITLE
fix(boringstack): apply deterministic auto-fixes before final acceptance (gate parity)

### DIFF
--- a/packages/core/src/loop/boringstack/build.ts
+++ b/packages/core/src/loop/boringstack/build.ts
@@ -415,6 +415,14 @@ export async function runBoringstackBuild(opts: {
       message: "final acceptance: full validate + build + size checks…",
     });
 
+    // GATE PARITY: the per-cycle fast gate applies deterministic auto-fixes
+    // (prettier + eslint --fix) BEFORE it runs, but the full acceptance gate did
+    // not — so a feature could freeze fast-green yet fail final `validate` on
+    // auto-fixable formatting the model was never shown (e.g. a missing `;`).
+    // Apply the SAME auto-fixes here so acceptance and the per-cycle gate agree;
+    // this normalizes formatting a dev gets on save, it does not suppress errors.
+    await autofixApps(cwd, exec);
+
     const full = await runBoringstackGate(cwd, exec, "full");
 
     onEvent?.({

--- a/packages/core/tests/boringstack-build.test.ts
+++ b/packages/core/tests/boringstack-build.test.ts
@@ -400,4 +400,83 @@ describe("runBoringstackBuild", () => {
       await rm(dir, { recursive: true, force: true });
     }
   });
+
+  test("gate parity: applies the deterministic auto-fixes right before final acceptance", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "bs-"));
+
+    try {
+      const plan: IProductPlan = {
+        product: "A simple app",
+        slices: [
+          {
+            entity: {
+              id: "Invoice",
+              desc: "A billable unit",
+              fields: [{ name: "amount", type: "number" }],
+              relationships: [],
+              rules: [],
+            },
+            ui: {
+              screens: ["list"],
+              action: "create invoices",
+              shows: ["amount"],
+              nav: "Invoices",
+            },
+            verification: {
+              mustRemainTrue: ["auth required"],
+              mustNotHappen: ["unauthenticated access"],
+              acceptanceCheck: "bun test",
+            },
+          },
+        ],
+      };
+
+      await writePlan(dir, plan, "approved");
+
+      const execCalls: { argv: string[]; cwd: string }[] = [];
+
+      const exec: Exec = async (argv, opts) => {
+        execCalls.push({ argv: [...argv], cwd: opts.cwd });
+
+        return { code: 0, stdout: "", stderr: "" };
+      };
+
+      const res = await runBoringstackBuild({
+        cwd: dir,
+        goal: "simple app",
+        host: createHost(),
+        evaluator: createEvaluator(),
+        exec,
+        generate: async () => undefined,
+        generateUi: async () => undefined,
+      });
+
+      expect(res.status).toBe("done");
+
+      // The FULL acceptance gate ran…
+      const full = execCalls.findIndex(
+        (c) =>
+          c.argv[0] === "bash" && c.argv.join(" ").includes("bun run validate")
+      );
+
+      expect(full).toBeGreaterThan(0);
+
+      // …and the FOUR exec calls immediately before it are the full autofixApps
+      // contract — format + lint:fix for BOTH apps — proving acceptance is
+      // preceded by the same deterministic auto-fixes the per-cycle gate applies.
+      // Dropping `format` or the api half must fail this (not just the last step).
+      const before = execCalls
+        .slice(full - 4, full)
+        .map((c) => `${c.argv.join(" ")} @ ${c.cwd.replace(dir, "")}`);
+
+      expect(before).toEqual([
+        "bun run format @ /apps/api",
+        "bun run lint:fix @ /apps/api",
+        "bun run format @ /apps/ui",
+        "bun run lint:fix @ /apps/ui",
+      ]);
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
 });


### PR DESCRIPTION
### The bug (the dominant build-park cause from the overnight findings)
The per-cycle **fast** gate runs `autofixApps` (prettier + eslint --fix) before it, but the **full acceptance** gate ran `runBoringstackGate('full')` with **no preceding auto-fix**. So a feature could freeze fast-green yet **fail final `validate`** on auto-fixable formatting it was never shown — e.g. expense[102] parked at final acceptance on 2 `Insert ;` prettier errors.

### Fix
Run `autofixApps` right before the final acceptance gate too, so acceptance and the per-cycle gate apply the **same deterministic normalization**. This is **not** a gate relaxation — prettier / eslint --fix normalize formatting a dev gets on save; they never suppress a real error (build / size / type / lint failures still fail acceptance).

### Test
`runBoringstackBuild` drives to `done` and asserts the four exec calls immediately before the full gate are the complete autofix contract — `format` + `lint:fix` for **both** apps/api and apps/ui — so dropping `format` or either app's half fails the test.

Full `bun run validate` green; independent panel PASS (4/4).