### PR TITLE
fix(memory): learn from real diagnostics, not phantom rules or stage verdicts

### DIFF
--- a/packages/core/src/loop/boringstack/extract-failures.ts
+++ b/packages/core/src/loop/boringstack/extract-failures.ts
@@ -210,6 +210,23 @@ function parsedDiagnostic(
     );
   }
 
+  // An eslint PARSING error carries no ruleId — the row is `L:C error Parsing
+  // error: <detail>`. normalize() has already collapsed the multi-space gap that
+  // separates an eslint message from its trailing ruleId, so the generic row
+  // regex below would grab the message's last word (`… ';' expected` → rule
+  // `expected`) and mint a phantom rule. Capture these as `syntax` (matching the
+  // tsc-parser convention) so no message word ever masquerades as a rule id.
+  const eslintParseError = /^(\d+):(\d+) error (Parsing error:.*)$/u.exec(line);
+
+  if (eslintParseError !== null && state.currentFile !== "") {
+    return structuredFailure(
+      state.currentFile,
+      Number(eslintParseError[1] ?? "0"),
+      "syntax",
+      eslintParseError[3] ?? line
+    );
+  }
+
   const eslintError = /^(\d+):(\d+) error (.+?) ([\w@/-]+)$/u.exec(line);
 
   if (eslintError !== null && state.currentFile !== "") {

--- a/packages/core/src/loop/memory/mine.ts
+++ b/packages/core/src/loop/memory/mine.ts
@@ -7,6 +7,36 @@ import type { ICandidateLesson } from "./memory.types";
  *  rest anyway). */
 const MAX_EDITS_PER_WINDOW = 3;
 
