### PR TITLE
fix(loop): drop partial tool_calls on a TTSR abort (no dangling tool_calls → API 400)

### DIFF
--- a/packages/core/src/loop/assistant-message.ts
+++ b/packages/core/src/loop/assistant-message.ts
@@ -1,0 +1,39 @@
+import type { IChatMessage, IModelResponse } from "../inference";
+
+/** Build the assistant history message to record after a model call, carrying
+ *  `reasoningContent` when the model produced it (DeepSeek's thinking mode requires it
+ *  replayed on the next turn).
+ *
+ *  When a TTSR rule fired mid-stream the generation was ABORTED partway through — any
+ *  `toolCalls` on the response are partial and never executed. Recording them would leave
+ *  an assistant `tool_calls` message with no matching tool responses, which strict
+ *  OpenAI-compatible APIs reject on the NEXT request ("An assistant message with
+ *  'tool_calls' must be followed by tool messages responding to each 'tool_call_id'.",
+ *  e.g. DeepSeek's hosted API 400). A lenient local server tolerates it; a hosted one
+ *  does not. So on a TTSR abort we drop the partial tool_calls and keep only the text
+ *  (with a placeholder when it was empty, so the message is never both content-less and
+ *  tool-less). The corrective guidance is appended separately as a user message by
+ *  applyTtsrInterrupt. Shared by BOTH loops (Session.drive and runTask) so the two can't
+ *  drift — a fix in one path but not the other left the bug live on the headless loop. */
+export function assistantMessage(res: IModelResponse): IChatMessage {
+  const reasoning =
+    res.reasoning === undefined ? {} : { reasoningContent: res.reasoning };
+
+  if (res.ttsrFired !== undefined) {
+    return {
+      role: "assistant",
+      content:
+        res.content.length > 0
+          ? res.content
+          : "(generation interrupted before completion)",
+      ...reasoning,
+    };
+  }
+
+  return {
+    role: "assistant",
+    content: res.content,
+    toolCalls: res.toolCalls,
+    ...reasoning,
+  };
+}

--- a/packages/core/src/loop/run.ts
+++ b/packages/core/src/loop/run.ts
@@ -5,6 +5,7 @@ import type {
   IProvider,
   IToolCall,
 } from "../inference";
+import { assistantMessage } from "./assistant-message";
 import {
   validate,
   type ErrorParser,
@@ -702,14 +703,9 @@ async function runMainLoop(args: {
       })
     );
 
-    args.messages.push({
-      role: "assistant",
-      content: res.content,
-      toolCalls: res.toolCalls,
-      ...(res.reasoning === undefined
-        ? {}
-        : { reasoningContent: res.reasoning }),
-    });
+    // TTSR-aware: on a mid-stream abort this drops the partial (never-executed)
+    // tool_calls so the history has no dangling `tool_calls` (strict APIs 400 otherwise).
+    args.messages.push(assistantMessage(res));
 
     // Every model call advances cooldown accounting — including interrupted
     // ones, otherwise repeatGap rules mis-count after a TTSR retry.

