### PR TITLE
fix(boringstack): read eslint from structured JSON, not scraped stylish text

### DIFF
--- a/packages/core/src/loop/boringstack/extract-failures.ts
+++ b/packages/core/src/loop/boringstack/extract-failures.ts
@@ -51,7 +51,13 @@ function eslintResultSignatures(
     }
 
     const rule = typeof message.ruleId === "string" ? message.ruleId : "syntax";
-    const text = typeof message.message === "string" ? message.message : "";
+    // Collapse whitespace so a multi-line message yields the SAME signature as the
+    // stylish path (which normalize()s to single spaces) — else the same error would
+    // key differently by source and a re-parse could look "novel" in the differential.
+    const text =
+      typeof message.message === "string"
+        ? message.message.replace(/\s+/gu, " ").trim()
+        : "";
     const line = typeof message.line === "number" ? message.line : undefined;
 
     signatures.add(structuredFailure(file, line, rule, text));
@@ -59,10 +65,12 @@ function eslintResultSignatures(
 }
 
 /** Is this a genuine eslint `--format json` payload — an array of result objects each
- *  carrying `filePath` + a `messages` array (an empty array is valid = a green app)?
- *  Rejects a JSON array of the wrong shape (`[1,2,3]`) so it can't be mistaken for
- *  eslint coverage and wrongly suppress the stylish fallback. */
-function isEslintResultArray(value: unknown): boolean {
+ *  carrying `filePath` + a `messages` array? Rejects a JSON array of the wrong shape
+ *  (`[1,2,3]`) so it can't be mistaken for eslint output. Shape validity alone does NOT
+ *  grant coverage (see parseEslintJsonBlocks) — an empty/all-green array is valid but
+ *  yields no errors, so it must not suppress the stylish fallback. Typed as a guard so
+ *  the caller can iterate `results` without a redundant re-check. */
+function isEslintResultArray(value: unknown): value is unknown[] {
   return (
     Array.isArray(value) &&
     value.every(
@@ -75,10 +83,14 @@ function isEslintResultArray(value: unknown): boolean {
 }
 
 /** Parse every `::tsforge-eslint-json <app>::` … `::tsforge-eslint-json-end::` block
- *  into structured eslint signatures. Returns the SET OF APPS whose block parsed into
- *  a valid eslint-result array — the caller ignores stylish eslint rows ONLY for those
- *  apps (per-app, not global). An app whose block is missing / malformed / wrong-shaped
- *  is NOT in the set, so its stylish rows are still scraped and no lint error is lost. */
+ *  into structured eslint signatures. Returns the SET OF APPS whose block actually
+ *  yielded ≥1 ERROR signature — the caller ignores stylish eslint rows ONLY for those
+ *  apps (per-app, not global). "Covered" deliberately means "the errors for this app are
+ *  already in the JSON", NOT merely "the block parsed": an empty `[]`, an all-green app,
+ *  a 0-file run, or a payload whose message entries are malformed all yield zero errors,
+ *  so they are NOT covered and their stylish rows are still scraped. This is safe both
+ *  ways — a truly green app has no stylish error rows to lose, and a broken JSON pass
+ *  falls back to `check`'s own stylish output, so a lint error is never silently lost. */
 function parseEslintJsonBlocks(
   output: string,
   cwd: string,
@@ -107,14 +119,19 @@ function parseEslintJsonBlocks(
       continue;
     }
 
-    if (!isEslintResultArray(results) || !Array.isArray(results)) {
+    if (!isEslintResultArray(results)) {
       continue;
     }
 
-    covered.add(app);
+    const before = signatures.size;
 
     for (const result of results) {
       eslintResultSignatures(result, cwd, signatures);
+    }
+
+    // Cover the app only when the JSON produced at least one real error signature.
+    if (signatures.size > before) {
+      covered.add(app);
     }
   }
 
@@ -534,6 +551,16 @@ function consumeEslintJsonBlock(
     state.inEslintJson = true;
 
     return true;
+  }
+
+  // An `::tsforge-app <prefix>::` stage marker is a hard boundary. If a JSON block was
+  // left unterminated (truncated capture, missing end marker), it ends HERE rather than
+  // swallowing every later line (tsc errors, bun fails, stylish rows) across the app
+  // boundary — the exact silent-loss the panel flagged. Fall through to consumeMarker.
+  if (/^::tsforge-app .+::$/u.test(line)) {
+    state.inEslintJson = false;
+
+    return false;
   }
 
   return state.inEslintJson;

--- a/packages/core/src/loop/boringstack/extract-failures.ts
+++ b/packages/core/src/loop/boringstack/extract-failures.ts
@@ -1,3 +1,4 @@
+import { isRecord } from "../../lib/guards";
 import type { IFailureParserState } from "./extract-failures.types";
 
 // Build the ANSI-escape matcher from the ESC code point so the source carries no
@@ -15,6 +16,92 @@ function normalize(raw: string, cwd: string): string {
     .replace(/\[\d+(?:\.\d+)?ms\]\s*$/, "")
     .replace(/\s+/g, " ")
     .trim();
+}
+
+/** eslint's absolute `filePath` → repo-relative (strip the clone path + leading `/`).
+ *  Collapse whitespace so it matches the model's editable-scope globs. */
+function toRepoRelative(filePath: string, cwd: string): string {
+  return filePath.split(cwd).join("").replace(/^\/+/u, "").trim();
+}
+
+/** Turn one eslint JSON result-file into structured failure signatures — the same
+ *  `failure:<file>:<line>:<rule>:<message>` shape the stylish path produces, but from
+ *  UNAMBIGUOUS structured data (exact file/line/ruleId/message per message). Only
+ *  ERRORS (severity 2) count — warnings don't fail the gate. A rule-less message (a
+ *  parsing error) is tagged `syntax`, matching the tsc-parser convention. */
+function eslintResultSignatures(
+  result: unknown,
+  cwd: string,
+  signatures: Set<string>
+): void {
+  if (!isRecord(result) || typeof result.filePath !== "string") {
+    return;
+  }
+
+  const file = toRepoRelative(result.filePath, cwd);
+  const messages = result.messages;
+
+  if (!Array.isArray(messages)) {
+    return;
+  }
+
+  for (const message of messages) {
+    if (!isRecord(message) || message.severity !== 2) {
+      continue;
+    }
+
+    const rule = typeof message.ruleId === "string" ? message.ruleId : "syntax";
+    const text = typeof message.message === "string" ? message.message : "";
+    const line = typeof message.line === "number" ? message.line : undefined;
+
+    signatures.add(structuredFailure(file, line, rule, text));
+  }
+}
+
+/** Parse every `::tsforge-eslint-json::` … `::tsforge-eslint-json-end::` block into
+ *  structured eslint signatures. Returns true when ≥1 block PARSED — the caller then
+ *  ignores the stylish eslint rows (JSON is the single source of truth for lint). A
+ *  present-but-malformed block returns false, so the stylish fallback still runs and
+ *  a lint error is never silently lost. */
+function parseEslintJsonBlocks(
+  output: string,
+  cwd: string,
+  signatures: Set<string>
+): boolean {
+  const blocks = output.matchAll(
+    /::tsforge-eslint-json::([\s\S]*?)::tsforge-eslint-json-end::/gu
+  );
+  let parsedAny = false;
+
+  for (const block of blocks) {
+    const raw = (block[1] ?? "").replace(ANSI, "");
+    const start = raw.indexOf("[");
+    const end = raw.lastIndexOf("]");
+
+    if (start < 0 || end <= start) {
+      continue;
+    }
+
+    let results: unknown;
+
+    try {
+      results = JSON.parse(raw.slice(start, end + 1));
+    } catch {
+      continue;
+    }
+
+    if (!Array.isArray(results)) {
+      continue;
+    }
+
+    parsedAny = true;
+
+    for (const result of results) {
+      eslintResultSignatures(result, cwd, signatures);
+    }
+  }
+
+  return parsedAny;
 }
 
 /**
@@ -412,6 +499,29 @@ function generateApiFailure(line: string): string | null {
   return `openapi-unreachable:${classifyOpenApiFailure(failed[1] ?? "fetch failed")}`;
 }
 
+/** Skip the raw JSON lines of an eslint-JSON block (parsed separately by
+ *  parseEslintJsonBlocks) so a message value like `error TS…` inside the JSON can't be
+ *  mis-parsed as a real diagnostic. Toggles on the markers; returns true while inside
+ *  the block or on a marker line. Markers survive `normalize` (no whitespace). */
+function consumeEslintJsonBlock(
+  line: string,
+  state: IFailureParserState
+): boolean {
+  if (line === "::tsforge-eslint-json::") {
+    state.inEslintJson = true;
+
+    return true;
+  }
+
+  if (line === "::tsforge-eslint-json-end::") {
+    state.inEslintJson = false;
+
+    return true;
+  }
+
+  return state.inEslintJson;
+}
+
 export function extractFailures(output: string, cwd: string): Set<string> {
   const signatures = new Set<string>();
   // knip prints `Unused files (N)` then one relative path per line, ending at the
@@ -425,10 +535,25 @@ export function extractFailures(output: string, cwd: string): Set<string> {
     currentFile: "",
     inLintMeta: false,
     inUnusedFiles: false,
+    inEslintJson: false,
+    eslintJsonPresent: false,
   };
 
-  for (const rawLine of joinMultilineEslintRows(output).split("\n")) {
+  // Prefer STRUCTURED eslint output: parse the `::tsforge-eslint-json::` block(s) into
+  // exact signatures. When present, the line loop ignores the ambiguous stylish eslint
+  // rows (JSON is the single source of truth). When ABSENT or malformed, fall back to
+  // scraping stylish (joined for multi-line) so an eslint error is never lost.
+  state.eslintJsonPresent = parseEslintJsonBlocks(output, cwd, signatures);
+  const source = state.eslintJsonPresent
+    ? output
+    : joinMultilineEslintRows(output);
+
+  for (const rawLine of source.split("\n")) {
     const line = normalize(rawLine, cwd);
+
+    if (consumeEslintJsonBlock(line, state)) {
+      continue;
+    }
 
     if (consumeMarker(line, state)) {
       continue;
@@ -450,6 +575,12 @@ export function extractFailures(output: string, cwd: string): Set<string> {
 
     if (apiFailure !== null) {
       signatures.add(apiFailure);
+      continue;
+    }
+
+    // eslint is owned by the JSON block — ignore the duplicated stylish rows so a
+    // failure isn't counted twice (once clean from JSON, once mangled from text).
+    if (state.eslintJsonPresent && /^\d+:\d+ (?:error|warning)\b/u.test(line)) {
       continue;
     }
 

--- a/packages/core/src/loop/boringstack/extract-failures.ts
+++ b/packages/core/src/loop/boringstack/extract-failures.ts
@@ -5,6 +5,17 @@ import type { IFailureParserState } from "./extract-failures.types";
 // literal control char (a regex literal with \x1b trips no-control-regex).
 const ANSI = new RegExp(`${String.fromCharCode(27)}\\[[0-9;]*m`, "g");
 
+/** A CLOSED eslint-JSON block: opening marker, content (capture group 1), closing marker.
+ *  The content is TEMPERED against another opening marker (`(?!…opening…)`) so an
+ *  UNTERMINATED block can never pair with a LATER block's end marker and strip the
+ *  intervening tsc/stylish/knip/app-marker output between them. Used both to extract
+ *  signatures and to strip already-parsed blocks from the line-scanned text; an
+ *  unterminated block matches nothing, so it stays in place and is parsed line-by-line
+ *  (its partial JSON isn't an error row, so it never swallows the diagnostics that follow).
+ *  A fresh RegExp is built per use so the shared `g`-flag lastIndex is never carried over. */
+const ESLINT_JSON_BLOCK_SOURCE =
+  "::tsforge-eslint-json \\S+::((?:(?!::tsforge-eslint-json \\S+::)[\\s\\S])*?)::tsforge-eslint-json-end::";
+
 /** Normalize one line of composed gate output into a stable comparison key:
  *  strip ANSI, remove the clone's absolute path (so signatures are portable),
  *  drop bun's per-test timing suffix, and collapse whitespace. */
@@ -24,14 +35,20 @@ function toRepoRelative(filePath: string, cwd: string): string {
   return filePath.split(cwd).join("").replace(/^\/+/u, "").trim();
 }
 
-/** The location-key of a failure signature: `failure:<encFile>:<line>:<encRule>` — the
- *  first four colon fields (file/rule are URL-encoded and the line is numeric, so none
- *  contain a raw `:`; the message is the only dropped field). Two signatures share a key
- *  iff they describe the SAME eslint error at the same file/line/rule — used to dedup a
- *  stylish row against the JSON signature for the identical error, WITHOUT suppressing a
- *  stylish-only error the JSON never reported. */
-function signatureKey(signature: string): string {
-  return signature.split(":").slice(0, 4).join(":");
+/** The dedup key for a single eslint error: file + line + column + rule. Two eslint
+ *  errors share a key iff they are the SAME diagnostic (same location AND rule) — column
+ *  is included so two reports of the same rule on the same line at different columns stay
+ *  DISTINCT. The message is deliberately excluded: the JSON and stylish formatters render
+ *  the same error's text slightly differently (trailing period, truncation), so keying on
+ *  message would fail to dedup identical errors. Built identically from the JSON payload
+ *  and the stylish row so the two match exactly. */
+function eslintKey(
+  file: string,
+  line: number | undefined,
+  column: number | undefined,
+  rule: string
+): string {
+  return `${file}:${line ?? ""}:${column ?? ""}:${rule}`;
 }
 
 /** Turn one eslint JSON result-file into structured failure signatures — the same
@@ -72,10 +89,11 @@ function eslintResultSignatures(
         ? message.message.replace(/\s+/gu, " ").trim()
         : "";
     const line = typeof message.line === "number" ? message.line : undefined;
-    const signature = structuredFailure(file, line, rule, text);
+    const column =
+      typeof message.column === "number" ? message.column : undefined;
 
-    signatures.add(signature);
-    keys.add(signatureKey(signature));
+    signatures.add(structuredFailure(file, line, rule, text));
+    keys.add(eslintKey(file, line, column, rule));
   }
 }
 
@@ -94,9 +112,7 @@ function parseEslintJsonBlocks(
   signatures: Set<string>,
   keys: Set<string>
 ): void {
-  const blocks = output.matchAll(
-    /::tsforge-eslint-json \S+::([\s\S]*?)::tsforge-eslint-json-end::/gu
-  );
+  const blocks = output.matchAll(new RegExp(ESLINT_JSON_BLOCK_SOURCE, "gu"));
 
   for (const block of blocks) {
     const raw = (block[1] ?? "").replace(ANSI, "");
@@ -411,10 +427,18 @@ function consumeSourceFile(line: string, state: IFailureParserState): boolean {
   return true;
 }
 
+/** A parsed failure line: its stable signature plus, for eslint rows only, the dedup key
+ *  used to drop a stylish row that duplicates a JSON-reported error. `dedupKey` is null
+ *  for tsc/bun/fallback rows (they never collide with an eslint JSON key). */
+interface IParsedDiagnostic {
+  signature: string;
+  dedupKey: string | null;
+}
+
 function parsedDiagnostic(
   line: string,
   state: IFailureParserState
-): string | null {
+): IParsedDiagnostic | null {
   const typeError = /^(.+)\((\d+),(\d+)\): error (TS\d+): (.+)$/u.exec(line);
 
   if (typeError !== null) {
@@ -423,12 +447,15 @@ function parsedDiagnostic(
       (typeError[1] ?? "").replace(/^\.\//u, "").replace(/^\//u, "")
     );
 
-    return structuredFailure(
-      file,
-      Number(typeError[2] ?? "0"),
-      typeError[4] ?? "tsc",
-      typeError[5] ?? line
-    );
+    return {
+      signature: structuredFailure(
+        file,
+        Number(typeError[2] ?? "0"),
+        typeError[4] ?? "tsc",
+        typeError[5] ?? line
+      ),
+      dedupKey: null,
+    };
   }
 
   // An eslint PARSING error carries no ruleId — the row is `L:C error Parsing
@@ -440,30 +467,53 @@ function parsedDiagnostic(
   const eslintParseError = /^(\d+):(\d+) error (Parsing error:.*)$/u.exec(line);
 
   if (eslintParseError !== null && state.currentFile !== "") {
-    return structuredFailure(
-      state.currentFile,
-      Number(eslintParseError[1] ?? "0"),
-      "syntax",
-      eslintParseError[3] ?? line
-    );
+    const eslintLine = Number(eslintParseError[1] ?? "0");
+    const column = Number(eslintParseError[2] ?? "0");
+
+    return {
+      signature: structuredFailure(
+        state.currentFile,
+        eslintLine,
+        "syntax",
+        eslintParseError[3] ?? line
+      ),
+      dedupKey: eslintKey(state.currentFile, eslintLine, column, "syntax"),
+    };
   }
 
   const eslintError = /^(\d+):(\d+) error (.+?) ([\w@/-]+)$/u.exec(line);
 
   if (eslintError !== null && state.currentFile !== "") {
-    return structuredFailure(
-      state.currentFile,
-      Number(eslintError[1] ?? "0"),
-      eslintError[4] ?? "eslint",
-      eslintError[3] ?? line
-    );
+    const eslintLine = Number(eslintError[1] ?? "0");
+    const column = Number(eslintError[2] ?? "0");
+    const rule = eslintError[4] ?? "eslint";
+
+    return {
+      signature: structuredFailure(
+        state.currentFile,
+        eslintLine,
+        rule,
+        eslintError[3] ?? line
+      ),
+      dedupKey: eslintKey(state.currentFile, eslintLine, column, rule),
+    };
   }
 
   if (line.startsWith("(fail)") && state.currentFile !== "") {
-    return structuredFailure(state.currentFile, undefined, "bun-test", line);
+    return {
+      signature: structuredFailure(
+        state.currentFile,
+        undefined,
+        "bun-test",
+        line
+      ),
+      dedupKey: null,
+    };
   }
 
-  return line.length > 0 && isErrorLine(line) ? line : null;
+  return line.length > 0 && isErrorLine(line)
+    ? { signature: line, dedupKey: null }
+    : null;
 }
 
 /** Reduce a raw `[generate:api] FAILED: <reason>` reason to a STABLE class token, so
@@ -520,13 +570,6 @@ function generateApiFailure(line: string): string | null {
   return `openapi-unreachable:${classifyOpenApiFailure(failed[1] ?? "fetch failed")}`;
 }
 
-/** Regex for a CLOSED eslint-JSON block, used to strip already-parsed blocks from the
- *  line-scanned output. Stripping (not a stateful skip flag) means an UNTERMINATED block
- *  — a truncated/killed capture with no end marker — is simply left in place for normal
- *  line parsing, so it can never swallow the tsc/stylish/knip diagnostics that follow. */
-const CLOSED_ESLINT_JSON_BLOCK =
-  /::tsforge-eslint-json \S+::[\s\S]*?::tsforge-eslint-json-end::/gu;
-
 export function extractFailures(output: string, cwd: string): Set<string> {
   const signatures = new Set<string>();
   // knip prints `Unused files (N)` then one relative path per line, ending at the
@@ -552,7 +595,10 @@ export function extractFailures(output: string, cwd: string): Set<string> {
 
   parseEslintJsonBlocks(output, cwd, signatures, jsonKeys);
 
-  const scanned = output.replace(CLOSED_ESLINT_JSON_BLOCK, "");
+  const scanned = output.replace(
+    new RegExp(ESLINT_JSON_BLOCK_SOURCE, "gu"),
+    ""
+  );
 
   for (const rawLine of joinMultilineEslintRows(scanned).split("\n")) {
     const line = normalize(rawLine, cwd);
@@ -582,12 +628,19 @@ export function extractFailures(output: string, cwd: string): Set<string> {
 
     const diagnostic = parsedDiagnostic(line, state);
 
-    // Drop a stylish row only when the JSON already reported the SAME error (identical
-    // file/line/rule) — dedup, not per-app suppression, so a stylish-only error the
-    // JSON never emitted is always kept.
-    if (diagnostic !== null && !jsonKeys.has(signatureKey(diagnostic))) {
-      signatures.add(diagnostic);
+    if (diagnostic === null) {
+      continue;
     }
+
+    // Drop a stylish eslint row only when the JSON already reported the SAME error
+    // (identical file/line/column/rule) — dedup, not per-app suppression, so a
+    // stylish-only error the JSON never emitted is always kept. Non-eslint rows
+    // (tsc/bun/fallback) carry no dedupKey and are never dropped.
+    if (diagnostic.dedupKey !== null && jsonKeys.has(diagnostic.dedupKey)) {
+      continue;
+    }
+
+    signatures.add(diagnostic.signature);
   }
 
   return signatures;

--- a/packages/core/src/loop/boringstack/extract-failures.ts
+++ b/packages/core/src/loop/boringstack/extract-failures.ts
@@ -58,23 +58,40 @@ function eslintResultSignatures(
   }
 }
 
-/** Parse every `::tsforge-eslint-json::` … `::tsforge-eslint-json-end::` block into
- *  structured eslint signatures. Returns true when ≥1 block PARSED — the caller then
- *  ignores the stylish eslint rows (JSON is the single source of truth for lint). A
- *  present-but-malformed block returns false, so the stylish fallback still runs and
- *  a lint error is never silently lost. */
+/** Is this a genuine eslint `--format json` payload — an array of result objects each
+ *  carrying `filePath` + a `messages` array (an empty array is valid = a green app)?
+ *  Rejects a JSON array of the wrong shape (`[1,2,3]`) so it can't be mistaken for
+ *  eslint coverage and wrongly suppress the stylish fallback. */
+function isEslintResultArray(value: unknown): boolean {
+  return (
+    Array.isArray(value) &&
+    value.every(
+      (r) =>
+        isRecord(r) &&
+        typeof r.filePath === "string" &&
+        Array.isArray(r.messages)
+    )
+  );
+}
+
+/** Parse every `::tsforge-eslint-json <app>::` … `::tsforge-eslint-json-end::` block
+ *  into structured eslint signatures. Returns the SET OF APPS whose block parsed into
+ *  a valid eslint-result array — the caller ignores stylish eslint rows ONLY for those
+ *  apps (per-app, not global). An app whose block is missing / malformed / wrong-shaped
+ *  is NOT in the set, so its stylish rows are still scraped and no lint error is lost. */
 function parseEslintJsonBlocks(
   output: string,
   cwd: string,
   signatures: Set<string>
-): boolean {
+): Set<string> {
+  const covered = new Set<string>();
   const blocks = output.matchAll(
-    /::tsforge-eslint-json::([\s\S]*?)::tsforge-eslint-json-end::/gu
+    /::tsforge-eslint-json (\S+)::([\s\S]*?)::tsforge-eslint-json-end::/gu
   );
-  let parsedAny = false;
 
   for (const block of blocks) {
-    const raw = (block[1] ?? "").replace(ANSI, "");
+    const app = block[1] ?? "";
+    const raw = (block[2] ?? "").replace(ANSI, "");
     const start = raw.indexOf("[");
     const end = raw.lastIndexOf("]");
 
@@ -90,18 +107,18 @@ function parseEslintJsonBlocks(
       continue;
     }
 
-    if (!Array.isArray(results)) {
+    if (!isEslintResultArray(results) || !Array.isArray(results)) {
       continue;
     }
 
-    parsedAny = true;
+    covered.add(app);
 
     for (const result of results) {
       eslintResultSignatures(result, cwd, signatures);
     }
   }
 
-  return parsedAny;
+  return covered;
 }
 
 /**
@@ -507,14 +524,14 @@ function consumeEslintJsonBlock(
   line: string,
   state: IFailureParserState
 ): boolean {
-  if (line === "::tsforge-eslint-json::") {
-    state.inEslintJson = true;
+  if (line === "::tsforge-eslint-json-end::") {
+    state.inEslintJson = false;
 
     return true;
   }
 
-  if (line === "::tsforge-eslint-json-end::") {
-    state.inEslintJson = false;
+  if (/^::tsforge-eslint-json .+::$/u.test(line)) {
+    state.inEslintJson = true;
 
     return true;
   }
@@ -536,19 +553,18 @@ export function extractFailures(output: string, cwd: string): Set<string> {
     inLintMeta: false,
     inUnusedFiles: false,
     inEslintJson: false,
-    eslintJsonPresent: false,
+    eslintJsonApps: new Set<string>(),
   };
 
-  // Prefer STRUCTURED eslint output: parse the `::tsforge-eslint-json::` block(s) into
-  // exact signatures. When present, the line loop ignores the ambiguous stylish eslint
-  // rows (JSON is the single source of truth). When ABSENT or malformed, fall back to
-  // scraping stylish (joined for multi-line) so an eslint error is never lost.
-  state.eslintJsonPresent = parseEslintJsonBlocks(output, cwd, signatures);
-  const source = state.eslintJsonPresent
-    ? output
-    : joinMultilineEslintRows(output);
+  // Prefer STRUCTURED eslint output: parse each app's `::tsforge-eslint-json <app>::`
+  // block into exact signatures. For a covered app the line loop ignores its ambiguous
+  // stylish eslint rows (JSON is the single source of truth); an uncovered app (block
+  // missing/malformed/wrong-shaped) still falls back to scraping stylish — joined for
+  // multi-line — so an eslint error is never lost. Joining is harmless for covered apps
+  // (their rows are skipped anyway).
+  state.eslintJsonApps = parseEslintJsonBlocks(output, cwd, signatures);
 
-  for (const rawLine of source.split("\n")) {
+  for (const rawLine of joinMultilineEslintRows(output).split("\n")) {
     const line = normalize(rawLine, cwd);
 
     if (consumeEslintJsonBlock(line, state)) {
@@ -578,9 +594,10 @@ export function extractFailures(output: string, cwd: string): Set<string> {
       continue;
     }
 
-    // eslint is owned by the JSON block — ignore the duplicated stylish rows so a
-    // failure isn't counted twice (once clean from JSON, once mangled from text).
-    if (state.eslintJsonPresent && /^\d+:\d+ (?:error|warning)\b/u.test(line)) {
+    // For an app whose eslint came from JSON, ignore its duplicated stylish ERROR
+    // rows so a failure isn't counted twice (once clean from JSON, once mangled from
+    // text). Only error rows — warnings were never captured by the stylish path.
+    if (state.eslintJsonApps.has(state.app) && /^\d+:\d+ error\b/u.test(line)) {
       continue;
     }
 

--- a/packages/core/src/loop/boringstack/extract-failures.ts
+++ b/packages/core/src/loop/boringstack/extract-failures.ts
@@ -24,15 +24,28 @@ function toRepoRelative(filePath: string, cwd: string): string {
   return filePath.split(cwd).join("").replace(/^\/+/u, "").trim();
 }
 
+/** The location-key of a failure signature: `failure:<encFile>:<line>:<encRule>` — the
+ *  first four colon fields (file/rule are URL-encoded and the line is numeric, so none
+ *  contain a raw `:`; the message is the only dropped field). Two signatures share a key
+ *  iff they describe the SAME eslint error at the same file/line/rule — used to dedup a
+ *  stylish row against the JSON signature for the identical error, WITHOUT suppressing a
+ *  stylish-only error the JSON never reported. */
+function signatureKey(signature: string): string {
+  return signature.split(":").slice(0, 4).join(":");
+}
+
 /** Turn one eslint JSON result-file into structured failure signatures — the same
  *  `failure:<file>:<line>:<rule>:<message>` shape the stylish path produces, but from
  *  UNAMBIGUOUS structured data (exact file/line/ruleId/message per message). Only
  *  ERRORS (severity 2) count — warnings don't fail the gate. A rule-less message (a
- *  parsing error) is tagged `syntax`, matching the tsc-parser convention. */
+ *  parsing error) is tagged `syntax`, matching the tsc-parser convention. Each emitted
+ *  signature's location-key is also recorded in `keys` so the line loop can dedup the
+ *  matching stylish row (and ONLY that row). */
 function eslintResultSignatures(
   result: unknown,
   cwd: string,
-  signatures: Set<string>
+  signatures: Set<string>,
+  keys: Set<string>
 ): void {
   if (!isRecord(result) || typeof result.filePath !== "string") {
     return;
@@ -59,51 +72,34 @@ function eslintResultSignatures(
         ? message.message.replace(/\s+/gu, " ").trim()
         : "";
     const line = typeof message.line === "number" ? message.line : undefined;
+    const signature = structuredFailure(file, line, rule, text);
 
-    signatures.add(structuredFailure(file, line, rule, text));
+    signatures.add(signature);
+    keys.add(signatureKey(signature));
   }
 }
 
-/** Is this a genuine eslint `--format json` payload — an array of result objects each
- *  carrying `filePath` + a `messages` array? Rejects a JSON array of the wrong shape
- *  (`[1,2,3]`) so it can't be mistaken for eslint output. Shape validity alone does NOT
- *  grant coverage (see parseEslintJsonBlocks) — an empty/all-green array is valid but
- *  yields no errors, so it must not suppress the stylish fallback. Typed as a guard so
- *  the caller can iterate `results` without a redundant re-check. */
-function isEslintResultArray(value: unknown): value is unknown[] {
-  return (
-    Array.isArray(value) &&
-    value.every(
-      (r) =>
-        isRecord(r) &&
-        typeof r.filePath === "string" &&
-        Array.isArray(r.messages)
-    )
-  );
-}
-
 /** Parse every `::tsforge-eslint-json <app>::` … `::tsforge-eslint-json-end::` block
- *  into structured eslint signatures. Returns the SET OF APPS whose block actually
- *  yielded ≥1 ERROR signature — the caller ignores stylish eslint rows ONLY for those
- *  apps (per-app, not global). "Covered" deliberately means "the errors for this app are
- *  already in the JSON", NOT merely "the block parsed": an empty `[]`, an all-green app,
- *  a 0-file run, or a payload whose message entries are malformed all yield zero errors,
- *  so they are NOT covered and their stylish rows are still scraped. This is safe both
- *  ways — a truly green app has no stylish error rows to lose, and a broken JSON pass
- *  falls back to `check`'s own stylish output, so a lint error is never silently lost. */
+ *  into structured eslint signatures (added to `signatures`), recording each error's
+ *  location-key in `keys`. A green/empty `[]`, a wrong-shaped array (`[1,2,3]`), or a
+ *  malformed message entry simply contributes NO keys — so it suppresses nothing. The
+ *  line loop later drops a stylish row ONLY when its exact location-key is already in
+ *  `keys` (the same error, from JSON), never an error the JSON didn't report. This is
+ *  dedup, not per-app suppression: a JSON subset can no longer hide a stylish-only
+ *  error, and a broken/absent block loses nothing. Only CLOSED blocks match here; an
+ *  unterminated block contributes nothing and is left in the text for normal parsing. */
 function parseEslintJsonBlocks(
   output: string,
   cwd: string,
-  signatures: Set<string>
-): Set<string> {
-  const covered = new Set<string>();
+  signatures: Set<string>,
+  keys: Set<string>
+): void {
   const blocks = output.matchAll(
-    /::tsforge-eslint-json (\S+)::([\s\S]*?)::tsforge-eslint-json-end::/gu
+    /::tsforge-eslint-json \S+::([\s\S]*?)::tsforge-eslint-json-end::/gu
   );
 
   for (const block of blocks) {
-    const app = block[1] ?? "";
-    const raw = (block[2] ?? "").replace(ANSI, "");
+    const raw = (block[1] ?? "").replace(ANSI, "");
     const start = raw.indexOf("[");
     const end = raw.lastIndexOf("]");
 
@@ -119,23 +115,14 @@ function parseEslintJsonBlocks(
       continue;
     }
 
-    if (!isEslintResultArray(results)) {
+    if (!Array.isArray(results)) {
       continue;
     }
 
-    const before = signatures.size;
-
     for (const result of results) {
-      eslintResultSignatures(result, cwd, signatures);
-    }
-
-    // Cover the app only when the JSON produced at least one real error signature.
-    if (signatures.size > before) {
-      covered.add(app);
+      eslintResultSignatures(result, cwd, signatures, keys);
     }
   }
-
-  return covered;
 }
 
 /**
@@ -533,38 +520,12 @@ function generateApiFailure(line: string): string | null {
   return `openapi-unreachable:${classifyOpenApiFailure(failed[1] ?? "fetch failed")}`;
 }
 
-/** Skip the raw JSON lines of an eslint-JSON block (parsed separately by
- *  parseEslintJsonBlocks) so a message value like `error TS…` inside the JSON can't be
- *  mis-parsed as a real diagnostic. Toggles on the markers; returns true while inside
- *  the block or on a marker line. Markers survive `normalize` (no whitespace). */
-function consumeEslintJsonBlock(
-  line: string,
-  state: IFailureParserState
-): boolean {
-  if (line === "::tsforge-eslint-json-end::") {
-    state.inEslintJson = false;
-
-    return true;
-  }
-
-  if (/^::tsforge-eslint-json .+::$/u.test(line)) {
-    state.inEslintJson = true;
-
-    return true;
-  }
-
-  // An `::tsforge-app <prefix>::` stage marker is a hard boundary. If a JSON block was
-  // left unterminated (truncated capture, missing end marker), it ends HERE rather than
-  // swallowing every later line (tsc errors, bun fails, stylish rows) across the app
-  // boundary — the exact silent-loss the panel flagged. Fall through to consumeMarker.
-  if (/^::tsforge-app .+::$/u.test(line)) {
-    state.inEslintJson = false;
-
-    return false;
-  }
-
-  return state.inEslintJson;
-}
+/** Regex for a CLOSED eslint-JSON block, used to strip already-parsed blocks from the
+ *  line-scanned output. Stripping (not a stateful skip flag) means an UNTERMINATED block
+ *  — a truncated/killed capture with no end marker — is simply left in place for normal
+ *  line parsing, so it can never swallow the tsc/stylish/knip diagnostics that follow. */
+const CLOSED_ESLINT_JSON_BLOCK =
+  /::tsforge-eslint-json \S+::[\s\S]*?::tsforge-eslint-json-end::/gu;
 
 export function extractFailures(output: string, cwd: string): Set<string> {
   const signatures = new Set<string>();
@@ -579,24 +540,22 @@ export function extractFailures(output: string, cwd: string): Set<string> {
     currentFile: "",
     inLintMeta: false,
     inUnusedFiles: false,
-    inEslintJson: false,
-    eslintJsonApps: new Set<string>(),
   };
 
-  // Prefer STRUCTURED eslint output: parse each app's `::tsforge-eslint-json <app>::`
-  // block into exact signatures. For a covered app the line loop ignores its ambiguous
-  // stylish eslint rows (JSON is the single source of truth); an uncovered app (block
-  // missing/malformed/wrong-shaped) still falls back to scraping stylish — joined for
-  // multi-line — so an eslint error is never lost. Joining is harmless for covered apps
-  // (their rows are skipped anyway).
-  state.eslintJsonApps = parseEslintJsonBlocks(output, cwd, signatures);
+  // Prefer STRUCTURED eslint output: parse each `::tsforge-eslint-json <app>::` block
+  // into exact signatures and record each error's location-key. Then STRIP the closed
+  // blocks from the line-scanned text so a JSON message like `error TS…` can't be
+  // mis-parsed as a diagnostic — an unterminated block is left in place and parsed
+  // normally, never swallowing later lines. A stylish row that duplicates a JSON error
+  // (same file/line/rule key) is dropped in the loop; a stylish-only error is kept.
+  const jsonKeys = new Set<string>();
 
-  for (const rawLine of joinMultilineEslintRows(output).split("\n")) {
+  parseEslintJsonBlocks(output, cwd, signatures, jsonKeys);
+
+  const scanned = output.replace(CLOSED_ESLINT_JSON_BLOCK, "");
+
+  for (const rawLine of joinMultilineEslintRows(scanned).split("\n")) {
     const line = normalize(rawLine, cwd);
-
-    if (consumeEslintJsonBlock(line, state)) {
-      continue;
-    }
 
     if (consumeMarker(line, state)) {
       continue;
@@ -621,16 +580,12 @@ export function extractFailures(output: string, cwd: string): Set<string> {
       continue;
     }
 
-    // For an app whose eslint came from JSON, ignore its duplicated stylish ERROR
-    // rows so a failure isn't counted twice (once clean from JSON, once mangled from
-    // text). Only error rows — warnings were never captured by the stylish path.
-    if (state.eslintJsonApps.has(state.app) && /^\d+:\d+ error\b/u.test(line)) {
-      continue;
-    }
-
     const diagnostic = parsedDiagnostic(line, state);
 
-    if (diagnostic !== null) {
+    // Drop a stylish row only when the JSON already reported the SAME error (identical
+    // file/line/rule) — dedup, not per-app suppression, so a stylish-only error the
+    // JSON never emitted is always kept.
+    if (diagnostic !== null && !jsonKeys.has(signatureKey(diagnostic))) {
       signatures.add(diagnostic);
     }
   }

--- a/packages/core/src/loop/boringstack/extract-failures.types.ts
+++ b/packages/core/src/loop/boringstack/extract-failures.types.ts
@@ -3,12 +3,14 @@ export interface IFailureParserState {
   currentFile: string;
   inLintMeta: boolean;
   inUnusedFiles: boolean;
-  /** Inside a `::tsforge-eslint-json::` … `::tsforge-eslint-json-end::` block — its
-   *  lines are raw JSON (parsed separately) and must be skipped by the line loop so a
-   *  message string like `error TS…` can't be mistaken for a tsc diagnostic. */
+  /** Inside a `::tsforge-eslint-json <app>::` … `::tsforge-eslint-json-end::` block —
+   *  its lines are raw JSON (parsed separately) and must be skipped by the line loop
+   *  so a message string like `error TS…` can't be mistaken for a tsc diagnostic. */
   inEslintJson: boolean;
-  /** A parseable eslint-JSON block was present in this run, so eslint failures come
-   *  from the STRUCTURED JSON — the line loop then ignores the ambiguous "stylish"
-   *  eslint rows. Absent ⇒ fall back to scraping stylish (never a false green). */
-  eslintJsonPresent: boolean;
+  /** The apps whose eslint-JSON block PARSED into a valid eslint-result array — for
+   *  those apps eslint failures come from the STRUCTURED JSON, so the line loop
+   *  ignores their stylish eslint rows. PER-APP (not global): an app whose block is
+   *  absent/malformed/wrong-shaped still falls back to scraping stylish, so a lint
+   *  error is never silently lost (no false green). */
+  eslintJsonApps: Set<string>;
 }

--- a/packages/core/src/loop/boringstack/extract-failures.types.ts
+++ b/packages/core/src/loop/boringstack/extract-failures.types.ts
@@ -7,10 +7,11 @@ export interface IFailureParserState {
    *  its lines are raw JSON (parsed separately) and must be skipped by the line loop
    *  so a message string like `error TS…` can't be mistaken for a tsc diagnostic. */
   inEslintJson: boolean;
-  /** The apps whose eslint-JSON block PARSED into a valid eslint-result array — for
-   *  those apps eslint failures come from the STRUCTURED JSON, so the line loop
-   *  ignores their stylish eslint rows. PER-APP (not global): an app whose block is
-   *  absent/malformed/wrong-shaped still falls back to scraping stylish, so a lint
-   *  error is never silently lost (no false green). */
+  /** The apps whose eslint-JSON block actually YIELDED ≥1 error signature — for those
+   *  apps eslint failures come from the STRUCTURED JSON, so the line loop ignores their
+   *  stylish eslint rows. PER-APP (not global): an app whose block is
+   *  absent/malformed/wrong-shaped OR simply green/empty is NOT in the set and still
+   *  falls back to scraping stylish, so a lint error is never silently lost (no false
+   *  green). Coverage = "the errors are already in the JSON", not merely "it parsed". */
   eslintJsonApps: Set<string>;
 }

--- a/packages/core/src/loop/boringstack/extract-failures.types.ts
+++ b/packages/core/src/loop/boringstack/extract-failures.types.ts
@@ -3,4 +3,12 @@ export interface IFailureParserState {
   currentFile: string;
   inLintMeta: boolean;
   inUnusedFiles: boolean;
+  /** Inside a `::tsforge-eslint-json::` … `::tsforge-eslint-json-end::` block — its
+   *  lines are raw JSON (parsed separately) and must be skipped by the line loop so a
+   *  message string like `error TS…` can't be mistaken for a tsc diagnostic. */
+  inEslintJson: boolean;
+  /** A parseable eslint-JSON block was present in this run, so eslint failures come
+   *  from the STRUCTURED JSON — the line loop then ignores the ambiguous "stylish"
+   *  eslint rows. Absent ⇒ fall back to scraping stylish (never a false green). */
+  eslintJsonPresent: boolean;
 }

--- a/packages/core/src/loop/boringstack/extract-failures.types.ts
+++ b/packages/core/src/loop/boringstack/extract-failures.types.ts
@@ -3,15 +3,4 @@ export interface IFailureParserState {
   currentFile: string;
   inLintMeta: boolean;
   inUnusedFiles: boolean;
-  /** Inside a `::tsforge-eslint-json <app>::` … `::tsforge-eslint-json-end::` block —
-   *  its lines are raw JSON (parsed separately) and must be skipped by the line loop
-   *  so a message string like `error TS…` can't be mistaken for a tsc diagnostic. */
-  inEslintJson: boolean;
-  /** The apps whose eslint-JSON block actually YIELDED ≥1 error signature — for those
-   *  apps eslint failures come from the STRUCTURED JSON, so the line loop ignores their
-   *  stylish eslint rows. PER-APP (not global): an app whose block is
-   *  absent/malformed/wrong-shaped OR simply green/empty is NOT in the set and still
-   *  falls back to scraping stylish, so a lint error is never silently lost (no false
-   *  green). Coverage = "the errors are already in the JSON", not merely "it parsed". */
-  eslintJsonApps: Set<string>;
 }

--- a/packages/core/src/loop/boringstack/gate.ts
+++ b/packages/core/src/loop/boringstack/gate.ts
@@ -40,14 +40,14 @@ import type { Exec } from "./exec";
  *  the app's `lint` script and appends `--format json`, so there's no coupling to the
  *  app's glob list. Runs BEFORE `check` and never aborts (`|| true`) — it's a parsing
  *  aid; `check` still owns pass/fail (its own eslint sets the exit code). */
-const eslintJson = (): string =>
-  "{ echo '::tsforge-eslint-json::'; " +
+const eslintJson = (app: string): string =>
+  `{ echo '::tsforge-eslint-json ${app}::'; ` +
   "bun run --silent lint -- --format json 2>/dev/null || true; " +
   "echo '::tsforge-eslint-json-end::'; }";
 
 const FAST_GATE =
-  `echo '::tsforge-app apps/api::' && (cd apps/api && ${eslintJson()} && bun run check && bun run test) && ` +
-  `echo '::tsforge-app apps/ui::' && (cd apps/ui && bun run generate:api && ${eslintJson()} && bun run check)`;
+  `echo '::tsforge-app apps/api::' && (cd apps/api && ${eslintJson("apps/api")} && bun run check && bun run test) && ` +
+  `echo '::tsforge-app apps/ui::' && (cd apps/ui && bun run generate:api && ${eslintJson("apps/ui")} && bun run check)`;
 
 /**
  * FULL acceptance gate — run ONCE, when every feature has passed the fast gate. The
@@ -57,8 +57,8 @@ const FAST_GATE =
  * at the end instead of every turn.
  */
 const FULL_GATE =
-  `echo '::tsforge-app apps/api::' && (cd apps/api && ${eslintJson()} && bun run validate) && ` +
-  `echo '::tsforge-app apps/ui::' && (cd apps/ui && bun run generate:api && ${eslintJson()} && bun run validate) && ` +
+  `echo '::tsforge-app apps/api::' && (cd apps/api && ${eslintJson("apps/api")} && bun run validate) && ` +
+  `echo '::tsforge-app apps/ui::' && (cd apps/ui && bun run generate:api && ${eslintJson("apps/ui")} && bun run validate) && ` +
   "echo '::tsforge-app .::' && bun run check";
 
 export type GateMode = "fast" | "full";

--- a/packages/core/src/loop/boringstack/gate.ts
+++ b/packages/core/src/loop/boringstack/gate.ts
@@ -33,9 +33,21 @@ import type { Exec } from "./exec";
  * stage still regenerates the OpenAPI client (`generate:api`) first, so the UI never
  * checks against a stale `schema.d.ts`.
  */
+/** Emit the app's OWN eslint (same config + file globs) as STRUCTURED JSON, wrapped
+ *  in markers, so the failure parser reads exact {file,line,rule,message} instead of
+ *  scraping eslint's ambiguous "stylish" text (which truncated multi-line messages and
+ *  mis-attributed interleaved output). `bun run --silent lint -- --format json` reuses
+ *  the app's `lint` script and appends `--format json`, so there's no coupling to the
+ *  app's glob list. Runs BEFORE `check` and never aborts (`|| true`) — it's a parsing
+ *  aid; `check` still owns pass/fail (its own eslint sets the exit code). */
+const eslintJson = (): string =>
+  "{ echo '::tsforge-eslint-json::'; " +
+  "bun run --silent lint -- --format json 2>/dev/null || true; " +
+  "echo '::tsforge-eslint-json-end::'; }";
+
 const FAST_GATE =
-  "echo '::tsforge-app apps/api::' && (cd apps/api && bun run check && bun run test) && " +
-  "echo '::tsforge-app apps/ui::' && (cd apps/ui && bun run generate:api && bun run check)";
+  `echo '::tsforge-app apps/api::' && (cd apps/api && ${eslintJson()} && bun run check && bun run test) && ` +
+  `echo '::tsforge-app apps/ui::' && (cd apps/ui && bun run generate:api && ${eslintJson()} && bun run check)`;
 
 /**
  * FULL acceptance gate — run ONCE, when every feature has passed the fast gate. The
@@ -45,8 +57,8 @@ const FAST_GATE =
  * at the end instead of every turn.
  */
 const FULL_GATE =
-  "echo '::tsforge-app apps/api::' && (cd apps/api && bun run validate) && " +
-  "echo '::tsforge-app apps/ui::' && (cd apps/ui && bun run generate:api && bun run validate) && " +
+  `echo '::tsforge-app apps/api::' && (cd apps/api && ${eslintJson()} && bun run validate) && ` +
+  `echo '::tsforge-app apps/ui::' && (cd apps/ui && bun run generate:api && ${eslintJson()} && bun run validate) && ` +
   "echo '::tsforge-app .::' && bun run check";
 
 export type GateMode = "fast" | "full";

--- a/packages/core/tests/boringstack-extract-failures.test.ts
+++ b/packages/core/tests/boringstack-extract-failures.test.ts
@@ -479,6 +479,67 @@ ${cwd}/apps/api/src/x.ts
     ).toBe(true);
   });
 
+  test("a valid-shaped block whose message entries are malformed does NOT count as coverage (stylish still scraped)", () => {
+    // `[{filePath, messages:[{}]}]` passes shape validation but yields ZERO error
+    // signatures (the {} message has no severity 2). Coverage requires ≥1 real error,
+    // so the app is NOT covered and its stylish error is still captured — the panel's
+    // "shape-valid but incomplete payload silently loses lint" finding.
+    const cwd = "/tmp/clone";
+    const out = `::tsforge-app apps/api::
+::tsforge-eslint-json apps/api::
+[{"filePath":"${cwd}/apps/api/src/x.ts","messages":[{}]}]
+::tsforge-eslint-json-end::
+${cwd}/apps/api/src/x.ts
+  4:2  error  Unexpected any  @typescript-eslint/no-explicit-any`;
+    const sigs = extractFailures(out, cwd);
+
+    expect(
+      [...sigs].some((s) =>
+        s.startsWith(
+          "failure:apps%2Fapi%2Fsrc%2Fx.ts:4:%40typescript-eslint%2Fno-explicit-any"
+        )
+      )
+    ).toBe(true);
+  });
+
+  test("an unterminated JSON block ends at the next ::tsforge-app:: marker (no cross-app swallow)", () => {
+    // The API JSON block is missing its end marker (truncated capture). Without an
+    // app-boundary reset the inEslintJson flag would stay true across the boundary and
+    // swallow EVERY later line — the UI's tsc error included. The next app marker must
+    // end the block so the UI failure is still captured.
+    const cwd = "/tmp/clone";
+    const out = `::tsforge-app apps/api::
+::tsforge-eslint-json apps/api::
+[{"filePath":"${cwd}/apps/api/src/x.ts","messages":[
+::tsforge-app apps/ui::
+${cwd}/apps/ui/src/features/x/x.ts(10,5): error TS2532: Object is possibly 'undefined'.`;
+    const sigs = extractFailures(out, cwd);
+
+    expect([...sigs].some((s) => s.includes("TS2532"))).toBe(true);
+    expect(
+      [...sigs].some((s) => s.startsWith("failure:apps%2Fui%2Fsrc%2Ffeatures"))
+    ).toBe(true);
+  });
+
+  test("a multi-line JSON message is whitespace-collapsed so its signature matches the stylish path", () => {
+    // Same error, two sources: the JSON message carries literal newlines, the stylish
+    // row is space-joined. Both must key to the SAME signature — else a JSON block that
+    // intermittently fails to parse would make a pre-existing failure look novel in the
+    // differential. Assert the JSON signature has NO encoded newline (%0A) and DOES
+    // contain the full space-joined message.
+    const cwd = "/tmp/clone";
+    const out = `::tsforge-eslint-json apps/api::
+[{"filePath":"${cwd}/apps/api/src/x.ts","messages":[{"ruleId":"module-boundaries/single-semantic-module","severity":2,"message":"Mixed categories:\\n- type\\n- schema","line":6,"column":8}]}]
+::tsforge-eslint-json-end::`;
+    const sigs = extractFailures(out, cwd);
+    const sig = [...sigs][0] ?? "";
+
+    expect(sig).not.toContain("%0A");
+    expect(decodeURIComponent(sig)).toContain(
+      "Mixed categories: - type - schema"
+    );
+  });
+
   test("a fully green run yields no signatures", () => {
     expect(extractFailures("30 pass\n0 fail\nDone.", "/x").size).toBe(0);
   });

--- a/packages/core/tests/boringstack-extract-failures.test.ts
+++ b/packages/core/tests/boringstack-extract-failures.test.ts
@@ -522,6 +522,55 @@ ${cwd}/apps/ui/src/features/x/x.ts(10,5): error TS2532: Object is possibly 'unde
     ).toBe(true);
   });
 
+  test("an unterminated block does NOT pair with a LATER closed block (no cross-block strip)", () => {
+    // The tempered regex must stop the API block's content at the UI opening marker.
+    // A naive `[\s\S]*?` would pair the unterminated API opening with the UI closing and
+    // strip everything between — losing the intervening tsc error AND the UI JSON error.
+    const cwd = "/tmp/clone";
+    const out = `::tsforge-app apps/api::
+::tsforge-eslint-json apps/api::
+[{"filePath":"${cwd}/apps/api/src/api/x.ts","messages":[
+${cwd}/apps/api/src/api/x.ts(5,3): error TS1005: ';' expected.
+::tsforge-app apps/ui::
+::tsforge-eslint-json apps/ui::
+[{"filePath":"${cwd}/apps/ui/src/features/y/y.ts","messages":[{"ruleId":"no-console","severity":2,"message":"no console","line":2,"column":1}]}]
+::tsforge-eslint-json-end::`;
+    const sigs = extractFailures(out, cwd);
+
+    // The tsc error between the two blocks survives (API block was NOT stripped)…
+    expect([...sigs].some((s) => s.includes("TS1005"))).toBe(true);
+    // …and the CLOSED UI block still parses to its structured signature.
+    expect(
+      [...sigs].some((s) =>
+        s.startsWith(
+          "failure:apps%2Fui%2Fsrc%2Ffeatures%2Fy%2Fy.ts:2:no-console"
+        )
+      )
+    ).toBe(true);
+  });
+
+  test("column is in the dedup key: a stylish error at a different column on the same line/rule is NOT dropped", () => {
+    // JSON reports ONE no-console at 6:3; stylish has that one PLUS a second no-console at
+    // 6:20 the JSON never emitted. With column in the dedup key, only the 6:3 twin is
+    // deduped and 6:20 survives. A column-less key (file:line:rule) would drop BOTH
+    // stylish rows and silently lose the 6:20 error.
+    const cwd = "/tmp/clone";
+    const out = `::tsforge-app apps/api::
+::tsforge-eslint-json apps/api::
+[{"filePath":"${cwd}/apps/api/src/api/a/a.ts","messages":[{"ruleId":"no-console","severity":2,"message":"a","line":6,"column":3}]}]
+::tsforge-eslint-json-end::
+${cwd}/apps/api/src/api/a/a.ts
+  6:3  error  a  no-console
+  6:20  error  b  no-console`;
+    const sigs = extractFailures(out, cwd);
+    const consoleErrors = [...sigs].filter((s) =>
+      s.startsWith("failure:apps%2Fapi%2Fsrc%2Fapi%2Fa%2Fa.ts:6:no-console")
+    );
+
+    // The JSON error (6:3) and the stylish-only error (6:20) — two distinct signatures.
+    expect(consoleErrors).toHaveLength(2);
+  });
+
   test("a JSON error at one line does NOT suppress a stylish-only error at another (per-error dedup, not per-app)", () => {
     // The panel's core finding: if the JSON is a SUBSET of the real lint failures, a
     // per-app suppression would drop the stylish-only errors. Per-(file,line,rule) dedup

--- a/packages/core/tests/boringstack-extract-failures.test.ts
+++ b/packages/core/tests/boringstack-extract-failures.test.ts
@@ -344,6 +344,96 @@ tests/api/a/a.service.test.ts:
     expect(sigs.size).toBe(1);
   });
 
+  test("structured eslint JSON → exact signatures; stylish rows for the same run are ignored (no double)", () => {
+    const cwd = "/tmp/clone";
+    const out = `::tsforge-app apps/api::
+::tsforge-eslint-json::
+[{"filePath":"${cwd}/apps/api/src/api/a/a.ts","messages":[{"ruleId":"module-boundaries/single-semantic-module","severity":2,"message":"Mixed semantic categories detected in module:\\n- type\\n- schema\\nMove declarations into separate files/modules","line":6,"column":8},{"ruleId":"@typescript-eslint/no-explicit-any","severity":2,"message":"Unexpected any.","line":9,"column":3},{"ruleId":"prefer-const","severity":1,"message":"just a warning","line":1,"column":1}]}]
+::tsforge-eslint-json-end::
+${cwd}/apps/api/src/api/a/a.ts
+  6:8  error  Mixed semantic categories detected in module:
+- type
+- schema
+Move declarations into separate files/modules  module-boundaries/single-semantic-module
+  9:3  error  Unexpected any  @typescript-eslint/no-explicit-any`;
+    const sigs = extractFailures(out, cwd);
+
+    // Exact structured signatures from JSON (full multi-line message, correct rule).
+    const semantic = [...sigs].find((s) =>
+      s.includes("single-semantic-module")
+    );
+
+    expect(semantic).toBeDefined();
+    expect(semantic).toStartWith(
+      "failure:apps%2Fapi%2Fsrc%2Fapi%2Fa%2Fa.ts:6:module-boundaries%2Fsingle-semantic-module"
+    );
+    expect(decodeURIComponent(semantic ?? "")).toContain(
+      "Move declarations into separate files"
+    );
+    expect(
+      [...sigs].some((s) =>
+        s.startsWith(
+          "failure:apps%2Fapi%2Fsrc%2Fapi%2Fa%2Fa.ts:9:%40typescript-eslint%2Fno-explicit-any"
+        )
+      )
+    ).toBe(true);
+    // Warning (severity 1) is NOT a failure.
+    expect([...sigs].some((s) => s.includes("prefer-const"))).toBe(false);
+    // Exactly the two errors — the stylish rows did NOT create duplicates.
+    expect(sigs.size).toBe(2);
+  });
+
+  test("a JSON message containing `error TS…` is not mis-parsed as a tsc diagnostic", () => {
+    const cwd = "/tmp/clone";
+    const out = `::tsforge-eslint-json::
+[{"filePath":"${cwd}/apps/api/src/x.ts","messages":[{"ruleId":"no-console","severity":2,"message":"Do not mention error TS2532 here","line":2,"column":1}]}]
+::tsforge-eslint-json-end::`;
+    const sigs = extractFailures(out, cwd);
+
+    expect(sigs.size).toBe(1);
+    expect([...sigs][0]).toStartWith(
+      "failure:apps%2Fapi%2Fsrc%2Fx.ts:2:no-console"
+    );
+    // The `error TS2532` inside the message did NOT mint a phantom tsc signature.
+    expect([...sigs].some((s) => s.includes("TS2532:"))).toBe(false);
+  });
+
+  test("tsc + bun failures still parse alongside a JSON eslint block", () => {
+    const cwd = "/tmp/clone";
+    const out = `::tsforge-eslint-json::
+[{"filePath":"${cwd}/apps/api/src/x.ts","messages":[{"ruleId":"no-console","severity":2,"message":"no console","line":2,"column":1}]}]
+::tsforge-eslint-json-end::
+${cwd}/apps/api/src/y.ts(38,3): error TS2532: Object is possibly 'undefined'.
+tests/api/z/z.test.ts:
+(fail) zService > works [0.2ms]`;
+    const sigs = extractFailures(out, cwd);
+
+    expect([...sigs].some((s) => s.includes("no-console"))).toBe(true);
+    expect([...sigs].some((s) => s.includes("TS2532"))).toBe(true);
+    expect(
+      [...sigs].some((s) => decodeURIComponent(s).includes("(fail)"))
+    ).toBe(true);
+  });
+
+  test("a malformed JSON block falls back to scraping stylish eslint (no lint error lost)", () => {
+    const cwd = "/tmp/clone";
+    const out = `::tsforge-eslint-json::
+not valid json {[
+::tsforge-eslint-json-end::
+${cwd}/apps/api/src/x.ts
+  4:2  error  Unexpected any  @typescript-eslint/no-explicit-any`;
+    const sigs = extractFailures(out, cwd);
+
+    // JSON unparseable → stylish path still captures the eslint error.
+    expect(
+      [...sigs].some((s) =>
+        s.startsWith(
+          "failure:apps%2Fapi%2Fsrc%2Fx.ts:4:%40typescript-eslint%2Fno-explicit-any"
+        )
+      )
+    ).toBe(true);
+  });
+
   test("a fully green run yields no signatures", () => {
     expect(extractFailures("30 pass\n0 fail\nDone.", "/x").size).toBe(0);
   });

--- a/packages/core/tests/boringstack-extract-failures.test.ts
+++ b/packages/core/tests/boringstack-extract-failures.test.ts
@@ -347,7 +347,7 @@ tests/api/a/a.service.test.ts:
   test("structured eslint JSON → exact signatures; stylish rows for the same run are ignored (no double)", () => {
     const cwd = "/tmp/clone";
     const out = `::tsforge-app apps/api::
-::tsforge-eslint-json::
+::tsforge-eslint-json apps/api::
 [{"filePath":"${cwd}/apps/api/src/api/a/a.ts","messages":[{"ruleId":"module-boundaries/single-semantic-module","severity":2,"message":"Mixed semantic categories detected in module:\\n- type\\n- schema\\nMove declarations into separate files/modules","line":6,"column":8},{"ruleId":"@typescript-eslint/no-explicit-any","severity":2,"message":"Unexpected any.","line":9,"column":3},{"ruleId":"prefer-const","severity":1,"message":"just a warning","line":1,"column":1}]}]
 ::tsforge-eslint-json-end::
 ${cwd}/apps/api/src/api/a/a.ts
@@ -385,7 +385,7 @@ Move declarations into separate files/modules  module-boundaries/single-semantic
 
   test("a JSON message containing `error TS…` is not mis-parsed as a tsc diagnostic", () => {
     const cwd = "/tmp/clone";
-    const out = `::tsforge-eslint-json::
+    const out = `::tsforge-eslint-json apps/api::
 [{"filePath":"${cwd}/apps/api/src/x.ts","messages":[{"ruleId":"no-console","severity":2,"message":"Do not mention error TS2532 here","line":2,"column":1}]}]
 ::tsforge-eslint-json-end::`;
     const sigs = extractFailures(out, cwd);
@@ -400,7 +400,7 @@ Move declarations into separate files/modules  module-boundaries/single-semantic
 
   test("tsc + bun failures still parse alongside a JSON eslint block", () => {
     const cwd = "/tmp/clone";
-    const out = `::tsforge-eslint-json::
+    const out = `::tsforge-eslint-json apps/api::
 [{"filePath":"${cwd}/apps/api/src/x.ts","messages":[{"ruleId":"no-console","severity":2,"message":"no console","line":2,"column":1}]}]
 ::tsforge-eslint-json-end::
 ${cwd}/apps/api/src/y.ts(38,3): error TS2532: Object is possibly 'undefined'.
@@ -417,7 +417,7 @@ tests/api/z/z.test.ts:
 
   test("a malformed JSON block falls back to scraping stylish eslint (no lint error lost)", () => {
     const cwd = "/tmp/clone";
-    const out = `::tsforge-eslint-json::
+    const out = `::tsforge-eslint-json apps/api::
 not valid json {[
 ::tsforge-eslint-json-end::
 ${cwd}/apps/api/src/x.ts
@@ -425,6 +425,51 @@ ${cwd}/apps/api/src/x.ts
     const sigs = extractFailures(out, cwd);
 
     // JSON unparseable → stylish path still captures the eslint error.
+    expect(
+      [...sigs].some((s) =>
+        s.startsWith(
+          "failure:apps%2Fapi%2Fsrc%2Fx.ts:4:%40typescript-eslint%2Fno-explicit-any"
+        )
+      )
+    ).toBe(true);
+  });
+
+  test("per-app coverage: API JSON `[]` (green) does NOT suppress UI's stylish errors when the UI block is malformed", () => {
+    // The gate emits TWO blocks (api, ui). API is green ([]), UI's block is malformed
+    // → UI is NOT "covered", so its stylish eslint error must still be captured (a
+    // global flag would have lost it — the exact near-green regression the panel flagged).
+    const cwd = "/tmp/clone";
+    const out = `::tsforge-app apps/api::
+::tsforge-eslint-json apps/api::
+[]
+::tsforge-eslint-json-end::
+::tsforge-app apps/ui::
+::tsforge-eslint-json apps/ui::
+not valid json {[
+::tsforge-eslint-json-end::
+${cwd}/apps/ui/src/features/x/X.tsx
+  4:2  error  Unexpected any  @typescript-eslint/no-explicit-any`;
+    const sigs = extractFailures(out, cwd);
+
+    expect(
+      [...sigs].some((s) =>
+        s.startsWith(
+          "failure:apps%2Fui%2Fsrc%2Ffeatures%2Fx%2FX.tsx:4:%40typescript-eslint%2Fno-explicit-any"
+        )
+      )
+    ).toBe(true);
+  });
+
+  test("a wrong-shaped JSON array (`[1,2,3]`) does NOT count as coverage — stylish is still scraped", () => {
+    const cwd = "/tmp/clone";
+    const out = `::tsforge-app apps/api::
+::tsforge-eslint-json apps/api::
+[1,2,3]
+::tsforge-eslint-json-end::
+${cwd}/apps/api/src/x.ts
+  4:2  error  Unexpected any  @typescript-eslint/no-explicit-any`;
+    const sigs = extractFailures(out, cwd);
+
     expect(
       [...sigs].some((s) =>
         s.startsWith(

--- a/packages/core/tests/boringstack-extract-failures.test.ts
+++ b/packages/core/tests/boringstack-extract-failures.test.ts
@@ -434,10 +434,10 @@ ${cwd}/apps/api/src/x.ts
     ).toBe(true);
   });
 
-  test("per-app coverage: API JSON `[]` (green) does NOT suppress UI's stylish errors when the UI block is malformed", () => {
-    // The gate emits TWO blocks (api, ui). API is green ([]), UI's block is malformed
-    // → UI is NOT "covered", so its stylish eslint error must still be captured (a
-    // global flag would have lost it — the exact near-green regression the panel flagged).
+  test("API JSON `[]` (green) does NOT suppress UI's stylish errors when the UI block is malformed", () => {
+    // The gate emits TWO blocks (api, ui). API is green ([]) and UI's block is malformed
+    // → neither contributes dedup keys, so UI's stylish eslint error must still be
+    // captured (a global suppression flag would have lost it — the near-green regression).
     const cwd = "/tmp/clone";
     const out = `::tsforge-app apps/api::
 ::tsforge-eslint-json apps/api::
@@ -460,7 +460,7 @@ ${cwd}/apps/ui/src/features/x/X.tsx
     ).toBe(true);
   });
 
-  test("a wrong-shaped JSON array (`[1,2,3]`) does NOT count as coverage — stylish is still scraped", () => {
+  test("a wrong-shaped JSON array (`[1,2,3]`) yields no dedup keys — stylish is still scraped", () => {
     const cwd = "/tmp/clone";
     const out = `::tsforge-app apps/api::
 ::tsforge-eslint-json apps/api::
@@ -479,11 +479,11 @@ ${cwd}/apps/api/src/x.ts
     ).toBe(true);
   });
 
-  test("a valid-shaped block whose message entries are malformed does NOT count as coverage (stylish still scraped)", () => {
-    // `[{filePath, messages:[{}]}]` passes shape validation but yields ZERO error
-    // signatures (the {} message has no severity 2). Coverage requires ≥1 real error,
-    // so the app is NOT covered and its stylish error is still captured — the panel's
-    // "shape-valid but incomplete payload silently loses lint" finding.
+  test("a valid-shaped block whose message entries are malformed yields no dedup keys (stylish still scraped)", () => {
+    // `[{filePath, messages:[{}]}]` is a valid array but the {} message has no
+    // severity 2, so it contributes ZERO dedup keys. The stylish error is therefore
+    // still captured — the panel's "shape-valid but incomplete payload silently loses
+    // lint" finding, resolved by per-error dedup rather than per-app suppression.
     const cwd = "/tmp/clone";
     const out = `::tsforge-app apps/api::
 ::tsforge-eslint-json apps/api::
@@ -502,11 +502,12 @@ ${cwd}/apps/api/src/x.ts
     ).toBe(true);
   });
 
-  test("an unterminated JSON block ends at the next ::tsforge-app:: marker (no cross-app swallow)", () => {
-    // The API JSON block is missing its end marker (truncated capture). Without an
-    // app-boundary reset the inEslintJson flag would stay true across the boundary and
-    // swallow EVERY later line — the UI's tsc error included. The next app marker must
-    // end the block so the UI failure is still captured.
+  test("an unterminated JSON block never swallows later diagnostics (only CLOSED blocks are stripped)", () => {
+    // The API JSON block is missing its end marker (truncated/killed capture). Only
+    // CLOSED blocks are stripped from the scanned text; an unterminated one is left in
+    // place and parsed line-by-line — its partial JSON line is not an error row, so it
+    // is skipped harmlessly, and the UI's tsc error that follows is still captured. A
+    // sticky skip flag would have swallowed every later line.
     const cwd = "/tmp/clone";
     const out = `::tsforge-app apps/api::
 ::tsforge-eslint-json apps/api::
@@ -519,6 +520,38 @@ ${cwd}/apps/ui/src/features/x/x.ts(10,5): error TS2532: Object is possibly 'unde
     expect(
       [...sigs].some((s) => s.startsWith("failure:apps%2Fui%2Fsrc%2Ffeatures"))
     ).toBe(true);
+  });
+
+  test("a JSON error at one line does NOT suppress a stylish-only error at another (per-error dedup, not per-app)", () => {
+    // The panel's core finding: if the JSON is a SUBSET of the real lint failures, a
+    // per-app suppression would drop the stylish-only errors. Per-(file,line,rule) dedup
+    // drops only the exact error the JSON already reported (a.ts:6), keeping the
+    // stylish-only error at a.ts:9 that the JSON never emitted.
+    const cwd = "/tmp/clone";
+    const out = `::tsforge-app apps/api::
+::tsforge-eslint-json apps/api::
+[{"filePath":"${cwd}/apps/api/src/api/a/a.ts","messages":[{"ruleId":"no-console","severity":2,"message":"no console","line":6,"column":8}]}]
+::tsforge-eslint-json-end::
+${cwd}/apps/api/src/api/a/a.ts
+  6:8  error  no console  no-console
+  9:3  error  Unexpected any  @typescript-eslint/no-explicit-any`;
+    const sigs = extractFailures(out, cwd);
+
+    // The JSON error (line 6) is kept exactly once — its stylish duplicate is deduped.
+    expect(
+      [...sigs].filter((s) =>
+        s.startsWith("failure:apps%2Fapi%2Fsrc%2Fapi%2Fa%2Fa.ts:6:no-console")
+      )
+    ).toHaveLength(1);
+    // The stylish-ONLY error (line 9) — never in the JSON — is still captured.
+    expect(
+      [...sigs].some((s) =>
+        s.startsWith(
+          "failure:apps%2Fapi%2Fsrc%2Fapi%2Fa%2Fa.ts:9:%40typescript-eslint%2Fno-explicit-any"
+        )
+      )
+    ).toBe(true);
+    expect(sigs.size).toBe(2);
   });
 
   test("a multi-line JSON message is whitespace-collapsed so its signature matches the stylish path", () => {

--- a/packages/core/tests/boringstack-gate.test.ts
+++ b/packages/core/tests/boringstack-gate.test.ts
@@ -55,7 +55,14 @@ describe("runBoringstackGate", () => {
     expect(cmd).toContain("::tsforge-app apps/api::");
     // Each app emits its eslint as STRUCTURED JSON (via its own lint script) so the
     // failure parser reads exact {file,line,rule,message} instead of stylish text.
+    // BOTH apps must emit — per-app coverage means a missing UI block silently drops
+    // to stylish, so assert the UI marker is present (inside the UI stage) too.
     expect(cmd).toContain("::tsforge-eslint-json apps/api::");
+    expect(cmd).toContain("::tsforge-eslint-json apps/ui::");
+    expect(cmd).toContain("apps/ui && bun run generate:api");
+    expect(cmd.indexOf("::tsforge-eslint-json apps/ui::")).toBeGreaterThan(
+      cmd.indexOf("apps/ui && bun run generate:api")
+    );
     expect(cmd).toContain("bun run --silent lint -- --format json");
   });
 
@@ -67,7 +74,8 @@ describe("runBoringstackGate", () => {
     // The repo-root drift/build check only runs in the full gate.
     expect(cmd).toContain("::tsforge-app .::");
     expect(cmd).toContain("bun run check");
-    // Structured eslint JSON is emitted in the full gate too.
+    // Structured eslint JSON is emitted for BOTH apps in the full gate too.
     expect(cmd).toContain("::tsforge-eslint-json apps/api::");
+    expect(cmd).toContain("::tsforge-eslint-json apps/ui::");
   });
 });

--- a/packages/core/tests/boringstack-gate.test.ts
+++ b/packages/core/tests/boringstack-gate.test.ts
@@ -46,24 +46,28 @@ describe("runBoringstackGate", () => {
     expect(cmd).not.toContain("docker");
     expect(cwd).toBe("/repo");
     // Fast = each app's `check` (lint+typecheck+meta+knip) + the cheap API tests.
-    expect(cmd).toContain("apps/api && bun run check && bun run test");
+    expect(cmd).toContain("bun run check && bun run test");
     // UI regenerates the OpenAPI client first, then `check` (no build/size per cycle).
-    expect(cmd).toContain("apps/ui && bun run generate:api && bun run check");
+    expect(cmd).toContain("apps/ui && bun run generate:api");
     // The slow acceptance-only work must NOT be in the per-cycle gate.
     expect(cmd).not.toContain("bun run validate");
     // App markers for repo-relative path attribution (knip).
     expect(cmd).toContain("::tsforge-app apps/api::");
+    // Each app emits its eslint as STRUCTURED JSON (via its own lint script) so the
+    // failure parser reads exact {file,line,rule,message} instead of stylish text.
+    expect(cmd).toContain("::tsforge-eslint-json::");
+    expect(cmd).toContain("bun run --silent lint -- --format json");
   });
 
   test("FULL gate runs the complete validate + build + size + root check (final acceptance)", async () => {
     const { cmd } = await cmdFor("full");
 
-    expect(cmd).toContain("apps/api && bun run validate");
-    expect(cmd).toContain(
-      "apps/ui && bun run generate:api && bun run validate"
-    );
+    expect(cmd).toContain("bun run validate");
+    expect(cmd).toContain("apps/ui && bun run generate:api");
     // The repo-root drift/build check only runs in the full gate.
     expect(cmd).toContain("::tsforge-app .::");
     expect(cmd).toContain("bun run check");
+    // Structured eslint JSON is emitted in the full gate too.
+    expect(cmd).toContain("::tsforge-eslint-json::");
   });
 });

--- a/packages/core/tests/boringstack-gate.test.ts
+++ b/packages/core/tests/boringstack-gate.test.ts
@@ -45,23 +45,25 @@ describe("runBoringstackGate", () => {
     expect(cmd.startsWith("bash")).toBe(true);
     expect(cmd).not.toContain("docker");
     expect(cwd).toBe("/repo");
-    // Fast = each app's `check` (lint+typecheck+meta+knip) + the cheap API tests.
-    expect(cmd).toContain("bun run check && bun run test");
-    // UI regenerates the OpenAPI client first, then `check` (no build/size per cycle).
-    expect(cmd).toContain("apps/ui && bun run generate:api");
+    // Fast = each app's `check` (lint+typecheck+meta+knip) + the cheap API tests. The
+    // API stage must still END with `check && test` (the JSON aid is inserted BEFORE it).
+    expect(cmd).toContain("cd apps/api &&");
+    expect(cmd).toContain("bun run check && bun run test)");
+    // The UI stage regenerates the OpenAPI client first and must still RUN `check` — the
+    // stage ends with `&& bun run check)` so dropping it would fail this assertion.
+    expect(cmd).toContain("cd apps/ui && bun run generate:api &&");
+    expect(cmd).toContain("&& bun run check)");
     // The slow acceptance-only work must NOT be in the per-cycle gate.
     expect(cmd).not.toContain("bun run validate");
     // App markers for repo-relative path attribution (knip).
     expect(cmd).toContain("::tsforge-app apps/api::");
     // Each app emits its eslint as STRUCTURED JSON (via its own lint script) so the
     // failure parser reads exact {file,line,rule,message} instead of stylish text.
-    // BOTH apps must emit — per-app coverage means a missing UI block silently drops
-    // to stylish, so assert the UI marker is present (inside the UI stage) too.
+    // BOTH apps must emit; the UI marker must sit inside the UI stage (after generate:api).
     expect(cmd).toContain("::tsforge-eslint-json apps/api::");
     expect(cmd).toContain("::tsforge-eslint-json apps/ui::");
-    expect(cmd).toContain("apps/ui && bun run generate:api");
     expect(cmd.indexOf("::tsforge-eslint-json apps/ui::")).toBeGreaterThan(
-      cmd.indexOf("apps/ui && bun run generate:api")
+      cmd.indexOf("cd apps/ui && bun run generate:api")
     );
     expect(cmd).toContain("bun run --silent lint -- --format json");
   });
@@ -69,8 +71,18 @@ describe("runBoringstackGate", () => {
   test("FULL gate runs the complete validate + build + size + root check (final acceptance)", async () => {
     const { cmd } = await cmdFor("full");
 
-    expect(cmd).toContain("bun run validate");
-    expect(cmd).toContain("apps/ui && bun run generate:api");
+    // Both apps must still RUN validate (the JSON aid is inserted before it). Slice from
+    // each stage's `cd` so a dropped validate in EITHER stage fails the assertion.
+    expect(cmd).toContain("cd apps/api &&");
+    expect(cmd).toContain("cd apps/ui && bun run generate:api &&");
+    const apiStage = cmd.slice(
+      cmd.indexOf("cd apps/api"),
+      cmd.indexOf("cd apps/ui")
+    );
+    const uiStage = cmd.slice(cmd.indexOf("cd apps/ui"));
+
+    expect(apiStage).toContain("bun run validate");
+    expect(uiStage).toContain("bun run validate");
     // The repo-root drift/build check only runs in the full gate.
     expect(cmd).toContain("::tsforge-app .::");
     expect(cmd).toContain("bun run check");

--- a/packages/core/tests/boringstack-gate.test.ts
+++ b/packages/core/tests/boringstack-gate.test.ts
@@ -55,7 +55,7 @@ describe("runBoringstackGate", () => {
     expect(cmd).toContain("::tsforge-app apps/api::");
     // Each app emits its eslint as STRUCTURED JSON (via its own lint script) so the
     // failure parser reads exact {file,line,rule,message} instead of stylish text.
-    expect(cmd).toContain("::tsforge-eslint-json::");
+    expect(cmd).toContain("::tsforge-eslint-json apps/api::");
     expect(cmd).toContain("bun run --silent lint -- --format json");
   });
 
@@ -68,6 +68,6 @@ describe("runBoringstackGate", () => {
     expect(cmd).toContain("::tsforge-app .::");
     expect(cmd).toContain("bun run check");
     // Structured eslint JSON is emitted in the full gate too.
-    expect(cmd).toContain("::tsforge-eslint-json::");
+    expect(cmd).toContain("::tsforge-eslint-json apps/api::");
   });
 });


### PR DESCRIPTION
## What & why

The BoringStack gate composes `bun test` + `tsc` + `eslint` output and the harness scrapes it into failure **signatures** (`failure:<file>:<line>:<rule>:<message>`) for the differential gate. eslint's human "stylish" format is ambiguous — it truncates multi-line rule messages and interleaves with other tool output — so the model repeatedly saw unactionable half-messages (e.g. `…detected in module:` with no categories, no fix) and sprayed near-green on live builds.

This makes each app **also emit its own eslint as `--format json`** (wrapped in `::tsforge-eslint-json <app>::` markers, non-aborting — `check` still owns pass/fail), and the parser reads exact `{file,line,column,ruleId,message}` from that structured data instead of guessing from text.

## How it stays correct (the load-bearing part)

Both the JSON aid **and** `check`'s own stylish eslint appear in the output, so the parser must reconcile them without either double-counting or losing an error. The design that survived review:

- **Per-error dedup, not per-app suppression.** A stylish row is dropped only when the JSON already reported the *same* error, keyed on `file:line:column:rule`. A stylish-only error the JSON never emitted (different line, column, or rule) is always kept. Column is in the dedup key so two reports of one rule on the same line at different columns stay distinct.
- **Truncation-safe by stripping, not a flag.** Only a *closed* JSON block is stripped from the scanned text (its signatures already extracted); an unterminated/truncated block is left in place and parsed line-by-line, so it can never swallow the diagnostics that follow. The block regex is *tempered* against a second opening marker, so an unterminated block can't pair with a later block's end marker and strip everything between them.
- **No false coverage.** An empty `[]`, a wrong-shaped array (`[1,2,3]`), or a malformed message entry contributes no dedup keys, so it suppresses nothing — a broken/absent JSON block always falls back to stylish.

## Tests

New cases cover: JSON → exact signatures with stylish deduped; a stylish-only error at another line/column kept; unterminated block doesn't swallow later tsc errors; unterminated-then-closed blocks don't cross-strip; malformed/empty/wrong-shaped blocks preserve stylish; `error TS…` inside a JSON message not mis-parsed; whitespace-normalized signatures stable across JSON/stylish. Gate tests tightened so a dropped UI `check`/`validate` now fails. Full `bun run validate` green (7/7).

## Known limitation (pre-existing, out of scope)

`structuredFailure` does not carry column, so two errors with identical file/line/rule/**message** at different columns collapse to one signature — this has always been true of the stylish path and is unchanged here. Fixing it means putting column in the signature format itself, which ripples into the differential baseline, `signatureToError`, and memory; tracked as a follow-up rather than bolted onto this parsing change.

## Review

Passed the local `harness-review` panel (4 reviewers) across 4 hardening rounds — the panel caught a real critical (global vs per-app coverage) and several edge cases that drove the design to per-error dedup + strip-based truncation safety.