### PR TITLE
fix(gate): collapse ESLint parserOptions.project parse cascade to one broken-file signal

### DIFF
--- a/packages/core/src/loop/boringstack/extract-failures.ts
+++ b/packages/core/src/loop/boringstack/extract-failures.ts
@@ -14,6 +14,15 @@ const ESLINT_JSON_END = "::tsforge-eslint-json-end::";
 // (`apps/api`, `apps/ui`, `.`) never contain a colon, so this matches every real marker.
 const ESLINT_JSON_OPEN = /::tsforge-eslint-json ([^\s:]+)::/gu;
 
+// One fixed, file-less signature for a WHOLE type-aware ESLint program-build failure.
+// When one file has a real syntax error, ESLint emits a `parserOptions.project` parse
+// error on EVERY .tsx file; collapsing them to this single signature keeps the error
+// COUNT at one-broken-program instead of N phantom regressions. signatureToError maps
+// it (file-less, like openapi-unreachable) to the actionable "find + rewrite the one
+// broken file" guidance. Bare token (not a `failure:…:file:…` shape) so it is never
+// mis-classified as an out-of-scope/locked-file error and stays model-visible.
+export const ESLINT_PROGRAM_UNPARSABLE = "eslint-program-unparsable";
+
 /** A CLOSED eslint-JSON block, located by index (not by a tempered regex). */
 interface IEslintJsonBlock {
   /** Raw text between the opening and closing markers (the JSON payload). */
@@ -577,6 +586,23 @@ function parsedDiagnostic(
   const eslintParseError = /^(\d+):(\d+) error (Parsing error:.*)$/u.exec(line);
 
   if (eslintParseError !== null && state.currentFile !== "") {
+    const detail = eslintParseError[3] ?? line;
+
+    // A `parserOptions.project` / "ESLint was configured to run on …" parse error is
+    // NOT an independent, model-fixable diagnostic: it is the TYPE-AWARE ESLint program
+    // failing to build because ANOTHER file has a real syntax error. One broken file
+    // fans this out across EVERY .tsx file, so a near-green build reads a phantom
+    // 1→38 spike and the oscillation logic thrashes. Collapse the whole cascade to ONE
+    // fixed, file-less signature (the Set dedups identical signatures) — the count then
+    // reflects one broken program, not N regressions. The REAL syntax error (`'}'
+    // expected`, etc.) is a DIFFERENT parse-error line and stays a distinct, located
+    // signature that points the model at the file to rewrite.
+    if (
+      /parserOptions\.project|ESLint was configured to run on/u.test(detail)
+    ) {
+      return { signature: ESLINT_PROGRAM_UNPARSABLE, dedupKey: null };
+    }
+
     const eslintLine = Number(eslintParseError[1] ?? "0");
     const column = Number(eslintParseError[2] ?? "0");
 
@@ -585,7 +611,7 @@ function parsedDiagnostic(
         state.currentFile,
         eslintLine,
         "syntax",
-        eslintParseError[3] ?? line
+        detail
       ),
       dedupKey: eslintKey(state.currentFile, eslintLine, column, "syntax"),
     };

--- a/packages/core/src/loop/boringstack/gate-stages.ts
+++ b/packages/core/src/loop/boringstack/gate-stages.ts
@@ -6,7 +6,7 @@ import type { IProvider } from "../../inference";
 import type { IFeature } from "../greenfield/greenfield.types";
 import type { Exec } from "./exec";
 import { runBoringstackGate } from "./gate";
-import { extractFailures } from "./extract-failures";
+import { extractFailures, ESLINT_PROGRAM_UNPARSABLE } from "./extract-failures";
 import { verifyFeatureReachable } from "./reachability";
 import { judgeFeature } from "../greenfield/judge";
 import { autofixApps, readResourceCode, rescueFileFor } from "./build";
@@ -75,6 +75,25 @@ export function signatureToError(sig: string): IErrorItem {
         `dev.sh up). If the stack IS up, your apps/api changes may have broken the ` +
         `server so it can't boot — check apps/api compiles and starts. Do NOT edit ` +
         `UI code to chase this.`,
+    };
+  }
+
+  if (sig === ESLINT_PROGRAM_UNPARSABLE) {
+    // The whole type-aware ESLint program failed to build — collapsed from a
+    // per-file `parserOptions.project` cascade (see extract-failures). File-less so
+    // it stays a model-visible "own" error, not an out-of-scope one.
+    return {
+      key: sig,
+      rule: "eslint-program-unparsable",
+      phase: 2,
+      message:
+        "The TypeScript-aware lint could not build its program: ONE file has a real " +
+        "syntax/parse error (`Parsing error: … expected`), which makes ESLint report a " +
+        "`parserOptions.project` parse error on EVERY .tsx file. This is ONE broken " +
+        "file, not many separate errors — do NOT chase the per-file parse errors. Find " +
+        "the file with the actual `Parsing error: … expected` and REWRITE IT IN FULL " +
+        "(a surgical patch on an already-broken file usually re-breaks its braces/" +
+        "generics). Once that file parses, the whole cascade clears at once.",
     };
   }
 

--- a/packages/core/tests/boringstack-extract-failures.test.ts
+++ b/packages/core/tests/boringstack-extract-failures.test.ts
@@ -129,6 +129,37 @@ ${cwd}/apps/api/src/api/b/b.ts
     expect(sigs.size).toBe(2);
   });
 
