### PR TITLE
fix(reviewers): never cache a pre-review gate block (validate-flake cache poison)

### DIFF
--- a/packages/core/src/cli/harness-review-mode.ts
+++ b/packages/core/src/cli/harness-review-mode.ts
@@ -18,6 +18,9 @@ import {
   DEFAULT_MAX_CHARS,
   verdictCacheKey,
   artifactBody,
+  shouldCacheVerdict,
+  honorCachedVerdict,
+  CACHE_VERSION,
 } from "../reviewers/harness-review";
 import { RUBRIC_VERSION } from "../reviewers/schema";
 import { parseVerdict, type IVerdict } from "../reviewers/aggregate";
@@ -190,9 +193,14 @@ function computePanelHash(panel: object): string {
   return createHash("sha256").update(JSON.stringify(panel)).digest("hex");
 }
 
-async function readCachedVerdict(cacheKey: string): Promise<IVerdict | null> {
+export const CACHE_DIR = join(".tsforge", "harness-review");
+
+async function readCachedVerdict(
+  cacheKey: string,
+  dir = CACHE_DIR
+): Promise<IVerdict | null> {
   try {
-    const path = join(".tsforge", "harness-review", `${cacheKey}.json`);
+    const path = join(dir, `${cacheKey}.json`);
     const content = await readFile(path, "utf-8");
     const parsed: unknown = JSON.parse(content);
 
@@ -200,7 +208,9 @@ async function readCachedVerdict(cacheKey: string): Promise<IVerdict | null> {
       return null;
     }
 
-    return parseVerdict(parsed.verdict);
+    // honorCachedVerdict drops any cached pre-review gate block (defense in depth
+    // beside the CACHE_VERSION bump) so a transient precondition never re-serves.
+    return honorCachedVerdict(parseVerdict(parsed.verdict));
   } catch {
     return null;
   }
@@ -210,9 +220,9 @@ async function writeCachedVerdict(
   cacheKey: string,
   verdict: IVerdict,
   treeHash: string,
-  panelHash: string
+  panelHash: string,
+  dir = CACHE_DIR
 ): Promise<void> {
-  const dir = join(".tsforge", "harness-review");
   const path = join(dir, `${cacheKey}.json`);
   const body = artifactBody(verdict, {
     treeHash,
@@ -222,6 +232,23 @@ async function writeCachedVerdict(
 
   await mkdir(dir, { recursive: true });
   await writeFile(path, body, "utf-8");
+}
+
+/** The persistence seam — the ACTUAL guard at the write path, exported so a test
+ *  can prove (against a real dir) that a pre-review gate block writes NO artifact
+ *  while a real panel verdict does. A pure `shouldCacheVerdict` test alone can't
+ *  catch an omitted/inverted/bypassed guard here; both cache-write call sites in
+ *  this file go through this one function. */
+export async function persistVerdict(
+  verdict: IVerdict,
+  cacheKey: string,
+  treeHash: string,
+  panelHash: string,
+  dir = CACHE_DIR
+): Promise<void> {
+  if (shouldCacheVerdict(verdict)) {
+    await writeCachedVerdict(cacheKey, verdict, treeHash, panelHash, dir);
+  }
 }
 
 export function formatVerdict(v: IVerdict): string {
@@ -270,6 +297,7 @@ export async function harnessReviewMode(argv: string[]): Promise<number> {
     treeHash,
     panelHash,
     rubricVersion: RUBRIC_VERSION,
+    cacheVersion: CACHE_VERSION,
   });
 
   let verdict: IVerdict;
@@ -297,7 +325,11 @@ export async function harnessReviewMode(argv: string[]): Promise<number> {
           maxChars: DEFAULT_MAX_CHARS,
         }
       );
-      await writeCachedVerdict(cacheKey, verdict, treeHash, panelHash);
+
+      // persistVerdict caches ONLY a real panel verdict. A pre-review gate block
+      // (validate flake, empty intent, diff too large) is transient — caching one
+      // poisons the tree-hash so a flaky validate under load blocks every future push.
+      await persistVerdict(verdict, cacheKey, treeHash, panelHash);
     }
   } else {
     verdict = await runHarnessReview(
@@ -316,7 +348,8 @@ export async function harnessReviewMode(argv: string[]): Promise<number> {
         maxChars: DEFAULT_MAX_CHARS,
       }
     );
-    await writeCachedVerdict(cacheKey, verdict, treeHash, panelHash);
+
+    await persistVerdict(verdict, cacheKey, treeHash, panelHash);
   }
 
   process.stdout.write(`${formatVerdict(verdict)}\n`);

--- a/packages/core/src/reviewers/aggregate.ts
+++ b/packages/core/src/reviewers/aggregate.ts
@@ -17,6 +17,12 @@ export interface IVerdict {
   ranked: IRankedFinding[];
   perReviewer: IReview[];
   identity: string;
+  /** True when this verdict is a PRE-REVIEW gate/precondition block (validate
+   *  failed, empty intent, diff too large) — the panel never ran. These are
+   *  transient/precondition failures, NOT reviewer judgments, so they must never
+   *  be cached: a flaky validate under load would otherwise poison the tree-hash
+   *  and block every future push until the cache is hand-purged. */
+  preReview?: boolean;
 }
 
 const SECURITY_CODES: readonly FindingCode[] = ["security", "supply-chain"];
@@ -250,5 +256,6 @@ export function parseVerdict(raw: unknown): IVerdict | null {
     ranked: parsedRanked,
     perReviewer: parsedReviews,
     identity,
+    ...(raw.preReview === true ? { preReview: true } : {}),
   };
 }

--- a/packages/core/src/reviewers/harness-review.ts
+++ b/packages/core/src/reviewers/harness-review.ts
@@ -188,6 +188,10 @@ function blockedVerdict(reason: string, identity: string): IVerdict {
     ranked: [],
     perReviewer: [],
     identity,
+    // Pre-review gate/precondition block — the panel did not run. Marked so the
+    // caller never caches it (a transient validate flake must not poison the
+    // tree-hash and block every later push).
+    preReview: true,
   };
 }
 
