### PR TITLE
fix(boringstack): run UI feature tests in the fast gate (gate parity) + parse vitest

### DIFF
--- a/packages/core/src/loop/boringstack/extract-failures.ts
+++ b/packages/core/src/loop/boringstack/extract-failures.ts
@@ -439,6 +439,11 @@ function consumeMarker(line: string, state: IFailureParserState): boolean {
   state.inUnusedFiles = false;
   state.inLintMeta = false;
   state.currentFile = "";
+  // Defense: a pending vitest FAIL must never survive into the next app (the loop flushes
+  // it just before this runs, so it's already emitted — this only guards against leak).
+  state.pendingVitestFile = "";
+  state.pendingVitestName = "";
+  state.pendingVitestError = "";
 
   return true;
 }
@@ -675,6 +680,97 @@ function generateApiFailure(line: string): string | null {
   return `openapi-unreachable:${classifyOpenApiFailure(failed[1] ?? "fetch failed")}`;
 }
 
+/** Emit the pending vitest FAIL as one signature and clear it. The detail composes the
+ *  test title and the captured error line (both VERBATIM — no truncation, per the
+ *  no-silent-truncation house rule). Called on the next FAIL, at an app boundary, and at
+ *  EOF so a pending file never leaks across an `::tsforge-app` marker and grabs the next
+ *  app's error line. */
+function flushPendingVitest(
+  state: IFailureParserState,
+  signatures: Set<string>
+): void {
+  if (state.pendingVitestFile === "") {
+    return;
+  }
+
+  const parts = [state.pendingVitestName, state.pendingVitestError].filter(
+    (p) => p !== ""
+  );
+  const detail =
+    parts.length > 0 ? parts.join(" — ") : "test suite failed to load";
+
+  signatures.add(
+    structuredFailure(state.pendingVitestFile, undefined, "vitest", detail)
+  );
+  state.pendingVitestFile = "";
+  state.pendingVitestName = "";
+  state.pendingVitestError = "";
+}
+
+/** An anchored error-header line: any `…Error` class — the base `Error`, plus TypeError /
+ *  ReferenceError / SyntaxError / AssertionError / RangeError / … (`\w*Error` matches the
+ *  bare `Error:` too, which the vi.mock suite-load message starts with) — or an
+ *  `Expected …` assertion body. Anchored at line start so prose lines don't false-match. */
+function isVitestErrorHeader(line: string): boolean {
+  return /^(?:\w*Error\b|Expected\b)/u.test(line);
+}
+
+/** Parse vitest's failure output (the UI test runner) into actionable signatures.
+ *  vitest prints ` FAIL  <file>[ [ file ]][ > describe > test [param]]` per failing
+ *  file/test, then error detail on following lines: a generic `*Error: …`/`Expected …`
+ *  first, then often the `Caused by: …` ROOT cause. One signature per failing FILE (rule
+ *  `vitest`), detail = the test title (with any `[param]` kept) + the error line. Every
+ *  FAIL holds pending until its detail arrives so named-test AssertionErrors are captured
+ *  too; `Caused by:` wins over the first error line and closes the block. Detail is stored
+ *  VERBATIM. Returns true when the line was a vitest FAIL or its captured detail.
+ *  `bun test` (API) uses `(fail)`, not `FAIL`, so no overlap. */
+function consumeVitest(
+  line: string,
+  state: IFailureParserState,
+  signatures: Set<string>
+): boolean {
+  // `[ file ]` (the bare-file echo) only appears right after the file; a `[param]` suffix
+  // rides along inside the `> test` capture (kept), so parameterized cases stay distinct.
+  const fail =
+    /^FAIL (\S+\.(?:test|spec)\.[cm]?[jt]sx?)(?: \[[^\]]*\])?(?: > (.+))?$/u.exec(
+      line
+    );
+
+  if (fail !== null) {
+    flushPendingVitest(state, signatures);
+
+    state.pendingVitestFile = qualify(
+      state.app,
+      (fail[1] ?? "").replace(/^\.\//u, "").replace(/^\//u, "")
+    );
+    state.pendingVitestName = fail[2] ?? "";
+    state.pendingVitestError = "";
+
+    return true;
+  }
+
+  if (state.pendingVitestFile === "") {
+    return false;
+  }
+
+  // The `Caused by:` root cause wins and closes the block.
+  if (/^Caused by:/iu.test(line)) {
+    state.pendingVitestError = line;
+    flushPendingVitest(state, signatures);
+
+    return true;
+  }
+
+  // The first error/assertion line — remember it, but keep waiting for a `Caused by:`.
+  if (state.pendingVitestError === "" && isVitestErrorHeader(line)) {
+    state.pendingVitestError = line;
+
+    return true;
+  }
+
+  return false;
+}
+
 export function extractFailures(output: string, cwd: string): Set<string> {
   const signatures = new Set<string>();
   // knip prints `Unused files (N)` then one relative path per line, ending at the
@@ -688,6 +784,9 @@ export function extractFailures(output: string, cwd: string): Set<string> {
     currentFile: "",
     inLintMeta: false,
     inUnusedFiles: false,
+    pendingVitestFile: "",
+    pendingVitestName: "",
+    pendingVitestError: "",
   };
 
   // Prefer STRUCTURED eslint output: parse each `::tsforge-eslint-json <app>::` block
@@ -706,6 +805,12 @@ export function extractFailures(output: string, cwd: string): Set<string> {
   for (const rawLine of joinMultilineEslintRows(scanned).split("\n")) {
     const line = normalize(rawLine, cwd);
 
+    // An app-stage marker is a hard boundary: flush any pending vitest FAIL BEFORE the
+    // marker resets the app, so it's attributed to the app it came from — never the next.
+    if (/^::tsforge-app .+::$/u.test(line)) {
+      flushPendingVitest(state, signatures);
+    }
+
     if (consumeMarker(line, state)) {
       continue;
     }
@@ -719,6 +824,10 @@ export function extractFailures(output: string, cwd: string): Set<string> {
     }
 
     if (consumeSourceFile(line, state)) {
+      continue;
+    }
+
+    if (consumeVitest(line, state, signatures)) {
       continue;
     }
 
@@ -745,6 +854,9 @@ export function extractFailures(output: string, cwd: string): Set<string> {
 
     signatures.add(diagnostic.signature);
   }
+
+  // A trailing bare-file vitest FAIL whose detail line never arrived (truncated output).
+  flushPendingVitest(state, signatures);
 
   return signatures;
 }

--- a/packages/core/src/loop/boringstack/extract-failures.types.ts
+++ b/packages/core/src/loop/boringstack/extract-failures.types.ts
@@ -3,4 +3,17 @@ export interface IFailureParserState {
   currentFile: string;
   inLintMeta: boolean;
   inUnusedFiles: boolean;
+  /** The vitest test file named by the most recent `FAIL <file>` line, awaiting its error
+   *  detail on following lines. Empty when not inside a vitest failure block. Lets a UI
+   *  test failure become an actionable `failure:<file>::vitest:<detail>` signature instead
+   *  of an opaque gate-nonzero. MUST be flushed/reset at an app boundary so a pending file
+   *  never grabs the next app's error line (cross-app contamination). */
+  pendingVitestFile: string;
+  /** The failing test title from a `FAIL <file> > <describe> > <test>` line (parameter
+   *  suffixes like `[mobile]` kept), or "" for a bare suite-load FAIL. */
+  pendingVitestName: string;
+  /** The captured error line for the pending vitest failure — a `Caused by:` root cause
+   *  wins over the first generic `*Error:`/`Expected` line. Stored verbatim (no
+   *  truncation); composed with the test name at flush. */
+  pendingVitestError: string;
 }

--- a/packages/core/src/loop/boringstack/gate.ts
+++ b/packages/core/src/loop/boringstack/gate.ts
@@ -45,9 +45,20 @@ const eslintJson = (app: string): string =>
   "bun run --silent lint -- --format json 2>/dev/null || true; " +
   "echo '::tsforge-eslint-json-end::'; }";
 
+// The UI stage runs the FEATURE test suite (`vitest run src/features`) too — NOT just
+// `check`. The API stage always ran its tests in the fast gate; the UI stage did not, so
+// a UI test that type-checks and lints but fails at RUNTIME (e.g. a `vi.mock` hoisting
+// TDZ: "Cannot access 'mockGet' before initialization") stayed invisible until the FULL
+// acceptance gate — the model froze the feature "green", then acceptance failed on a test
+// it never saw and couldn't fix (gate-parity gap, 4/4 panel). Scoped to `src/features`
+// (where feature tests live) so it's ~20s, not the full ~32s suite; cross-cutting UI
+// regressions still surface at the full gate's `validate`. Invoked as `bun run test --
+// run src/features`: the app's own `test` script is vitest (WATCH by default — it would
+// hang a gate), and passing `run` switches it to a single non-watch run via the LOCAL
+// vitest (no `bunx` network/install risk), scoped to the feature tests.
 const FAST_GATE =
   `echo '::tsforge-app apps/api::' && (cd apps/api && ${eslintJson("apps/api")} && bun run check && bun run test) && ` +
-  `echo '::tsforge-app apps/ui::' && (cd apps/ui && bun run generate:api && ${eslintJson("apps/ui")} && bun run check)`;
+  `echo '::tsforge-app apps/ui::' && (cd apps/ui && bun run generate:api && ${eslintJson("apps/ui")} && bun run check && bun run test -- run src/features)`;
 
 /**
  * FULL acceptance gate — run ONCE, when every feature has passed the fast gate. The

--- a/packages/core/src/loop/memory/mine.ts
+++ b/packages/core/src/loop/memory/mine.ts
@@ -11,7 +11,7 @@ const MAX_EDITS_PER_WINDOW = 3;
  *  rule with a before→after edit snippet, which only generalizes when the rule
  *  names a *code construct* (a TS error code, an eslint rule). These verdicts are
  *  structural or behavioral — a route not wired (`reachability`), a quality
- *  critique (`judge`), a failing assertion (`bun-test`), an unreachable file
+ *  critique (`judge`), a failing assertion (`bun-test`/`vitest`), an unreachable file
  *  (`knip/unused-files`), or an unparseable source (`syntax`) — so the edit that
  *  clears one is arbitrary; attaching it to the verdict just noises up the ledger.
  *
@@ -24,6 +24,10 @@ const NON_PATTERN_VERDICTS = new Set<string>([
   "reachability",
   "judge",
   "bun-test",
+  // `vitest` is the UI twin of `bun-test`: a failing UI assertion / suite-load error is
+  // behavioral, not a code-construct diagnostic, so the edit that clears it doesn't
+  // generalize into a learnable rule. Denylist it for the same reason as `bun-test`.
+  "vitest",
   "syntax",
   "knip/unused-files",
   // The unclassified-gate fallback. Today opaqueGateError carries no `.rule`, so

--- a/packages/core/tests/boringstack-extract-failures.test.ts
+++ b/packages/core/tests/boringstack-extract-failures.test.ts
@@ -675,6 +675,170 @@ ${cwd}/apps/api/src/api/a/a.ts
     expect(sigs.size).toBe(0);
   });
 
+  test("parses a vitest suite-load FAIL (vi.mock hoisting): Caused-by root cause wins, verbatim", () => {
+    // The EXACT gate-parity failure, with REAL vitest 4 output: a long generic Error line
+    // (with a URL) FIRST, then the `Caused by:` root cause. The root cause must win and be
+    // captured VERBATIM (no truncation — house rule).
+    const cwd = "/tmp/clone";
+    const out = `::tsforge-app apps/ui::
+ FAIL  src/features/task/hooks/useTasks.test.tsx [ src/features/task/hooks/useTasks.test.tsx ]
+Error: [vitest] There was an error when mocking a module. If you are using "vi.mock" factory, make sure there are no top level variables inside, since this call is hoisted to top of the file. Read more: https://vitest.dev/api/vi.html#vi-mock
+Caused by: ReferenceError: Cannot access 'mockGet' before initialization`;
+    const sigs = extractFailures(out, cwd);
+    const vitest = [...sigs].find((s) => s.includes(":vitest:"));
+
+    expect(vitest).toBeDefined();
+    expect(vitest).toStartWith(
+      "failure:apps%2Fui%2Fsrc%2Ffeatures%2Ftask%2Fhooks%2FuseTasks.test.tsx::vitest:"
+    );
+    // The ROOT cause (Caused by) is captured, in FULL — not the generic first line, and
+    // not truncated mid-word.
+    const decoded = decodeURIComponent(vitest ?? "");
+
+    expect(decoded).toContain(
+      "Caused by: ReferenceError: Cannot access 'mockGet' before initialization"
+    );
+  });
+
+  test("a bare-file vitest FAIL does NOT leak across an app boundary (no cross-app contamination)", () => {
+    // A UI suite-load FAIL with no detail line before the next ::tsforge-app marker. The
+    // pending file must be flushed to apps/ui at the boundary — the api error line that
+    // follows must NOT be attributed to the ui test file.
+    const cwd = "/tmp/clone";
+    const out = `::tsforge-app apps/ui::
+ FAIL  src/features/task/hooks/useTasks.test.tsx [ src/features/task/hooks/useTasks.test.tsx ]
+::tsforge-app apps/api::
+${cwd}/apps/api/src/x.ts(3,3): error TS2532: Object is possibly 'undefined'.`;
+    const sigs = extractFailures(out, cwd);
+    const vitest = [...sigs].find((s) => s.includes(":vitest:")) ?? "";
+
+    // The vitest signature is attributed to apps/ui and carries a generic (not api) detail.
+    expect(vitest).toStartWith(
+      "failure:apps%2Fui%2Fsrc%2Ffeatures%2Ftask%2Fhooks%2FuseTasks.test.tsx::vitest:"
+    );
+    expect(decodeURIComponent(vitest)).toContain("test suite failed to load");
+    // The api tsc error is its OWN signature, not swallowed as the ui test's detail.
+    expect([...sigs].some((s) => s.includes("TS2532"))).toBe(true);
+  });
+
+  test("parses a named vitest test FAIL: keeps the test name AND its AssertionError body", () => {
+    const cwd = "/tmp/clone";
+    const out = `::tsforge-app apps/ui::
+ FAIL  src/features/task/TaskList.test.tsx > TaskList > renders empty state
+AssertionError: expected element to be in the document`;
+    const sigs = extractFailures(out, cwd);
+    const vitest = [...sigs].find((s) =>
+      s.startsWith(
+        "failure:apps%2Fui%2Fsrc%2Ffeatures%2Ftask%2FTaskList.test.tsx::vitest:"
+      )
+    );
+
+    expect(vitest).toBeDefined();
+    const decoded = decodeURIComponent(vitest ?? "");
+
+    expect(decoded).toContain("renders empty state");
+    expect(decoded).toContain(
+      "AssertionError: expected element to be in the document"
+    );
+  });
+
+  test("keeps a parameterized test's [param] suffix so distinct cases stay distinct", () => {
+    const cwd = "/tmp/clone";
+    const mobile = `::tsforge-app apps/ui::\n FAIL  src/features/task/TaskList.test.tsx > renders [mobile]`;
+    const desktop = `::tsforge-app apps/ui::\n FAIL  src/features/task/TaskList.test.tsx > renders [desktop]`;
+    const a =
+      [...extractFailures(mobile, cwd)].find((s) => s.includes(":vitest:")) ??
+      "";
+    const b =
+      [...extractFailures(desktop, cwd)].find((s) => s.includes(":vitest:")) ??
+      "";
+
+    expect(decodeURIComponent(a)).toContain("[mobile]");
+    expect(decodeURIComponent(b)).toContain("[desktop]");
+    expect(a).not.toBe(b); // different params → different signatures, not a collision
+  });
+
+  test("captures an Error-only suite-load failure (no Caused by), e.g. SyntaxError", () => {
+    const cwd = "/tmp/clone";
+    const out = `::tsforge-app apps/ui::
+ FAIL  src/features/task/Task.utils.test.ts [ src/features/task/Task.utils.test.ts ]
+SyntaxError: Unexpected token '}'`;
+    const vitest =
+      [...extractFailures(out, cwd)].find((s) => s.includes(":vitest:")) ?? "";
+
+    expect(vitest).toStartWith(
+      "failure:apps%2Fui%2Fsrc%2Ffeatures%2Ftask%2FTask.utils.test.ts::vitest:"
+    );
+    expect(decodeURIComponent(vitest)).toContain(
+      "SyntaxError: Unexpected token '}'"
+    );
+  });
+
+  test("captures a BASE `Error:` suite-load line (no Caused by) — not just prefixed *Errors", () => {
+    // The vi.mock message starts with a bare `Error: [vitest] …`; if no `Caused by:`
+    // follows, that line MUST still be captured (a prior regex required a char before
+    // "Error" and dropped it, flushing a useless "test suite failed to load").
+    const cwd = "/tmp/clone";
+    const out = `::tsforge-app apps/ui::
+ FAIL  src/features/task/hooks/useTasks.test.tsx [ src/features/task/hooks/useTasks.test.tsx ]
+Error: [vitest] There was an error when mocking a module.`;
+    const vitest =
+      [...extractFailures(out, cwd)].find((s) => s.includes(":vitest:")) ?? "";
+
+    expect(decodeURIComponent(vitest)).toContain(
+      "Error: [vitest] There was an error"
+    );
+    expect(decodeURIComponent(vitest)).not.toContain(
+      "test suite failed to load"
+    );
+  });
+
+  test("two sequential vitest FAILs each flush with their OWN detail (flush-on-next-FAIL)", () => {
+    const cwd = "/tmp/clone";
+    const out = `::tsforge-app apps/ui::
+ FAIL  src/features/task/A.test.tsx > A > one
+AssertionError: expected 1 to be 2
+ FAIL  src/features/task/B.test.tsx > B > two
+AssertionError: expected 3 to be 4`;
+    const sigs = [...extractFailures(out, cwd)];
+    const a =
+      sigs.find((s) =>
+        s.startsWith("failure:apps%2Fui%2Fsrc%2Ffeatures%2Ftask%2FA.test.tsx")
+      ) ?? "";
+    const b =
+      sigs.find((s) =>
+        s.startsWith("failure:apps%2Fui%2Fsrc%2Ffeatures%2Ftask%2FB.test.tsx")
+      ) ?? "";
+
+    expect(decodeURIComponent(a)).toContain("expected 1 to be 2");
+    expect(decodeURIComponent(b)).toContain("expected 3 to be 4");
+    // Details didn't cross-contaminate.
+    expect(decodeURIComponent(a)).not.toContain("expected 3");
+  });
+
+  test("parses a .spec.ts vitest FAIL (not just .test.*)", () => {
+    const cwd = "/tmp/clone";
+    const out = `::tsforge-app apps/ui::
+ FAIL  src/features/task/Task.spec.ts > does a thing`;
+    const vitest =
+      [...extractFailures(out, cwd)].find((s) => s.includes(":vitest:")) ?? "";
+
+    expect(vitest).toStartWith(
+      "failure:apps%2Fui%2Fsrc%2Ffeatures%2Ftask%2FTask.spec.ts::vitest:"
+    );
+  });
+
+  test("a passing vitest summary yields no vitest signatures", () => {
+    const out =
+      "::tsforge-app apps/ui::\n Test Files  129 passed (129)\n      Tests  413 passed (413)";
+
+    expect(
+      [...extractFailures(out, "/tmp/clone")].some((s) =>
+        s.includes(":vitest:")
+      )
+    ).toBe(false);
+  });
+
   test("a fully green run yields no signatures", () => {
     expect(extractFailures("30 pass\n0 fail\nDone.", "/x").size).toBe(0);
   });

--- a/packages/core/tests/boringstack-gate.test.ts
+++ b/packages/core/tests/boringstack-gate.test.ts
@@ -49,10 +49,12 @@ describe("runBoringstackGate", () => {
     // API stage must still END with `check && test` (the JSON aid is inserted BEFORE it).
     expect(cmd).toContain("cd apps/api &&");
     expect(cmd).toContain("bun run check && bun run test)");
-    // The UI stage regenerates the OpenAPI client first and must still RUN `check` — the
-    // stage ends with `&& bun run check)` so dropping it would fail this assertion.
+    // The UI stage regenerates the OpenAPI client first and must still RUN `check`, then
+    // the feature tests — the stage ends with `&& bun run test -- run src/features)`.
     expect(cmd).toContain("cd apps/ui && bun run generate:api &&");
-    expect(cmd).toContain("&& bun run check)");
+    expect(cmd).toContain(
+      "&& bun run check && bun run test -- run src/features)"
+    );
     // The slow acceptance-only work must NOT be in the per-cycle gate.
     expect(cmd).not.toContain("bun run validate");
     // App markers for repo-relative path attribution (knip).
@@ -66,6 +68,13 @@ describe("runBoringstackGate", () => {
       cmd.indexOf("cd apps/ui && bun run generate:api")
     );
     expect(cmd).toContain("bun run --silent lint -- --format json");
+    // The UI stage now runs the feature test suite too (gate parity with acceptance) —
+    // a UI test that lints/typechecks but fails at runtime (vi.mock hoisting) must fail
+    // the FAST gate, not only the full acceptance gate.
+    expect(cmd).toContain("bun run test -- run src/features");
+    expect(cmd.indexOf("bun run test -- run src/features")).toBeGreaterThan(
+      cmd.indexOf("cd apps/ui")
+    );
   });
 
   test("FULL gate runs the complete validate + build + size + root check (final acceptance)", async () => {

--- a/packages/core/tests/memory.test.ts
+++ b/packages/core/tests/memory.test.ts
@@ -113,8 +113,8 @@ describe("mineLessons", () => {
 
   test("drops non-pattern gate verdicts but keeps every real rule id", () => {
     // The boringstack gate surfaces structural/behavioral VERDICTS — `reachability`
-    // (route not wired), `judge` (quality critique), `bun-test` (failing assertion),
-    // `syntax` (unparseable) — that name no code construct, so a mined snippet keyed
+    // (route not wired), `judge` (quality critique), `bun-test`/`vitest` (failing
+    // assertion), `syntax` (unparseable) — that name no code construct, so a mined keyed
     // to one is noise. Everything else is a real diagnostic id and stays learnable,
     // INCLUDING bare eslint core rules like `eqeqeq`/`curly` that carry no `/` or `-`
     // (this repo's gate enables them as errors — dropping them would be silent loss).
@@ -123,6 +123,7 @@ describe("mineLessons", () => {
         "reachability",
         "judge",
         "bun-test",
+        "vitest",
         "syntax",
         "knip/unused-files",
         "gate-nonzero",


### PR DESCRIPTION
## Problem

The per-cycle fast gate ran the API test suite but **not** the UI test suite — only `check` (typecheck/lint/meta/knip). A UI test that type-checks and lints but fails at **runtime** (e.g. a `vi.mock` hoisting TDZ: "Cannot access 'mockGet' before initialization") was invisible during the whole build and only bit at the FULL acceptance gate. The model froze the feature "green" (1/1 verified), then acceptance failed on a test it had never seen and couldn't fix. A live TaskFlow build did exactly this; the panel called it 4/4 gate-parity.

## Fix

1. **`gate.ts`** — the FAST gate's UI stage now runs the feature test suite after `check`: `bun run test -- run src/features`. This invokes the app's own `test` script (local vitest, no `bunx` network/install risk); `run` switches vitest out of watch mode; scoped to `src/features` (~20s, not the full ~32s suite — cross-cutting UI regressions still surface at the full gate's `validate`).
2. **`extract-failures.ts`** — a vitest parser: ` FAIL <file>[ > describe > test [param]]` plus the following `*Error:`/`Expected`/`Caused by:` detail line become one actionable `failure:<file>::vitest:<detail>` signature per failing file. `Caused by:` (root cause) wins over the first error line; parameterized `[param]` suffixes are kept; `.test.*` and `.spec.*` both recognized; pending failures flush at app boundaries (no cross-app contamination) and EOF. So a UI test failure is trackable by the differential/steer, not an opaque gate-nonzero.
3. **`mine.ts`** — `vitest` added to the memory miner's non-pattern denylist (the UI twin of `bun-test`): a failing assertion is behavioral, not a learnable code construct, so it must not noise the memory ledger.

## Tests

vitest suite-load (vi.mock hoisting, Caused-by root cause captured verbatim), named-test + AssertionError, base `Error:` line, `SyntaxError`, `.spec.ts`, `[param]` kept distinct, two sequential FAILs each flushing their own detail, cross-app boundary flush, passing summary → no signatures. Gate tests assert the UI stage runs the feature tests. Miner test asserts `vitest` is dropped. Full `bun run validate` green.

## Review

Passed the local `harness-review` panel across several hardening rounds — it drove out a cross-app leak, a `\S+::` latent ReDoS in the marker regex, a base-`Error` regex miss, `.spec` support, and the `mine.ts` denylist. One deferred nit: multi-line assertion diffs are summarized to the first error line + root cause (a stable signature key by design; full diffs are unstable across runs).