+/** Gate verdicts that are NOT line-level code patterns. A mined lesson pairs a
+ *  rule with a before→after edit snippet, which only generalizes when the rule
+ *  names a *code construct* (a TS error code, an eslint rule). These verdicts are
+ *  structural or behavioral — a route not wired (`reachability`), a quality
+ *  critique (`judge`), a failing assertion (`bun-test`), an unreachable file
+ *  (`knip/unused-files`), or an unparseable source (`syntax`) — so the edit that
+ *  clears one is arbitrary; attaching it to the verdict just noises up the ledger.
+ *
+ *  This is a DENYLIST, keep-by-default: every real diagnostic id is learnable,
+ *  including bare eslint core rules with no `/` or `-` (`eqeqeq`, `curly`, `semi`,
+ *  `quotes`, `radix`), which this repo's gate enables as errors. A pattern
+ *  allowlist that required a `/` or `-` would silently drop those — the exact
+ *  no-silent-truncation trap this replaces. */
+const NON_PATTERN_VERDICTS = new Set<string>([
+  "reachability",
+  "judge",
+  "bun-test",
+  "syntax",
+  "knip/unused-files",
+  // The unclassified-gate fallback. Today opaqueGateError carries no `.rule`, so
+  // turn.ts drops it before mining — but it is precisely the kind of opaque
+  // verdict this set names, so denylist it too: cheap insurance if the gate ever
+  // starts surfacing the fallback as a rule id.
+  "gate-nonzero",
+]);
+
+function isLearnableRule(rule: string): boolean {
+  return !NON_PATTERN_VERDICTS.has(rule);
+}
+
 interface IEditWindow {
   file: string;
   before: string;
@@ -63,7 +93,9 @@ export function mineLessons(events: readonly ILoopEvent[]): ICandidateLesson[] {
     const failing = new Set(event.rules ?? []);
 
     if (prevFailing !== null && edits.length > 0) {
-      const fixed = [...prevFailing].filter((rule) => !failing.has(rule));
+      const fixed = [...prevFailing].filter(
+        (rule) => !failing.has(rule) && isLearnableRule(rule)
+      );
 
       for (const rule of fixed) {
         for (const edit of edits.slice(-MAX_EDITS_PER_WINDOW)) {

--- a/packages/core/tests/boringstack-extract-failures.test.ts
+++ b/packages/core/tests/boringstack-extract-failures.test.ts
@@ -72,6 +72,23 @@ error: script "lint:meta" exited with code 1`;
     );
   });
 
+  test("an eslint PARSING error is captured as `syntax`, not the message's last word", () => {
+    // A parsing-error row carries no ruleId; after normalize() collapses the
+    // message↔ruleId gap the generic row regex would grab `expected` (the last
+    // word of `… ';' expected`) and mint a phantom rule that later poisons mined
+    // lessons. It must be tagged `syntax` (the tsc-parser convention) instead.
+    const cwd = "/tmp/clone";
+    const out = `${cwd}/apps/api/src/api/note/note.routes.ts
+  12:5  error  Parsing error: ';' expected`;
+    const sigs = extractFailures(out, cwd);
+    const signature = [...sigs][0] ?? "";
+
+    expect(signature).toContain(
+      "failure:apps%2Fapi%2Fsrc%2Fapi%2Fnote%2Fnote.routes.ts:12:syntax"
+    );
+    expect(signature).not.toContain(":expected:");
+  });
+
   test("captures eslint error rows but ignores passing/summary noise", () => {
     const out = `
   12:10  error  Unexpected any  @typescript-eslint/no-explicit-any

--- a/packages/core/tests/memory.test.ts
+++ b/packages/core/tests/memory.test.ts
@@ -110,6 +110,42 @@ describe("mineLessons", () => {
 
     expect(mineLessons(events)).toHaveLength(0);
   });
+
+  test("drops non-pattern gate verdicts but keeps every real rule id", () => {
+    // The boringstack gate surfaces structural/behavioral VERDICTS — `reachability`
+    // (route not wired), `judge` (quality critique), `bun-test` (failing assertion),
+    // `syntax` (unparseable) — that name no code construct, so a mined snippet keyed
+    // to one is noise. Everything else is a real diagnostic id and stays learnable,
+    // INCLUDING bare eslint core rules like `eqeqeq`/`curly` that carry no `/` or `-`
+    // (this repo's gate enables them as errors — dropping them would be silent loss).
+    const events: ILoopEvent[] = [
+      red([
+        "reachability",
+        "judge",
+        "bun-test",
+        "syntax",
+        "knip/unused-files",
+        "gate-nonzero",
+        "TS2345",
+        "no-invalid-void-type",
+        "eqeqeq",
+        "curly",
+      ]),
+      edit("src/a.ts", "async f(this: void)", "async f()"),
+      validated([]),
+    ];
+
+    const rules = mineLessons(events)
+      .map((c) => c.rule)
+      .sort();
+
+    expect(rules).toEqual([
+      "TS2345",
+      "curly",
+      "eqeqeq",
+      "no-invalid-void-type",
+    ]);
+  });
 });
 
 describe("mergeCandidates + activeRules", () => {


### PR DESCRIPTION
## Problem

The learned-rule miner (`mineLessons`) recorded a lesson for **every** token in a gate's failing-rule set — including tokens that aren't code-pattern rules. A live `.tsforge/memory.json` held a bogus `rule:"expected"` entry attached to a normal method signature.

Root cause, traced end to end: an eslint **parsing-error** row carries no ruleId. `extract-failures.ts` runs every row through `normalize()`, which collapses the multi-space gap that separates an eslint *message* from its trailing *ruleId*. The generic row regex then grabs the message's last word — `… ';' expected` → phantom rule `expected`.

## Fix (two coupled changes)

1. **Source — `extract-failures.ts`:** eslint `Parsing error:` rows are now tagged `syntax` (the tsc-parser convention), so no message word can masquerade as a rule id.
2. **Miner — `mine.ts`:** the rule filter is now a **keep-by-default denylist** of non-code-pattern gate verdicts — `reachability`, `judge`, `bun-test`, `syntax`, `knip/unused-files`, `gate-nonzero`. A mined lesson pairs a rule with a before→after snippet, which only generalizes when the rule names a *code construct*; these are structural/behavioral verdicts, so the clearing edit is arbitrary noise.

Everything else stays learnable, **including bare eslint core rules** (`eqeqeq`, `curly`, `semi`, `quotes`, `radix`) that carry no `/` or `-`.

## Why not a pattern allowlist

The first cut required `TS\d+` or a `/`/`-`. The reviewer panel **BLOCKED** it (major): that silently drops bare core rules like `eqeqeq`/`curly`, which this repo's gate enables as errors — silent lesson loss, the exact no-silent-truncation trap. A bare word is pattern-indistinguishable from a real core rule, so the id-space must never be guessed: fix at the source + denylist the *known, harness-emitted* verdicts.

## Tests
- `boringstack-extract-failures`: a `Parsing error: ';' expected` row → `syntax`, never `expected`.
- `memory`: `mineLessons` drops all six verdicts while keeping `TS2345`, `no-invalid-void-type`, and the bare core rules `eqeqeq` + `curly`.

## Review
Reviewer panel (deepseek-4-pro, glm, grok, codex): **PASS** on the corrected approach. Residual findings addressed: `gate-nonzero` added to the denylist (defense; it currently reaches the miner ruleless), `knip/unused-files` + `gate-nonzero` added to test coverage.

Full `bun run validate` green.