### PR TITLE
fix(boringstack): clear eslint cache each gate cycle (sound type-aware lint)

### DIFF
--- a/packages/core/src/loop/boringstack/build.ts
+++ b/packages/core/src/loop/boringstack/build.ts
@@ -33,6 +33,15 @@ export async function autofixApps(cwd: string, exec: Exec): Promise<void> {
   for (const app of ["apps/api", "apps/ui"]) {
     const appCwd = join(cwd, app);
 
+    // Clear eslint's cache FIRST. `eslint --cache` (which the app's lint/lint:fix scripts
+    // use) is UNSOUND for TYPE-AWARE rules: it keys on a file's own content, so a file
+    // whose content is unchanged stays cached-CLEAN even when a CROSS-FILE type change
+    // introduced a `no-unsafe-*` / type-checked violation in it. Live-observed break: the
+    // fast gate read a stale-clean cache and marked a feature GREEN while
+    // `no-unsafe-assignment` errors existed in a route test, which only surfaced at full
+    // acceptance — a gate-parity hole (4/4 panel). `lint:fix` re-populates a fresh cache
+    // for this cycle right after, so the later `check` → `lint` read stays fast AND sound.
+    await exec(["rm", "-f", ".eslintcache"], { cwd: appCwd });
     await exec(["bun", "run", "format"], { cwd: appCwd });
     await exec(["bun", "run", "lint:fix"], { cwd: appCwd });
   }

--- a/packages/core/tests/boringstack-build.test.ts
+++ b/packages/core/tests/boringstack-build.test.ts
@@ -550,17 +550,22 @@ describe("runBoringstackBuild", () => {
 
       expect(full).toBeGreaterThan(0);
 
-      // …and the FOUR exec calls immediately before it are the full autofixApps
-      // contract — format + lint:fix for BOTH apps — proving acceptance is
-      // preceded by the same deterministic auto-fixes the per-cycle gate applies.
-      // Dropping `format` or the api half must fail this (not just the last step).
+      // …and the SIX exec calls immediately before it are the full autofixApps
+      // contract — clear eslint cache + format + lint:fix for BOTH apps — proving
+      // acceptance is preceded by the same deterministic auto-fixes the per-cycle gate
+      // applies. The `rm -f .eslintcache` FIRST is the type-aware-lint soundness fix:
+      // eslint --cache can return a stale-clean result for a file whose content is
+      // unchanged but whose cross-file types changed, so the cache is cleared each cycle.
+      // Dropping the cache clear, `format`, or the api half must fail this.
       const before = execCalls
-        .slice(full - 4, full)
+        .slice(full - 6, full)
         .map((c) => `${c.argv.join(" ")} @ ${c.cwd.replace(dir, "")}`);
 
       expect(before).toEqual([
+        "rm -f .eslintcache @ /apps/api",
         "bun run format @ /apps/api",
         "bun run lint:fix @ /apps/api",
+        "rm -f .eslintcache @ /apps/ui",
         "bun run format @ /apps/ui",
         "bun run lint:fix @ /apps/ui",
       ]);


### PR DESCRIPTION
## Problem

`eslint --cache` is **unsound for type-aware rules**. The cache keys on a file's own content hash; a cross-file *type* change (e.g. an API response type narrowing) does not invalidate the cache entry of a content-unchanged file that consumes that type. So `no-unsafe-*` / `no-unnecessary-condition` violations introduced by a change elsewhere are served a stale-clean verdict — the gate reports green on code that a cold lint would flag. This is the same unsoundness class that let broken drops slip past locally.

## Fix

`autofixApps` removes `.eslintcache` per app before each `format`/`lint:fix` cycle, so every gate lint is a cold, sound run. Small cost (full lint each cycle) bought for gate correctness — never trade the gate's soundness for cache speed.

## Tests
`packages/core/tests/boringstack-build.test.ts` — asserts the cache file is cleared before the autofix lint runs.

## Verification
- `bun run validate` green (fresh cache).
- Reviewer panel on pre-push: pushed clean (no block).