### PR TITLE
fix(greenfield): make the feature judge slice-aware (stop demanding cross-slice links)

### DIFF
--- a/packages/core/src/loop/boringstack/build.ts
+++ b/packages/core/src/loop/boringstack/build.ts
@@ -245,7 +245,7 @@ export function boringstackDeps(opts: {
   return {
     async implement(
       feature: IFeature,
-      _state: IGreenfieldState,
+      state: IGreenfieldState,
       seed?: { triedLevers: EscalationRung[] }
     ): Promise<{ done: boolean; handoff?: IHandoff }> {
       // Pre-step: generate the full vertical slice + sync the STUB schema. The
@@ -263,8 +263,22 @@ export function boringstackDeps(opts: {
       // Inject THIS feature's composed gate (differential command + reachability +
       // judge). Now settleGate runs it every cycle and the shared ladder escalates
       // on lint/judge/reachability failures — the whole point of the unification.
+      // The OTHER features' ids are handed to the judge so it scopes to this
+      // feature's own responsibilities and never rejects it for lacking a link to a
+      // sibling entity a different slice owns (the relational-collision park).
+      const siblingEntities = state.features
+        .filter((f) => f.id !== feature.id)
+        .map((f) => f.id);
+
       host.setGate(
-        composeBoringstackGate({ cwd, exec, evaluator, baseline, feature })
+        composeBoringstackGate({
+          cwd,
+          exec,
+          evaluator,
+          baseline,
+          feature,
+          siblingEntities,
+        })
       );
 
       const slice = sliceFor?.(feature.id);

--- a/packages/core/src/loop/boringstack/gate-stages.ts
+++ b/packages/core/src/loop/boringstack/gate-stages.ts
@@ -219,7 +219,8 @@ export function reachabilityStage(cwd: string, featureId: string): IStage {
 export function judgeStage(
   evaluator: IProvider,
   cwd: string,
-  feature: IFeature
+  feature: IFeature,
+  siblingEntities: readonly string[] = []
 ): IStage {
   return {
     async run(): Promise<IValidateResult> {
@@ -227,6 +228,9 @@ export function judgeStage(
       const verdict = await judgeFeature(evaluator, {
         feature: feature.desc,
         code,
+        // The other slices' entities: the judge must not reject THIS feature for
+        // lacking a cross-slice link a later slice owns (the relational-collision bug).
+        siblingEntities: [...siblingEntities],
       });
 
       if (verdict.ok) {
@@ -264,12 +268,15 @@ export function composeBoringstackGate(opts: {
   evaluator: IProvider;
   baseline: ReadonlySet<string>;
   feature: IFeature;
+  /** The OTHER features/entities in this build, so the judge scopes to this
+   *  feature's own responsibilities and never demands a link to an unbuilt slice. */
+  siblingEntities?: readonly string[];
 }): IGate {
   const { cwd, exec, evaluator, baseline, feature } = opts;
 
   return composeGate([
     differentialStage(boringstackCommandStage(cwd, exec), baseline),
     reachabilityStage(cwd, feature.id),
-    judgeStage(evaluator, cwd, feature),
+    judgeStage(evaluator, cwd, feature, opts.siblingEntities ?? []),
   ]);
 }

--- a/packages/core/src/loop/greenfield/judge.ts
+++ b/packages/core/src/loop/greenfield/judge.ts
@@ -22,6 +22,13 @@ export interface IFeatureJudgeInput {
   feature: string;
   /** The relevant built code. */
   code: string;
+  /** Entities/features that belong to OTHER slices in the same build and are NOT
+   *  this feature's responsibility. Names only. When set, the judge is told not to
+   *  reject THIS feature for lacking associations to a sibling that a later slice
+   *  owns — the bug that parked a live inventory build: the Supplier judge demanded
+   *  a link to Product (a not-yet-built slice), so the model created Product early
+   *  and the Product slice's scaffolder then collided on the duplicate. */
+  siblingEntities?: string[];
 }
 
 /**
@@ -60,17 +67,42 @@ export function parseFeatureVerdict(raw: string): IJudgeOutcome {
   };
 }
 
+/** Build the sibling-scope clause: tells the judge which entities belong to OTHER
+ *  slices so it does not reject THIS feature for lacking a cross-slice association.
+ *  Empty when there are no siblings, so a single-entity build judges exactly as
+ *  before. Pure — unit-testable. */
+export function siblingScopeClause(siblings: readonly string[]): string {
+  const named = siblings.map((s) => s.trim()).filter((s) => s.length > 0);
+
+  if (named.length === 0) {
+    return "";
+  }
+
+  return (
+    `\n\nThis feature is ONE slice of a larger app. These other entities have their ` +
+    `OWN separate slices, built elsewhere: ${named.join(", ")}. Judge THIS feature's ` +
+    `own responsibilities in full — its own fields, validation, endpoints, and UI. But ` +
+    `do NOT reject it for not BUILDING those other entities here: their tables, ` +
+    `resources, CRUD, and pages belong to their slices, and creating them here collides ` +
+    `with the slice that owns them. A relationship BETWEEN entities is owned by exactly ` +
+    `one side (the slice that holds the foreign key); judge it only in that owning slice, ` +
+    `not in the other. If THIS feature's own description requires a field or behavior, ` +
+    `still require it.`
+  );
+}
+
 /** Run the reject-by-default feature judge. */
 export async function judgeFeature(
   provider: IProvider,
   input: IFeatureJudgeInput
 ): Promise<IJudgeOutcome> {
+  const scope = siblingScopeClause(input.siblingEntities ?? []);
   const res = await provider.complete(
     [
       { role: "system", content: SYSTEM },
       {
         role: "user",
-        content: `Feature: ${input.feature}\n\nCode:\n${input.code}`,
+        content: `Feature: ${input.feature}${scope}\n\nCode:\n${input.code}`,
       },
     ],
     { temperature: 0 }

--- a/packages/core/tests/boringstack-build.test.ts
+++ b/packages/core/tests/boringstack-build.test.ts
@@ -14,6 +14,7 @@ import {
   LOCALE_GLOB,
 } from "../src/loop/boringstack/build";
 import type { IProvider } from "../src/inference";
+import type { IGate } from "../src/gate/gate-runner";
 import { writePlan } from "../src/loop/planning/plan-store";
 import type { IProductPlan } from "../src/loop/planning/plan-types";
 
@@ -115,6 +116,95 @@ describe("boringstackDeps.implement", () => {
     expect(host.gates.length).toBe(1);
     expect(host.sent.length).toBe(1);
     expect(host.sent[0]).toContain("Invoice");
+  });
+
+  test("hands the OTHER features to the judge as siblings, derived from state", async () => {
+    // Guards the state→gate wiring itself: the judge must receive the sibling ids that
+    // come from state.features (minus the current one). A judgeStage-only test can't
+    // catch this closure omitting siblings, including the current feature, or reading
+    // the wrong state. Run the injected gate so the real judge prompt is observed.
+    const base = createHost();
+    let gate: IGate | undefined;
+    const host = {
+      ...base,
+      setGate: (g: IGate) => {
+        gate = g;
+      },
+    };
+    const seen: string[] = [];
+    const evaluator: IProvider = {
+      complete: async (messages) => {
+        for (const m of messages) {
+          if (m.role === "user") {
+            seen.push(m.content);
+          }
+        }
+
+        return { content: '{"pass":true,"notes":"ok"}', toolCalls: [] };
+      },
+    };
+    const st = {
+      goal: "g",
+      features: [feature("Supplier"), feature("Product")],
+    };
+
+    const deps = boringstackDeps({
+      host,
+      cwd: "/repo",
+      exec: createExec(0),
+      evaluator,
+      generate: async () => {},
+      generateUi: async () => {},
+    });
+
+    await deps.implement(feature("Supplier"), st);
+    await gate?.run("/repo");
+
+    const prompt = seen.join("\n");
+
+    // The sibling (Product) reaches the judge; the clause is present.
+    expect(prompt).toContain("Product");
+    expect(prompt).toContain("separate slices");
+  });
+
+  test("a single-feature build passes NO sibling clause (current feature is excluded)", async () => {
+    // Proves the current feature is not handed to itself as a sibling: with only
+    // Supplier in state, siblings is empty, so the judge gets the unchanged prompt.
+    const base = createHost();
+    let gate: IGate | undefined;
+    const host = {
+      ...base,
+      setGate: (g: IGate) => {
+        gate = g;
+      },
+    };
+    const seen: string[] = [];
+    const evaluator: IProvider = {
+      complete: async (messages) => {
+        for (const m of messages) {
+          if (m.role === "user") {
+            seen.push(m.content);
+          }
+        }
+
+        return { content: '{"pass":true,"notes":"ok"}', toolCalls: [] };
+      },
+    };
+    const st = { goal: "g", features: [feature("Supplier")] };
+
+    const deps = boringstackDeps({
+      host,
+      cwd: "/repo",
+      exec: createExec(0),
+      evaluator,
+      generate: async () => {},
+      generateUi: async () => {},
+    });
+
+    await deps.implement(feature("Supplier"), st);
+    await gate?.run("/repo");
+
+    expect(seen.join("\n")).not.toContain("separate slices");
   });
 
   test("syncs DB after generation but before sending to the model", async () => {

--- a/packages/core/tests/boringstack-gate-stages.test.ts
+++ b/packages/core/tests/boringstack-gate-stages.test.ts
@@ -140,6 +140,29 @@ describe("judgeStage", () => {
     expect(r.errors[0]?.message).toContain("stub only");
   });
 
+  test("threads siblingEntities into the judge prompt (scopes to this feature's own job)", async () => {
+    const seen: string[] = [];
+    const capturing: IProvider = {
+      complete: async (messages) => {
+        for (const m of messages) {
+          if (m.role === "user") {
+            seen.push(m.content);
+          }
+        }
+
+        return { content: '{"pass":true,"notes":"ok"}', toolCalls: [] };
+      },
+    };
+    const stage = judgeStage(capturing, "/tmp/clone", feature, ["product"]);
+
+    await stage.run("/tmp/clone");
+
+    // The other slice's entity reaches the judge, so it won't reject this feature for
+    // lacking a link to a not-yet-built child (the relational-collision park).
+    expect(seen.join("\n")).toContain("product");
+    expect(seen.join("\n")).toContain("separate slices");
+  });
+
   test("judge passes → green", async () => {
     const providerWithPass: IProvider = {
       complete: async () => ({

--- a/packages/core/tests/greenfield-judge.test.ts
+++ b/packages/core/tests/greenfield-judge.test.ts
@@ -1,0 +1,76 @@
+import { test, expect, describe } from "bun:test";
+import { siblingScopeClause, judgeFeature } from "../src/loop/greenfield/judge";
+import type { IProvider, IChatMessage } from "../src/inference";
+
+/** A provider that records the messages it was given, for prompt assertions. */
+function capturingProvider(reply: string): {
+  provider: IProvider;
+  seen: IChatMessage[];
+} {
+  const seen: IChatMessage[] = [];
+
+  return {
+    seen,
+    provider: {
+      async complete(messages) {
+        seen.push(...messages);
+
+        return { content: reply, toolCalls: [] };
+      },
+    },
+  };
+}
+
+describe("siblingScopeClause", () => {
+  test("empty when there are no siblings (single-entity build judges as before)", () => {
+    expect(siblingScopeClause([])).toBe("");
+    expect(siblingScopeClause(["", "  "])).toBe("");
+  });
+
+  test("names the siblings and forbids rejecting for a cross-slice link", () => {
+    const clause = siblingScopeClause(["product", "invoice"]);
+
+    expect(clause).toContain("product, invoice");
+    expect(clause).toContain("separate slices");
+    // Narrow exemption: don't reject for not BUILDING the other entities here…
+    expect(clause).toMatch(/do NOT reject/iu);
+    expect(clause).toContain("not BUILDING");
+    // …and the FK-owner rule (a relationship is judged only in its owning slice).
+    expect(clause).toMatch(/foreign key/u);
+    // …but this feature's OWN requirements still stand (not a blanket pass).
+    expect(clause).toMatch(/still require it|own responsibilities/u);
+  });
+});
+
+describe("judgeFeature sibling scoping", () => {
+  test("injects the sibling clause into the prompt when siblings are given", async () => {
+    const { provider, seen } = capturingProvider('{"pass":true,"notes":"ok"}');
+
+    await judgeFeature(provider, {
+      feature: "A supplier that provides products",
+      code: "export const supplier = {}",
+      siblingEntities: ["product"],
+    });
+
+    const user = seen.find((m) => m.role === "user")?.content ?? "";
+
+    // The judge must be told product belongs to another slice — the exact context
+    // whose absence parked the inventory build (Supplier judged as missing a product link).
+    expect(user).toContain("product");
+    expect(user).toContain("not BUILDING");
+  });
+
+  test("omits the clause entirely with no siblings (unchanged single-entity prompt)", async () => {
+    const { provider, seen } = capturingProvider('{"pass":true,"notes":"ok"}');
+
+    await judgeFeature(provider, {
+      feature: "A standalone note",
+      code: "export const note = {}",
+    });
+
+    const user = seen.find((m) => m.role === "user")?.content ?? "";
+
+    expect(user).not.toContain("separate slices");
+    expect(user).toContain("A standalone note");
+  });
+});


### PR DESCRIPTION
The per-feature LLM judge saw only one feature's description + code, blind to the other slices. On a live inventory build it rejected Supplier for 'no product association' — but Product is a LATER slice that owns the FK. The model then created the product table during the Supplier slice, and the Product slice's scaffolder hard-failed on the duplicate, parking the build (reviewer panel 4/4 agreement on this root cause).

Fix: thread the other features' ids into the judge. `siblingScopeClause` tells it those entities are built in separate slices — judge THIS feature's own responsibilities in full, but do NOT reject it for not BUILDING the other entities here (their tables/CRUD/pages belong to their slices); a relationship is judged only in the slice that owns the FK. Empty for single-entity builds (judges exactly as before). Narrowed from a first version the panel flagged as too broad (a blanket 'ignore all cross-slice links' would let an incomplete app pass).

Scoped to the judge only; the new:resource idempotency backstop is separate. Tests: siblingScopeClause + judgeFeature prompt + judgeStage threading + the state→gate wiring (siblings derived from state, current feature excluded).