### PR TITLE
fix(boringstack): verify the API/OpenAPI spec as a build precondition, fail closed

### DIFF
--- a/packages/core/scripts/headless-build.ts
+++ b/packages/core/scripts/headless-build.ts
@@ -20,6 +20,10 @@ import { renderEvent } from "../src/render";
 import { logsDir } from "../src/session-store";
 import { loadApprovedPlan, parsePlan } from "../src/loop/planning/plan-store";
 import { readHostPorts, hostPortOr } from "../src/scaffold";
+import {
+  preflightOrExit,
+  resolveOpenApiUrl,
+} from "../src/loop/boringstack/openapi-preflight";
 
 export interface IHeadlessArgs {
   prompt?: string;
@@ -309,7 +313,11 @@ async function main(): Promise<void> {
     const valkeyPort = hostPortOr(ports, "VALKEY_HOST_PORT");
 
     process.env.TSFORGE_BORINGSTACK_DATABASE_URL ??= `postgresql://app:app_dev_password@localhost:${String(pgPort)}/app`;
-    process.env.OPENAPI_URL ??= `http://localhost:${String(apiPort)}/swagger/json`;
+    // Resolve the OpenAPI URL once (explicit env wins) and reuse it for both the
+    // gate's generate:api and the pre-flight below.
+    const openApiUrl = resolveOpenApiUrl(process.env.OPENAPI_URL, apiPort);
+
+    process.env.OPENAPI_URL = openApiUrl;
     // The host-run gate must reach the clone's PUBLISHED Valkey (isolated port), or
     // Valkey-dependent tests (e.g. the OAuth state store) fail on a locked, out-of-
     // scope file the model can't fix — wrongly blocking the feature. The app's Valkey
@@ -321,6 +329,16 @@ async function main(): Promise<void> {
     process.stdout.write(
       `isolated ports → postgres ${String(pgPort)} · api ${String(apiPort)} · valkey ${String(valkeyPort)}\n`
     );
+
+    // PRECONDITION: the stack's API must already be serving its OpenAPI spec — the
+    // UI regenerates its typed client from it on EVERY gate cycle. Verify it up
+    // front and fail LOUD + closed if not, rather than starting a build that would
+    // oscillate the model against an opaque, un-fixable "API unreachable" gate error.
+    await preflightOrExit(openApiUrl, dir, {
+      writeOut: (text) => process.stdout.write(text),
+      writeErr: (text) => process.stderr.write(text),
+      exit: (code) => process.exit(code),
+    });
   }
 
   // An autonomous build agent must be able to LOOK THINGS UP — `package_docs`

--- a/packages/core/src/loop/boringstack/build.ts
+++ b/packages/core/src/loop/boringstack/build.ts
@@ -309,6 +309,41 @@ export function describeBaseline(
   };
 }
 
+export interface IBaselinePartition {
+  /** `openapi-unreachable` signatures from the pristine gate: an INFRA precondition
+   *  failure (the API isn't serving its OpenAPI spec), never a real baseline. */
+  infra: string[];
+  /** Everything else — the genuine pre-existing scaffold defects that form the
+   *  differential baseline features are graded against. */
+  baseline: Set<string>;
+}
+
+/**
+ * Split the pristine gate's failure signatures into infra-precondition failures
+ * (`openapi-unreachable`) and everything else. `openapi-unreachable` must NEVER enter
+ * the differential baseline: if it did, `differentialStage` would suppress it forever
+ * and a feature whose only failure is the API being down would "pass" green with a
+ * stale/wrong client. It also must not be silently dropped (that would let
+ * `describeBaseline` misreport a RED-only-because-of-infra gate as "did NOT parse").
+ * The caller fails LOUD + closed on a non-empty `infra` list instead.
+ */
+export function partitionBaseline(
+  signatures: Iterable<string>
+): IBaselinePartition {
+  const infra: string[] = [];
+  const baseline = new Set<string>();
+
+  for (const sig of signatures) {
+    if (sig.startsWith("openapi-unreachable:")) {
+      infra.push(sig);
+    } else {
+      baseline.add(sig);
+    }
+  }
+
+  return { infra, baseline };
+}
+
 /**
  * Run the BoringStack build driver: require an approved plan, derive features
  * from its slices, and drive them through the greenfield loop
@@ -358,9 +393,32 @@ export async function runBoringstackBuild(opts: {
   });
 
   const baseRun = await runBoringstackGate(cwd, exec);
-  const baseline = baseRun.passed
-    ? new Set<string>()
-    : extractFailures(baseRun.output, cwd);
+  const { infra, baseline } = baseRun.passed
+    ? { infra: [], baseline: new Set<string>() }
+    : partitionBaseline(extractFailures(baseRun.output, cwd));
+
+  // FAIL CLOSED on an unmet infra precondition. If the pristine gate can't reach the
+  // API's OpenAPI spec, the UI's generate:api will fail EVERY cycle — driving the
+  // model against infra it cannot fix. Stop here with a clear, actionable status
+  // rather than start a build (this covers every entry path, and an API death between
+  // the headless pre-flight and this baseline).
+  if (infra.length > 0) {
+    const classes = infra
+      .map((sig) => sig.slice("openapi-unreachable:".length))
+      .join(", ");
+    const message =
+      `the BoringStack API is not serving its OpenAPI spec (${classes}) — the UI ` +
+      `regenerates its typed client from it every gate cycle. Bring the stack up ` +
+      `(dev.sh up) before building. This is an infra precondition, not a code fix.`;
+
+    onEvent?.({
+      kind: "stuck",
+      task: "boringstack",
+      message: `✗ precondition not met: ${message}`,
+    });
+
+    return { status: "needs-infra", features: [], infra: message };
+  }
 
   const report = describeBaseline(baseRun.passed, baseline.size);
 

--- a/packages/core/src/loop/boringstack/extract-failures.ts
+++ b/packages/core/src/loop/boringstack/extract-failures.ts
@@ -245,6 +245,60 @@ function parsedDiagnostic(
   return line.length > 0 && isErrorLine(line) ? line : null;
 }
 
+/** Reduce a raw `[generate:api] FAILED: <reason>` reason to a STABLE class token, so
+ *  the same infra failure class ("API down") yields the same signature regardless of
+ *  the exact wording (ECONNREFUSED vs. timeout vs. a status line). A fingerprint that
+ *  drifted with the reason text would defeat stuck-detection for one infra class. */
+export function classifyOpenApiFailure(reason: string): string {
+  const r = reason.toLowerCase();
+
+  if (r.includes("econnrefused") || r.includes("connection refused")) {
+    return "connection-refused";
+  }
+
+  if (
+    r.includes("etimedout") ||
+    r.includes("timeout") ||
+    r.includes("timed out")
+  ) {
+    return "timeout";
+  }
+
+  if (
+    r.includes("enotfound") ||
+    r.includes("getaddrinfo") ||
+    r.includes("dns")
+  ) {
+    return "dns";
+  }
+
+  const status = /\b([1-5]\d\d)\b/u.exec(reason);
+
+  if (status !== null) {
+    return `http-${status[1] ?? ""}`;
+  }
+
+  return "unreachable";
+}
+
+/** The BoringStack UI's `generate:api` step fetches the OpenAPI spec from the
+ *  running API and prints `[generate:api] FAILED: <reason>` when it can't. That is
+ *  an INFRA/precondition failure (the API isn't serving /swagger/json), not a lint
+ *  or type diagnostic the model can edit toward — left unrecognized it collapses
+ *  into an opaque `gate-nonzero` the model oscillated on for 5 cycles then regressed.
+ *  Surface it as one clear, actionable signature (rule `openapi-unreachable`) keyed by
+ *  a STABLE failure class (NO file component — signatureToError maps it to a file-less
+ *  "own" error; the full actionable guidance is built there). */
+function generateApiFailure(line: string): string | null {
+  const failed = /^\[generate:api\] FAILED: (.+)$/u.exec(line);
+
+  if (failed === null) {
+    return null;
+  }
+
+  return `openapi-unreachable:${classifyOpenApiFailure(failed[1] ?? "fetch failed")}`;
+}
+
 export function extractFailures(output: string, cwd: string): Set<string> {
   const signatures = new Set<string>();
   // knip prints `Unused files (N)` then one relative path per line, ending at the
@@ -276,6 +330,13 @@ export function extractFailures(output: string, cwd: string): Set<string> {
     }
 
     if (consumeSourceFile(line, state)) {
+      continue;
+    }
+
+    const apiFailure = generateApiFailure(line);
+
+    if (apiFailure !== null) {
+      signatures.add(apiFailure);
       continue;
     }
 

--- a/packages/core/src/loop/boringstack/gate-stages.ts
+++ b/packages/core/src/loop/boringstack/gate-stages.ts
@@ -29,7 +29,7 @@ function phaseForFile(file: string): number | undefined {
   return file.length > 0 ? 3 : undefined;
 }
 
-function signatureToError(sig: string): IErrorItem {
+export function signatureToError(sig: string): IErrorItem {
   const knip = /^knip:unused-file:(.+)$/u.exec(sig);
 
   if (knip !== null) {
@@ -48,6 +48,33 @@ function signatureToError(sig: string): IErrorItem {
         `it and put the test at the mirrored tests/ path instead (this stack's knip ` +
         `entries for tests are tests/**/*.test.ts, NOT co-located src tests). For a ` +
         `production file, wire it from an entry (e.g. an index.ts barrel) or delete it.`,
+    };
+  }
+
+  const openapi = /^openapi-unreachable:(.*)$/u.exec(sig);
+
+  if (openapi !== null) {
+    // NO file — this is an infra/precondition failure (the API isn't serving its
+    // spec), not a diagnostic in an editable file. A file (even "") would get it
+    // mis-classified as an out-of-scope/locked-file error; with no file it stays an
+    // "own", model-visible error carrying the actionable infra message. Phase 2
+    // (the apps/ui stage it comes from) so the frontier accounting matches the
+    // opaque apps/ui fallback it replaces. The signature carries a STABLE failure
+    // class (connection-refused / timeout / dns / http-NNN / unreachable); the full
+    // guidance is built here so the key stays stable across reason wording.
+    const failureClass = openapi[1] ?? "unreachable";
+
+    return {
+      key: sig,
+      rule: "openapi-unreachable",
+      phase: 2,
+      message:
+        `generate:api could not fetch the OpenAPI spec (${failureClass}). The API ` +
+        `is not serving /swagger/json. This is an INFRA PRECONDITION, not something ` +
+        `to fix in code — the BoringStack stack must be running (bring it up with ` +
+        `dev.sh up). If the stack IS up, your apps/api changes may have broken the ` +
+        `server so it can't boot — check apps/api compiles and starts. Do NOT edit ` +
+        `UI code to chase this.`,
     };
   }
 

--- a/packages/core/src/loop/boringstack/openapi-preflight.ts
+++ b/packages/core/src/loop/boringstack/openapi-preflight.ts
@@ -1,0 +1,207 @@
+import { isRecord } from "../../lib/guards";
+
+/** The BoringStack UI regenerates its typed API client from the running API's
+ *  OpenAPI spec (`bun run generate:api`) on EVERY gate cycle. If that spec URL is
+ *  unreachable, generate:api exits non-zero with output the gate parser can't
+ *  classify — an opaque `gate-nonzero` the MODEL cannot fix, which oscillated a
+ *  live build for 5 cycles then regressed. Pre-flighting the endpoint once, before
+ *  the loop, turns that into a single clear infra failure (fail-closed) instead. */
+
+/** Minimal shape of the fetch result we care about — so a test can inject a fake
+ *  without constructing a whole Response. */
+export interface IHttpProbe {
+  ok: boolean;
+  status: number;
+}
+
+export interface IWaitForOpenApiOpts {
+  /** Total budget before giving up (default 60s — a cold API can take a while). */
+  timeoutMs?: number;
+  /** Delay between attempts (default 1s). */
+  intervalMs?: number;
+  /** Per-attempt hard cap (default 10s) so a hung connect can't block the whole
+   *  budget — the real probe aborts the fetch after this. */
+  perAttemptMs?: number;
+  /** Injected probe; defaults to a real `fetch` (with abort + spec validation). */
+  probe?: (url: string) => Promise<IHttpProbe>;
+  /** Injected clock (defaults to Date.now) — lets tests run without real time. */
+  now?: () => number;
+  /** Injected sleep (defaults to setTimeout) — no-op in tests. */
+  sleep?: (ms: number) => Promise<void>;
+}
+
+export interface IWaitResult {
+  ok: boolean;
+  /** The last failure reason (HTTP status or thrown message); "" once ok. */
+  lastError: string;
+  /** How many probes were attempted (≥ 1). */
+  attempts: number;
+}
+
+/** The pre-flight decision: wait for the API's OpenAPI spec, and on failure return
+ *  the actionable, fail-closed message the caller prints before refusing to build.
+ *  Testable (inject the probe/clock via `opts`) so "unavailable endpoint blocks the
+ *  build" is proven without a real server or process.exit. */
+export async function preflightApi(
+  url: string,
+  cloneDir: string,
+  opts: IWaitForOpenApiOpts = {}
+): Promise<{ ok: true; attempts: number } | { ok: false; message: string }> {
+  const result = await waitForOpenApi(url, opts);
+
+  if (result.ok) {
+    return { ok: true, attempts: result.attempts };
+  }
+
+  return {
+    ok: false,
+    message:
+      `the BoringStack API is not serving its OpenAPI spec at ${url} ` +
+      `(${result.lastError}).\n` +
+      `  The stack must be running before a build — the UI regenerates its API ` +
+      `client from this spec every gate cycle.\n` +
+      `  Bring it up:  cd ${cloneDir}/infra/compose/compose && ./dev.sh up -d --build`,
+  };
+}
+
+/** The IO a headless caller needs to run the pre-flight as a hard gate: two writers
+ *  and a terminating `exit`. Injected so the gate decision (pass → continue, fail →
+ *  exit non-zero with the actionable message) is unit-testable without a real process. */
+export interface IPreflightIo {
+  writeOut: (text: string) => void;
+  writeErr: (text: string) => void;
+  /** Terminate the process with `code`; typed `never` because it does not return. */
+  exit: (code: number) => never;
+}
+
+/**
+ * Run the pre-flight as a fail-closed build gate: on success, print how many probes
+ * it took and return; on failure, print the actionable infra message to stderr and
+ * `exit(2)` — never starting a build against an API that can't serve its spec.
+ */
+export async function preflightOrExit(
+  url: string,
+  cloneDir: string,
+  io: IPreflightIo,
+  opts: IWaitForOpenApiOpts = {}
+): Promise<void> {
+  io.writeOut(`preflight: waiting for the API at ${url}…\n`);
+
+  const result = await preflightApi(url, cloneDir, opts);
+
+  if (!result.ok) {
+    io.writeErr(`\n✗ ${result.message}\n`);
+    io.exit(2);
+
+    return;
+  }
+
+  io.writeOut(
+    `preflight: API reachable (${String(result.attempts)} probe(s))\n`
+  );
+}
+
+/** Resolve the OpenAPI spec URL the gate + pre-flight use: an explicit `OPENAPI_URL`
+ *  wins; otherwise default to the API's published host port. Pure + testable. */
+export function resolveOpenApiUrl(
+  envUrl: string | undefined,
+  apiPort: number | string
+): string {
+  return envUrl !== undefined && envUrl.length > 0
+    ? envUrl
+    : `http://localhost:${String(apiPort)}/swagger/json`;
+}
+
+/** Is a parsed response body actually an OpenAPI/Swagger document generate:api can
+ *  consume? A version string ALONE isn't proof — `{"openapi":"garbage"}` or a version
+ *  with no `paths` still make the client generator fail, returning the harness to the
+ *  very gate failure the pre-flight exists to prevent. Require the three fields every
+ *  real spec (and the generator) needs: a non-empty version STRING, an `info` object,
+ *  and a `paths` object (even an empty `{}` is fine). Pure + testable. */
+export function isOpenApiSpec(body: unknown): boolean {
+  if (!isRecord(body)) {
+    return false;
+  }
+
+  const hasVersion =
+    (typeof body.openapi === "string" && body.openapi.length > 0) ||
+    (typeof body.swagger === "string" && body.swagger.length > 0);
+
+  return hasVersion && isRecord(body.info) && isRecord(body.paths);
+}
+
+/** The real probe: abort a hung connect after `perAttemptMs`, and require the body
+ *  to actually BE an OpenAPI/Swagger document — a 2xx that returns 204/HTML/garbage
+ *  would still make generate:api fail, so it must not pass pre-flight. Throws a
+ *  descriptive error on a 2xx-but-not-a-spec response (surfaced as the last error). */
+async function realProbe(
+  url: string,
+  perAttemptMs: number
+): Promise<IHttpProbe> {
+  const res = await fetch(url, { signal: AbortSignal.timeout(perAttemptMs) });
+
+  if (!res.ok) {
+    return { ok: false, status: res.status };
+  }
+
+  const body: unknown = await res.json();
+
+  if (!isOpenApiSpec(body)) {
+    throw new Error(
+      `HTTP ${String(res.status)} but the response is not a usable OpenAPI spec ` +
+        `(needs a non-empty "openapi"/"swagger" version plus "info" and "paths" ` +
+        `objects)`
+    );
+  }
+
+  return { ok: true, status: res.status };
+}
+
+function realSleep(ms: number): Promise<void> {
+  return new Promise((resolve) => {
+    setTimeout(resolve, ms);
+  });
+}
+
+/**
+ * Poll an OpenAPI spec URL until it responds OK or the timeout elapses. Returns
+ * ok=false with the last error (never throws), so the caller decides how to fail.
+ * At least one probe always runs, even with a zero timeout.
+ */
+export async function waitForOpenApi(
+  url: string,
+  opts: IWaitForOpenApiOpts = {}
+): Promise<IWaitResult> {
+  const timeoutMs = opts.timeoutMs ?? 60_000;
+  const intervalMs = opts.intervalMs ?? 1_000;
+  const perAttemptMs = opts.perAttemptMs ?? 10_000;
+  const probe = opts.probe ?? ((url) => realProbe(url, perAttemptMs));
+  const now = opts.now ?? Date.now;
+  const sleep = opts.sleep ?? realSleep;
+
+  const deadline = now() + timeoutMs;
+  let attempts = 0;
+
+  for (;;) {
+    attempts += 1;
+    let lastError: string;
+
+    try {
+      const result = await probe(url);
+
+      if (result.ok) {
+        return { ok: true, lastError: "", attempts };
+      }
+
+      lastError = `HTTP ${String(result.status)}`;
+    } catch (err: unknown) {
+      lastError = err instanceof Error ? err.message : String(err);
+    }
+
+    if (now() >= deadline) {
+      return { ok: false, lastError, attempts };
+    }
+
+    await sleep(intervalMs);
+  }
+}

--- a/packages/core/src/loop/greenfield/greenfield.types.ts
+++ b/packages/core/src/loop/greenfield/greenfield.types.ts
@@ -42,10 +42,14 @@ export interface IGreenfieldState {
 }
 
 export interface IGreenfieldResult {
-  status: "done" | "stuck" | "needs-plan";
+  status: "done" | "stuck" | "needs-plan" | "needs-infra";
   features: IFeature[];
   /** When stuck: the feature that exhausted its attempts. */
   stuckFeature?: string;
+  /** When needs-infra: the unmet precondition (e.g. the API isn't serving its
+   *  OpenAPI spec), so the caller can fail LOUD + closed rather than drive the model
+   *  against infra it cannot fix. */
+  infra?: string;
 }
 
 /**

--- a/packages/core/tests/boringstack-build.test.ts
+++ b/packages/core/tests/boringstack-build.test.ts
@@ -5,6 +5,7 @@ import { join } from "node:path";
 import type { Exec } from "../src/loop/boringstack/exec";
 import {
   boringstackDeps,
+  partitionBaseline,
   describeBaseline,
   rescueFileFor,
   runBoringstackBuild,
@@ -228,6 +229,31 @@ describe("describeBaseline", () => {
   });
 });
 
+describe("partitionBaseline", () => {
+  test("keeps ordinary pre-existing failures as the baseline, no infra", () => {
+    const { infra, baseline } = partitionBaseline([
+      "failure:apps%2Fapi%2Fsrc%2Ffoo.ts:1:TS2322:bad",
+      "knip:unused-file:src/orphan.ts",
+    ]);
+
+    expect(baseline.size).toBe(2);
+    expect(infra).toEqual([]);
+  });
+
+  test("splits openapi-unreachable OUT into infra (never the baseline) so the differential gate can't suppress the infra signal → false green", () => {
+    const { infra, baseline } = partitionBaseline([
+      "failure:apps%2Fapi%2Fsrc%2Ffoo.ts:1:TS2322:bad",
+      "openapi-unreachable:connection-refused",
+    ]);
+
+    expect(baseline.size).toBe(1);
+    expect(
+      [...baseline].some((s) => s.startsWith("openapi-unreachable:"))
+    ).toBe(false);
+    expect(infra).toEqual(["openapi-unreachable:connection-refused"]);
+  });
+});
+
 describe("scopeFor", () => {
   test("includes the resource dir, tests, UI feature, app schema, AND locale files", () => {
     const scope = scopeFor("Invoice");
@@ -396,6 +422,69 @@ describe("runBoringstackBuild", () => {
       expect(host.metaBaselineCaptures.count).toBe(1);
       // The per-feature expert rescue target was set (Invoice's service file).
       expect(host.rescueTargets.length).toBeGreaterThan(0);
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  test("fails CLOSED (needs-infra) when the pristine gate can't reach the API's OpenAPI spec", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "bs-"));
+
+    try {
+      const plan: IProductPlan = {
+        product: "A simple app",
+        slices: [
+          {
+            entity: {
+              id: "Invoice",
+              desc: "A billable unit",
+              fields: [{ name: "amount", type: "number" }],
+              relationships: [],
+              rules: [],
+            },
+            ui: {
+              screens: ["list"],
+              action: "create invoices",
+              shows: ["amount"],
+              nav: "Invoices",
+            },
+            verification: {
+              mustRemainTrue: ["auth required"],
+              mustNotHappen: ["unauthenticated access"],
+              acceptanceCheck: "bun test",
+            },
+          },
+        ],
+      };
+
+      await writePlan(dir, plan, "approved");
+
+      const host = createHost();
+      // The pristine baseline gate is RED solely because generate:api can't reach
+      // the API — an infra precondition, not a code defect the model can fix.
+      const exec: Exec = async () => ({
+        code: 1,
+        stdout:
+          "::tsforge-app apps/ui::\n" +
+          "[generate:api] FAILED: fetch failed (ECONNREFUSED)",
+        stderr: "",
+      });
+
+      const res = await runBoringstackBuild({
+        cwd: dir,
+        goal: "simple app",
+        host,
+        evaluator: createEvaluator(),
+        exec,
+        generate: async () => undefined,
+        generateUi: async () => undefined,
+      });
+
+      expect(res.status).toBe("needs-infra");
+      expect(res.infra).toContain("OpenAPI spec");
+      // It stopped BEFORE any feature work: no meta-baseline, nothing sent to the model.
+      expect(host.metaBaselineCaptures.count).toBe(0);
+      expect(host.sent.length).toBe(0);
     } finally {
       await rm(dir, { recursive: true, force: true });
     }

--- a/packages/core/tests/boringstack-extract-failures.test.ts
+++ b/packages/core/tests/boringstack-extract-failures.test.ts
@@ -2,6 +2,7 @@ import { test, expect, describe } from "bun:test";
 import {
   extractFailures,
   novelFailures,
+  classifyOpenApiFailure,
 } from "../src/loop/boringstack/extract-failures";
 
 describe("extractFailures", () => {
@@ -87,6 +88,41 @@ error: script "lint:meta" exited with code 1`;
       "failure:apps%2Fapi%2Fsrc%2Fapi%2Fnote%2Fnote.routes.ts:12:syntax"
     );
     expect(signature).not.toContain(":expected:");
+  });
+
+  test("a generate:api FAILED line becomes a clear, STABLE openapi-unreachable infra signature (not opaque)", () => {
+    const out =
+      "::tsforge-app apps/ui::\n" +
+      "[generate:api] Fetching http://localhost:62306/swagger/json\n" +
+      "[generate:api] FAILED: fetch failed (ECONNREFUSED)\n" +
+      "[generate:api] Hint: start apps/api or set OPENAPI_URL to a reachable spec.";
+    const sigs = extractFailures(out, "/tmp/clone");
+    const sig =
+      [...sigs].find((s) => s.startsWith("openapi-unreachable:")) ?? "";
+
+    // The signature has NO file component (prefix is `openapi-unreachable:`, not
+    // `failure:<file>:…`) so it maps to a file-less "own" error the model sees, not
+    // an out-of-scope/locked-file diagnostic. The suffix is a STABLE failure CLASS
+    // (not the raw prose) so the fingerprint doesn't drift with the wording.
+    expect(sig).toBe("openapi-unreachable:connection-refused");
+    expect(sig).not.toStartWith("failure:");
+    expect(sig).not.toContain("gate-nonzero");
+  });
+
+  describe("classifyOpenApiFailure", () => {
+    test("maps distinct wordings of the same infra class to one stable token", () => {
+      expect(classifyOpenApiFailure("fetch failed (ECONNREFUSED)")).toBe(
+        "connection-refused"
+      );
+      expect(classifyOpenApiFailure("The operation timed out")).toBe("timeout");
+      expect(classifyOpenApiFailure("getaddrinfo ENOTFOUND api")).toBe("dns");
+      expect(classifyOpenApiFailure("responded with 503 Service")).toBe(
+        "http-503"
+      );
+      expect(classifyOpenApiFailure("something weird happened")).toBe(
+        "unreachable"
+      );
+    });
   });
 
   test("captures eslint error rows but ignores passing/summary noise", () => {

--- a/packages/core/tests/boringstack-gate-stages.test.ts
+++ b/packages/core/tests/boringstack-gate-stages.test.ts
@@ -3,6 +3,7 @@ import {
   boringstackCommandStage,
   reachabilityStage,
   judgeStage,
+  signatureToError,
 } from "../src/loop/boringstack/gate-stages";
 import type { Exec } from "../src/loop/boringstack/exec";
 import type { IFeature } from "../src/loop/greenfield/greenfield.types";
@@ -79,6 +80,24 @@ UNFAMILIAR TOOL FAILURE: the useful downstream detail`;
     expect(error?.phase).toBe(2);
     expect(error?.message).toContain("useful downstream detail");
     expect(error?.message).not.toContain("healthy API output");
+  });
+});
+
+describe("signatureToError", () => {
+  test("an openapi-unreachable signature maps to a file-less, model-visible infra error", () => {
+    const sig = "openapi-unreachable:connection-refused";
+    const err = signatureToError(sig);
+
+    // NO file — so it stays an "own" error the model sees, not a locked/out-of-scope
+    // diagnostic. Phase 2 matches the apps/ui stage it replaces. The key stays the
+    // stable class; the actionable guidance (incl. the class + dev.sh) is built here.
+    expect(err.key).toBe(sig);
+    expect(err.rule).toBe("openapi-unreachable");
+    expect(err.file).toBeUndefined();
+    expect(err.phase).toBe(2);
+    expect(err.message).toContain("connection-refused");
+    expect(err.message).toContain("dev.sh up");
+    expect(err.message).toContain("Do NOT edit");
   });
 });
 

--- a/packages/core/tests/openapi-preflight.test.ts
+++ b/packages/core/tests/openapi-preflight.test.ts
@@ -1,0 +1,240 @@
+import { test, expect, describe } from "bun:test";
+import {
+  waitForOpenApi,
+  preflightApi,
+  preflightOrExit,
+  resolveOpenApiUrl,
+  isOpenApiSpec,
+  type IHttpProbe,
+  type IPreflightIo,
+} from "../src/loop/boringstack/openapi-preflight";
+
+describe("isOpenApiSpec (2xx alone is not proof)", () => {
+  test("true for an OpenAPI or Swagger document with version + info + paths", () => {
+    expect(isOpenApiSpec({ openapi: "3.1.0", info: {}, paths: {} })).toBe(true);
+    expect(isOpenApiSpec({ swagger: "2.0", info: {}, paths: {} })).toBe(true);
+  });
+
+  test("false for a non-spec body (204/HTML/arbitrary JSON)", () => {
+    expect(isOpenApiSpec(null)).toBe(false);
+    expect(isOpenApiSpec("<html>not found</html>")).toBe(false);
+    expect(isOpenApiSpec({ message: "ok" })).toBe(false);
+  });
+
+  test("false when the version string is present but info/paths are missing (generate:api would still fail)", () => {
+    // A bare version with no `paths` (or no `info`) is not a spec the client
+    // generator can consume — accepting it returns the harness to the gate failure
+    // the pre-flight exists to prevent.
+    expect(isOpenApiSpec({ openapi: "3.1.0" })).toBe(false);
+    expect(isOpenApiSpec({ openapi: "3.1.0", info: {} })).toBe(false);
+    expect(isOpenApiSpec({ openapi: "garbage" })).toBe(false);
+  });
+});
+
+describe("resolveOpenApiUrl", () => {
+  test("an explicit OPENAPI_URL wins", () => {
+    expect(resolveOpenApiUrl("http://explicit/spec", 62306)).toBe(
+      "http://explicit/spec"
+    );
+  });
+
+  test("falls back to the API's published port when unset or empty", () => {
+    expect(resolveOpenApiUrl(undefined, 62306)).toBe(
+      "http://localhost:62306/swagger/json"
+    );
+    expect(resolveOpenApiUrl("", 7330)).toBe(
+      "http://localhost:7330/swagger/json"
+    );
+  });
+});
+
+/** A virtual clock so tests never wait on real time. */
+function fakeClock(): {
+  now: () => number;
+  sleep: (ms: number) => Promise<void>;
+} {
+  let t = 0;
+
+  return {
+    now: () => t,
+    sleep: async (ms: number) => {
+      t += ms;
+    },
+  };
+}
+
+describe("waitForOpenApi", () => {
+  test("returns ok once the endpoint responds (after transient failures)", async () => {
+    const clock = fakeClock();
+    let calls = 0;
+
+    const probe = async (): Promise<IHttpProbe> => {
+      calls += 1;
+
+      return calls < 3 ? { ok: false, status: 503 } : { ok: true, status: 200 };
+    };
+
+    const r = await waitForOpenApi("http://api/swagger/json", {
+      probe,
+      now: clock.now,
+      sleep: clock.sleep,
+      intervalMs: 10,
+      timeoutMs: 10_000,
+    });
+
+    expect(r.ok).toBe(true);
+    expect(r.attempts).toBe(3);
+  });
+
+  test("returns ok=false with the last error on timeout, never throws", async () => {
+    const clock = fakeClock();
+
+    const probe = async (): Promise<IHttpProbe> => {
+      throw new Error("ECONNREFUSED");
+    };
+
+    const r = await waitForOpenApi("http://api/swagger/json", {
+      probe,
+      now: clock.now,
+      sleep: clock.sleep,
+      intervalMs: 100,
+      timeoutMs: 250,
+    });
+
+    expect(r.ok).toBe(false);
+    expect(r.lastError).toBe("ECONNREFUSED");
+    expect(r.attempts).toBeGreaterThan(0);
+  });
+
+  test("a non-OK HTTP status is reported as the last error", async () => {
+    const clock = fakeClock();
+    const probe = async (): Promise<IHttpProbe> => ({ ok: false, status: 404 });
+
+    const r = await waitForOpenApi("http://api/swagger/json", {
+      probe,
+      now: clock.now,
+      sleep: clock.sleep,
+      intervalMs: 100,
+      timeoutMs: 0,
+    });
+
+    expect(r.ok).toBe(false);
+    expect(r.lastError).toBe("HTTP 404");
+    // At least one probe runs even with a zero timeout.
+    expect(r.attempts).toBe(1);
+  });
+});
+
+describe("preflightApi (fail-closed build guard)", () => {
+  test("ok when the spec becomes reachable", async () => {
+    const clock = fakeClock();
+    const probe = async (): Promise<IHttpProbe> => ({ ok: true, status: 200 });
+
+    const r = await preflightApi("http://api/swagger/json", "/tmp/clone", {
+      probe,
+      now: clock.now,
+      sleep: clock.sleep,
+    });
+
+    expect(r.ok).toBe(true);
+
+    if (r.ok) {
+      expect(r.attempts).toBe(1);
+    }
+  });
+
+  test("an unreachable endpoint blocks the build with an actionable message", async () => {
+    const clock = fakeClock();
+
+    const probe = async (): Promise<IHttpProbe> => {
+      throw new Error("ECONNREFUSED");
+    };
+
+    const r = await preflightApi("http://api/swagger/json", "/tmp/clone", {
+      probe,
+      now: clock.now,
+      sleep: clock.sleep,
+      intervalMs: 100,
+      timeoutMs: 0,
+    });
+
+    expect(r.ok).toBe(false);
+
+    if (!r.ok) {
+      // Carries the URL, the fetch reason, and the exact command to bring the
+      // stack up — a human (or the model's operator) can act on it immediately.
+      expect(r.message).toContain("http://api/swagger/json");
+      expect(r.message).toContain("ECONNREFUSED");
+      expect(r.message).toContain("./dev.sh up -d --build");
+      expect(r.message).toContain("/tmp/clone/infra/compose/compose");
+    }
+  });
+});
+
+/** A fake IO that records writes and turns exit into a throw (real exit doesn't
+ *  return), so a failing pre-flight's control flow is observable in a test. */
+function fakeIo(): {
+  io: IPreflightIo;
+  out: string[];
+  err: string[];
+  exits: number[];
+} {
+  const out: string[] = [];
+  const err: string[] = [];
+  const exits: number[] = [];
+
+  const io: IPreflightIo = {
+    writeOut: (text) => {
+      out.push(text);
+    },
+    writeErr: (text) => {
+      err.push(text);
+    },
+    exit: (code) => {
+      exits.push(code);
+
+      throw new Error(`__exit_${String(code)}__`);
+    },
+  };
+
+  return { io, out, err, exits };
+}
+
+describe("preflightOrExit (fail-closed build gate)", () => {
+  test("reachable → writes progress and never exits", async () => {
+    const { io, out, exits } = fakeIo();
+    const probe = async (): Promise<IHttpProbe> => ({ ok: true, status: 200 });
+
+    await preflightOrExit("http://api/swagger/json", "/tmp/clone", io, {
+      probe,
+      now: () => 0,
+      sleep: async () => undefined,
+    });
+
+    expect(exits).toEqual([]);
+    expect(out.join("")).toContain("API reachable");
+  });
+
+  test("unreachable → exits(2) with the actionable message on stderr", async () => {
+    const clock = fakeClock();
+    const { io, err, exits } = fakeIo();
+
+    const probe = async (): Promise<IHttpProbe> => {
+      throw new Error("ECONNREFUSED");
+    };
+
+    await expect(
+      preflightOrExit("http://api/swagger/json", "/tmp/clone", io, {
+        probe,
+        now: clock.now,
+        sleep: clock.sleep,
+        intervalMs: 100,
+        timeoutMs: 0,
+      })
+    ).rejects.toThrow("__exit_2__");
+
+    expect(exits).toEqual([2]);
+    expect(err.join("")).toContain("ECONNREFUSED");
+    expect(err.join("")).toContain("./dev.sh up -d --build");
+  });
+});


### PR DESCRIPTION
## What

The BoringStack UI regenerates its typed API client from the running API's OpenAPI spec (`generate:api`) on **every** gate cycle. When that spec is unreachable, the step exits non-zero with output the gate parser couldn't classify — an opaque `gate-nonzero` the model can't fix. On a live build this oscillated for 5 cycles then regressed. The panel diagnosed it as `scaffold-infra`, not the code.

The stack's services should always be running; needing the API up to generate the client SDK is a **precondition**, not a design flaw to engineer around. So verify it and fail **loud + closed**.

## Changes

- **`openapi-preflight.ts`** — `waitForOpenApi` (injectable probe/clock), `preflightApi`, and `preflightOrExit` (fail-closed gate with injected IO; headless uses it, tests drive it without a real process). `isOpenApiSpec` requires a non-empty version string **plus** `info` and `paths` objects. `realProbe` aborts a hung connect and validates the body.
- **`extract-failures.ts`** — `[generate:api] FAILED: <reason>` → a **stable** `openapi-unreachable:<class>` signature (`connection-refused` / `timeout` / `dns` / `http-NNN` / `unreachable`) via `classifyOpenApiFailure`, so the fingerprint doesn't drift with reason wording. No file component — stays a model-visible "own" error.
- **`gate-stages.ts`** — `signatureToError` maps it to a file-less, phase-2 infra error whose message says explicitly: this is infra, do **not** edit UI code.
- **`build.ts`** — `partitionBaseline` splits infra out of the differential baseline (never suppressed → no false green), and `runBoringstackBuild` fails closed with a new **`needs-infra`** status when the pristine gate can't reach the spec — before any feature work, covering every entry path and a death between pre-flight and baseline.

## Scope

Covers the **start-time and baseline-time** precondition (the common case: the stack isn't up). A mid-build API death still surfaces the clear, bounded infra error to the model (parks via the escalation ladder, not the old infinite oscillation); a hard loop-level abort that skips the ladder on mid-cycle infra failure needs the shared `settleGate`/escalation seam and is a deliberate follow-up.

## Verification

- All touched source files carry mirrored tests (`openapi-preflight.test.ts`, `boringstack-extract-failures.test.ts`, `boringstack-gate-stages.test.ts`, `boringstack-build.test.ts`).
- Full `bun run validate` green.
- Passed the pre-push reviewer panel (4 reviewers, 0 blocking).