### PR TITLE
fix(boringstack): capture full multi-line eslint messages (don't truncate the fix)

### DIFF
--- a/packages/core/src/loop/boringstack/extract-failures.ts
+++ b/packages/core/src/loop/boringstack/extract-failures.ts
@@ -41,9 +41,30 @@ function joinMultilineEslintRows(output: string): string {
   const plain = (s: string): string => s.replace(ANSI, "");
   const isErrorStart = (s: string): boolean =>
     /^\s*\d+:\d+\s+error\s/u.test(plain(s));
-  // eslint right-pads the ruleId with 2+ spaces: `… message  rule/id`.
+  // A join TERMINATOR is eslint's padded ruleId column: 2+ spaces then a
+  // PLUGIN-qualified id (contains `/`, e.g. `module-boundaries/single-semantic-module`
+  // or `@typescript-eslint/x`). Requiring the slash avoids a prose continuation like
+  // `Do not use  console` being mistaken for a ruleId and terminating early.
   const endsWithRuleId = (s: string): boolean =>
-    /\S {2,}[\w@/-]+\s*$/u.test(plain(s));
+    /\S {2,}@?[\w-]+\/[\w@/-]+\s*$/u.test(plain(s));
+
+  // A BOUNDARY stops the join WITHOUT being consumed — the multi-line message can't
+  // legitimately cross it: a new error row, a source-file header (a path ending in
+  // .ts/.tsx), an `::tsforge-app::` stage marker, or a `$` command echo. This stops
+  // a rule-LESS row (e.g. a `Parsing error`, which carries no ruleId) from swallowing
+  // the next file's header + diagnostics.
+  const isBoundary = (s: string): boolean => {
+    const p = plain(s).trim();
+
+    return (
+      isErrorStart(s) ||
+      p.startsWith("$") ||
+      /^::tsforge-app .+::$/u.test(p) ||
+      /\.[cm]?[jt]sx?:?$/u.test(p)
+    );
+  };
+
+  const MAX_SPAN = 15;
 
   const out: string[] = [];
 
@@ -57,26 +78,31 @@ function joinMultilineEslintRows(output: string): string {
       continue;
     }
 
-    // Accumulate continuation lines until one carries the ruleId (inclusive),
-    // stopping short of the next error row so a missing ruleId can't swallow it.
+    // Scan forward for the ruleId terminator, but STOP at a boundary or the span cap.
+    // Only collapse when a terminator is actually found — otherwise a rule-less error
+    // (parse error) or an unterminated block is emitted UNCHANGED (old per-line
+    // behavior), so nothing downstream is swallowed.
     let j = i + 1;
 
     while (
       j < lines.length &&
+      j - i <= MAX_SPAN &&
       !endsWithRuleId(lines[j] ?? "") &&
-      !isErrorStart(lines[j] ?? "")
+      !isBoundary(lines[j] ?? "")
     ) {
       j += 1;
     }
 
-    const consumedRuleId =
+    if (
       j < lines.length &&
-      endsWithRuleId(lines[j] ?? "") &&
-      !isErrorStart(lines[j] ?? "");
-    const end = consumedRuleId ? j + 1 : j;
-
-    out.push(lines.slice(i, end).join(" "));
-    i = end - 1;
+      j - i <= MAX_SPAN &&
+      endsWithRuleId(lines[j] ?? "")
+    ) {
+      out.push(lines.slice(i, j + 1).join(" "));
+      i = j;
+    } else {
+      out.push(start);
+    }
   }
 
   return out.join("\n");

--- a/packages/core/src/loop/boringstack/extract-failures.ts
+++ b/packages/core/src/loop/boringstack/extract-failures.ts
@@ -18,6 +18,71 @@ function normalize(raw: string, cwd: string): string {
 }
 
 /**
+ * eslint's stylish formatter renders a MULTI-LINE rule message across several lines:
+ * the `L:C error <first line>` row, then the raw continuation lines, with the ruleId
+ * appended (after 2+ spaces of padding) to the LAST line. Example (module-boundaries
+ * `single-semantic-module`):
+ *
+ *   6:8  error  Mixed semantic categories detected in module:
+ *   - function
+ *   - class
+ *
+ *   A module must contain only one semantic concern.
+ *   Move declarations into separate files/modules  module-boundaries/single-semantic-module
+ *
+ * The per-line parser would keep only the first line (and miss the ruleId), so the
+ * model sees a truncated, unactionable message ("…detected in module:" — no categories,
+ * no fix) and sprays near-green (observed live). Collapse each such multi-line row into
+ * ONE line so the full message + ruleId parse. Single-line rows (message + ruleId
+ * already together) pass through untouched.
+ */
+function joinMultilineEslintRows(output: string): string {
+  const lines = output.split("\n");
+  const plain = (s: string): string => s.replace(ANSI, "");
+  const isErrorStart = (s: string): boolean =>
+    /^\s*\d+:\d+\s+error\s/u.test(plain(s));
+  // eslint right-pads the ruleId with 2+ spaces: `… message  rule/id`.
+  const endsWithRuleId = (s: string): boolean =>
+    /\S {2,}[\w@/-]+\s*$/u.test(plain(s));
+
+  const out: string[] = [];
+
+  for (let i = 0; i < lines.length; i += 1) {
+    const start = lines[i] ?? "";
+
+    // Not a multi-line START (either not an error row, or already a complete
+    // single-line row with its ruleId) → pass through.
+    if (!isErrorStart(start) || endsWithRuleId(start)) {
+      out.push(start);
+      continue;
+    }
+
+    // Accumulate continuation lines until one carries the ruleId (inclusive),
+    // stopping short of the next error row so a missing ruleId can't swallow it.
+    let j = i + 1;
+
+    while (
+      j < lines.length &&
+      !endsWithRuleId(lines[j] ?? "") &&
+      !isErrorStart(lines[j] ?? "")
+    ) {
+      j += 1;
+    }
+
+    const consumedRuleId =
+      j < lines.length &&
+      endsWithRuleId(lines[j] ?? "") &&
+      !isErrorStart(lines[j] ?? "");
+    const end = consumedRuleId ? j + 1 : j;
+
+    out.push(lines.slice(i, end).join(" "));
+    i = end - 1;
+  }
+
+  return out.join("\n");
+}
+
+/**
  * Extract a set of FAILURE SIGNATURES from a composed BoringStack gate run
  * (`bun test` + `tsc` + `eslint`, all interleaved). Each signature identifies one
  * distinct failure so two gate runs can be diffed: a feature is judged only on the
@@ -260,7 +325,7 @@ export function extractFailures(output: string, cwd: string): Set<string> {
     inUnusedFiles: false,
   };
 
-  for (const rawLine of output.split("\n")) {
+  for (const rawLine of joinMultilineEslintRows(output).split("\n")) {
     const line = normalize(rawLine, cwd);
 
     if (consumeMarker(line, state)) {

--- a/packages/core/src/loop/boringstack/extract-failures.ts
+++ b/packages/core/src/loop/boringstack/extract-failures.ts
@@ -53,16 +53,21 @@ function joinMultilineEslintRows(output: string): string {
   const isRuleIdTerminator = (s: string): boolean =>
     /\S {2,}@?[\w-]+\/[\w@/-]+\s*$/u.test(plain(s));
 
-  // A BOUNDARY the join must NOT cross or consume: a new error row, a source-file
-  // header (path ending in .ts/.tsx), an `::tsforge-app::` marker, or a `$` echo.
-  // This is what stops a rule-LESS row (a `Parsing error` carries no ruleId) from
-  // swallowing the next file's header + diagnostics, and stops a following error row
-  // (which is itself plugin-qualified) from being fused into the current one.
+  // Any diagnostic row (error OR warning) — a following one must never be fused into
+  // the current message, even though a warning row is also plugin-qualified.
+  const isDiagnosticRow = (s: string): boolean =>
+    /^\s*\d+:\d+\s+(?:error|warning)\s/u.test(plain(s));
+
+  // A BOUNDARY the join must NOT cross or consume: another diagnostic row, a source-
+  // file header (path ending in .ts/.tsx), an `::tsforge-app::` marker, or a `$` echo.
+  // This stops a rule-LESS row (a `Parsing error` carries no ruleId) from swallowing
+  // the next file's header + diagnostics, and stops a following error/warning row
+  // (itself plugin-qualified) from being fused into the current one.
   const isBoundary = (s: string): boolean => {
     const p = plain(s).trim();
 
     return (
-      isErrorStart(s) ||
+      isDiagnosticRow(s) ||
       p.startsWith("$") ||
       /^::tsforge-app .+::$/u.test(p) ||
       /\.[cm]?[jt]sx?:?$/u.test(p)

--- a/packages/core/src/loop/boringstack/extract-failures.ts
+++ b/packages/core/src/loop/boringstack/extract-failures.ts
@@ -58,18 +58,24 @@ function joinMultilineEslintRows(output: string): string {
   const isDiagnosticRow = (s: string): boolean =>
     /^\s*\d+:\d+\s+(?:error|warning)\s/u.test(plain(s));
 
-  // A BOUNDARY the join must NOT cross or consume: another diagnostic row, an
-  // `::tsforge-app::` marker, a `$` echo, or a source-file HEADER. The header must be
-  // a BARE path (the whole trimmed line is a single path token) — NOT any line that
-  // merely ends in `.ts`, else a prose message body like `Move types into
-  // bookmark.types.ts` would abort the join. This stops a rule-LESS row (a `Parsing
-  // error` carries no ruleId) from swallowing the next file's header + diagnostics,
-  // and stops a following error/warning row from being fused into the current one.
+  // A BOUNDARY the join must NOT cross or consume — ANY other failure/structural line
+  // in the interleaved gate output: an eslint diagnostic row (error/warning), a tsc
+  // `error TS…`, a bun `(fail)` row, a knip `Unused files` header, a `[lint:meta]`
+  // block, an `::tsforge-app::` marker, a `$` echo, or a source-file HEADER. The
+  // header must be a BARE path (the whole trimmed line is a single path token) — NOT
+  // any line that merely ends in `.ts`, else a prose body like `Move types into
+  // bookmark.types.ts` would abort the join. This keeps the join from swallowing an
+  // interleaved OTHER failure (which the outer parser would then never see) and from
+  // fusing a following diagnostic into the current message.
   const isBoundary = (s: string): boolean => {
     const p = plain(s).trim();
 
     return (
       isDiagnosticRow(s) ||
+      /\berror TS\d+/u.test(p) ||
+      p.startsWith("(fail)") ||
+      /^Unused files \(\d+\)$/u.test(p) ||
+      p.startsWith("[lint:meta]") ||
       p.startsWith("$") ||
       /^::tsforge-app .+::$/u.test(p) ||
       /^\S+\.[cm]?[jt]sx?:?$/u.test(p)
@@ -165,11 +171,14 @@ function structuredFailure(
   ].join(":");
 }
 
-/** A source-file header printed before bun/eslint/lint-meta diagnostics. */
+/** A source-file header printed before bun/eslint/lint-meta diagnostics. A real header
+ *  is a BARE path (the whole line is one path token) — require that, so a prose line
+ *  that merely ENDS in `.ts` (e.g. a rule message "Move types into bookmark.types.ts")
+ *  is never mistaken for a header and promoted to `currentFile`. */
 function sourceFileFromLine(line: string, app: string): string | null {
   const withoutColon = line.endsWith(":") ? line.slice(0, -1) : line;
 
-  if (!/\.[cm]?[jt]sx?$/u.test(withoutColon)) {
+  if (!/^\S+\.[cm]?[jt]sx?$/u.test(withoutColon.trim())) {
     return null;
   }
 

--- a/packages/core/src/loop/boringstack/extract-failures.ts
+++ b/packages/core/src/loop/boringstack/extract-failures.ts
@@ -41,18 +41,23 @@ function joinMultilineEslintRows(output: string): string {
   const plain = (s: string): string => s.replace(ANSI, "");
   const isErrorStart = (s: string): boolean =>
     /^\s*\d+:\d+\s+error\s/u.test(plain(s));
-  // A join TERMINATOR is eslint's padded ruleId column: 2+ spaces then a
-  // PLUGIN-qualified id (contains `/`, e.g. `module-boundaries/single-semantic-module`
-  // or `@typescript-eslint/x`). Requiring the slash avoids a prose continuation like
-  // `Do not use  console` being mistaken for a ruleId and terminating early.
-  const endsWithRuleId = (s: string): boolean =>
+  // A COMPLETE single-line row already has its ruleId (ANY id, incl. bare core rules
+  // like `eqeqeq`) in eslint's padded right column: `… message  rule`. Such rows —
+  // and rule-LESS ones we can't safely join — pass through untouched.
+  const isCompleteRow = (s: string): boolean =>
+    isErrorStart(s) && /\S {2,}[\w@/-]+\s*$/u.test(plain(s));
+  // A multi-line TERMINATOR is the padded ruleId column carrying a PLUGIN-qualified id
+  // (contains `/`, e.g. `module-boundaries/single-semantic-module`). Requiring the
+  // slash keeps a prose continuation like `Do not use  console` from being mistaken
+  // for a ruleId and terminating the join early.
+  const isRuleIdTerminator = (s: string): boolean =>
     /\S {2,}@?[\w-]+\/[\w@/-]+\s*$/u.test(plain(s));
 
-  // A BOUNDARY stops the join WITHOUT being consumed — the multi-line message can't
-  // legitimately cross it: a new error row, a source-file header (a path ending in
-  // .ts/.tsx), an `::tsforge-app::` stage marker, or a `$` command echo. This stops
-  // a rule-LESS row (e.g. a `Parsing error`, which carries no ruleId) from swallowing
-  // the next file's header + diagnostics.
+  // A BOUNDARY the join must NOT cross or consume: a new error row, a source-file
+  // header (path ending in .ts/.tsx), an `::tsforge-app::` marker, or a `$` echo.
+  // This is what stops a rule-LESS row (a `Parsing error` carries no ruleId) from
+  // swallowing the next file's header + diagnostics, and stops a following error row
+  // (which is itself plugin-qualified) from being fused into the current one.
   const isBoundary = (s: string): boolean => {
     const p = plain(s).trim();
 
@@ -64,40 +69,43 @@ function joinMultilineEslintRows(output: string): string {
     );
   };
 
-  const MAX_SPAN = 15;
-
+  const MAX_SPAN = 40;
   const out: string[] = [];
 
   for (let i = 0; i < lines.length; i += 1) {
     const start = lines[i] ?? "";
 
-    // Not a multi-line START (either not an error row, or already a complete
-    // single-line row with its ruleId) → pass through.
-    if (!isErrorStart(start) || endsWithRuleId(start)) {
+    // Only a multi-line OPEN — an error row that is NOT already complete — can start a
+    // join. Everything else (non-errors, complete single-line rows, rule-less rows)
+    // passes through.
+    if (!isErrorStart(start) || isCompleteRow(start)) {
       out.push(start);
       continue;
     }
 
-    // Scan forward for the ruleId terminator, but STOP at a boundary or the span cap.
-    // Only collapse when a terminator is actually found — otherwise a rule-less error
-    // (parse error) or an unterminated block is emitted UNCHANGED (old per-line
-    // behavior), so nothing downstream is swallowed.
+    // Scan forward for a plugin-qualified terminator, STOPPING at (never crossing) a
+    // boundary or the span cap.
     let j = i + 1;
 
     while (
       j < lines.length &&
       j - i <= MAX_SPAN &&
-      !endsWithRuleId(lines[j] ?? "") &&
+      !isRuleIdTerminator(lines[j] ?? "") &&
       !isBoundary(lines[j] ?? "")
     ) {
       j += 1;
     }
 
-    if (
+    // Collapse ONLY when the stop line is a genuine terminator that is NOT itself a
+    // boundary (a following error row is both, and must stay separate). Otherwise emit
+    // the start row UNCHANGED — a parse error / unterminated block never absorbs.
+    const terminator =
       j < lines.length &&
       j - i <= MAX_SPAN &&
-      endsWithRuleId(lines[j] ?? "")
-    ) {
+      isRuleIdTerminator(lines[j] ?? "") &&
+      !isBoundary(lines[j] ?? "");
+
+    if (terminator) {
       out.push(lines.slice(i, j + 1).join(" "));
       i = j;
     } else {

--- a/packages/core/src/loop/boringstack/extract-failures.ts
+++ b/packages/core/src/loop/boringstack/extract-failures.ts
@@ -58,11 +58,13 @@ function joinMultilineEslintRows(output: string): string {
   const isDiagnosticRow = (s: string): boolean =>
     /^\s*\d+:\d+\s+(?:error|warning)\s/u.test(plain(s));
 
-  // A BOUNDARY the join must NOT cross or consume: another diagnostic row, a source-
-  // file header (path ending in .ts/.tsx), an `::tsforge-app::` marker, or a `$` echo.
-  // This stops a rule-LESS row (a `Parsing error` carries no ruleId) from swallowing
-  // the next file's header + diagnostics, and stops a following error/warning row
-  // (itself plugin-qualified) from being fused into the current one.
+  // A BOUNDARY the join must NOT cross or consume: another diagnostic row, an
+  // `::tsforge-app::` marker, a `$` echo, or a source-file HEADER. The header must be
+  // a BARE path (the whole trimmed line is a single path token) — NOT any line that
+  // merely ends in `.ts`, else a prose message body like `Move types into
+  // bookmark.types.ts` would abort the join. This stops a rule-LESS row (a `Parsing
+  // error` carries no ruleId) from swallowing the next file's header + diagnostics,
+  // and stops a following error/warning row from being fused into the current one.
   const isBoundary = (s: string): boolean => {
     const p = plain(s).trim();
 
@@ -70,11 +72,10 @@ function joinMultilineEslintRows(output: string): string {
       isDiagnosticRow(s) ||
       p.startsWith("$") ||
       /^::tsforge-app .+::$/u.test(p) ||
-      /\.[cm]?[jt]sx?:?$/u.test(p)
+      /^\S+\.[cm]?[jt]sx?:?$/u.test(p)
     );
   };
 
-  const MAX_SPAN = 40;
   const out: string[] = [];
 
   for (let i = 0; i < lines.length; i += 1) {
@@ -89,12 +90,12 @@ function joinMultilineEslintRows(output: string): string {
     }
 
     // Scan forward for a plugin-qualified terminator, STOPPING at (never crossing) a
-    // boundary or the span cap.
+    // boundary. No line cap: the boundary IS the stop condition, so nothing is
+    // silently truncated by an arbitrary length limit.
     let j = i + 1;
 
     while (
       j < lines.length &&
-      j - i <= MAX_SPAN &&
       !isRuleIdTerminator(lines[j] ?? "") &&
       !isBoundary(lines[j] ?? "")
     ) {
@@ -106,7 +107,6 @@ function joinMultilineEslintRows(output: string): string {
     // the start row UNCHANGED — a parse error / unterminated block never absorbs.
     const terminator =
       j < lines.length &&
-      j - i <= MAX_SPAN &&
       isRuleIdTerminator(lines[j] ?? "") &&
       !isBoundary(lines[j] ?? "");
 

--- a/packages/core/src/loop/feedback/rule-docs.ts
+++ b/packages/core/src/loop/feedback/rule-docs.ts
@@ -388,6 +388,19 @@ const RULE_DOCS: Record<string, IRuleDoc> = {
     bad: "export const plugin = new Elysia();",
     good: "export const plugin = new Elysia({ name: 'auth-plugin' });",
   },
+  // BoringStack module-boundaries: a file must hold ONE semantic category. The
+  // message lists the mixed categories (type / schema / constant / function / class /
+  // react-component / hook) — the fix is always to MOVE the odd one(s) out into the
+  // conventionally-named sibling file, never to merge or suppress. (A live build
+  // oscillated here once the full message finally surfaced but it couldn't pick the
+  // split.)
+  "module-boundaries/single-semantic-module": {
+    what: "This file mixes semantic categories (the message lists which, e.g. `type` + `schema`). A module must contain exactly ONE concern — split the odd category into its own file and import it back.",
+    bad: "// bookmark.schemas.ts\nexport interface IBookmark { url: string } // type\nexport const CreateBookmark = z.object({ url: z.string() }); // schema",
+    good: "// bookmark.types.ts\nexport interface IBookmark { url: string }\n// bookmark.schemas.ts\nimport type { IBookmark } from './bookmark.types';\nexport const CreateBookmark = z.object({ url: z.string() });",
+    procedure:
+      "1. Read the message: it names the categories present (type/schema/constant/function/class/react-component/hook).\n2. Keep the file's PRIMARY category (the one its name implies: *.schemas.ts→schema, *.types.ts→type, *.constants.ts→constant, *.utils.ts→function, *.service.ts→class+singleton).\n3. MOVE every declaration of the other category into its conventional sibling file (create it if absent): types→*.types.ts, zod/valibot schemas→*.schemas.ts, runtime constants→*.constants.ts, plain functions→*.utils.ts.\n4. Re-import the moved names where they were used. Do NOT merge categories or add an eslint-disable.",
+  },
 };
 
 /**

--- a/packages/core/src/loop/feedback/rule-docs.ts
+++ b/packages/core/src/loop/feedback/rule-docs.ts
@@ -397,7 +397,7 @@ const RULE_DOCS: Record<string, IRuleDoc> = {
   "module-boundaries/single-semantic-module": {
     what: "This file mixes semantic categories (the message lists which, e.g. `type` + `schema`). A module must contain exactly ONE concern — split the odd category into its own file and import it back.",
     bad: "// bookmark.schemas.ts\nexport interface IBookmark { url: string } // type\nexport const CreateBookmark = z.object({ url: z.string() }); // schema",
-    good: "// bookmark.types.ts\nexport interface IBookmark { url: string }\n// bookmark.schemas.ts\nimport type { IBookmark } from './bookmark.types';\nexport const CreateBookmark = z.object({ url: z.string() });",
+    good: "// bookmark.types.ts (types only)\nexport interface IBookmark { url: string }\n// bookmark.schemas.ts (schemas only — no type declarations)\nexport const CreateBookmark = z.object({ url: z.string() });",
     procedure:
       "1. Read the message: it names the categories present (type/schema/constant/function/class/react-component/hook).\n2. Keep the file's PRIMARY category (the one its name implies: *.schemas.ts→schema, *.types.ts→type, *.constants.ts→constant, *.utils.ts→function, *.service.ts→class+singleton).\n3. MOVE every declaration of the other category into its conventional sibling file (create it if absent): types→*.types.ts, zod/valibot schemas→*.schemas.ts, runtime constants→*.constants.ts, plain functions→*.utils.ts.\n4. Re-import the moved names where they were used. Do NOT merge categories or add an eslint-disable.",
   },

--- a/packages/core/tests/boringstack-extract-failures.test.ts
+++ b/packages/core/tests/boringstack-extract-failures.test.ts
@@ -153,6 +153,54 @@ ${cwd}/apps/api/src/api/b/b.ts
     expect(sigs.size).toBe(2);
   });
 
+  test("an INCOMPLETE multi-line open is NOT fused with a following plugin-qualified error (the boundary-terminator guard)", () => {
+    // The actual hole the guard closes: an open row (no ruleId on line 1, ends with
+    // `:`) immediately followed by a complete plugin-qualified error. The following
+    // error is a boundary AND matches the ruleId pattern — it must NOT be consumed as
+    // this open's terminator.
+    const cwd = "/tmp/clone";
+    const out = `${cwd}/apps/api/src/api/a/a.ts
+  3:8  error  Mixed semantic categories detected in module:
+  9:1  error  Unexpected any  @typescript-eslint/no-explicit-any`;
+    const sigs = extractFailures(out, cwd);
+
+    // The open row stays its OWN signature (unterminated → truncated first line, NOT
+    // fused) — it must NOT carry the following error's rule id.
+    expect(
+      [...sigs].some(
+        (s) =>
+          decodeURIComponent(s).includes("Mixed semantic categories") &&
+          !s.includes("no-explicit-any")
+      )
+    ).toBe(true);
+    // …and the following error remains a SEPARATE, correctly-attributed signature.
+    expect(
+      [...sigs].some((s) =>
+        s.startsWith(
+          "failure:apps%2Fapi%2Fsrc%2Fapi%2Fa%2Fa.ts:9:%40typescript-eslint%2Fno-explicit-any"
+        )
+      )
+    ).toBe(true);
+    expect(sigs.size).toBe(2);
+  });
+
+  test("a following WARNING row is a boundary, not a terminator (not fused into the error)", () => {
+    const cwd = "/tmp/clone";
+    const out = `${cwd}/apps/api/src/api/a/a.ts
+  3:8  error  Mixed semantic categories detected in module:
+  9:1  warning  Prefer const  sonarjs/prefer-const`;
+    const sigs = extractFailures(out, cwd);
+
+    // The error's (truncated) signature must NOT carry the warning's rule id — the
+    // warning row is a boundary, and warnings aren't captured as failures at all.
+    expect([...sigs].some((s) => s.includes("prefer-const"))).toBe(false);
+    expect(
+      [...sigs].some((s) =>
+        decodeURIComponent(s).includes("Mixed semantic categories")
+      )
+    ).toBe(true);
+  });
+
   test("a single-line eslint row is unaffected by the multi-line join", () => {
     const cwd = "/tmp/clone";
     const out = `${cwd}/apps/api/src/api/x/x.ts

--- a/packages/core/tests/boringstack-extract-failures.test.ts
+++ b/packages/core/tests/boringstack-extract-failures.test.ts
@@ -72,6 +72,48 @@ error: script "lint:meta" exited with code 1`;
     );
   });
 
+  test("captures the FULL multi-line eslint message (rule + fix), not just its truncated first line", () => {
+    // The EXACT stylish shape that ground a live build near-green: the model saw only
+    // "…detected in module:" (no categories, no fix) and sprayed. The parser must
+    // stitch the continuation lines + the trailing ruleId into one signature.
+    const cwd = "/tmp/clone";
+    const out = `${cwd}/apps/api/src/api/bookmark/bookmark.service.ts
+  6:8  error  Mixed semantic categories detected in module:
+- function
+- class
+
+A module must contain only one semantic concern.
+Move declarations into separate files/modules  module-boundaries/single-semantic-module`;
+    const sigs = extractFailures(out, cwd);
+    const signature = [...sigs][0] ?? "";
+
+    // Rule id captured (enables rule-help), file + line correct…
+    expect(signature).toContain(
+      "failure:apps%2Fapi%2Fsrc%2Fapi%2Fbookmark%2Fbookmark.service.ts:6:module-boundaries%2Fsingle-semantic-module"
+    );
+    // …and the ACTIONABLE detail survives (categories + the fix), decoded.
+    const decoded = decodeURIComponent(signature);
+
+    expect(decoded).toContain("- function");
+    expect(decoded).toContain("- class");
+    expect(decoded).toContain("Move declarations into separate files");
+    // Exactly one signature — the continuation lines didn't leak as junk rows.
+    expect(sigs.size).toBe(1);
+  });
+
+  test("a single-line eslint row is unaffected by the multi-line join", () => {
+    const cwd = "/tmp/clone";
+    const out = `${cwd}/apps/api/src/api/x/x.ts
+  6:1  error  Expected blank line before this statement  padding-line-between-statements`;
+    const sigs = extractFailures(out, cwd);
+    const signature = [...sigs][0] ?? "";
+
+    expect(signature).toContain(
+      "failure:apps%2Fapi%2Fsrc%2Fapi%2Fx%2Fx.ts:6:padding-line-between-statements"
+    );
+    expect(sigs.size).toBe(1);
+  });
+
   test("an eslint PARSING error is captured as `syntax`, not the message's last word", () => {
     // A parsing-error row carries no ruleId; after normalize() collapses the
     // message↔ruleId gap the generic row regex would grab `expected` (the last

--- a/packages/core/tests/boringstack-extract-failures.test.ts
+++ b/packages/core/tests/boringstack-extract-failures.test.ts
@@ -201,6 +201,45 @@ ${cwd}/apps/api/src/api/b/b.ts
     ).toBe(true);
   });
 
+  test("a multi-line message whose BODY mentions a .ts path still joins (no abort, no currentFile corruption)", () => {
+    // A prose line like `Move the type into a.types.ts` ends in .ts but is NOT a file
+    // header — it must not abort the join nor be promoted to currentFile. The join
+    // reaches its real terminator; the NEXT file's error attributes to the NEXT file.
+    const cwd = "/tmp/clone";
+    const out = `${cwd}/apps/api/src/api/a/a.ts
+  6:8  error  Mixed semantic categories detected in module:
+- type
+- schema
+Move the type into a.types.ts instead
+Move declarations into separate files/modules  module-boundaries/single-semantic-module
+${cwd}/apps/api/src/api/b/b.ts
+  2:1  error  Unexpected any  @typescript-eslint/no-explicit-any`;
+    const sigs = extractFailures(out, cwd);
+
+    // a.ts joined to its real terminator (rule id captured; prose body survives).
+    expect(
+      [...sigs].some((s) =>
+        s.startsWith(
+          "failure:apps%2Fapi%2Fsrc%2Fapi%2Fa%2Fa.ts:6:module-boundaries%2Fsingle-semantic-module"
+        )
+      )
+    ).toBe(true);
+    // b.ts's error attributes to b.ts — NOT to `a.types.ts` from the prose body.
+    expect(
+      [...sigs].some((s) =>
+        s.startsWith(
+          "failure:apps%2Fapi%2Fsrc%2Fapi%2Fb%2Fb.ts:2:%40typescript-eslint%2Fno-explicit-any"
+        )
+      )
+    ).toBe(true);
+    // No signature is ATTRIBUTED to the prose path (that would be currentFile
+    // corruption); the prose may appear inside a message, but never as a file.
+    expect([...sigs].some((s) => s.startsWith("failure:a.types.ts"))).toBe(
+      false
+    );
+    expect(sigs.size).toBe(2);
+  });
+
   test("a single-line eslint row is unaffected by the multi-line join", () => {
     const cwd = "/tmp/clone";
     const out = `${cwd}/apps/api/src/api/x/x.ts

--- a/packages/core/tests/boringstack-extract-failures.test.ts
+++ b/packages/core/tests/boringstack-extract-failures.test.ts
@@ -101,6 +101,33 @@ Move declarations into separate files/modules  module-boundaries/single-semantic
     expect(sigs.size).toBe(1);
   });
 
+  test("a rule-less parse error does NOT swallow the next file's header + diagnostics (join stops at boundaries)", () => {
+    // The regression the join must avoid: a `Parsing error` carries no ruleId, so a
+    // greedy join would absorb every following line — losing file B's header and
+    // mis-attributing its error to file A. The join must stop at the next file header.
+    const cwd = "/tmp/clone";
+    const out = `${cwd}/apps/api/src/api/a/a.ts
+  1:1  error  Parsing error: ';' expected
+${cwd}/apps/api/src/api/b/b.ts
+  2:3  error  Unexpected any  @typescript-eslint/no-explicit-any`;
+    const sigs = extractFailures(out, cwd);
+
+    // Two DISTINCT signatures, each attributed to its OWN file.
+    expect(
+      [...sigs].some((s) =>
+        s.startsWith("failure:apps%2Fapi%2Fsrc%2Fapi%2Fa%2Fa.ts:1:syntax")
+      )
+    ).toBe(true);
+    expect(
+      [...sigs].some((s) =>
+        s.startsWith(
+          "failure:apps%2Fapi%2Fsrc%2Fapi%2Fb%2Fb.ts:2:%40typescript-eslint%2Fno-explicit-any"
+        )
+      )
+    ).toBe(true);
+    expect(sigs.size).toBe(2);
+  });
+
   test("a single-line eslint row is unaffected by the multi-line join", () => {
     const cwd = "/tmp/clone";
     const out = `${cwd}/apps/api/src/api/x/x.ts

--- a/packages/core/tests/boringstack-extract-failures.test.ts
+++ b/packages/core/tests/boringstack-extract-failures.test.ts
@@ -201,16 +201,16 @@ ${cwd}/apps/api/src/api/b/b.ts
     ).toBe(true);
   });
 
-  test("a multi-line message whose BODY mentions a .ts path still joins (no abort, no currentFile corruption)", () => {
-    // A prose line like `Move the type into a.types.ts` ends in .ts but is NOT a file
-    // header — it must not abort the join nor be promoted to currentFile. The join
+  test("a multi-line message whose BODY ends in a .ts path still joins (no abort, no currentFile corruption)", () => {
+    // A prose line ENDING in `.ts` (`Move the type into a.types.ts`) is NOT a bare-path
+    // file header — it must not abort the join nor be promoted to currentFile. The join
     // reaches its real terminator; the NEXT file's error attributes to the NEXT file.
     const cwd = "/tmp/clone";
     const out = `${cwd}/apps/api/src/api/a/a.ts
   6:8  error  Mixed semantic categories detected in module:
 - type
 - schema
-Move the type into a.types.ts instead
+Move the type into a.types.ts
 Move declarations into separate files/modules  module-boundaries/single-semantic-module
 ${cwd}/apps/api/src/api/b/b.ts
   2:1  error  Unexpected any  @typescript-eslint/no-explicit-any`;
@@ -238,6 +238,30 @@ ${cwd}/apps/api/src/api/b/b.ts
       false
     );
     expect(sigs.size).toBe(2);
+  });
+
+  test("an unterminated eslint open does NOT swallow an interleaved tsc/bun failure", () => {
+    // Interleaved gate output: an eslint multi-line-looking open (no plugin terminator)
+    // followed by a tsc error then a bun (fail). The join must stop at each — never
+    // absorb them — so the outer parser still sees all three failures.
+    const cwd = "/tmp/clone";
+    const out = `${cwd}/apps/api/src/api/a/a.ts
+  6:8  error  Some message with no ruleId on this line:
+${cwd}/apps/api/src/api/a/a.service.ts(4,3): error TS2532: Object is possibly 'undefined'.
+tests/api/a/a.service.test.ts:
+(fail) aService > creates [0.2ms]`;
+    const sigs = extractFailures(out, cwd);
+
+    expect(
+      [...sigs].some((s) => s.includes("TS2532") || s.includes("2532"))
+    ).toBe(true);
+    expect(
+      [...sigs].some((s) => decodeURIComponent(s).includes("(fail)"))
+    ).toBe(true);
+    // The eslint open is still its own (truncated) signature — nothing was fused.
+    expect(
+      [...sigs].some((s) => decodeURIComponent(s).includes("no ruleId on this"))
+    ).toBe(true);
   });
 
   test("a single-line eslint row is unaffected by the multi-line join", () => {

--- a/packages/core/tests/boringstack-extract-failures.test.ts
+++ b/packages/core/tests/boringstack-extract-failures.test.ts
@@ -128,6 +128,31 @@ ${cwd}/apps/api/src/api/b/b.ts
     expect(sigs.size).toBe(2);
   });
 
+  test("two single-line eslint errors in ONE file stay separate (a following error is a boundary, never fused)", () => {
+    // The exact hole the conservative join must close: a bare CORE-rule error (no
+    // slash in its id) is not "complete" under the terminator check, so it must NOT
+    // open a join that swallows the NEXT (@typescript-eslint) error row.
+    const cwd = "/tmp/clone";
+    const out = `${cwd}/apps/api/src/api/a/a.ts
+  3:1  error  Expected '===' and instead saw '=='  eqeqeq
+  4:7  error  Unexpected any  @typescript-eslint/no-explicit-any`;
+    const sigs = extractFailures(out, cwd);
+
+    expect(
+      [...sigs].some((s) =>
+        s.startsWith("failure:apps%2Fapi%2Fsrc%2Fapi%2Fa%2Fa.ts:3:eqeqeq")
+      )
+    ).toBe(true);
+    expect(
+      [...sigs].some((s) =>
+        s.startsWith(
+          "failure:apps%2Fapi%2Fsrc%2Fapi%2Fa%2Fa.ts:4:%40typescript-eslint%2Fno-explicit-any"
+        )
+      )
+    ).toBe(true);
+    expect(sigs.size).toBe(2);
+  });
+
   test("a single-line eslint row is unaffected by the multi-line join", () => {
     const cwd = "/tmp/clone";
     const out = `${cwd}/apps/api/src/api/x/x.ts

--- a/packages/core/tests/rule-docs.test.ts
+++ b/packages/core/tests/rule-docs.test.ts
@@ -88,6 +88,25 @@ test("injects React framework idiom cards keyed by the gate's rule id", () => {
   expect(key).toContain("stable id");
 });
 
+test("gives the concrete split procedure for module-boundaries/single-semantic-module", () => {
+  // A live build oscillated here: once the full message surfaced (multi-line fix),
+  // the model saw the categories but not HOW to split — this card gives the fix.
+  const h = ruleHelp([
+    {
+      key: "k",
+      rule: "module-boundaries/single-semantic-module",
+      message: "Mixed semantic categories detected in module: - type - schema",
+    },
+  ]);
+
+  expect(h).toContain("module-boundaries/single-semantic-module");
+  expect(h.toLowerCase()).toContain("one concern");
+  // The actionable split procedure, not just "don't mix".
+  expect(h).toContain("*.types.ts");
+  expect(h).toContain("*.schemas.ts");
+  expect(h.toLowerCase()).toContain("move");
+});
+
 test("gives the guard idiom (bad/good) for a TS unchecked-index error", () => {
   const h = ruleHelp([
     { key: "k", rule: "TS2532", message: "Object is possibly 'undefined'." },


### PR DESCRIPTION
## What

A live overnight build ground **near-green** (down to 1 error, oscillating): the model was stuck on the `single-semantic-module` rule ("Mixed semantic categories detected in module") but only ever saw the message's **first line** — `…detected in module:` — with no category list and no fix.

## Root cause

eslint's stylish formatter renders a multi-line rule message across several physical lines and appends the ruleId (after 2+ spaces of padding) to the **last** line:

```
  6:8  error  Mixed semantic categories detected in module:
- function
- class

A module must contain only one semantic concern.
Move declarations into separate files/modules  module-boundaries/single-semantic-module
```

The per-line failure parser kept only the first line and **lost the ruleId** — so the model got a truncated, unactionable error (→ near-green spray) and no rule-help could fire (no ruleId to key on). Same class as the diag-cap whack-a-mole.

## Fix

`joinMultilineEslintRows` collapses each multi-line eslint row (an `L:C error` line whose ruleId isn't on the same line) into one line — accumulating continuation lines up to the one carrying the ruleId, and stopping short of the next error row so a missing ruleId can't swallow it. Single-line rows pass through untouched. The parser then captures the **full** message + ruleId.

## Verification

- Reproduced the exact stylish shape against the real `@boring-stack-pkg/eslint-plugin-module-boundaries` rule.
- Tests: full multi-line capture (rule + `- function`/`- class`/`Move declarations…` fix all survive, decoded) + a single-line-unaffected regression guard.
- Full `bun run validate` green. Passed the pre-push reviewer panel.

Found by an overnight live build (killed on the near-green oscillation, per kill-fast-and-fix).