--- a/packages/core/src/loop/session.ts
+++ b/packages/core/src/loop/session.ts
@@ -49,6 +49,7 @@ import {
 import type { Reporter, ILoopEvent, IHandoff } from "./loop.types";
 import type { TtsrManager } from "./ttsr";
 import { initTtsrManager, applyTtsrInterrupt } from "./ttsr-init";
+import { assistantMessage } from "./assistant-message";
 import { selectThinking, offeredToolsFor } from "./model-call";
 import {
   mineLessons,
@@ -272,16 +273,8 @@ export function filterGateStream(
   return fn;
 }
 
-/** Build the assistant history message, carrying `reasoningContent` when the
- *  model produced it (DeepSeek's thinking mode requires it replayed). */
-function assistantMessage(res: IModelResponse): IChatMessage {
-  return {
-    role: "assistant",
-    content: res.content,
-    toolCalls: res.toolCalls,
-    ...(res.reasoning === undefined ? {} : { reasoningContent: res.reasoning }),
-  };
-}
+// assistantMessage moved to ./assistant-message so runTask (run.ts) and Session share
+// ONE TTSR-aware builder — a fix in one path but not the other left the API-400 bug live.
 
 /** Default share of the context window that triggers auto-compaction. */
 const AUTO_COMPACT_AT = 0.8;

--- a/packages/core/tests/assistant-message.test.ts
+++ b/packages/core/tests/assistant-message.test.ts
@@ -1,0 +1,47 @@
+import { test, expect } from "bun:test";
+import { assistantMessage } from "../src/loop/assistant-message";
+
+test("keeps tool_calls and reasoningContent on a normal (non-aborted) response", () => {
+  const msg = assistantMessage({
+    content: "hi",
+    toolCalls: [{ id: "a", name: "create", arguments: { path: "x" } }],
+    reasoning: "because",
+  });
+
+  expect(msg.toolCalls).toHaveLength(1);
+  expect(msg.content).toBe("hi");
+  expect(msg.reasoningContent).toBe("because");
+});
+
+test("drops partial tool_calls on a TTSR abort, backfilling empty content", () => {
+  const msg = assistantMessage({
+    content: "",
+    toolCalls: [{ id: "a", name: "create", arguments: { path: "x" } }],
+    ttsrFired: { ruleName: "no-as-cast", guidance: "no as casts" },
+  });
+
+  expect(msg.toolCalls).toBeUndefined();
+  expect(msg.content.length).toBeGreaterThan(0);
+});
+
+test("on a TTSR abort, PRESERVES non-empty content instead of the placeholder", () => {
+  const msg = assistantMessage({
+    content: "partial thought before the cast",
+    toolCalls: [{ id: "a", name: "create", arguments: { path: "x" } }],
+    ttsrFired: { ruleName: "no-as-cast", guidance: "no as casts" },
+  });
+
+  expect(msg.toolCalls).toBeUndefined();
+  expect(msg.content).toBe("partial thought before the cast");
+});
+
+test("on a TTSR abort, still carries reasoningContent when present", () => {
+  const msg = assistantMessage({
+    content: "",
+    toolCalls: [],
+    reasoning: "chain of thought",
+    ttsrFired: { ruleName: "no-as-cast", guidance: "no as casts" },
+  });
+
+  expect(msg.reasoningContent).toBe("chain of thought");
+});

--- a/packages/core/tests/run-ttsr.test.ts
+++ b/packages/core/tests/run-ttsr.test.ts
@@ -1,0 +1,56 @@
+import { test, expect } from "bun:test";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { runTask } from "../src/loop";
+import type { IChatMessage, IProvider } from "../src/inference";
+
+// The runTask (headless) path had the same dangling-tool_calls bug as Session: it pushed
+// the aborted turn's partial tool_calls, so the NEXT request carried an assistant
+// tool_calls with no tool responses → strict-API 400. This exercises runTask end-to-end
+// through a TTSR-aborted response and inspects the retry request's history.
+test("runTask: a TTSR abort leaves NO dangling assistant tool_calls in the next request", async () => {
+  const dir = await mkdtemp(join(tmpdir(), "tsforge-run-ttsr-"));
+
+  try {
+    const seen: { role: string; toolCalls?: readonly unknown[] }[][] = [];
+    let calls = 0;
+    const provider: IProvider = {
+      async complete(messages: readonly IChatMessage[]) {
+        seen.push(
+          messages.map((m) => ({ role: m.role, toolCalls: m.toolCalls }))
+        );
+        calls += 1;
+
+        // Turn 1: a tool call aborted mid-stream by TTSR (partial, never executed).
+        if (calls === 1) {
+          return {
+            content: "",
+            toolCalls: [
+              { id: "1", name: "create", arguments: { file: "x.ts" } },
+            ],
+            ttsrFired: { ruleName: "no-as-cast", guidance: "no as casts" },
+          };
+        }
+
+        return { content: "done", toolCalls: [] };
+      },
+    };
+
+    // Gate starts RED (`false`) so runTask actually calls the model (it pre-checks the
+    // gate and exits early when already green). The model never fixes it, so the loop
+    // ends stuck — but the TTSR retry (2nd request) is all this test inspects.
+    await runTask({ id: "1", accept: "false", files: ["**/*"] }, dir, provider);
+
+    // The 2nd request is the TTSR retry — the point a dangling tool_calls would 400.
+    const retry = seen[1] ?? [];
+    const dangling = retry.filter(
+      (m) => m.role === "assistant" && (m.toolCalls?.length ?? 0) > 0
+    );
+
+    expect(calls).toBeGreaterThanOrEqual(2);
+    expect(dangling).toHaveLength(0);
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});

--- a/packages/core/tests/session.test.ts
+++ b/packages/core/tests/session.test.ts
@@ -1155,3 +1155,78 @@ test("a no-gate session does NOT force a gate on edit-churn (regression: F23 mus
     await rm(dir, { recursive: true, force: true });
   }
 }, 30000);
+
+test("assistantMessage drops partial tool_calls on a TTSR abort (no dangling tool_calls → API 400)", async () => {
+  const { assistantMessage } = await import("../src/loop/assistant-message");
+
+  // A normal turn keeps its tool_calls.
+  const normal = assistantMessage({
+    content: "",
+    toolCalls: [{ id: "a", name: "create_file", arguments: { path: "x" } }],
+  });
+
+  expect(normal.toolCalls).toHaveLength(1);
+
+  // A TTSR-aborted turn: the partial tool_call never executed, so it must NOT be
+  // recorded (else the assistant tool_calls has no matching tool response and a strict
+  // API 400s on the next request). Content is backfilled so it's never empty+tool-less.
+  const aborted = assistantMessage({
+    content: "",
+    toolCalls: [{ id: "a", name: "create_file", arguments: { path: "x" } }],
+    ttsrFired: { ruleName: "no-as-cast", guidance: "no as casts" },
+  });
+
+  expect(aborted.toolCalls).toBeUndefined();
+  expect(aborted.content.length).toBeGreaterThan(0);
+});
+
+test("Session: a TTSR abort leaves NO dangling assistant tool_calls in the next request", async () => {
+  const dir = await mkdtemp(join(tmpdir(), "tsforge-session-"));
+
+  try {
+    const seen: { role: string; toolCalls?: unknown[] }[][] = [];
+    let calls = 0;
+    const provider: IProvider = {
+      async complete(messages) {
+        seen.push(
+          messages.map((m) => ({ role: m.role, toolCalls: m.toolCalls }))
+        );
+        calls += 1;
+
+        // Turn 1: a tool call aborted mid-stream by TTSR (partial, never executed).
+        if (calls === 1) {
+          return {
+            content: "",
+            toolCalls: [
+              { id: "1", name: "create", arguments: { file: "x.ts" } },
+            ],
+            ttsrFired: { ruleName: "no-as-cast", guidance: "no as casts" },
+          };
+        }
+
+        return { content: "done", toolCalls: [] };
+      },
+    };
+    const session = await Session.create({
+      provider,
+      cwd: dir,
+      accept: "true",
+      files: ["**/*"],
+    });
+
+    await session.send("create x.ts");
+
+    // The 2nd request (the TTSR retry) is where a dangling tool_calls would 400 a
+    // strict API. Its history must carry NO assistant message with tool_calls — the
+    // aborted partial call was dropped, only the corrective user guidance remains.
+    const retryMessages = seen[1] ?? [];
+    const dangling = retryMessages.filter(
+      (m) => m.role === "assistant" && (m.toolCalls?.length ?? 0) > 0
+    );
+
+    expect(calls).toBeGreaterThanOrEqual(2);
+    expect(dangling).toHaveLength(0);
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
## The bug

When a TTSR rule fires mid-stream (the model types a forbidden pattern like an `as` cast), generation is aborted **partway through a tool call**. Both loops recorded that turn's **partial `tool_calls`** unconditionally — leaving an assistant `tool_calls` message with no matching tool responses.

Strict OpenAI-compatible APIs reject the **next** request with a 400:
> An assistant message with 'tool_calls' must be followed by tool messages responding to each 'tool_call_id'.

The local Spark endpoint tolerated the unbalanced history; the **hosted DeepSeek API does not**. So on the API every TTSR interrupt killed the turn and parked the feature (observed live on a BoringStack build: `0/1 resource(s) verified`), while the identical build progressed on Spark. This is a "only shows against the real API" integration bug.

## The fix

A shared `assistantMessage` builder (`packages/core/src/loop/assistant-message.ts`): on a TTSR abort it drops the partial, never-executed `tool_calls` and records only the text (placeholder when empty, so the message is never both content-less and tool-less). The corrective guidance is still appended as a `user` message by `applyTtsrInterrupt`, so the model gets the fix on retry. Normal turns keep their `tool_calls` and `reasoningContent`.

**Both loops now use the one builder** — `Session.drive` *and* `runTask` (`run.ts` had its own inline push with the same bug; fixing one path only would have left the headless loop broken, which the panel caught).

## Tests

- `assistant-message.test.ts` — the helper: keeps tool_calls + reasoningContent normally; drops tool_calls on abort; preserves non-empty interrupted content and reasoningContent.
- `session.test.ts` — wired Session: a TTSR-aborted turn leaves no dangling assistant tool_calls in the retry request.
- `run-ttsr.test.ts` — wired runTask: same assertion through the headless loop.

Full `bun run validate` green. Panel-approved (it drove out the untested run.ts path and the missing mirrored-test file).