### PR TITLE
fix(loop): polishOnGreen re-gates via injected gate, not empty task.accept

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,4 @@ models.json
 /src/
 __pycache__/
 .claude/settings.local.json
+packages/core/scripts/gen-plan.ts

--- a/packages/core/src/loop/turn.ts
+++ b/packages/core/src/loop/turn.ts
@@ -2,7 +2,7 @@ import { basename, join, relative, isAbsolute } from "node:path";
 import type { ITask } from "../spec";
 import type { IChatMessage, IToolCall } from "../inference";
 import {
-  validate,
+  type validate,
   runAccept,
   sameErrorSet,
   type ErrorParser,
@@ -689,9 +689,8 @@ async function applyDeterministicFixes(ctx: ILoopCtx): Promise<void> {
  * so a drop that changed an inferred type can never ship. Runs once, on the turn
  * the task goes green; a no-op when ast-grep is off or nothing is redundant.
  */
-async function polishOnGreen(ctx: ILoopCtx): Promise<void> {
+export async function polishOnGreen(ctx: ILoopCtx): Promise<void> {
   const { task, cwd, report } = ctx;
-  const parse = ctx.gate.parse;
 
   // Resolve globs so a glob scope is polished too (not silently skipped).
   const files = await resolveScopeFiles(cwd, task.files);
@@ -729,14 +728,53 @@ async function polishOnGreen(ctx: ILoopCtx): Promise<void> {
     );
   }
 
-  const recheck = await validate(
-    task,
-    cwd,
-    parse,
-    ctx.tool.signal === undefined ? {} : { signal: ctx.tool.signal }
-  );
+  // Re-gate with the SAME gate the loop uses (`ctx.gate.runner`), NOT
+  // `validate(task, …)`. `validate` runs `task.accept`, which is EMPTY for the
+  // boringstack build — it drives an INJECTED gate via `setGate`, not `task.accept` — so
+  // `validate` returned a VACUOUS pass and the "revert if regressed" guarantee below was
+  // dead: dropping a load-bearing annotation (e.g. `: unknown` on `await res.json()`,
+  // which suppresses `no-unsafe-*`) shipped green, and only final acceptance caught it —
+  // after the feature was already verified. The injected gate runs the real checks
+  // (including its own format/autofix), so a drop that changed an inferred type fails
+  // here and is rolled back. For `runTask` this is equivalent (its gate runs `accept`).
+  // The injected gate can THROW (its composed stages include a judge MODEL call whose
+  // provider request can fail transiently). A throw must NOT leave the unverified drops
+  // on disk — treat any failure OR error as "not verified" and fall through to the
+  // rollback, so the pre-polish green state is always restored. Polish is best-effort;
+  // a transient gate error must never ship an unsafe drop nor crash the turn.
+  let passed = false;
+  let abortErr: unknown = null;
 
-  if (recheck.passed) {
+  try {
+    const recheck = await ctx.gate.runner.run(cwd, {
+      ...(ctx.gate.onGateChunk === undefined
+        ? {}
+        : { onChunk: ctx.gate.onGateChunk }),
+      ...(ctx.tool.signal === undefined ? {} : { signal: ctx.tool.signal }),
+    });
+
+    passed = recheck.passed;
+  } catch (err) {
+    // A caller CANCELLATION is not a transient gate failure — it must not be swallowed
+    // (settleGate would then report the task done, breaking the signal contract). Capture
+    // it and re-throw AFTER the rollback below, so the tree is still restored to green.
+    if (ctx.tool.signal?.aborted === true) {
+      abortErr = err;
+    } else {
+      // Transient gate/judge failure → do not trust the drop; revert below.
+      trace("polishOnGreen.recheck", err);
+    }
+  } finally {
+    // Flush any final newline-less gate line the stream filter still holds (mirrors
+    // runGateStep). GUARDED: a throwing flush must never mask the rollback below.
+    try {
+      ctx.gate.onGateChunk?.flush?.();
+    } catch (err) {
+      trace("polishOnGreen.flush", err);
+    }
+  }
+
+  if (passed) {
     report({
       kind: "tool",
       task: task.id,
@@ -746,9 +784,15 @@ async function polishOnGreen(ctx: ILoopCtx): Promise<void> {
     return;
   }
 
-  // A drop changed an inferred type — roll the whole file set back to green.
+  // A drop changed an inferred type (or the recheck failed/was aborted) — roll the whole
+  // file set back to the pre-polish green state.
   for (const [f, content] of snapshot) {
     await Bun.write(join(cwd, f), content);
+  }
+
+  // Cancellation was deferred past the rollback so the tree is restored — now honor it.
+  if (abortErr !== null) {
+    throw abortErr;
   }
 }
 

--- a/packages/core/src/loop/turn.ts
+++ b/packages/core/src/loop/turn.ts
@@ -681,6 +681,98 @@ async function applyDeterministicFixes(ctx: ILoopCtx): Promise<void> {
   }
 }
 
+/** Snapshot the current on-disk contents of every existing file in `files`. */
+async function snapshotFiles(
+  cwd: string,
+  files: readonly string[]
+): Promise<Map<string, string>> {
+  const snapshot = new Map<string, string>();
+
+  for (const f of files) {
+    if (await fileExists(cwd, f)) {
+      snapshot.set(f, await Bun.file(join(cwd, f)).text());
+    }
+  }
+
+  return snapshot;
+}
+
+/** Drop redundant annotations across `files`, degrading silently per-file. */
+async function dropRedundantAcross(
+  cwd: string,
+  files: readonly string[]
+): Promise<number> {
+  let dropped = 0;
+
+  for (const f of files) {
+    if (await fileExists(cwd, f)) {
+      try {
+        dropped += await dropRedundantAnnotations(join(cwd, f));
+      } catch (err) {
+        // degrade silently — we revalidate and revert below
+        trace("polishOnGreen.dropAnnotations", err);
+      }
+    }
+  }
+
+  return dropped;
+}
+
+/**
+ * Re-gate after a polish drop using the SAME gate the loop uses
+ * (`ctx.gate.runner`), NOT `validate(task, …)`. `validate` runs `task.accept`,
+ * which is EMPTY for the boringstack build — it drives an INJECTED gate via
+ * `setGate`, not `task.accept` — so `validate` returned a VACUOUS pass and the
+ * "revert if regressed" guarantee was dead: dropping a load-bearing annotation
+ * (e.g. `: unknown` on `await res.json()`, which suppresses `no-unsafe-*`)
+ * shipped green, and only final acceptance caught it — after the feature was
+ * already verified. The injected gate runs the real checks (including its own
+ * format/autofix), so a drop that changed an inferred type fails here. For
+ * `runTask` this is equivalent (its gate runs `accept`).
+ *
+ * The injected gate can THROW (its composed stages include a judge MODEL call
+ * whose provider request can fail transiently). A throw must NOT be trusted as a
+ * pass. Returns `passed=false` on any transient failure so the caller reverts.
+ * A caller CANCELLATION is not a transient failure — it is captured as `abortErr`
+ * and re-thrown by the caller AFTER the rollback, honoring the signal contract.
+ */
+async function recheckAfterPolish(
+  ctx: ILoopCtx,
+  cwd: string
+): Promise<{ passed: boolean; abortErr: unknown }> {
+  let passed = false;
+  let abortErr: unknown = null;
+
+  try {
+    const recheck = await ctx.gate.runner.run(cwd, {
+      ...(ctx.gate.onGateChunk === undefined
+        ? {}
+        : { onChunk: ctx.gate.onGateChunk }),
+      ...(ctx.tool.signal === undefined ? {} : { signal: ctx.tool.signal }),
+    });
+
+    passed = recheck.passed;
+  } catch (err) {
+    if (ctx.tool.signal?.aborted === true) {
+      abortErr = err;
+    } else {
+      // Transient gate/judge failure → do not trust the drop; caller reverts.
+      trace("polishOnGreen.recheck", err);
+    }
+  } finally {
+    // Flush any final newline-less gate line the stream filter still holds
+    // (mirrors runGateStep). GUARDED: a throwing flush must never mask the
+    // caller's rollback.
+    try {
+      ctx.gate.onGateChunk?.flush?.();
+    } catch (err) {
+      trace("polishOnGreen.flush", err);
+    }
+  }
+
+  return { passed, abortErr };
+}
+
 /**
  * On a GREEN task, strip the redundant `const` annotations no stock lint rule
  * catches (over-annotation of call/expression-initialized locals) — then re-gate
@@ -694,26 +786,8 @@ export async function polishOnGreen(ctx: ILoopCtx): Promise<void> {
 
   // Resolve globs so a glob scope is polished too (not silently skipped).
   const files = await resolveScopeFiles(cwd, task.files);
-  const snapshot = new Map<string, string>();
-
-  for (const f of files) {
-    if (await fileExists(cwd, f)) {
-      snapshot.set(f, await Bun.file(join(cwd, f)).text());
-    }
-  }
-
-  let dropped = 0;
-
-  for (const f of files) {
-    if (await fileExists(cwd, f)) {
-      try {
-        dropped += await dropRedundantAnnotations(join(cwd, f));
-      } catch (err) {
-        // degrade silently — we revalidate and revert below
-        trace("applyDeterministicFixes.dropAnnotations", err);
-      }
-    }
-  }
+  const snapshot = await snapshotFiles(cwd, files);
+  const dropped = await dropRedundantAcross(cwd, files);
 
   if (dropped === 0) {
     return;
@@ -728,51 +802,7 @@ export async function polishOnGreen(ctx: ILoopCtx): Promise<void> {
     );
   }
 
-  // Re-gate with the SAME gate the loop uses (`ctx.gate.runner`), NOT
-  // `validate(task, …)`. `validate` runs `task.accept`, which is EMPTY for the
-  // boringstack build — it drives an INJECTED gate via `setGate`, not `task.accept` — so
-  // `validate` returned a VACUOUS pass and the "revert if regressed" guarantee below was
-  // dead: dropping a load-bearing annotation (e.g. `: unknown` on `await res.json()`,
-  // which suppresses `no-unsafe-*`) shipped green, and only final acceptance caught it —
-  // after the feature was already verified. The injected gate runs the real checks
-  // (including its own format/autofix), so a drop that changed an inferred type fails
-  // here and is rolled back. For `runTask` this is equivalent (its gate runs `accept`).
-  // The injected gate can THROW (its composed stages include a judge MODEL call whose
-  // provider request can fail transiently). A throw must NOT leave the unverified drops
-  // on disk — treat any failure OR error as "not verified" and fall through to the
-  // rollback, so the pre-polish green state is always restored. Polish is best-effort;
-  // a transient gate error must never ship an unsafe drop nor crash the turn.
-  let passed = false;
-  let abortErr: unknown = null;
-
-  try {
-    const recheck = await ctx.gate.runner.run(cwd, {
-      ...(ctx.gate.onGateChunk === undefined
-        ? {}
-        : { onChunk: ctx.gate.onGateChunk }),
-      ...(ctx.tool.signal === undefined ? {} : { signal: ctx.tool.signal }),
-    });
-
-    passed = recheck.passed;
-  } catch (err) {
-    // A caller CANCELLATION is not a transient gate failure — it must not be swallowed
-    // (settleGate would then report the task done, breaking the signal contract). Capture
-    // it and re-throw AFTER the rollback below, so the tree is still restored to green.
-    if (ctx.tool.signal?.aborted === true) {
-      abortErr = err;
-    } else {
-      // Transient gate/judge failure → do not trust the drop; revert below.
-      trace("polishOnGreen.recheck", err);
-    }
-  } finally {
-    // Flush any final newline-less gate line the stream filter still holds (mirrors
-    // runGateStep). GUARDED: a throwing flush must never mask the rollback below.
-    try {
-      ctx.gate.onGateChunk?.flush?.();
-    } catch (err) {
-      trace("polishOnGreen.flush", err);
-    }
-  }
+  const { passed, abortErr } = await recheckAfterPolish(ctx, cwd);
 
   if (passed) {
     report({
@@ -792,7 +822,9 @@ export async function polishOnGreen(ctx: ILoopCtx): Promise<void> {
 
   // Cancellation was deferred past the rollback so the tree is restored — now honor it.
   if (abortErr !== null) {
-    throw abortErr;
+    throw abortErr instanceof Error
+      ? abortErr
+      : new Error("polishOnGreen: re-gate aborted by caller signal");
   }
 }
 

--- a/packages/core/tests/polish-on-green.test.ts
+++ b/packages/core/tests/polish-on-green.test.ts
@@ -1,0 +1,170 @@
+import { test, expect } from "bun:test";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { ILoopCtx } from "../src/loop/turn";
+import { polishOnGreen } from "../src/loop/turn";
+import type { IValidateResult } from "../src/validate";
+
+/** A file with a droppable annotation (`const abs: number = Math.abs(...)` — the exact
+ *  shape dropRedundantAnnotations removes). Dropping it is the "polish". */
+const SOURCE = "const cents = 1;\nconst abs: number = Math.abs(cents);\n";
+
+/** Build a minimal ILoopCtx whose INJECTED gate returns `gatePassed`, with an EMPTY
+ *  `task.accept` — the boringstack shape (it drives an injected gate, not `accept`). */
+function ctxWith(
+  cwd: string,
+  gatePassed: boolean
+): { ctx: ILoopCtx; calls: { runCalls: number } } {
+  const box = { runCalls: 0 };
+  const ctx: ILoopCtx = {
+    task: { id: "t", intent: "test", accept: "", files: ["a.ts"], context: [] },
+    cwd,
+    tsService: null,
+    report: () => undefined,
+    messages: [],
+    tool: {},
+    gate: {
+      parse: undefined,
+      runner: {
+        run: async (): Promise<IValidateResult> => {
+          box.runCalls += 1;
+
+          return { passed: gatePassed, errors: [], output: "" };
+        },
+      },
+    },
+  };
+
+  return { ctx, calls: box };
+}
+
+test("polishOnGreen REVERTS the drop when the INJECTED gate regresses (empty task.accept)", async () => {
+  const dir = await mkdtemp(join(tmpdir(), "tsforge-polish-"));
+
+  try {
+    await Bun.write(join(dir, "a.ts"), SOURCE);
+
+    // The injected gate reports RED after the drop (the drop removed a load-bearing
+    // annotation). With the OLD code — validate(task.accept="") — this recheck passed
+    // vacuously and the broken drop shipped; the injected gate must drive the revert.
+    const { ctx, calls } = ctxWith(dir, false);
+
+    await polishOnGreen(ctx);
+
+    // The INJECTED gate was actually invoked for the recheck (not a vacuous pass).
+    expect(calls.runCalls).toBeGreaterThan(0);
+    // Rolled back: the annotation is restored (the drop did NOT ship).
+    expect(await Bun.file(join(dir, "a.ts")).text()).toBe(SOURCE);
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test("polishOnGreen REVERTS the drop when the injected gate THROWS (transient judge failure)", async () => {
+  const dir = await mkdtemp(join(tmpdir(), "tsforge-polish-"));
+
+  try {
+    await Bun.write(join(dir, "a.ts"), SOURCE);
+
+    // The composed gate's judge model call can throw transiently. A throw must not leave
+    // the unverified drop on disk, nor crash — it must roll back to the pre-polish state.
+    const ctx: ILoopCtx = {
+      task: {
+        id: "t",
+        intent: "test",
+        accept: "",
+        files: ["a.ts"],
+        context: [],
+      },
+      cwd: dir,
+      tsService: null,
+      report: () => undefined,
+      messages: [],
+      tool: {},
+      gate: {
+        parse: undefined,
+        runner: {
+          run: async (): Promise<IValidateResult> => {
+            throw new Error("judge provider timed out");
+          },
+        },
+      },
+    };
+
+    await polishOnGreen(ctx); // must not throw
+
+    expect(await Bun.file(join(dir, "a.ts")).text()).toBe(SOURCE);
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test("polishOnGreen re-throws on caller cancellation (honors the signal) but still reverts", async () => {
+  const dir = await mkdtemp(join(tmpdir(), "tsforge-polish-"));
+
+  try {
+    await Bun.write(join(dir, "a.ts"), SOURCE);
+
+    const controller = new AbortController();
+    controller.abort();
+
+    const ctx: ILoopCtx = {
+      task: {
+        id: "t",
+        intent: "test",
+        accept: "",
+        files: ["a.ts"],
+        context: [],
+      },
+      cwd: dir,
+      tsService: null,
+      report: () => undefined,
+      messages: [],
+      tool: { signal: controller.signal },
+      gate: {
+        parse: undefined,
+        runner: {
+          run: async (): Promise<IValidateResult> => {
+            throw new Error("aborted");
+          },
+        },
+      },
+    };
+
+    // A cancellation must NOT be swallowed as a transient failure — it re-throws…
+    let threw = false;
+
+    try {
+      await polishOnGreen(ctx);
+    } catch {
+      threw = true;
+    }
+
+    expect(threw).toBe(true);
+    // …but the tree is still restored to the pre-polish green state first.
+    expect(await Bun.file(join(dir, "a.ts")).text()).toBe(SOURCE);
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test("polishOnGreen KEEPS the drop when the injected gate stays green", async () => {
+  const dir = await mkdtemp(join(tmpdir(), "tsforge-polish-"));
+
+  try {
+    await Bun.write(join(dir, "a.ts"), SOURCE);
+
+    const { ctx } = ctxWith(dir, true);
+
+    await polishOnGreen(ctx);
+
+    // The redundant `: number` was dropped and (gate green) kept.
+    const out = await Bun.file(join(dir, "a.ts")).text();
+
+    expect(out).toContain("const abs = Math.abs(cents)");
+    expect(out).not.toContain(": number");
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});

--- a/packages/core/tests/polish-on-green.test.ts
+++ b/packages/core/tests/polish-on-green.test.ts
@@ -107,6 +107,7 @@ test("polishOnGreen re-throws on caller cancellation (honors the signal) but sti
     await Bun.write(join(dir, "a.ts"), SOURCE);
 
     const controller = new AbortController();
+
     controller.abort();
 
     const ctx: ILoopCtx = {
@@ -143,6 +144,67 @@ test("polishOnGreen re-throws on caller cancellation (honors the signal) but sti
 
     expect(threw).toBe(true);
     // …but the tree is still restored to the pre-polish green state first.
+    expect(await Bun.file(join(dir, "a.ts")).text()).toBe(SOURCE);
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test("polishOnGreen wraps a NON-Error abort rejection in an Error (typed re-throw)", async () => {
+  const dir = await mkdtemp(join(tmpdir(), "tsforge-polish-"));
+
+  try {
+    await Bun.write(join(dir, "a.ts"), SOURCE);
+
+    const controller = new AbortController();
+
+    controller.abort();
+
+    const ctx: ILoopCtx = {
+      task: {
+        id: "t",
+        intent: "test",
+        accept: "",
+        files: ["a.ts"],
+        context: [],
+      },
+      cwd: dir,
+      tsService: null,
+      report: () => undefined,
+      messages: [],
+      tool: { signal: controller.signal },
+      gate: {
+        parse: undefined,
+        runner: {
+          // A rejection that is NOT an Error (some providers reject with a
+          // string/object). Typed `unknown` so it is a rejection reason, not a
+          // literal throw. The typed-throw branch must wrap it in an Error so
+          // only-throw-error holds and the caller gets a real Error.
+          run: async (): Promise<IValidateResult> => {
+            const reason: unknown = "aborted-string";
+
+            throw reason;
+          },
+        },
+      },
+    };
+
+    let caught: unknown = null;
+
+    try {
+      await polishOnGreen(ctx);
+    } catch (err) {
+      caught = err;
+    }
+
+    // Re-thrown as a real Error (not the raw string) with the abort message…
+    expect(caught).toBeInstanceOf(Error);
+
+    if (caught instanceof Error) {
+      expect(caught.message).toContain("aborted by caller signal");
+    }
+
+    // …and the tree is still restored first.
     expect(await Bun.file(join(dir, "a.ts")).text()).toBe(SOURCE);
   } finally {
     await rm(dir, { recursive: true, force: true });


### PR DESCRIPTION
## Problem

Every fast-green→acceptance-red BoringStack build traced to `polishOnGreen`. On a green task it drops "redundant" type annotations, then **re-checks and reverts if regressed** — a verified-safe contract. But the re-check used `validate(task, cwd)` = `task.accept`, which is **empty on the boringstack/Session path** (it drives an INJECTED gate via `setGate`, not `task.accept`). So `validate` ran an empty command → **vacuous pass** → the revert never fired. A dropped load-bearing annotation (e.g. `: unknown` on `await res.json()`, which suppresses `no-unsafe-*`) shipped green, and only *final acceptance* caught it — after the feature was already "verified".

## Fix

Re-gate through `ctx.gate.runner.run(cwd, …)` — the SAME injected gate the loop used to declare green (runs its own format/autofix) — never `validate(task.accept)`. A drop that changes an inferred type now fails the recheck and rolls the whole file set back. Equivalent for `runTask` (its injected gate runs `accept`).

- Extracted `snapshotFiles` / `dropRedundantAcross` / `recheckAfterPolish` helpers (cognitive complexity ≤ 20).
- Abort during recheck is captured and re-thrown **after** rollback (honors the signal contract); wrapped in a typed `Error` (`only-throw-error`).
- Guarded `onGateChunk.flush()` so a throwing flush can't mask the rollback.

## Tests (`packages/core/tests/polish-on-green.test.ts`)
- revert-on-red with **empty** `task.accept` (the exact case the old code silently passed)
- revert-on-throw (transient judge failure)
- re-throw-on-abort but still revert first
- non-Error abort rejection → wrapped in a typed `Error`
- keep-on-green

## Verification
- `bun run validate` green (fresh eslint cache).
- Reviewer panel: **PASS — all 4 reviewers approved**.
- End-to-end: first fully-green autonomous BoringStack build on the DeepSeek API (proof-121), re-verified harness-free — API `bun run validate` exit 0 (1204 pass/0 fail), UI exit 0 (build + size).

## Reviewer follow-ups (agreement-1, non-blocking)
1. **task.fix throw before rollback** — defensive; `runAccept`/`runShellCommand` catch spawn failures (exit 127) and handle abort by returning, not throwing, and the abort case already rolls back via `recheckAfterPolish`. Practically unreachable today; noted for a future hardening pass.
2. **Rollback scoped to `task.files`** — by design: polish only mutates `task.files`; the injected gate's own autofix side-effects are normal loop behavior re-gated on the next iteration, not polish's to revert.
3. **.gitignore for `gen-plan.ts`** — deliberate hygiene: the local untracked build-helper was accidentally swept in by `git add -A`; ignoring it prevents recurrence.