### PR TITLE
fix(headless): canonicalize the clone dir so gate paths aren't mangled (symlinked /tmp)

### DIFF
--- a/packages/core/scripts/headless-build.ts
+++ b/packages/core/scripts/headless-build.ts
@@ -8,7 +8,7 @@
 //
 // The driver plans resources, runs BoringStack's generators + wiring per resource,
 // the model fills the domain, and BoringStack's own `validate`/`check` is the gate.
-import { appendFileSync, existsSync, mkdirSync } from "node:fs";
+import { appendFileSync, existsSync, mkdirSync, realpathSync } from "node:fs";
 import { join } from "node:path";
 import { OpenAICompatibleProvider, PROVIDER_LIMITS } from "../src/inference";
 import { resolveActiveModel, resolveApiKey } from "../src/models-config";
@@ -58,6 +58,21 @@ async function installPlanFile(
     return `failed to process plan from ${planPath}: ${
       err instanceof Error ? err.message : String(err)
     }`;
+  }
+}
+
+/**
+ * Resolve a clone dir to its REAL (symlink-canonical) path so it matches the paths
+ * the gate's tools print. macOS resolves `/tmp/x` → `/private/tmp/x`; without this,
+ * cwd-stripping in the failure parser leaves a stray prefix and mangles every file
+ * path, so the model is wrongly told editable files are out of scope. A missing dir
+ * is returned unchanged — the downstream `apps/api` check reports it cleanly.
+ */
+export function resolveWorkspaceDir(dir: string): string {
+  try {
+    return realpathSync(dir);
+  } catch {
+    return dir;
   }
 }
 
@@ -258,19 +273,28 @@ async function main(): Promise<void> {
   const args = parseHeadlessArgs(process.argv.slice(2));
 
   const prompt = args.prompt;
-  const dir = args.dir;
+  const rawDir = args.dir;
 
   if (
     prompt === undefined ||
     prompt.length === 0 ||
-    dir === undefined ||
-    dir.length === 0
+    rawDir === undefined ||
+    rawDir.length === 0
   ) {
     process.stderr.write(
       'usage: headless-build.ts "<build goal>" <boringstack-clone-dir> [--log-file <path>] [--plan <file>]\n'
     );
     process.exit(2);
   }
+
+  // Canonicalize the clone dir to its REAL path. The gate's tools (bun/eslint/tsc)
+  // emit OS-resolved absolute paths — on macOS `/tmp/x` is really `/private/tmp/x` —
+  // so if we stripped a logical/symlinked cwd from those, a stray prefix would remain
+  // and every file path would be mangled (`apps/api/private/apps/api/…`). That path
+  // matches no editable-scope glob, so the model gets told real, editable files are
+  // "locked" and parks (observed live on a `/tmp` clone). Resolving up front makes the
+  // cwd match what the tools print.
+  const dir = resolveWorkspaceDir(rawDir);
 
   // For a greenfield boringstack clone (has apps/api directory), enforce that an
   // approved plan is either already in place or supplied via --plan.

--- a/packages/core/tests/headless-build-args.test.ts
+++ b/packages/core/tests/headless-build-args.test.ts
@@ -1,5 +1,11 @@
 import { describe, expect, test } from "bun:test";
-import { parseHeadlessArgs } from "../scripts/headless-build";
+import { mkdtemp, rm, mkdir, symlink, realpath } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  parseHeadlessArgs,
+  resolveWorkspaceDir,
+} from "../scripts/headless-build";
 
 describe("parseHeadlessArgs", () => {
   test("parses prompt and dir from positional arguments", () => {
@@ -65,5 +71,32 @@ describe("parseHeadlessArgs", () => {
 
     expect(result.prompt).toBe("goal");
     expect(result.dir).toBeUndefined();
+  });
+});
+
+describe("resolveWorkspaceDir", () => {
+  test("resolves a symlinked clone dir to its real path (so gate paths match cwd)", async () => {
+    const base = await mkdtemp(join(tmpdir(), "hb-real-"));
+
+    try {
+      const real = join(base, "real-clone");
+      const link = join(base, "link-clone");
+
+      await mkdir(real, { recursive: true });
+      await symlink(real, link);
+
+      // The symlink resolves to the real dir — this is the macOS /tmp→/private/tmp
+      // class of mismatch that mangled gate paths and falsely "locked" files.
+      expect(await realpath(link)).toBe(await realpath(real));
+      expect(resolveWorkspaceDir(link)).toBe(await realpath(real));
+    } finally {
+      await rm(base, { recursive: true, force: true });
+    }
+  });
+
+  test("returns a non-existent dir unchanged (the apps/api check reports it later)", () => {
+    const missing = join(tmpdir(), "hb-does-not-exist-xyz-12345");
+
+    expect(resolveWorkspaceDir(missing)).toBe(missing);
   });
 });


### PR DESCRIPTION
## What

A live BoringStack build on a `/tmp` clone parked with the model repeatedly insisting that real, editable files were **"locked"** — e.g. stuck on `sonarjs/no-duplicate-string` in a bookmark test it was told it couldn't touch.

## Root cause

The gate's tools (bun/eslint/tsc) print OS-resolved absolute paths. On macOS `/tmp/x` resolves to `/private/tmp/x`, but the clone dir was passed logically as `/tmp/x`. Stripping the logical cwd from a physical path left a stray `/private`, and `qualify()` then produced `apps/api/private/apps/api/tests/…` — a path that matches **no** editable-scope glob. So every real failure in a real file looked out-of-scope and the loop parked.

## Fix

`resolveWorkspaceDir` canonicalizes the clone dir with `realpathSync` at the headless entry, so the cwd used for path-stripping matches exactly what the tools emit. A missing dir is returned unchanged (the later `apps/api` existence check reports it cleanly).

## Verification

- New tests: `resolveWorkspaceDir` resolves a symlinked dir to its real path, and passes a non-existent dir through.
- Full `bun run validate` green.
- Passed the pre-push reviewer panel.

Found by a live overnight build (killed on the oscillation, per the kill-fast-and-fix rule).