### PR TITLE
fix(boringstack): O(n) eslint-JSON block scan — kill the ReDoS that hung the gate

### DIFF
--- a/packages/core/src/loop/boringstack/extract-failures.ts
+++ b/packages/core/src/loop/boringstack/extract-failures.ts
@@ -5,16 +5,123 @@ import type { IFailureParserState } from "./extract-failures.types";
 // literal control char (a regex literal with \x1b trips no-control-regex).
 const ANSI = new RegExp(`${String.fromCharCode(27)}\\[[0-9;]*m`, "g");
 
-/** A CLOSED eslint-JSON block: opening marker, content (capture group 1), closing marker.
- *  The content is TEMPERED against another opening marker (`(?!…opening…)`) so an
- *  UNTERMINATED block can never pair with a LATER block's end marker and strip the
- *  intervening tsc/stylish/knip/app-marker output between them. Used both to extract
- *  signatures and to strip already-parsed blocks from the line-scanned text; an
- *  unterminated block matches nothing, so it stays in place and is parsed line-by-line
- *  (its partial JSON isn't an error row, so it never swallows the diagnostics that follow).
- *  A fresh RegExp is built per use so the shared `g`-flag lastIndex is never carried over. */
-const ESLINT_JSON_BLOCK_SOURCE =
-  "::tsforge-eslint-json \\S+::((?:(?!::tsforge-eslint-json \\S+::)[\\s\\S])*?)::tsforge-eslint-json-end::";
+const ESLINT_JSON_END = "::tsforge-eslint-json-end::";
+// Matches ONLY an opening marker: `::tsforge-eslint-json <app>::`. The required space
+// after `json` means it never matches the end marker (`…json-end::`). The app token is
+// `[^\s:]+` (NOT `\S+`): forbidding `:` means the `+` deterministically stops at the
+// closing `::` and cannot backtrack across colon runs — so a malformed `…json <long-run>`
+// with no closer can't trigger `\S+::` O(n²) backtracking (a latent ReDoS). App prefixes
+// (`apps/api`, `apps/ui`, `.`) never contain a colon, so this matches every real marker.
+const ESLINT_JSON_OPEN = /::tsforge-eslint-json ([^\s:]+)::/gu;
+
+/** A CLOSED eslint-JSON block, located by index (not by a tempered regex). */
+interface IEslintJsonBlock {
+  /** Raw text between the opening and closing markers (the JSON payload). */
+  readonly content: string;
+  /** Index of the opening marker's first char. */
+  readonly start: number;
+  /** Index just past the closing marker (exclusive) — for range-based stripping. */
+  readonly end: number;
+}
+
+/** Every start index of a literal `needle` in `haystack`, ascending. One linear pass —
+ *  each `indexOf` resumes past the previous hit, so total work is O(n), not O(n·hits). */
+function allIndicesOf(haystack: string, needle: string): number[] {
+  const out: number[] = [];
+
+  for (
+    let i = haystack.indexOf(needle);
+    i !== -1;
+    i = haystack.indexOf(needle, i + needle.length)
+  ) {
+    out.push(i);
+  }
+
+  return out;
+}
+
+/** Locate every CLOSED `::tsforge-eslint-json <app>::` … `::…-end::` block in O(n).
+ *  Collect all opening and closing marker positions (both ascending) in single passes,
+ *  then MERGE them with one forward-only pointer: each opening claims the first end that
+ *  comes after it and before the next opening. An opening with no such end is UNTERMINATED
+ *  → skipped, so a truncated block never pairs with a later block's end and never swallows
+ *  the diagnostics between them. Replaces a tempered-quantifier regex whose backtracking
+ *  was O(n²)+ and hung the gate on 100KB+ output; the earlier per-opening `indexOf(END)`
+ *  was also O(n²) when many openings each rescanned to EOF — this merge fixes both. */
+function findClosedEslintJsonBlocks(output: string): IEslintJsonBlock[] {
+  const opens: { markerStart: number; contentStart: number }[] = [];
+
+  ESLINT_JSON_OPEN.lastIndex = 0;
+
+  for (
+    let m = ESLINT_JSON_OPEN.exec(output);
+    m !== null;
+    m = ESLINT_JSON_OPEN.exec(output)
+  ) {
+    opens.push({ markerStart: m.index, contentStart: m.index + m[0].length });
+  }
+
+  const ends = allIndicesOf(output, ESLINT_JSON_END);
+  const blocks: IEslintJsonBlock[] = [];
+  let e = 0;
+
+  for (let i = 0; i < opens.length; i += 1) {
+    const open = opens[i];
+
+    if (open === undefined) {
+      continue;
+    }
+
+    const nextOpen = opens[i + 1]?.markerStart ?? output.length;
+
+    // Forward-only: skip end markers that fall before this opening's content (they
+    // belonged to an earlier block, or to none). The pointer never rewinds → O(n).
+    while (e < ends.length && (ends[e] ?? Infinity) < open.contentStart) {
+      e += 1;
+    }
+
+    const endIdx = ends[e];
+
+    // No remaining end, or the next block opens first → unterminated; skip.
+    if (endIdx === undefined || endIdx >= nextOpen) {
+      continue;
+    }
+
+    blocks.push({
+      content: output.slice(open.contentStart, endIdx),
+      start: open.markerStart,
+      end: endIdx + ESLINT_JSON_END.length,
+    });
+    e += 1;
+  }
+
+  return blocks;
+}
+
+/** Remove the given (already-parsed) block ranges from `output` in one O(n) pass, so a
+ *  JSON message like `error TS…` can't be re-parsed as a diagnostic by the line loop.
+ *  Blocks are in ascending, non-overlapping order (findClosedEslintJsonBlocks emits them
+ *  left-to-right). An unterminated block is NOT in the list, so it stays in the text. */
+function stripRanges(
+  output: string,
+  blocks: readonly IEslintJsonBlock[]
+): string {
+  if (blocks.length === 0) {
+    return output;
+  }
+
+  const parts: string[] = [];
+  let cursor = 0;
+
+  for (const block of blocks) {
+    parts.push(output.slice(cursor, block.start));
+    cursor = block.end;
+  }
+
+  parts.push(output.slice(cursor));
+
+  return parts.join("");
+}
 
 /** Normalize one line of composed gate output into a stable comparison key:
  *  strip ANSI, remove the clone's absolute path (so signatures are portable),
@@ -107,15 +214,13 @@ function eslintResultSignatures(
  *  error, and a broken/absent block loses nothing. Only CLOSED blocks match here; an
  *  unterminated block contributes nothing and is left in the text for normal parsing. */
 function parseEslintJsonBlocks(
-  output: string,
+  blocks: readonly IEslintJsonBlock[],
   cwd: string,
   signatures: Set<string>,
   keys: Set<string>
 ): void {
-  const blocks = output.matchAll(new RegExp(ESLINT_JSON_BLOCK_SOURCE, "gu"));
-
   for (const block of blocks) {
-    const raw = (block[1] ?? "").replace(ANSI, "");
+    const raw = block.content.replace(ANSI, "");
     const start = raw.indexOf("[");
     const end = raw.lastIndexOf("]");
 
@@ -592,13 +697,11 @@ export function extractFailures(output: string, cwd: string): Set<string> {
   // normally, never swallowing later lines. A stylish row that duplicates a JSON error
   // (same file/line/rule key) is dropped in the loop; a stylish-only error is kept.
   const jsonKeys = new Set<string>();
+  const jsonBlocks = findClosedEslintJsonBlocks(output);
 
-  parseEslintJsonBlocks(output, cwd, signatures, jsonKeys);
+  parseEslintJsonBlocks(jsonBlocks, cwd, signatures, jsonKeys);
 
-  const scanned = output.replace(
-    new RegExp(ESLINT_JSON_BLOCK_SOURCE, "gu"),
-    ""
-  );
+  const scanned = stripRanges(output, jsonBlocks);
 
   for (const rawLine of joinMultilineEslintRows(scanned).split("\n")) {
     const line = normalize(rawLine, cwd);

--- a/packages/core/tests/boringstack-extract-failures.test.ts
+++ b/packages/core/tests/boringstack-extract-failures.test.ts
@@ -622,6 +622,59 @@ ${cwd}/apps/api/src/api/a/a.ts
     );
   });
 
+  test("parses a LARGE (~1MB) realistic gate output in well under a second (ReDoS regression guard)", () => {
+    // A prior tempered-quantifier regex (`(?:(?!open)[\\s\\S])*?`) backtracked O(n²)+
+    // and hung the whole gate for minutes on real ~1MB output — tiny fixtures hid it.
+    const cwd = "/tmp/clone";
+    const chunk =
+      `::tsforge-app apps/api::\n` +
+      `::tsforge-eslint-json apps/api::\n` +
+      `[{"filePath":"${cwd}/apps/api/src/f.ts","messages":[]}]\n` +
+      `::tsforge-eslint-json-end::\n` +
+      `${cwd}/apps/api/src/f.ts(3,3): error TS2532: Object is possibly 'undefined'.\n` +
+      `tests/api/a/a.test.ts:\n(fail) svc > works [0.2ms]\n` +
+      ` 100 pass\n 1 fail\n`;
+    const out = chunk.repeat(4000); // ~1MB+
+
+    const started = Date.now();
+    const sigs = extractFailures(out, cwd);
+
+    expect(Date.now() - started).toBeLessThan(2000);
+    // Still correct: the tsc error is captured (deduped across identical chunks).
+    expect([...sigs].some((s) => s.includes("TS2532"))).toBe(true);
+  });
+
+  test("stays fast with MANY opening markers and NO end markers (the O(n²) per-open trap)", () => {
+    // The pathological input the merge scan must handle: thousands of UNTERMINATED
+    // `::tsforge-eslint-json <app>::` openings and no end marker. A per-opening
+    // `indexOf(END, …)` would rescan to EOF for every one → O(n²). The forward-only
+    // end-pointer merge keeps it O(n). Also asserts no block is wrongly closed.
+    const cwd = "/tmp/clone";
+    const open = `::tsforge-eslint-json apps/api::\n[{"filePath":"x"}]\n`;
+    const out = open.repeat(20000); // ~1MB of openings, zero end markers
+
+    const started = Date.now();
+    const sigs = extractFailures(out, cwd);
+
+    expect(Date.now() - started).toBeLessThan(2000);
+    // No end markers → no closed blocks parsed, nothing spuriously matched.
+    expect(sigs.size).toBe(0);
+  });
+
+  test("a long non-space run after an opener with no closer stays fast (\\S+:: backtracking guard)", () => {
+    // The precise catastrophic shape: `::tsforge-eslint-json ` then a long unbroken
+    // non-space run and NO closing `::`. A `(\\S+)::` app token would backtrack O(n²)
+    // trying every split for the missing `::`. `[^\\s:]+` stops dead at the first colon,
+    // so there is nothing to backtrack. Assert it parses near-instantly.
+    const out = `::tsforge-eslint-json ${"a".repeat(300000)}\nno end marker here`;
+
+    const started = Date.now();
+    const sigs = extractFailures(out, "/tmp/clone");
+
+    expect(Date.now() - started).toBeLessThan(2000);
+    expect(sigs.size).toBe(0);
+  });
+
   test("a fully green run yields no signatures", () => {
     expect(extractFailures("30 pass\n0 fail\nDone.", "/x").size).toBe(0);
   });


### PR DESCRIPTION
## The bug (introduced by #121)

#121 added a tempered-quantifier regex to locate closed eslint-JSON blocks:
`::…json \S+::((?:(?!::…json \S+::)[\s\S])*?)::…json-end::`

On the tiny unit-test fixtures it was instant. On **real** gate output it is catastrophic: measured on a captured 1.24 MB gate run (full `bun test` + `eslint --format json` for ~160 files × 2 apps), `extractFailures` ran **>240s without finishing** — pure CPU, no subprocess. That is exactly the "`⚙ running gate · turn N…`" freeze seen on a live build: the gate looked hung for ~180s because the *failure parser* was backtracking, not because any command was slow.

## The fix

Locate closed blocks by a **linear merge scan** instead of a regex:
- `ESLINT_JSON_OPEN` finds opening markers in one pass; the app token is `[^\s:]+` (not `\S+`) so it can't backtrack across the `::` boundary — closing a *second* latent `\S+::` ReDoS.
- `allIndicesOf` finds every end marker in one pass.
- One forward-only pointer pairs each opening with the first end after it and before the next opening. Unterminated blocks are skipped (same semantics as before). No per-opening `indexOf`-to-EOF (which is itself O(n²) with many openings).
- Parsed blocks are stripped from the line-scanned text by range (`stripRanges`), not a second catastrophic `.replace`.

**Result: the 1.24 MB output parses in ~4ms.** All #121 structured-JSON behavior is unchanged — per-error dedup, column-in-key, whitespace-normalized signatures, truncation safety.

## Tests

Three perf guards (each asserts <2s on ~1MB) plus the existing correctness suite:
- realistic ~1MB gate output (repeated closed blocks + tsc/test rows),
- ~1MB of unterminated openings (the many-openings merge case),
- a long non-space run after an opener with no closer (the `\S+::` backtracking trigger).

Full `bun run validate` green. Verified against the real captured output (>240s → ~4ms).

## Review

Passed the local `harness-review` panel (4 reviewers). The panel drove the fix from a first-cut linear-but-still-O(n²)-in-the-pathological-case scan to the true O(n) merge, and surfaced the latent `\S+::` backtracking in the opener regex (now `[^\s:]+`).