### PR TITLE
fix(loop): stuck steer shows the true all-time low, not the escalation-rebased local best

### DIFF
--- a/packages/core/src/loop/turn.ts
+++ b/packages/core/src/loop/turn.ts
@@ -1444,7 +1444,7 @@ function applyRungLogic(
 }
 
 /** Determine the stall reason from guard states. Returns null if not stalled. */
-function getStuckReason(
+export function getStuckReason(
   persisted: IErrorItem | null,
   wholeSetStuck: boolean,
   noNetProgress: boolean,
@@ -1463,7 +1463,17 @@ function getStuckReason(
   }
 
   if (noNetProgress) {
-    return `no net progress: ${String(gateErrors.length)} error(s) open, none cleared in ${String(progressCap)} cycles (best ${String(state.bestErrorCount)})`;
+    // Show the true ALL-TIME low (plateauBest), not bestErrorCount — the latter is the
+    // fine guard's local watermark that resetConvergenceGuards rebases to the current
+    // count on every steer escalation, so it would tell the model "best 17" after an
+    // escalation even though it once reached 6. The guard logic still uses the local
+    // watermark; only this displayed number is the honest all-time best.
+    const bestEver = Math.min(
+      state.bestErrorCount,
+      state.plateauBest ?? state.bestErrorCount
+    );
+
+    return `no net progress: ${String(gateErrors.length)} error(s) open, none cleared in ${String(progressCap)} cycles (best ever ${String(bestEver)})`;
   }
 
   if (plateaued) {

--- a/packages/core/tests/steer.test.ts
+++ b/packages/core/tests/steer.test.ts
@@ -7,7 +7,9 @@ import {
   STEER_LADDER_MAX,
   type ISteerError,
 } from "../src/loop/feedback/steer";
-import { hasPendingDiagnosis } from "../src/loop/turn";
+import { hasPendingDiagnosis, getStuckReason } from "../src/loop/turn";
+import type { ILoopState } from "../src/loop/turn";
+import type { IErrorItem } from "../src/validate";
 
 const err = (rule: string): ISteerError => ({
   rule,
@@ -231,5 +233,64 @@ describe("R1 two-phase decision logic", () => {
       false
     );
     expect(hasPendingDiagnosis({})).toBe(false);
+  });
+});
+
+describe("getStuckReason best-ever display", () => {
+  function stuckState(overrides: Partial<ILoopState>): ILoopState {
+    return {
+      prevGateErrors: [],
+      gateNoProgress: 0,
+      bestErrorCount: Number.POSITIVE_INFINITY,
+      noNewLow: 0,
+      errorAge: new Map(),
+      lastGateCount: -1,
+      edits: 0,
+      regressions: 0,
+      ttsrInterrupts: 0,
+      steerLevel: 4,
+      ...overrides,
+    };
+  }
+
+  const errors: IErrorItem[] = [
+    { key: "a", message: "a" },
+    { key: "b", message: "b" },
+    { key: "c", message: "c" },
+  ];
+
+  test("no-net-progress cites the ALL-TIME low (plateauBest), not the escalation-rebased local best", () => {
+    // bestErrorCount is rebased to the current count on every steer escalation, so it
+    // can read 17 while the true all-time low was 6. The message must show 6.
+    const state = stuckState({ bestErrorCount: 17, plateauBest: 6 });
+    const reason = getStuckReason(
+      null,
+      false,
+      true,
+      false,
+      3,
+      2,
+      errors,
+      state
+    );
+
+    expect(reason).toContain("best ever 6");
+    expect(reason).not.toContain("17");
+  });
+
+  test("falls back to bestErrorCount when no plateauBest is recorded yet", () => {
+    const state = stuckState({ bestErrorCount: 4 });
+    const reason = getStuckReason(
+      null,
+      false,
+      true,
+      false,
+      3,
+      2,
+      errors,
+      state
+    );
+
+    expect(reason).toContain("best ever 4");
   });
 });


### PR DESCRIPTION
The 'no net progress' steer cited `state.bestErrorCount`, which `resetConvergenceGuards` rebases to the CURRENT count on every steer escalation — so it told the model "best 17" after an escalation even though the build once reached 6 (flagged by harness-diagnose). That under-sells the model's own progress and points it at the wrong target.

Show the true all-time low instead: `min(bestErrorCount, plateauBest)` — `plateauBest` is never rebased on escalation (only on a new all-time low or after an expert fix), so it is the honest "best ever". Only the displayed number changes; the guard logic still uses the local watermark for its fresh-cycles-after-escalation behavior. `getStuckReason` exported + tested.