### PR TITLE
feat(scaffold): conditional wizard steps — stop asking questions that can't matter

### DIFF
--- a/packages/core/src/render/wizard.ts
+++ b/packages/core/src/render/wizard.ts
@@ -35,13 +35,22 @@ export function initWizard(steps: readonly IWizardStep[]): IWizardState {
     }
   }
 
-  return {
+  const base: IWizardState = {
     stepIndex: 0,
-    cursor: steps[0]?.defaultIndex ?? 0,
+    cursor: 0,
     single: {},
     multi,
     text,
     status: "active",
+  };
+  // Start on the first VISIBLE step — an initially-hidden step 0 must be skipped
+  // so the wizard never opens on a question it means to hide.
+  const startIndex = nextVisibleIndex(steps, 0, base);
+
+  return {
+    ...base,
+    stepIndex: startIndex,
+    cursor: steps[startIndex]?.defaultIndex ?? 0,
   };
 }
 
@@ -66,6 +75,107 @@ function cursorForStep(step: IWizardStep, state: IWizardState): number {
   }
 
   return step.defaultIndex ?? 0;
+}
+
+/** A step with no predicate is always shown; otherwise its predicate decides. */
+function isVisible(step: IWizardStep, state: IWizardState): boolean {
+  return step.visibleWhen === undefined || step.visibleWhen(state);
+}
+
+/** First index >= `from` whose step is visible; `steps.length` if none remain. */
+function nextVisibleIndex(
+  steps: readonly IWizardStep[],
+  from: number,
+  state: IWizardState
+): number {
+  let i = Math.max(0, from);
+
+  while (i < steps.length) {
+    const s = steps[i];
+
+    if (s !== undefined && isVisible(s, state)) {
+      return i;
+    }
+
+    i += 1;
+  }
+
+  return steps.length;
+}
+
+/** Last index <= `from` whose step is visible; -1 if none remain before it. */
+function prevVisibleIndex(
+  steps: readonly IWizardStep[],
+  from: number,
+  state: IWizardState
+): number {
+  let i = Math.min(from, steps.length - 1);
+
+  while (i >= 0) {
+    const s = steps[i];
+
+    if (s !== undefined && isVisible(s, state)) {
+      return i;
+    }
+
+    i -= 1;
+  }
+
+  return -1;
+}
+
+/** Overlay each unanswered single step's DEFAULT value onto the state. The "Step X
+ *  of N" counter uses this so a default-ON gate's dependent is counted from the
+ *  start — without it, a dependent reads as hidden until its gate is confirmed and
+ *  the total would jump (e.g. "1 of 14" → "of 15" after confirming the cache). */
+function withDefaultAnswers(
+  steps: readonly IWizardStep[],
+  state: IWizardState
+): IWizardState {
+  const single: Record<string, string> = { ...state.single };
+
+  for (const s of steps) {
+    if (s.kind === "single" && single[s.key] === undefined) {
+      const v = s.options[s.defaultIndex ?? 0]?.value;
+
+      if (v !== undefined) {
+        single[s.key] = v;
+      }
+    }
+  }
+
+  return { ...state, single };
+}
+
+/** Count of visible steps under the current answers + unanswered defaults (the
+ *  denominator for "Step X of N"). */
+function visibleTotal(
+  steps: readonly IWizardStep[],
+  state: IWizardState
+): number {
+  const eff = withDefaultAnswers(steps, state);
+
+  return steps.filter((s) => isVisible(s, eff)).length;
+}
+
+/** 1-based position of `stepIndex` among the visible steps (for "Step X of N"). */
+function visiblePosition(
+  steps: readonly IWizardStep[],
+  state: IWizardState,
+  stepIndex: number
+): number {
+  const eff = withDefaultAnswers(steps, state);
+  let n = 0;
+
+  for (let i = 0; i <= stepIndex && i < steps.length; i += 1) {
+    const s = steps[i];
+
+    if (s !== undefined && isVisible(s, eff)) {
+      n += 1;
+    }
+  }
+
+  return n;
 }
 
 function toggleCheck(state: IWizardState, step: IWizardStep): IWizardState {
@@ -146,9 +256,12 @@ function confirmStep(
               ?.value ?? "",
         }
       : state.single;
-  const nextIndex = state.stepIndex + 1;
+  // Visibility of later steps can depend on the answer just recorded (e.g. turning
+  // the cache off hides "cache provider"), so evaluate against the updated state.
+  const advanced = { ...state, single };
+  const nextIndex = nextVisibleIndex(steps, state.stepIndex + 1, advanced);
 
-  // Review off + last step → apply immediately, skipping the overview.
+  // Review off + no visible step left → apply immediately, skipping the overview.
   if (opts.review === false && nextIndex >= steps.length) {
     return { ...state, single, status: "apply" };
   }
@@ -159,7 +272,7 @@ function confirmStep(
     ...state,
     single,
     stepIndex: nextIndex,
-    cursor: next === undefined ? 0 : cursorForStep(next, { ...state, single }),
+    cursor: next === undefined ? 0 : cursorForStep(next, advanced),
   };
 }
 
