### PR TITLE
fix(gate): collapse the parserOptions.project cascade in the JSON path too (completes #133)

### DIFF
--- a/packages/core/src/loop/boringstack/extract-failures.ts
+++ b/packages/core/src/loop/boringstack/extract-failures.ts
@@ -204,6 +204,20 @@ function eslintResultSignatures(
       typeof message.message === "string"
         ? message.message.replace(/\s+/gu, " ").trim()
         : "";
+
+    // Same `parserOptions.project` cascade collapse as the stylish path (parsedDiagnostic):
+    // one broken file makes the type-aware program report this parse error on EVERY .tsx.
+    // Collapse the whole fan-out to ONE token so the JSON path can't re-inflate the count
+    // (the gate emits eslint as JSON blocks in production, so this path is the live one).
+    // A real syntax error ('}' expected) does NOT match this and stays a per-file signature.
+    if (
+      rule === "syntax" &&
+      /parserOptions\.project|ESLint was configured to run on/u.test(text)
+    ) {
+      signatures.add(ESLINT_PROGRAM_UNPARSABLE);
+      continue;
+    }
+
     const line = typeof message.line === "number" ? message.line : undefined;
     const column =
       typeof message.column === "number" ? message.column : undefined;

--- a/packages/core/tests/boringstack-extract-failures.test.ts
+++ b/packages/core/tests/boringstack-extract-failures.test.ts
@@ -414,6 +414,33 @@ Move declarations into separate files/modules  module-boundaries/single-semantic
     expect(sigs.size).toBe(2);
   });
 
+  test("collapses a parserOptions.project cascade in the JSON path too (the production path)", () => {
+    // The gate emits eslint as JSON blocks in production, so the cascade must collapse
+    // HERE as well — otherwise the per-file JSON `syntax` signatures re-inflate the count
+    // even though the stylish path collapses. One real syntax error + two cascade errors.
+    const cwd = "/tmp/clone";
+    const base = "apps/ui/src/features/task";
+    const cfg =
+      "ESLint was configured to run on X using parserOptions.project: tsconfig.json";
+    const out = `::tsforge-eslint-json apps/ui::
+[{"filePath":"${cwd}/${base}/Task.mutations.test.tsx","messages":[{"ruleId":null,"severity":2,"message":"Parsing error: '}' expected","line":12,"column":3}]},{"filePath":"${cwd}/${base}/Task.queries.test.tsx","messages":[{"ruleId":null,"severity":2,"message":"Parsing error: ${cfg}","line":1,"column":1}]},{"filePath":"${cwd}/${base}/Task.hooks.ts","messages":[{"ruleId":null,"severity":2,"message":"Parsing error: ${cfg}","line":1,"column":1}]}]
+::tsforge-eslint-json-end::`;
+    const sigs = extractFailures(out, cwd);
+
+    // The two cascade parse errors collapse to ONE token...
+    expect(sigs.has("eslint-program-unparsable")).toBe(true);
+    // ...the real syntax error stays its own located signature...
+    expect(
+      [...sigs].some((s) =>
+        s.startsWith(
+          "failure:apps%2Fui%2Fsrc%2Ffeatures%2Ftask%2FTask.mutations.test.tsx:12:syntax"
+        )
+      )
+    ).toBe(true);
+    // ...so the count is 2, NOT 3.
+    expect(sigs.size).toBe(2);
+  });
+
   test("a JSON message containing `error TS…` is not mis-parsed as a tsc diagnostic", () => {
     const cwd = "/tmp/clone";
     const out = `::tsforge-eslint-json apps/api::


### PR DESCRIPTION
#133 collapsed the parse-error cascade only on the **stylish** eslint path, but the gate emits eslint as `::tsforge-eslint-json` blocks in production — and that path (`eslintResultSignatures`) still minted a per-file `syntax` signature for each file's `parserOptions.project` error. So both the N per-file signatures **and** the 1 collapsed token survived (N+1, not 1) — the collapse was defeated exactly where it runs live. A reviewer on the steer PR caught this.

This applies the same collapse in the JSON path. Test: a JSON block with 2 cascade parse errors + 1 real syntax error → 2 signatures, not 3.

Note (reviewer follow-up): the collapse also matches a *genuine* single "file not in tsconfig" error, losing its file/app (phase always 2). In practice the baseline scaffold is green so the token can't pre-exist and be diffed away; a future refinement could collapse only when ≥2 such errors fan out (a true cascade) and preserve the app for a lone one.