### PR TITLE
fix(config): accept every CapabilityName in models.json, not just three

### DIFF
--- a/packages/core/src/models-config.ts
+++ b/packages/core/src/models-config.ts
@@ -332,10 +332,14 @@ function parseCapabilities(
 
   const out: Partial<Record<CapabilityName, string>> = {};
 
+  const capabilityNames: ReadonlySet<string> = new Set(CAPABILITY_NAMES);
+  const isCapabilityName = (cap: string): cap is CapabilityName =>
+    capabilityNames.has(cap);
+
   for (const [cap, target] of Object.entries(raw)) {
-    if (cap !== "vision" && cap !== "imageGen" && cap !== "expert") {
+    if (!isCapabilityName(cap)) {
       throw new Error(
-        `models.json: unknown capability "${cap}" — expected vision, imageGen, expert`
+        `models.json: unknown capability "${cap}" — expected ${CAPABILITY_NAMES.join(", ")}`
       );
     }
 

--- a/packages/core/tests/models-config.test.ts
+++ b/packages/core/tests/models-config.test.ts
@@ -285,6 +285,28 @@ test("capabilities: parse validates known keys + real entry targets, round-trips
   ).toThrow(/capability "vision" must name a model/);
 });
 
+test("capabilities: every CAPABILITY_NAMES key (incl. planner + expert) is a valid config target", () => {
+  // Regression: parseCapabilities hardcoded {vision,imageGen,expert} and rejected
+  // `planner`, even though planner IS a CapabilityName routable via env — so a
+  // planner role could never be set in models.json. The allowlist now derives from
+  // CAPABILITY_NAMES, so config and env agree on the full capability set.
+  const cfg = parseModelsConfig({
+    active: "a",
+    models: { a: { baseUrl: "u", model: "m" } },
+    capabilities: {
+      vision: "a",
+      imageGen: "a",
+      expert: "a",
+      planner: "a",
+    },
+  });
+
+  expect(cfg.capabilities?.vision).toBe("a");
+  expect(cfg.capabilities?.imageGen).toBe("a");
+  expect(cfg.capabilities?.expert).toBe("a");
+  expect(cfg.capabilities?.planner).toBe("a");
+});
+
 test("parseModelsConfig rejects a bad imageApi (fails loud, no silent fallback)", () => {
   expect(() =>
     parseModelsConfig({


### PR DESCRIPTION
## Problem

`planner` is a first-class `CapabilityName` — `resolveCapabilityModel` routes it via `TSFORGE_PLANNER_*` env — but `parseCapabilities` hardcoded its allowlist to `{vision, imageGen, expert}`. So a `planner` role set in `models.json` threw `unknown capability "planner"` and could only ever be configured through env. Config and env disagreed on the capability set.

Found while wiring a config-routed planner for a live build (planning is otherwise REPL-only).

## Fix

Derive the allowlist from `CAPABILITY_NAMES` — the single `as const` array that also types `CapabilityName` — so any capability in that set is settable in `models.json`, and no future capability can drift out of the config path. Uses a `ReadonlySet.has` guard: no type assertion (house rule), no duplicated allowlist.

## Test
`parseModelsConfig` accepts a capabilities block naming all four (`vision`/`imageGen`/`expert`/`planner`) and each round-trips.

## Review
Reviewer panel (deepseek-4-pro, glm, grok, codex): **PASS**. Minor finding addressed — the test now asserts all four outputs, not just two.

Full `bun run validate` green.