+  test("collapses a parserOptions.project parse-error cascade to ONE signature (one broken file, not N regressions)", () => {
+    // When ONE file has a real syntax error, the type-aware ESLint program fails to
+    // build and reports a `parserOptions.project` parse error on EVERY other .tsx.
+    // Counting each as a distinct error inflates a near-green build 1→N and makes the
+    // oscillation logic thrash. The cascade must collapse to one signature; the REAL
+    // syntax error stays distinct so the model knows which file to rewrite.
+    const cwd = "/tmp/clone";
+    const out = `${cwd}/apps/ui/src/features/ticket/Ticket.mutations.test.tsx
+  12:3  error  Parsing error: '}' expected
+${cwd}/apps/ui/src/features/ticket/Ticket.queries.test.tsx
+  1:1  error  Parsing error: ESLint was configured to run on \`<tsconfigRootDir>/src/features/ticket/Ticket.queries.test.tsx\` using \`parserOptions.project\`: tsconfig.json
+${cwd}/apps/ui/src/features/ticket/Ticket.hooks.ts
+  1:1  error  Parsing error: ESLint was configured to run on \`<tsconfigRootDir>/src/features/ticket/Ticket.hooks.ts\` using \`parserOptions.project\`: tsconfig.json
+${cwd}/apps/ui/src/features/ticket/TicketPage.tsx
+  1:1  error  Parsing error: ESLint was configured to run on \`<tsconfigRootDir>/src/features/ticket/TicketPage.tsx\` using \`parserOptions.project\`: tsconfig.json`;
+    const sigs = extractFailures(out, cwd);
+
+    // The three parserOptions.project cascade errors collapse to ONE token...
+    expect(sigs.has("eslint-program-unparsable")).toBe(true);
+    // ...the real syntax error stays its own located signature...
+    expect(
+      [...sigs].some((s) =>
+        s.startsWith(
+          "failure:apps%2Fui%2Fsrc%2Ffeatures%2Fticket%2FTicket.mutations.test.tsx:12:syntax"
+        )
+      )
+    ).toBe(true);
+    // ...so the count is 2 (broken program + the real break), NOT 4.
+    expect(sigs.size).toBe(2);
+  });
+
   test("two single-line eslint errors in ONE file stay separate (a following error is a boundary, never fused)", () => {
     // The exact hole the conservative join must close: a bare CORE-rule error (no
     // slash in its id) is not "complete" under the terminator check, so it must NOT

--- a/packages/core/tests/boringstack-gate-stages.test.ts
+++ b/packages/core/tests/boringstack-gate-stages.test.ts
@@ -99,6 +99,18 @@ describe("signatureToError", () => {
     expect(err.message).toContain("dev.sh up");
     expect(err.message).toContain("Do NOT edit");
   });
+
+  test("the eslint-program-unparsable signature maps to a file-less rewrite-the-broken-file error", () => {
+    const err = signatureToError("eslint-program-unparsable");
+
+    // File-less (model-visible "own" error), phase 2, and steers toward a FULL
+    // rewrite of the one broken file — not chasing the per-file cascade.
+    expect(err.rule).toBe("eslint-program-unparsable");
+    expect(err.file).toBeUndefined();
+    expect(err.phase).toBe(2);
+    expect(err.message).toContain("ONE broken file");
+    expect(err.message).toContain("REWRITE IT IN FULL");
+  });
 });
 
 describe("reachabilityStage", () => {


### PR DESCRIPTION
## The problem (why near-green builds thrash 200+ turns)

When one file has a real syntax error, the **type-aware ESLint program can't build**, so it emits a `parserOptions.project` parse error on **every** `.tsx` file — one brace typo fans out to 38-42 "errors". `extract-failures` counted each as a distinct signature, so the progress/oscillation logic read a **1 → 38 phantom spike** and fired oscillation steers on a build that really had *one* broken file. The model then kept surgically patching the already-broken file instead of rewriting it.

Observed live and confirmed by harness-diagnose (near-green-oscillation, **4/4 agreement**): a helpdesk build reached near-green (1 error, turns 103-119), a surgical test edit broke a brace (`Parsing error: '}' expected`), the count ballooned to 38 → 42, and it thrashed 60+ turns.

## Fix (no rollback, no edit-restriction)

- **extract-failures:** any `parserOptions.project` / "ESLint was configured to run on …" parse error collapses to **one** fixed, file-less signature (`ESLINT_PROGRAM_UNPARSABLE`), deduped by the Set. The **real** syntax error (`'}' expected`) stays a distinct, located signature pointing at the file to fix. The error *count* now reflects one broken program, not N regressions — so the oscillation logic stops mis-firing.
- **signatureToError:** maps it file-less (model-visible "own" error, like `openapi-unreachable`) to guidance that steers the model to find the one file with the real parse error and **rewrite it in full** (a surgical patch on an already-broken file usually re-breaks its braces/generics).

Tests: a cascade of 3 `parserOptions` errors + 1 real syntax error → **2** signatures (not 4); the token maps to a file-less rewrite-the-broken-file error.