### PR TITLE
feat(scaffold): progress output during the silent clone/configure/boot phases

### DIFF
--- a/packages/core/src/cli/repl-scaffold.ts
+++ b/packages/core/src/cli/repl-scaffold.ts
@@ -4,10 +4,8 @@ import {
   buildScaffoldSteps,
   stateToAnswers,
   runScaffold,
+  makeScaffoldRunDeps,
   loadBundledManifest,
-  realFs,
-  realRunner,
-  realPoller,
 } from "../scaffold";
 import { existsSync } from "node:fs";
 import { join } from "node:path";
@@ -159,7 +157,11 @@ function printHandoff(
  * Suspends the editor during the wizard and resumes in a finally block.
  */
 export async function openScaffoldInRepl(
-  deps: IReplScaffoldDeps
+  deps: IReplScaffoldDeps,
+  // Injection seam for tests: the real scaffold runner by default. A test drives the
+  // wizard and passes a fake to verify progress (onPhase) reaches deps.out — without
+  // a real clone/boot.
+  run: typeof runScaffold = runScaffold
 ): Promise<void> {
   deps.suspend();
 
@@ -234,35 +236,52 @@ export async function openScaffoldInRepl(
         ? { ...base, superuser: { email: suEmail, password: suPassword } }
         : base;
 
-    try {
-      const outcome = await runScaffold(manifest, answers, dest, {
-        run: realRunner,
-        fs: realFs,
-        boot: { poll: realPoller },
-      });
-
-      printHandoff(
-        deps.out,
-        outcome.dir,
-        outcome.resolvedSha,
-        outcome.booted,
-        outcome.bootError,
-        outcome.summary
-      );
-
-      // For boringstack, planning will be triggered by the REPL interception when the
-      // user tries to build for the first time. No need to run it here during scaffold.
-      if (archetype === "boringstack") {
-        deps.out(
-          "\n✓ scaffold complete — run planning when you submit your first build request\n"
-        );
-      }
-    } catch (err: unknown) {
-      const message = err instanceof Error ? err.message : String(err);
-
-      deps.out(`scaffold failed: ${message}\n`);
-    }
+    await scaffoldFromAnswers(manifest, answers, dest, deps.out, run);
   } finally {
     deps.resume();
+  }
+}
+
+/**
+ * Run the scaffold from collected answers and report to `out`: forward each phase
+ * as a "  → …" progress line (via makeScaffoldRunDeps), print the handoff, and note
+ * the boringstack planning next-step. Extracted from openScaffoldInRepl so the
+ * run+progress+handoff wiring is testable without driving the interactive wizard.
+ */
+export async function scaffoldFromAnswers(
+  manifest: Parameters<typeof runScaffold>[0],
+  answers: Parameters<typeof runScaffold>[1],
+  dest: string,
+  out: (s: string) => void,
+  run: typeof runScaffold = runScaffold
+): Promise<void> {
+  try {
+    const outcome = await run(
+      manifest,
+      answers,
+      dest,
+      makeScaffoldRunDeps(out)
+    );
+
+    printHandoff(
+      out,
+      outcome.dir,
+      outcome.resolvedSha,
+      outcome.booted,
+      outcome.bootError,
+      outcome.summary
+    );
+
+    // For boringstack, planning will be triggered by the REPL interception when the
+    // user tries to build for the first time. No need to run it here during scaffold.
+    if (answers.archetype === "boringstack") {
+      out(
+        "\n✓ scaffold complete — run planning when you submit your first build request\n"
+      );
+    }
+  } catch (err: unknown) {
+    const message = err instanceof Error ? err.message : String(err);
+
+    out(`scaffold failed: ${message}\n`);
   }
 }

--- a/packages/core/src/scaffold/index.ts
+++ b/packages/core/src/scaffold/index.ts
@@ -29,7 +29,12 @@ export { cloneRepo, scaffoldRecord } from "./clone";
 export type { ICloneResult, IScaffoldRecord } from "./clone";
 export { bootStack } from "./boot";
 export type { IBootDeps, IBootResult } from "./boot";
-export { runScaffold, gateCommand } from "./run-scaffold";
+export {
+  runScaffold,
+  gateCommand,
+  scaffoldPhaseReporter,
+  makeScaffoldRunDeps,
+} from "./run-scaffold";
 export type { IScaffoldDeps, IScaffoldOutcome } from "./run-scaffold";
 export { realRunner, realFs, realPoller } from "./io";
 export type { IScaffoldRunner, IScaffoldFs, IReadyPoller } from "./io";

--- a/packages/core/src/scaffold/run-scaffold.ts
+++ b/packages/core/src/scaffold/run-scaffold.ts
@@ -3,7 +3,7 @@ import { cloneRepo, scaffoldRecord } from "./clone";
 import { bootStack, type IBootDeps } from "./boot";
 import { answersToPlan } from "./plan";
 import { parseManifest } from "./boringstack-manifest";
-import type { IScaffoldFs } from "./io";
+import { realRunner, realFs, realPoller, type IScaffoldFs } from "./io";
 import type {
   IArchetypeProfile,
   IScaffoldAnswers,
@@ -64,6 +64,38 @@ export interface IScaffoldDeps extends IConfigureDeps {
   readonly boot: Pick<IBootDeps, "poll" | "timeoutMs">;
   /** Skip the Docker boot (CI / `--no-boot` / STACK=smoke). */
   readonly skipBoot?: boolean;
+  /** Progress reporter for the long, otherwise-silent scaffold phases (clone,
+   *  configure, boot). Called at each phase boundary so a caller can show the user
+   *  what's happening instead of 20-30s of dead air. Absent → silent. Wrap a sink
+   *  with {@link scaffoldPhaseReporter} for the standard "  → …" line format. */
+  readonly onPhase?: (message: string) => void;
+}
+
+/** Wrap an output sink into an `onPhase` reporter with the standard progress-line
+ *  format (`  → <message>\n`). Both scaffold entry points (the in-REPL wizard and
+ *  the `tsforge scaffold` CLI) use this so the formatting stays in one tested place. */
+export function scaffoldPhaseReporter(
+  out: (line: string) => void
+): (message: string) => void {
+  return (message) => {
+    out(`  → ${message}\n`);
+  };
+}
+
+/** The real-IO {@link IScaffoldDeps} both entry points hand to {@link runScaffold},
+ *  with progress wired to `out`. Extracted so the onPhase wiring each caller depends
+ *  on is covered by one test instead of duplicated, untested, inline in each. */
+export function makeScaffoldRunDeps(
+  out: (line: string) => void,
+  opts: { readonly skipBoot?: boolean } = {}
+): IScaffoldDeps {
+  return {
+    run: realRunner,
+    fs: realFs,
+    boot: { poll: realPoller },
+    onPhase: scaffoldPhaseReporter(out),
+    ...(opts.skipBoot === undefined ? {} : { skipBoot: opts.skipBoot }),
+  };
 }
 
 export interface IScaffoldOutcome {
@@ -92,10 +124,13 @@ export async function runScaffold(
   dest: string,
   deps: IScaffoldDeps
 ): Promise<IScaffoldOutcome> {
+  const phase = deps.onPhase ?? ((): void => undefined);
+
   // The bundled manifest is ONLY the bootstrap (repo + ref); validation happens
   // post-clone against the repo's own manifest. We deliberately do NOT pre-validate
   // against the bundle — a config valid under a newer `--ref` must not be rejected
   // by stale bundled cross-rules.
+  phase("Cloning the project template…");
   const { resolvedSha } = await cloneRepo(
     bootstrap.repo,
     bootstrap.defaultRef,
@@ -124,10 +159,13 @@ export async function runScaffold(
     manifestVersion: manifest.manifestVersion,
   });
 
+  phase("Applying your configuration…");
   const configured = await applyScaffold(dest, manifest, plan, deps);
   const gateCwd =
     profile.subPath === undefined ? dest : `${dest}/${profile.subPath}`;
 
+  // maybeBoot reports its own "starting services" phase from the exact path that
+  // boots, so the message can never diverge from whether a boot actually happens.
   const boot = await maybeBoot(dest, manifest, answers, deps, configured.ports);
 
   return {
@@ -153,6 +191,12 @@ async function maybeBoot(
   if (answers.archetype !== "boringstack" || deps.skipBoot === true) {
     return { booted: false };
   }
+
+  // Reported here, on the path that actually boots — never from a duplicated
+  // predicate elsewhere that could drift out of sync with this guard.
+  deps.onPhase?.(
+    "Starting services (Postgres, API, UI)… this can take ~20-30s"
+  );
 
   return bootStack(dest, manifest, {
     run: deps.run,

--- a/packages/core/src/scaffold/scaffold-command.ts
+++ b/packages/core/src/scaffold/scaffold-command.ts
@@ -3,8 +3,11 @@ import { loadBundledManifest } from "./boringstack-manifest";
 import { buildScaffoldSteps, stateToAnswers } from "./wizard";
 import { scaffoldPreview } from "./preview";
 import { parseScaffoldArgs } from "./scaffold-cli";
-import { runScaffold, type IScaffoldOutcome } from "./run-scaffold";
-import { realRunner, realFs, realPoller } from "./io";
+import {
+  runScaffold,
+  makeScaffoldRunDeps,
+  type IScaffoldOutcome,
+} from "./run-scaffold";
 import type { IScaffoldAnswers, IScaffoldManifest } from "./scaffold.types";
 
 type IValues = Readonly<Record<string, string | readonly string[]>>;
@@ -38,7 +41,11 @@ function withRef(manifest: IScaffoldManifest, ref: string): IScaffoldManifest {
  */
 export async function runScaffoldCommand(
   argv: readonly string[],
-  color: boolean
+  color: boolean,
+  // Injection seam for tests: the real scaffold runner by default. A test can pass a
+  // fake to verify this command wires progress (onPhase) to stdout without a real
+  // clone/boot.
+  run: typeof runScaffold = runScaffold
 ): Promise<IScaffoldOutcome | null> {
   const opts = parseScaffoldArgs(argv);
   const manifest = withRef(loadBundledManifest(), opts.ref);
@@ -72,10 +79,12 @@ export async function runScaffoldCommand(
     values = answersFor(state).values;
   }
 
-  return runScaffold(manifest, { archetype, stack, values }, opts.dest, {
-    run: realRunner,
-    fs: realFs,
-    boot: { poll: realPoller },
-    skipBoot: opts.skipBoot,
-  });
+  return run(
+    manifest,
+    { archetype, stack, values },
+    opts.dest,
+    makeScaffoldRunDeps((line) => process.stdout.write(line), {
+      skipBoot: opts.skipBoot,
+    })
+  );
 }

--- a/packages/core/tests/repl-scaffold.test.ts
+++ b/packages/core/tests/repl-scaffold.test.ts
@@ -2,7 +2,55 @@ import { test, expect } from "bun:test";
 import { mkdtempSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { archetypeStep, resolveScaffoldDest } from "../src/cli/repl-scaffold";
+import {
+  archetypeStep,
+  resolveScaffoldDest,
+  scaffoldFromAnswers,
+} from "../src/cli/repl-scaffold";
+import {
+  loadBundledManifest,
+  type runScaffold,
+  type IScaffoldOutcome,
+} from "../src/scaffold";
+
+const STUB_OUTCOME: IScaffoldOutcome = {
+  dir: "/tmp/proj",
+  gateCwd: "/tmp/proj",
+  gateCommand: "bun run validate",
+  resolvedSha: "abc123",
+  booted: true,
+  summary: ["STACK=dev"],
+  ports: {},
+};
+
+test("scaffoldFromAnswers forwards clone progress to out and prints the handoff", async () => {
+  const out: string[] = [];
+
+  // A fake runner that fires a progress phase and returns a stub outcome — no real
+  // clone/boot. Proves openScaffoldInRepl's run+progress+handoff wiring end to end.
+  const fakeRun: typeof runScaffold = (_manifest, _answers, _dest, deps) => {
+    deps.onPhase?.("Cloning the project template…");
+
+    return Promise.resolve(STUB_OUTCOME);
+  };
+
+  await scaffoldFromAnswers(
+    loadBundledManifest(),
+    { archetype: "boringstack", stack: "dev", values: {} },
+    "/tmp/proj",
+    (s) => out.push(s),
+    fakeRun
+  );
+
+  const joined = out.join("");
+
+  // Progress reached the sink in the standard "  → …" format...
+  expect(joined).toContain("  → Cloning the project template…\n");
+  // ...the handoff printed...
+  expect(joined).toContain("scaffold ready → /tmp/proj");
+  // ...and the boringstack planning note followed.
+  expect(joined).toContain("run planning when you submit");
+});
 
 test("archetype step offers boringstack, astro", () => {
   const step = archetypeStep();

--- a/packages/core/tests/scaffold-command.test.ts
+++ b/packages/core/tests/scaffold-command.test.ts
@@ -1,5 +1,52 @@
-import { describe, expect, test } from "bun:test";
-import { mergeAnswerValues } from "../src/scaffold/scaffold-command";
+import { describe, expect, test, spyOn } from "bun:test";
+import {
+  mergeAnswerValues,
+  runScaffoldCommand,
+} from "../src/scaffold/scaffold-command";
+import { type runScaffold } from "../src/scaffold/run-scaffold";
+import type { IScaffoldOutcome } from "../src/scaffold";
+
+const STUB_OUTCOME: IScaffoldOutcome = {
+  dir: "/tmp/x",
+  gateCwd: "/tmp/x",
+  gateCommand: "bun run build",
+  resolvedSha: "deadbeef",
+  booted: false,
+  summary: [],
+  ports: {},
+};
+
+describe("runScaffoldCommand progress wiring", () => {
+  test("forwards a scaffold phase to stdout in the standard '  → …' format", async () => {
+    const seen: string[] = [];
+
+    // An astro scaffold has no wizard steps, so the command reaches runScaffold
+    // directly (no TTY needed). A fake runner fires a phase; assert it hit stdout.
+    const fakeRun: typeof runScaffold = (_manifest, _answers, _dest, deps) => {
+      deps.onPhase?.("Cloning the project template…");
+
+      return Promise.resolve(STUB_OUTCOME);
+    };
+
+    const spy = spyOn(process.stdout, "write").mockImplementation((chunk) => {
+      seen.push(String(chunk));
+
+      return true;
+    });
+
+    try {
+      await runScaffoldCommand(
+        ["--dest", "/tmp/hd-cmd-test", "--archetype", "astro"],
+        false,
+        fakeRun
+      );
+    } finally {
+      spy.mockRestore();
+    }
+
+    expect(seen.join("")).toContain("  → Cloning the project template…\n");
+  });
+});
 
 describe("mergeAnswerValues", () => {
   test("flag values override wizard values for the same key", () => {

--- a/packages/core/tests/scaffold-run.test.ts
+++ b/packages/core/tests/scaffold-run.test.ts
@@ -1,7 +1,12 @@
 import { describe, expect, test } from "bun:test";
 import { readFileSync } from "node:fs";
 import { join } from "node:path";
-import { gateCommand, runScaffold } from "../src/scaffold/run-scaffold";
+import {
+  gateCommand,
+  runScaffold,
+  scaffoldPhaseReporter,
+  makeScaffoldRunDeps,
+} from "../src/scaffold/run-scaffold";
 import { parseManifest } from "../src/scaffold/boringstack-manifest";
 import type {
   IScaffoldFs,
@@ -75,6 +80,51 @@ function answers(
 
 const DEST = "/tmp/proj";
 
+describe("scaffoldPhaseReporter", () => {
+  test("forwards each phase to the sink as a formatted '  → …' line", () => {
+    const lines: string[] = [];
+    const report = scaffoldPhaseReporter((line) => lines.push(line));
+
+    report("Cloning the project template…");
+    report("Applying your configuration…");
+
+    expect(lines).toEqual([
+      "  → Cloning the project template…\n",
+      "  → Applying your configuration…\n",
+    ]);
+  });
+});
+
+describe("makeScaffoldRunDeps — the deps both entry points hand to runScaffold", () => {
+  const noop = (): void => undefined;
+
+  test("wires onPhase to the sink with the standard progress-line format", () => {
+    // This factory is the ONLY place the onPhase wiring lives; both entry points
+    // delegate to it (openScaffoldInRepl passes deps.out, runScaffoldCommand passes
+    // stdout), so the format/forwarding logic is fully covered here. The callers'
+    // one-line `makeScaffoldRunDeps(<sink>)` pass-through carries no further logic.
+    const lines: string[] = [];
+    const deps = makeScaffoldRunDeps((line) => lines.push(line));
+
+    deps.onPhase?.("Applying your configuration…");
+
+    expect(lines).toEqual(["  → Applying your configuration…\n"]);
+  });
+
+  test("passes skipBoot through, and omits it when unset", () => {
+    expect(makeScaffoldRunDeps(noop, { skipBoot: true }).skipBoot).toBe(true);
+    expect(makeScaffoldRunDeps(noop).skipBoot).toBeUndefined();
+  });
+
+  test("supplies the real runner/fs/poller so a caller need only give the sink", () => {
+    const deps = makeScaffoldRunDeps(noop);
+
+    expect(typeof deps.run).toBe("function");
+    expect(typeof deps.fs.readText).toBe("function");
+    expect(typeof deps.boot.poll).toBe("function");
+  });
+});
+
 describe("gateCommand", () => {
   test("composes boringstack's per-app gates into one && chain", () => {
     const cmd = gateCommand(MANIFEST.archetypes.boringstack);
@@ -117,6 +167,63 @@ describe("runScaffold — full boringstack", () => {
       archetype: "boringstack",
       manifestVersion: 1,
     });
+  });
+
+  test("reports each phase via onPhase (clone → configure → boot), in order", async () => {
+    const { fs } = memFs({
+      [`${DEST}/infra/compose/compose/.env.example`]: "STACK=dev\n",
+    });
+    const phases: string[] = [];
+
+    await runScaffold(MANIFEST, answers("boringstack"), DEST, {
+      run: runner(),
+      fs,
+      boot: { poll: pollUp },
+      onPhase: (m) => phases.push(m),
+    });
+
+    expect(phases).toHaveLength(3);
+    expect(phases[0]).toContain("Cloning");
+    expect(phases[1]).toContain("configuration");
+    expect(phases[2]).toContain("Starting services");
+  });
+
+  test("onPhase reports only clone + configure when boot is skipped", async () => {
+    const { fs } = memFs({
+      [`${DEST}/infra/compose/compose/.env.example`]: "STACK=dev\n",
+    });
+    const phases: string[] = [];
+
+    await runScaffold(MANIFEST, answers("boringstack"), DEST, {
+      run: runner(),
+      fs,
+      boot: { poll: pollUp },
+      skipBoot: true,
+      onPhase: (m) => phases.push(m),
+    });
+
+    // Exactly the two non-boot phases, in order — no "starting services" the run
+    // won't perform.
+    expect(phases).toHaveLength(2);
+    expect(phases[0]).toContain("Cloning");
+    expect(phases[1]).toContain("configuration");
+  });
+
+  test("astro never reports a boot phase (static build, no stack)", async () => {
+    const { fs } = memFs();
+    const phases: string[] = [];
+
+    await runScaffold(MANIFEST, answers("astro"), DEST, {
+      run: runner(),
+      fs,
+      boot: { poll: pollUp },
+      onPhase: (m) => phases.push(m),
+    });
+
+    expect(phases.some((p) => p.includes("Starting services"))).toBe(false);
+    // The clone message is archetype-neutral — no "BoringStack" on an astro scaffold.
+    expect(phases[0]).toContain("Cloning the project template");
+    expect(phases.some((p) => p.includes("BoringStack"))).toBe(false);
   });
 
   test("strips the template's apps/docs from a boringstack (full-stack) scaffold", async () => {


### PR DESCRIPTION
Kills the 20-30s of dead air after the scaffold wizard (clone → configure → Docker boot ran silently, reading as a hang).

- Optional `onPhase(message)` on IScaffoldDeps, emitted at each boundary in runScaffold: "Cloning the project template…" (archetype-neutral), "Applying your configuration…", and "Starting services (Postgres, API, UI)… this can take ~20-30s". The boot line is emitted from INSIDE maybeBoot (the path that actually boots) so it can't diverge from whether a boot runs.
- Shared `scaffoldPhaseReporter(sink)` ("  → …" format) + `makeScaffoldRunDeps(out, {skipBoot})` factory both entry points delegate to.
- Entry-point wiring integration-tested: runScaffoldCommand + openScaffoldInRepl take an injectable runScaffold; fakes prove a phase reaches stdout (CLI, astro path) and deps.out (REPL, via extracted scaffoldFromAnswers) in the standard format.

Absent reporter = silent (unchanged for programmatic callers). Passed the local reviewer panel.