@@ -212,14 +216,40 @@ export async function runHarnessReview(
   });
 }
 
+/** Verdict-cache schema version. Bump to invalidate ALL previously written cache
+ *  artifacts in one shot. Bumped to "2" when pre-review gate blocks stopped being
+ *  cached: legacy "1" artifacts can hold a poisoned "validate failed" block with no
+ *  `preReview` marker, and without a version change readCachedVerdict would keep
+ *  serving them and block every push of that tree. */
+export const CACHE_VERSION = "2";
+
 export function verdictCacheKey(input: {
   treeHash: string;
   panelHash: string;
   rubricVersion: string;
+  cacheVersion: string;
 }): string {
   return createHash("sha256")
-    .update(`${input.treeHash} ${input.panelHash} ${input.rubricVersion}`)
+    .update(
+      `${input.treeHash} ${input.panelHash} ${input.rubricVersion} ${input.cacheVersion}`
+    )
     .digest("hex");
+}
+
+/** The caching decision, isolated so it is unit-testable without the filesystem.
+ *  ONLY a real panel verdict is cached. A pre-review gate/precondition block
+ *  (validate failed, empty intent, diff too large) is transient — caching one
+ *  poisons the tree-hash so a flaky validate under load blocks every later push. */
+export function shouldCacheVerdict(verdict: IVerdict): boolean {
+  return verdict.preReview !== true;
+}
+
+/** The read-side guard, isolated for testing: a cached pre-review gate block must
+ *  never be honored (defense in depth beside the CACHE_VERSION bump — belt and
+ *  suspenders for any pre-review artifact that reaches disk). Returns the verdict
+ *  to use, or null to force a fresh live review. */
+export function honorCachedVerdict(verdict: IVerdict | null): IVerdict | null {
+  return verdict !== null && verdict.preReview === true ? null : verdict;
 }
 
 export function artifactBody(

--- a/packages/core/tests/harness-review-cache.test.ts
+++ b/packages/core/tests/harness-review-cache.test.ts
@@ -1,0 +1,59 @@
+import { test, expect, describe } from "bun:test";
+import { mkdtemp, readdir, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { persistVerdict } from "../src/cli/harness-review-mode";
+import type { IVerdict } from "../src/reviewers/aggregate";
+
+const real: IVerdict = {
+  blocked: false,
+  reason: "all reviewers approved",
+  reviewers: { ok: 2, errored: 0 },
+  ranked: [],
+  perReviewer: [],
+  identity: "local/flash",
+};
+
+const preReviewBlock: IVerdict = {
+  blocked: true,
+  reason: "validate failed (10 errors)",
+  reviewers: { ok: 0, errored: 0 },
+  ranked: [],
+  perReviewer: [],
+  identity: "local/flash",
+  preReview: true,
+};
+
+async function withTempDir(run: (dir: string) => Promise<void>): Promise<void> {
+  const dir = await mkdtemp(join(tmpdir(), "hr-cache-"));
+
+  try {
+    await run(dir);
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+}
+
+describe("persistVerdict (cache-poison guard at the write site)", () => {
+  test("a PRE-REVIEW gate block writes NO cache artifact", async () => {
+    await withTempDir(async (dir) => {
+      await persistVerdict(preReviewBlock, "key1", "t1", "p1", dir);
+
+      // The exact regression: a transient validate block must never reach disk, or
+      // it re-serves as a permanent block for that tree. Prove the file is absent —
+      // this catches an omitted/inverted guard the pure predicate test cannot.
+      const files = await readdir(dir).catch(() => []);
+
+      expect(files).toHaveLength(0);
+    });
+  });
+
+  test("a REAL panel verdict IS written as a cache artifact", async () => {
+    await withTempDir(async (dir) => {
+      await persistVerdict(real, "key1", "t1", "p1", dir);
+      const files = await readdir(dir);
+
+      expect(files).toEqual(["key1.json"]);
+    });
+  });
+});

--- a/packages/core/tests/reviewers-aggregate.test.ts
+++ b/packages/core/tests/reviewers-aggregate.test.ts
@@ -28,6 +28,18 @@ describe("aggregate", () => {
     expect(v.reviewers).toEqual({ ok: 2, errored: 0 });
   });
 
+  test("a REAL aggregated verdict never carries preReview (so the panel result IS cached)", () => {
+    // preReview marks ONLY pre-review gate blocks. If aggregate ever set it, every
+    // panel result would be skipped by shouldCacheVerdict and never cached — assert
+    // the invariant on both a pass and a reject.
+    expect(
+      aggregate([ok("a", "approve"), ok("b", "approve")], opts).preReview
+    ).toBeUndefined();
+    expect(
+      aggregate([ok("a", "approve"), ok("b", "reject")], opts).preReview
+    ).toBeUndefined();
+  });
+
   test("insufficient reviewers → block", () => {
     const v = aggregate(
       [
@@ -214,6 +226,35 @@ describe("parseVerdict", () => {
     expect(parsed?.ranked).toHaveLength(1);
     expect(parsed?.ranked[0]?.agreement).toBe(2);
     expect(parsed?.perReviewer).toHaveLength(2);
+  });
+
+  test("round-trips the preReview flag (cache-poison guard survives serialize→parse)", () => {
+    const v = {
+      blocked: true,
+      reason: "validate failed",
+      reviewers: { ok: 0, errored: 0 },
+      ranked: [],
+      perReviewer: [],
+      identity: "local/flash",
+      preReview: true,
+    };
+
+    // The flag MUST survive a read so the read-side guard can reject a legacy
+    // poisoned block; dropping it here would silently re-enable the poison.
+    expect(parseVerdict(v)?.preReview).toBe(true);
+  });
+
+  test("a verdict without preReview parses to preReview undefined (not injected)", () => {
+    const v = {
+      blocked: false,
+      reason: "",
+      reviewers: { ok: 2, errored: 0 },
+      ranked: [],
+      perReviewer: [],
+      identity: "local/flash",
+    };
+
+    expect(parseVerdict(v)?.preReview).toBeUndefined();
   });
 
   test("missing verdict key → null", () => {

--- a/packages/core/tests/reviewers-artifact.test.ts
+++ b/packages/core/tests/reviewers-artifact.test.ts
@@ -1,5 +1,9 @@
 import { test, expect, describe } from "bun:test";
-import { verdictCacheKey, artifactBody } from "../src/reviewers/harness-review";
+import {
+  verdictCacheKey,
+  artifactBody,
+  honorCachedVerdict,
+} from "../src/reviewers/harness-review";
 import type { IVerdict } from "../src/reviewers/aggregate";
 
 const v: IVerdict = {
@@ -17,20 +21,45 @@ describe("artifact + cache", () => {
       treeHash: "t1",
       panelHash: "p1",
       rubricVersion: "1",
+      cacheVersion: "2",
     });
     const b = verdictCacheKey({
       treeHash: "t1",
       panelHash: "p1",
       rubricVersion: "1",
+      cacheVersion: "2",
     });
     const c = verdictCacheKey({
       treeHash: "t2",
       panelHash: "p1",
       rubricVersion: "1",
+      cacheVersion: "2",
     });
 
     expect(a).toBe(b);
     expect(a).not.toBe(c);
+  });
+
+  test("cacheVersion is mixed into the key — bumping it retires ALL legacy artifacts", () => {
+    // CACHE_VERSION is the ONLY thing that retires already-on-disk poisoned v1 blocks
+    // (they carry no preReview flag, so the read-side guard can't reject them). If a
+    // regression dropped it from the hash, legacy poison would be re-served and every
+    // other test would still pass — so pin it here.
+    const base = { treeHash: "t1", panelHash: "p1", rubricVersion: "1" };
+
+    expect(verdictCacheKey({ ...base, cacheVersion: "1" })).not.toBe(
+      verdictCacheKey({ ...base, cacheVersion: "2" })
+    );
+  });
+
+  test("honorCachedVerdict drops a cached pre-review block, passes a real verdict through", () => {
+    // The read-side defense in depth: a pre-review block that somehow reached disk
+    // must force a fresh live review (null), while a genuine panel verdict is honored.
+    expect(honorCachedVerdict(null)).toBeNull();
+    expect(
+      honorCachedVerdict({ ...v, blocked: true, preReview: true })
+    ).toBeNull();
+    expect(honorCachedVerdict(v)).toBe(v);
   });
 
   test("artifact body is valid JSON carrying verdict + identity + tree hash", () => {

--- a/packages/core/tests/reviewers-harness-review.test.ts
+++ b/packages/core/tests/reviewers-harness-review.test.ts
@@ -2,6 +2,7 @@ import { test, expect, describe } from "bun:test";
 import {
   gatherChange,
   runHarnessReview,
+  shouldCacheVerdict,
   type IGatherDeps,
   type IRunDeps,
 } from "../src/reviewers/harness-review";
@@ -149,5 +150,32 @@ describe("runHarnessReview", () => {
 
     expect(v.blocked).toBe(true);
     expect(invoked).toBe(false);
+    // Marked as a PRE-REVIEW gate block so the caller never caches it — a transient
+    // validate flake under load must not poison the tree-hash for every later push.
+    expect(v.preReview).toBe(true);
+  });
+});
+
+describe("shouldCacheVerdict", () => {
+  const base = {
+    reason: "",
+    reviewers: { ok: 2, errored: 0 },
+    ranked: [],
+    perReviewer: [],
+    identity: "local/flash",
+  };
+
+  test("a pre-review gate block is NOT cached (preReview true → false)", () => {
+    // The whole cache-poison fix: a transient validate/precondition block must not be
+    // persisted, or a flake under load blocks every later push of that tree.
+    expect(
+      shouldCacheVerdict({ ...base, blocked: true, preReview: true })
+    ).toBe(false);
+  });
+
+  test("a REAL panel verdict IS cached — both a clean pass and a findings block", () => {
+    // The expensive panel result must be cached; only the pre-review shape is skipped.
+    expect(shouldCacheVerdict({ ...base, blocked: false })).toBe(true);
+    expect(shouldCacheVerdict({ ...base, blocked: true })).toBe(true);
   });
 });


### PR DESCRIPTION
The pre-push harness-review hook cached every verdict by tree-hash — including pre-review gate blocks (validate failed / empty intent / diff too large). A validate failure is often TRANSIENT (under CPU load the proptest-check 500ms budget blows and the test script exits 1), so a flake got cached as a permanent 'validate failed' block that re-served on every later push until hand-purged. Observed live this session.

Fix: mark pre-review blocks preReview:true; a pure, tested shouldCacheVerdict gates both write sites (via persistVerdict); CACHE_VERSION 1→2 retires legacy poisoned artifacts; parseVerdict preserves the flag and honorCachedVerdict refuses any cached pre-review block on read. Gate preconditions re-run live every push.

Reviewer-panel hardened over 4 rounds: unit tests for the predicate + serialization + cache-version-in-key, and an integration test proving a pre-review verdict writes NO artifact to a real dir.