@@ -167,11 +280,14 @@ function goBack(
   state: IWizardState,
   steps: readonly IWizardStep[]
 ): IWizardState {
-  if (state.stepIndex === 0) {
+  // Step back to the previous VISIBLE step; if none precede this one, cancel
+  // (mirrors the old stepIndex===0 behavior once hidden steps are skipped).
+  const idx = prevVisibleIndex(steps, state.stepIndex - 1, state);
+
+  if (idx < 0) {
     return { ...state, status: "cancel" };
   }
 
-  const idx = state.stepIndex - 1;
   const step = steps[idx];
 
   return {
@@ -229,7 +345,14 @@ function reduceOverview(
   }
 
   if (action === "back") {
-    const idx = steps.length - 1;
+    const idx = prevVisibleIndex(steps, steps.length - 1, state);
+
+    if (idx < 0) {
+      // No visible step to return to (every step is hidden) — treat back as
+      // cancel, matching goBack, rather than dead-ending on the review screen.
+      return { ...state, status: "cancel" };
+    }
+
     const step = steps[idx];
 
     return {
@@ -411,12 +534,13 @@ function renderStep(
   step: IWizardStep,
   state: IWizardState,
   color: boolean,
+  position: number,
   total: number,
   title: string
 ): string {
   return [
     paint(title, STYLE.brand, color),
-    `${paint(`Step ${state.stepIndex + 1} of ${total}`, STYLE.bold, color)} · ${step.title}`,
+    `${paint(`Step ${position} of ${total}`, STYLE.bold, color)} · ${step.title}`,
     RULE,
     step.explanation,
     "",
@@ -433,11 +557,14 @@ function overviewLines(
   state: IWizardState,
   color: boolean
 ): string[] {
-  return steps.map((step) => {
-    const value = overviewValue(step, state);
+  // Hidden steps have no answer that matters — omit them from the review.
+  return steps
+    .filter((step) => isVisible(step, state))
+    .map((step) => {
+      const value = overviewValue(step, state);
 
-    return `  ${paint(step.title, STYLE.bold, color)}: ${value}`;
-  });
+      return `  ${paint(step.title, STYLE.bold, color)}: ${value}`;
+    });
 }
 
 /** The one-line answer shown for a step on the review screen. */
@@ -496,7 +623,14 @@ export function renderFrame(
 
   return step === undefined
     ? ""
-    : renderStep(step, state, color, steps.length, title);
+    : renderStep(
+        step,
+        state,
+        color,
+        visiblePosition(steps, state, state.stepIndex),
+        visibleTotal(steps, state),
+        title
+      );
 }
 
 // ──────────────────────────── interactive driver ────────────────────────────

--- a/packages/core/src/render/wizard.types.ts
+++ b/packages/core/src/render/wizard.types.ts
@@ -29,6 +29,24 @@ export interface IWizardStep {
   readonly mask?: boolean;
   /** Text: return an error message to block confirm, or null when valid. */
   readonly validate?: (value: string) => string | null;
+  /** Conditional visibility: when present and it returns false for the current
+   *  state, the step is SKIPPED (navigation jumps over it in both directions and
+   *  it is omitted from the review overview). A dependent step — e.g. "cache
+   *  provider" only when the cache is enabled — sets this so the wizard never asks
+   *  a question whose answer cannot matter. Absent = always visible.
+   *
+   *  CONTRACT: the engine does NOT erase a hidden step's recorded value from
+   *  `single`/`multi`/`text` (a step answered, then re-hidden by changing its gate,
+   *  keeps its raw value). Any consumer that reads answers from a wizard using
+   *  `visibleWhen` MUST drop values for steps that are hidden under the final state
+   *  — otherwise a stale answer leaks. See scaffold `stateToAnswers` (hiddenKeys).
+   *
+   *  ORDER: a dependent step MUST appear AFTER the step(s) its predicate reads.
+   *  Navigation only scans forward on confirm, so a step that becomes visible at a
+   *  LOWER index than the current one is never revisited (it would still list as
+   *  "(default)" in the review). Scaffold enforces this via `askWhen` validation
+   *  (the gate must be asked earlier); a hand-built step list must honor it too. */
+  readonly visibleWhen?: (state: IWizardState) => boolean;
 }
 
 /** Normalized input action (the driver maps raw keypresses to these). `{ char }`

--- a/packages/core/src/scaffold/boringstack-manifest.ts
+++ b/packages/core/src/scaffold/boringstack-manifest.ts
@@ -26,6 +26,98 @@ export function loadBundledManifest(): IScaffoldManifest {
   return bundled;
 }
 
+/** The recorded values a dependency field can actually take in the wizard's
+ *  single-select state: a toggle stores "1"/"0"; a one-of stores one of its
+ *  options. Anything else (multi lives in state.multi; secret/text/STACK are never
+ *  single wizard answers) can never match, so it's not a valid askWhen target. */
+function recordableValues(field: IConfigField): readonly string[] | null {
+  if (field.key === "STACK") {
+    return null; // STACK is not a wizard question
+  }
+
+  if (field.kind === "toggle") {
+    return ["1", "0"];
+  }
+
+  if (field.kind === "one-of") {
+    return field.options ?? [];
+  }
+
+  return null; // multi / secret / text never populate state.single
+}
+
+/** Fail loud on a malformed or dangerous `askWhen`: it must be exactly `KEY=value`
+ *  (non-empty key and value, a single `=`), reference a real field asked EARLIER,
+ *  not depend on a field that itself has an `askWhen` (chains would read a hidden
+ *  field's stale answer), and name a value the dependency can actually record. A
+ *  silent skip would apply the default forever, so this throws. */
+function validateAskWhen(fields: readonly IConfigField[]): void {
+  const byKey = new Map(fields.map((f, i) => [f.key, { field: f, index: i }]));
+  const gated = new Set(
+    fields.filter((f) => f.askWhen !== undefined).map((f) => f.key)
+  );
+
+  fields.forEach((field, i) => {
+    const token = field.askWhen;
+
+    if (token === undefined) {
+      return;
+    }
+
+    const where = `fields[${String(i)}] (${field.key}).askWhen`;
+    const eq = token.indexOf("=");
+
+    if (eq <= 0 || eq !== token.lastIndexOf("=")) {
+      throw new Error(
+        `scaffold manifest: ${where} must be exactly "KEY=value" — got "${token}"`
+      );
+    }
+
+    const key = token.slice(0, eq);
+    const value = token.slice(eq + 1);
+
+    if (value.length === 0) {
+      throw new Error(
+        `scaffold manifest: ${where} has an empty value in "${token}"`
+      );
+    }
+
+    const dep = byKey.get(key);
+
+    if (dep === undefined) {
+      throw new Error(
+        `scaffold manifest: ${where} references unknown field "${key}"`
+      );
+    }
+
+    if (dep.index >= i) {
+      throw new Error(
+        `scaffold manifest: ${where} references "${key}", which must be asked before it`
+      );
+    }
+
+    if (gated.has(key)) {
+      throw new Error(
+        `scaffold manifest: ${where} depends on "${key}", which itself has askWhen — chained conditions are not supported`
+      );
+    }
+
+    const valid = recordableValues(dep.field);
+
+    if (valid === null) {
+      throw new Error(
+        `scaffold manifest: ${where} depends on "${key}", which is not a yes/no or single-choice wizard question (its answer never reaches the gate)`
+      );
+    }
+
+    if (!valid.includes(value)) {
+      throw new Error(
+        `scaffold manifest: ${where} value "${value}" can never match "${key}" — expected one of ${valid.join(" | ")} (a toggle records "1"/"0", not "true")`
+      );
+    }
+  });
+}
+
 /** Parse + validate the boringstack scaffold manifest (read from the cloned repo
  *  or a test fixture). Narrows `unknown` with guards (no casts); throws a clear
  *  error on malformed input so a bad manifest fails loudly rather than producing
@@ -56,6 +148,15 @@ export function parseManifest(raw: unknown): IScaffoldManifest {
       );
     }
 
+    // askWhen must be a STRING when present. optStrField silently drops a non-string
+    // (e.g. `askWhen: true`), which would leave the step unconditional — the opposite
+    // of the fail-loud contract validateAskWhen enforces. Reject it here.
+    if ("askWhen" in f && typeof f.askWhen !== "string") {
+      throw new Error(
+        `scaffold manifest: fields[${String(i)}] askWhen must be a string, got ${typeof f.askWhen}`
+      );
+    }
+
     return {
       key: str(f, "key", `fields[${String(i)}]`),
       kind: narrowKind(kind),
@@ -69,6 +170,7 @@ export function parseManifest(raw: unknown): IScaffoldManifest {
       ...optRecordOfStrArr(f, "requiresSecrets"),
       ...optBool(f, "requiresSecretsProdOnly"),
       ...optStrField(f, "requiresSecretsWhen"),
+      ...optStrField(f, "askWhen"),
       ...optBool(f, "prodOnly"),
       ...optGenerate(f),
       ...optStrField(f, "envFile"),
@@ -95,6 +197,8 @@ export function parseManifest(raw: unknown): IScaffoldManifest {
       };
     }
   );
+
+  validateAskWhen(fields);
 
   return {
     manifestVersion: num(raw, "manifestVersion"),

--- a/packages/core/src/scaffold/scaffold-manifest.json
+++ b/packages/core/src/scaffold/scaffold-manifest.json
@@ -148,7 +148,8 @@
       "group": "features",
       "label": "Cache provider",
       "options": ["memory", "valkey"],
-      "devDefault": "valkey"
+      "devDefault": "valkey",
+      "askWhen": "CACHE_ENABLED=1"
     },
     {
       "key": "NOTIFICATIONS_SSE_ENABLED",
@@ -173,7 +174,8 @@
       "label": "AI provider",
       "options": ["openai", "anthropic", "noop"],
       "devDefault": "openai",
-      "requiresSecretsWhen": "AI_ENABLED=true",
+      "askWhen": "AI_ENABLED=1",
+      "requiresSecretsWhen": "AI_ENABLED:*",
       "requiresSecrets": {
         "openai": ["OPENAI_API_KEY"],
         "anthropic": ["ANTHROPIC_API_KEY"]

--- a/packages/core/src/scaffold/scaffold.types.ts
+++ b/packages/core/src/scaffold/scaffold.types.ts
@@ -59,9 +59,17 @@ export interface IConfigField {
    *  (STRIPE, email, OAuth) are required whenever the field is on, regardless. */
   readonly requiresSecretsProdOnly?: boolean;
   /** Gate `requiresSecrets` on another field being active (a `field=value` or
-   *  `field:*` token, same grammar as cross-rules). E.g. AI_PROVIDER's provider
-   *  keys are required only when `AI_ENABLED=true`. Absent → always evaluated. */
+   *  `field:*` token, same grammar as cross-rules). Use the `field:*` "is on" form
+   *  for a toggle gate — the wizard records toggles as "1"/"0", so a literal
+   *  `field=true` would never match a wizard answer. E.g. AI_PROVIDER's keys are
+   *  required only when `AI_ENABLED:*`. Absent → always evaluated. */
   readonly requiresSecretsWhen?: string;
+  /** Gate whether the WIZARD even ASKS this field on another field's answer, as a
+   *  `KEY=value` token. The wizard records toggles as "1"/"0", so a field that only
+   *  matters when a toggle is on uses `KEY=1` (e.g. CACHE_PROVIDER → `CACHE_ENABLED=1`).
+   *  When the token doesn't match, the step is skipped and the planner falls back to
+   *  the field's default. Absent → always asked. */
+  readonly askWhen?: string;
   /** Only required when STACK=prod (e.g. JWT_SECRET, VALKEY_PASSWORD). */
   readonly prodOnly?: boolean;
   /** Generate via `openssl rand` rather than prompting (JWT_SECRET, MFA key). */

--- a/packages/core/src/scaffold/wizard.ts
+++ b/packages/core/src/scaffold/wizard.ts
@@ -101,9 +101,51 @@ function multiStep(field: IConfigField, stack: IStack): IWizardStep {
   };
 }
 
+/** Build a step visibility predicate from a field's `askWhen` token ("KEY=value").
+ *  The wizard records toggles as "1"/"0", so a field gated on a toggle uses `KEY=1`.
+ *  Absent or malformed → undefined (the step is always shown). */
+function visibleWhenFor(
+  askWhen: string | undefined
+): ((state: IWizardState) => boolean) | undefined {
+  if (askWhen === undefined) {
+    return undefined;
+  }
+
+  // Split on the FIRST "=" only, so a value is never silently truncated. Require a
+  // non-empty key AND value ("=v" / "KEY=" are malformed). parseManifest already
+  // rejects these loudly; this stays defensive for any direct caller.
+  const eq = askWhen.indexOf("=");
+
+  if (eq <= 0) {
+    return undefined;
+  }
+
+  const key = askWhen.slice(0, eq);
+  const value = askWhen.slice(eq + 1);
+
+  if (value.length === 0) {
+    return undefined;
+  }
+
+  return (state) => state.single[key] === value;
+}
+
+function stepFor(field: IConfigField, stack: IStack): IWizardStep {
+  if (field.kind === "toggle") {
+    return toggleStep(field, stack);
+  }
+
+  if (field.kind === "multi") {
+    return multiStep(field, stack);
+  }
+
+  return oneOfStep(field, stack);
+}
+
 /** Generate the wizard steps for an archetype from the manifest. Astro takes no
  *  further config (static site, no env); boringstack yields one select step per
- *  selectable field, in manifest order. Pure — driven/tested via render/wizard. */
+ *  selectable field, in manifest order. A field with `askWhen` becomes a step that
+ *  the wizard skips unless the gate matches. Pure — driven/tested via render/wizard. */
 export function buildScaffoldSteps(
   manifest: IScaffoldManifest,
   archetype: IArchetype,
@@ -114,21 +156,35 @@ export function buildScaffoldSteps(
   }
 
   return manifest.fields.filter(isSelectable).map((field) => {
-    if (field.kind === "toggle") {
-      return toggleStep(field, stack);
-    }
+    const step = stepFor(field, stack);
+    const visibleWhen = visibleWhenFor(field.askWhen);
 
-    if (field.kind === "multi") {
-      return multiStep(field, stack);
-    }
-
-    return oneOfStep(field, stack);
+    return visibleWhen === undefined ? step : { ...step, visibleWhen };
   });
 }
 
+/** Keys whose step is hidden for the given state (gate answered off). A hidden
+ *  field must NOT contribute an answer — even if it was visited earlier and then
+ *  hidden by flipping its gate back — so a later disable can't leave a stale value
+ *  that the review never showed. Recomputed from the same askWhen→visibleWhen path
+ *  buildScaffoldSteps uses, so projection and navigation agree on visibility. */
+function hiddenKeys(
+  manifest: IScaffoldManifest,
+  archetype: IArchetype,
+  stack: IStack,
+  state: IWizardState
+): ReadonlySet<string> {
+  return new Set(
+    buildScaffoldSteps(manifest, archetype, stack)
+      .filter((s) => s.visibleWhen !== undefined && !s.visibleWhen(state))
+      .map((s) => s.key)
+  );
+}
+
 /** Read a finished (or partial) wizard state back into scaffold answers. Missing
- *  selections are simply absent — the planner falls back to the stack default for
- *  any unanswered field, so this is safe on an un-driven state too. */
+ *  selections — and any field whose gate is off (see hiddenKeys) — are simply
+ *  absent, so the planner falls back to the stack default. Safe on an un-driven
+ *  state too. */
 export function stateToAnswers(
   manifest: IScaffoldManifest,
   archetype: IArchetype,
@@ -138,7 +194,13 @@ export function stateToAnswers(
   const values: Record<string, string | readonly string[]> = {};
 
   if (archetype === "boringstack") {
+    const hidden = hiddenKeys(manifest, archetype, stack, state);
+
     for (const field of manifest.fields.filter(isSelectable)) {
+      if (hidden.has(field.key)) {
+        continue; // gate is off — no answer, planner uses the default
+      }
+
       if (field.kind === "multi") {
         const idxs = state.multi[field.key] ?? [];
         const opts = field.options ?? [];

--- a/packages/core/tests/fixtures/scaffold/scaffold-manifest.json
+++ b/packages/core/tests/fixtures/scaffold/scaffold-manifest.json
@@ -230,7 +230,8 @@
         "memory",
         "valkey"
       ],
-      "devDefault": "valkey"
+      "devDefault": "valkey",
+      "askWhen": "CACHE_ENABLED=1"
     },
     {
       "key": "NOTIFICATIONS_SSE_ENABLED",
@@ -259,7 +260,8 @@
         "noop"
       ],
       "devDefault": "openai",
-      "requiresSecretsWhen": "AI_ENABLED=true",
+      "askWhen": "AI_ENABLED=1",
+      "requiresSecretsWhen": "AI_ENABLED:*",
       "requiresSecrets": {
         "openai": [
           "OPENAI_API_KEY"

--- a/packages/core/tests/scaffold-bundled-manifest.test.ts
+++ b/packages/core/tests/scaffold-bundled-manifest.test.ts
@@ -30,3 +30,133 @@ describe("bundled scaffold manifest", () => {
     expect(loadBundledManifest()).toEqual(fixture);
   });
 });
+
+function isRecordLike(v: unknown): v is Record<string, unknown> {
+  return typeof v === "object" && v !== null;
+}
+
+/** The fixture manifest with `askWhen` overrides applied to the named fields. */
+function withAskWhens(overrides: Record<string, string>): unknown {
+  const raw: unknown = JSON.parse(
+    readFileSync(
+      join(import.meta.dir, "fixtures/scaffold/scaffold-manifest.json"),
+      "utf8"
+    )
+  );
+
+  if (!isRecordLike(raw) || !Array.isArray(raw.fields)) {
+    throw new Error("fixture manifest is malformed");
+  }
+
+  for (const f of raw.fields) {
+    if (isRecordLike(f) && typeof f.key === "string" && f.key in overrides) {
+      f.askWhen = overrides[f.key];
+    }
+  }
+
+  return raw;
+}
+
+/** The fixture manifest with a NON-STRING askWhen forced onto a field, to exercise
+ *  the parse-time type guard (optStrField would otherwise silently drop it). */
+function withNonStringAskWhen(key: string): unknown {
+  const raw: unknown = JSON.parse(
+    readFileSync(
+      join(import.meta.dir, "fixtures/scaffold/scaffold-manifest.json"),
+      "utf8"
+    )
+  );
+
+  if (!isRecordLike(raw) || !Array.isArray(raw.fields)) {
+    throw new Error("fixture manifest is malformed");
+  }
+
+  for (const f of raw.fields) {
+    if (isRecordLike(f) && f.key === key) {
+      f.askWhen = true; // a boolean, not a string
+    }
+  }
+
+  return raw;
+}
+
+describe("askWhen validation (fail-loud)", () => {
+  test("rejects a non-string askWhen (would otherwise be silently dropped)", () => {
+    expect(() => parseManifest(withNonStringAskWhen("CACHE_PROVIDER"))).toThrow(
+      /askWhen must be a string/u
+    );
+  });
+
+  test("rejects a token with no '='", () => {
+    expect(() =>
+      parseManifest(withAskWhens({ CACHE_PROVIDER: "CACHE_ENABLED" }))
+    ).toThrow(/KEY=value/u);
+  });
+
+  test("rejects an empty key", () => {
+    expect(() => parseManifest(withAskWhens({ CACHE_PROVIDER: "=1" }))).toThrow(
+      /KEY=value/u
+    );
+  });
+
+  test("rejects multiple '=' (would silently truncate the value)", () => {
+    expect(() =>
+      parseManifest(withAskWhens({ CACHE_PROVIDER: "CACHE_ENABLED=a=b" }))
+    ).toThrow(/KEY=value/u);
+  });
+
+  test("rejects an empty value", () => {
+    expect(() =>
+      parseManifest(withAskWhens({ CACHE_PROVIDER: "CACHE_ENABLED=" }))
+    ).toThrow(/empty value/u);
+  });
+
+  test("rejects an unknown referenced field", () => {
+    expect(() =>
+      parseManifest(withAskWhens({ CACHE_PROVIDER: "NOPE=1" }))
+    ).toThrow(/unknown field/u);
+  });
+
+  test("rejects a forward/self dependency (must be asked earlier)", () => {
+    // CACHE_ENABLED depends on CACHE_PROVIDER, which is asked AFTER it.
+    expect(() =>
+      parseManifest(withAskWhens({ CACHE_ENABLED: "CACHE_PROVIDER=valkey" }))
+    ).toThrow(/asked before it/u);
+  });
+
+  test("rejects a chained dependency (gate that itself has askWhen)", () => {
+    // CACHE_ENABLED gains an askWhen; CACHE_PROVIDER then depends on it → chain.
+    expect(() =>
+      parseManifest(
+        withAskWhens({
+          CACHE_ENABLED: "QUEUES_ENABLED=1",
+          CACHE_PROVIDER: "CACHE_ENABLED=1",
+        })
+      )
+    ).toThrow(/chained conditions are not supported/u);
+  });
+
+  test('rejects a toggle token with "=true" (wizard records "1"/"0")', () => {
+    expect(() =>
+      parseManifest(withAskWhens({ CACHE_PROVIDER: "CACHE_ENABLED=true" }))
+    ).toThrow(/can never match/u);
+  });
+
+  test("rejects an impossible one-of value", () => {
+    expect(() =>
+      parseManifest(withAskWhens({ CACHE_PROVIDER: "EMAIL_PROVIDER=nope" }))
+    ).toThrow(/can never match/u);
+  });
+
+  test("rejects a dependency on a multi field (answer lives in state.multi)", () => {
+    expect(() =>
+      parseManifest(withAskWhens({ CACHE_PROVIDER: "OAUTH_PROVIDERS=google" }))
+    ).toThrow(/not a yes\/no or single-choice/u);
+  });
+
+  test("rejects a dependency on STACK (never a wizard question)", () => {
+    expect(() =>
+      parseManifest(withAskWhens({ CACHE_PROVIDER: "STACK=dev" }))
+    ).toThrow(/not a yes\/no or single-choice/u);
+  });
+});

--- a/packages/core/tests/scaffold-wizard.test.ts
+++ b/packages/core/tests/scaffold-wizard.test.ts
@@ -5,7 +5,7 @@ import { buildScaffoldSteps, stateToAnswers } from "../src/scaffold/wizard";
 import { answersToPlan } from "../src/scaffold/plan";
 import { parseManifest } from "../src/scaffold/boringstack-manifest";
 import { driveWizard, initWizard } from "../src/render/wizard";
-import type { IWizardAction } from "../src/render/wizard.types";
+import type { IWizardAction, IWizardState } from "../src/render/wizard.types";
 
 const MANIFEST = parseManifest(
   JSON.parse(
@@ -19,6 +19,19 @@ const MANIFEST = parseManifest(
 /** Confirm straight through every step + the overview, accepting defaults. */
 function acceptAllDefaults(stepCount: number): readonly IWizardAction[] {
   return Array.from({ length: stepCount + 1 }, () => "confirm");
+}
+
+/** Minimal wizard state carrying only the given single-select answers, for
+ *  exercising a step's visibleWhen predicate in isolation. */
+function base(single: Record<string, string>): IWizardState {
+  return {
+    stepIndex: 0,
+    cursor: 0,
+    single,
+    multi: {},
+    text: {},
+    status: "active",
+  };
 }
 
 describe("buildScaffoldSteps", () => {
@@ -41,6 +54,73 @@ describe("buildScaffoldSteps", () => {
     expect(steps.some((s) => s.key === "JWT_SECRET")).toBe(false);
     // STACK mode (dev/prod/smoke) is NOT a wizard question.
     expect(steps.some((s) => s.key === "STACK")).toBe(false);
+  });
+
+  test("askWhen becomes a visibleWhen predicate on the dependent step", () => {
+    const steps = buildScaffoldSteps(MANIFEST, "boringstack", "dev");
+    const provider = steps.find((s) => s.key === "CACHE_PROVIDER");
+
+    expect(provider?.visibleWhen).toBeDefined();
+    // Shown only when the cache toggle recorded "1"; hidden for "0".
+    expect(provider?.visibleWhen?.(base({ CACHE_ENABLED: "1" }))).toBe(true);
+    expect(provider?.visibleWhen?.(base({ CACHE_ENABLED: "0" }))).toBe(false);
+
+    // A field with no askWhen stays unconditional.
+    const email = steps.find((s) => s.key === "EMAIL_PROVIDER");
+
+    expect(email?.visibleWhen).toBeUndefined();
+  });
+
+  test("driving the wizard with the cache OFF never asks the cache provider", () => {
+    const steps = buildScaffoldSteps(MANIFEST, "boringstack", "dev");
+    // CACHE_ENABLED default is on; toggle it off when we reach it, accept the rest.
+    const actions: IWizardAction[] = steps.flatMap((s) =>
+      s.key === "CACHE_ENABLED" ? ["down", "confirm"] : ["confirm"]
+    );
+    const state = driveWizard(steps, [...actions, "confirm"]);
+    const answers = stateToAnswers(MANIFEST, "boringstack", "dev", state);
+
+    // CACHE_PROVIDER was skipped → no recorded answer (planner uses the default).
+    expect(answers.values.CACHE_ENABLED).toBe("0");
+    expect(answers.values.CACHE_PROVIDER).toBeUndefined();
+  });
+
+  test("answering the cache provider then disabling the cache drops the stale answer", () => {
+    const steps = buildScaffoldSteps(MANIFEST, "boringstack", "dev");
+    const ci = steps.findIndex((s) => s.key === "CACHE_ENABLED");
+    // Reach CACHE_ENABLED (cache on by default), confirm it, land on CACHE_PROVIDER,
+    // pick "memory" (up from the "valkey" default), then go BACK to CACHE_ENABLED and
+    // turn it OFF — the provider is now hidden. Finish to apply.
+    const actions: IWizardAction[] = [
+      ...Array.from({ length: ci }, (): IWizardAction => "confirm"),
+      "confirm", // CACHE_ENABLED stays on → on CACHE_PROVIDER
+      "up", // valkey → memory
+      "confirm", // provider = memory → advance
+      "back", // back to CACHE_PROVIDER
+      "back", // back to CACHE_ENABLED
+      "down", // → Disabled
+      "confirm", // cache off → provider now hidden, skipped
+      ...Array.from(
+        { length: steps.length + 1 },
+        (): IWizardAction => "confirm"
+      ),
+    ];
+    const state = driveWizard(steps, actions);
+    const answers = stateToAnswers(MANIFEST, "boringstack", "dev", state);
+    const plan = answersToPlan(MANIFEST, answers);
+
+    // The stale "memory" choice must NOT survive — the cache is off, so the answer
+    // is dropped and the planner falls back to the default (as if never visited).
+    expect(answers.values.CACHE_ENABLED).toBe("0");
+    expect(answers.values.CACHE_PROVIDER).toBeUndefined();
+    // The env edit therefore carries the DEFAULT ("valkey"), never the stale "memory".
+    const providerEdit = plan.envEdits.find((e) => e.key === "CACHE_PROVIDER");
+
+    expect(providerEdit?.value).toBe("valkey");
+    expect(providerEdit?.value).not.toBe("memory");
+    expect(
+      plan.envEdits.some((e) => e.key === "CACHE_ENABLED" && e.value === "0")
+    ).toBe(true);
   });
 
   test("a toggle becomes a 2-option single step, default reflecting the stack", () => {
@@ -179,6 +259,40 @@ describe("wizard flow → answers → plan", () => {
 
     expect(plan.requiredSecrets).toContain("GOOGLE_OAUTH_CLIENT_ID");
     expect(plan.requiredSecrets).toContain("GOOGLE_OAUTH_CLIENT_SECRET");
+  });
+
+  test("enabling AI shows the provider step and requires its secret (AI_ENABLED:* gate)", () => {
+    const steps = buildScaffoldSteps(MANIFEST, "boringstack", "dev");
+    const ai = steps.findIndex((s) => s.key === "AI_ENABLED");
+    // AI defaults OFF (cursor on "Disabled"): "up" flips it on, then the now-visible
+    // AI_PROVIDER step keeps its "openai" default.
+    const actions: IWizardAction[] = [
+      ...Array.from({ length: ai }, (): IWizardAction => "confirm"),
+      "up", // AI_ENABLED → Enabled ("1")
+      ...Array.from(
+        { length: steps.length + 1 },
+        (): IWizardAction => "confirm"
+      ),
+    ];
+    const state = driveWizard(steps, actions);
+    const answers = stateToAnswers(MANIFEST, "boringstack", "dev", state);
+    const plan = answersToPlan(MANIFEST, answers);
+
+    expect(answers.values.AI_ENABLED).toBe("1");
+    expect(answers.values.AI_PROVIDER).toBe("openai"); // provider WAS asked
+    // The secret must be required — the pre-existing "=true" gate never matched "1".
+    expect(plan.requiredSecrets).toContain("OPENAI_API_KEY");
+  });
+
+  test("leaving AI off skips the provider step and requires no AI secret", () => {
+    const steps = buildScaffoldSteps(MANIFEST, "boringstack", "dev");
+    const state = driveWizard(steps, acceptAllDefaults(steps.length));
+    const answers = stateToAnswers(MANIFEST, "boringstack", "dev", state);
+    const plan = answersToPlan(MANIFEST, answers);
+
+    expect(answers.values.AI_ENABLED).toBe("0");
+    expect(answers.values.AI_PROVIDER).toBeUndefined(); // provider was skipped
+    expect(plan.requiredSecrets).not.toContain("OPENAI_API_KEY");
   });
 
   test("stateToAnswers carries the chosen stack through to the plan", () => {

--- a/packages/core/tests/wizard.test.ts
+++ b/packages/core/tests/wizard.test.ts
@@ -392,3 +392,217 @@ describe("wizardOwnsRawMode: raw-mode ownership rule", () => {
     expect(wizardOwnsRawMode(true, true, false, 0)).toBe(false);
   });
 });
+
+describe("conditional step visibility (visibleWhen)", () => {
+  // A: an enable toggle ("1"/"0"). B: shown only when A === "1". C: always shown.
+  const COND: IWizardStep[] = [
+    {
+      key: "A",
+      kind: "single",
+      title: "Enable cache",
+      explanation: "on?",
+      evidence: [],
+      options: [
+        { label: "Enabled", value: "1" },
+        { label: "Disabled", value: "0" },
+      ],
+      defaultIndex: 0,
+    },
+    {
+      key: "B",
+      kind: "single",
+      title: "Cache provider",
+      explanation: "which?",
+      evidence: [],
+      options: [
+        { label: "memory", value: "memory" },
+        { label: "valkey", value: "valkey" },
+      ],
+      defaultIndex: 1,
+      visibleWhen: (s) => s.single.A === "1",
+    },
+    {
+      key: "C",
+      kind: "single",
+      title: "Notifications",
+      explanation: "on?",
+      evidence: [],
+      options: [
+        { label: "Enabled", value: "1" },
+        { label: "Disabled", value: "0" },
+      ],
+      defaultIndex: 0,
+    },
+  ];
+
+  test("confirming the gate ON shows the dependent step next", () => {
+    let s = initWizard(COND);
+
+    expect(s.stepIndex).toBe(0); // A is visible from the start
+    // cursor already on "Enabled" (index 0) → confirm keeps A="1".
+    s = reduceWizard(s, "confirm", COND);
+    expect(s.stepIndex).toBe(1); // B is shown because A === "1"
+  });
+
+  test("confirming the gate OFF skips the dependent step", () => {
+    let s = initWizard(COND);
+
+    s = reduceWizard(s, "down", COND); // move cursor to "Disabled"
+    s = reduceWizard(s, "confirm", COND); // A = "0"
+    expect(s.single.A).toBe("0");
+    expect(s.stepIndex).toBe(2); // jumped over B straight to C
+  });
+
+  test("going back from C skips the hidden dependent step", () => {
+    let s = initWizard(COND);
+
+    s = reduceWizard(s, "down", COND);
+    s = reduceWizard(s, "confirm", COND); // A="0", now on C (index 2)
+    expect(s.stepIndex).toBe(2);
+    s = reduceWizard(s, "back", COND); // back must skip hidden B → A
+    expect(s.stepIndex).toBe(0);
+  });
+
+  test("the review overview omits a hidden step", () => {
+    let s = initWizard(COND);
+
+    s = reduceWizard(s, "down", COND);
+    s = reduceWizard(s, "confirm", COND); // A="0" → B hidden
+    s = reduceWizard(s, "confirm", COND); // confirm C → overview
+    const frame = renderFrame(s, COND, false);
+
+    expect(frame).toContain("Enable cache");
+    expect(frame).toContain("Notifications");
+    expect(frame).not.toContain("Cache provider"); // hidden B absent from review
+  });
+
+  test('"Step X of N" reflects the visible count, not the raw index', () => {
+    let s = initWizard(COND);
+
+    s = reduceWizard(s, "down", COND);
+    s = reduceWizard(s, "confirm", COND); // A="0" → only A and C are visible
+    // Now on C: it is the 2nd (and last) visible step of 2.
+    expect(renderFrame(s, COND, false)).toContain("Step 2 of 2");
+  });
+
+  test('"Step X of N" counts a default-ON gate\'s dependent before it is confirmed', () => {
+    // A defaults to "Enabled" (index 0 = "1"), so B is visible on the default path.
+    // On step A (unanswered yet), the total must already be 3 — not 2 that jumps to 3.
+    const s = initWizard(COND);
+
+    expect(s.stepIndex).toBe(0);
+    expect(renderFrame(s, COND, false)).toContain("Step 1 of 3");
+  });
+
+  test("review:false applies immediately when every remaining step is hidden", () => {
+    const steps: IWizardStep[] = [
+      {
+        key: "a",
+        kind: "single",
+        title: "A",
+        explanation: "",
+        evidence: [],
+        options: [{ label: "x", value: "x" }],
+        defaultIndex: 0,
+      },
+      {
+        key: "b",
+        kind: "single",
+        title: "B",
+        explanation: "",
+        evidence: [],
+        options: [{ label: "y", value: "y" }],
+        defaultIndex: 0,
+        visibleWhen: () => false, // never shown
+      },
+    ];
+    let s = initWizard(steps); // on A (index 0)
+
+    expect(s.stepIndex).toBe(0);
+    // Confirming A with review off: the only remaining step (B) is hidden, so the
+    // wizard applies immediately instead of stopping on a hidden step.
+    s = reduceWizard(s, "confirm", steps, { review: false });
+    expect(s.status).toBe("apply");
+  });
+
+  test("overview back cancels when every step is hidden (no dead-end)", () => {
+    const allHidden: IWizardStep[] = [
+      {
+        key: "x",
+        kind: "single",
+        title: "X",
+        explanation: "",
+        evidence: [],
+        options: [{ label: "a", value: "a" }],
+        defaultIndex: 0,
+        visibleWhen: () => false,
+      },
+    ];
+    let s = initWizard(allHidden);
+
+    expect(s.stepIndex).toBe(allHidden.length); // straight to the overview
+    s = reduceWizard(s, "back", allHidden);
+    expect(s.status).toBe("cancel");
+  });
+
+  test("review ON: a step whose gate is on still shows the dependent in the overview", () => {
+    let s = initWizard(COND);
+
+    s = reduceWizard(s, "confirm", COND); // A="1" → B visible, now on B
+    s = reduceWizard(s, "confirm", COND); // confirm B (valkey default)
+    s = reduceWizard(s, "confirm", COND); // confirm C → overview
+    const frame = renderFrame(s, COND, false);
+
+    expect(frame).toContain("Cache provider");
+    expect(frame).toContain("valkey"); // its chosen value appears in the review
+  });
+
+  test("initWizard lands on the first VISIBLE step when step 0 is initially hidden", () => {
+    const steps: IWizardStep[] = [
+      {
+        key: "hidden",
+        kind: "single",
+        title: "Never shown",
+        explanation: "",
+        evidence: [],
+        options: [{ label: "x", value: "x" }],
+        defaultIndex: 0,
+        visibleWhen: () => false,
+      },
+      {
+        key: "shown",
+        kind: "single",
+        title: "First visible",
+        explanation: "",
+        evidence: [],
+        options: [{ label: "y", value: "y" }],
+        defaultIndex: 0,
+      },
+    ];
+    const s = initWizard(steps);
+
+    expect(s.stepIndex).toBe(1);
+  });
+
+  test("answering a dependent then flipping the gate off re-hides it (review omits it; engine keeps the raw value for the projection layer to drop)", () => {
+    let s = initWizard(COND);
+
+    s = reduceWizard(s, "confirm", COND); // A="1" → on B
+    s = reduceWizard(s, "confirm", COND); // B="valkey" (default) → on C
+    s = reduceWizard(s, "back", COND); // back to B (still visible, A="1")
+    expect(s.stepIndex).toBe(1);
+    s = reduceWizard(s, "back", COND); // back to A
+    expect(s.stepIndex).toBe(0);
+    s = reduceWizard(s, "down", COND); // cursor → Disabled
+    s = reduceWizard(s, "confirm", COND); // A="0" → B now hidden, skip to C
+    expect(s.stepIndex).toBe(2);
+    s = reduceWizard(s, "confirm", COND); // confirm C → overview
+
+    const frame = renderFrame(s, COND, false);
+
+    expect(frame).not.toContain("Cache provider"); // hidden B omitted from review
+    // The engine intentionally does NOT clear B's recorded value; dropping the
+    // stale answer is the projection layer's job (scaffold stateToAnswers).
+    expect(s.single.B).toBe("valkey");
+  });
+});


### PR DESCRIPTION
Conditional wizard-step visibility so the scaffold stops asking questions whose answer can't matter (the "mutually exclusive questions" UX complaint — e.g. "which cache provider?" after the cache was disabled).

- `IWizardStep.visibleWhen(state)`: a false predicate SKIPS the step (navigation jumps it both directions, it's omitted from the review, and "Step X of N" uses the visible count with unanswered-defaults overlaid so a default-on gate's dependent counts from the start).
- Manifest `askWhen: "KEY=value"` (toggles record "1"/"0", so `KEY=1`); wired CACHE_PROVIDER→CACHE_ENABLED=1 and AI_PROVIDER→AI_ENABLED=1.
- `stateToAnswers` drops hidden fields (answer-then-hide can't leak a stale value); overview "back" cancels when all steps are hidden.
- Fail-loud parse validation of `askWhen`: exactly KEY=value, references a real field asked earlier, no chains, a single-backed dep (toggle/one-of, not multi/secret/text/STACK), and a possible value. Non-string `askWhen` rejected too.
- Fixed a pre-existing bug the change surfaced: AI_PROVIDER's `requiresSecretsWhen: "AI_ENABLED=true"` never matched the wizard's "1" → switched to the on-agnostic `AII_ENABLED:*` idiom so enabling AI actually requires OPENAI_API_KEY.

Passed the local reviewer panel (4 rounds; it caught real bugs each round). Engine change is backward-compatible (absent predicate = always visible), so the setup/config wizards are unaffected.