### PR TITLE
fix(boringstack): prevent dual-extension .test.ts+.test.tsx twins at create (unwedge builds)

### DIFF
--- a/packages/core/scripts/headless-build.ts
+++ b/packages/core/scripts/headless-build.ts
@@ -14,7 +14,7 @@ import { OpenAICompatibleProvider, PROVIDER_LIMITS } from "../src/inference";
 import { resolveActiveModel, resolveApiKey } from "../src/models-config";
 import { Session, LOOP_LIMITS, type Reporter } from "../src/loop";
 import { runBoringstackBuild } from "../src/loop/boringstack/build";
-import { makeBoringstackEditGuard } from "../src/loop/boringstack/i18n-guard";
+import { makeBoringstackBuildGuard } from "../src/loop/boringstack/dual-extension-guard";
 import type { Exec } from "../src/loop/boringstack/exec";
 import { detectContextWindow } from "../src/cli/model-setup";
 import { renderEvent } from "../src/render";
@@ -251,10 +251,11 @@ async function driveBuild(
     // BoringStack ships a convention library — offer pull_conventions so the model
     // can fetch its how-to patterns on demand (decoupled from any flag).
     pullConventions: true,
-    // BoringStack overlay: veto deletion of a feature translation key the model
-    // authored earlier this build (its lazy "clear the unused-key check" shortcut
-    // that ships a hollow app). Stateful → one instance per build.
-    editGuard: makeBoringstackEditGuard(),
+    // BoringStack overlays (composed, see makeBoringstackBuildGuard): (1) veto
+    // deletion of a feature translation key the model authored earlier this build;
+    // (2) veto creating a same-basename .test.ts + .test.tsx twin that orphans the
+    // .tsx from the TS program and wedges the type-aware lint for the whole app.
+    editGuard: makeBoringstackBuildGuard(dir),
     report,
   });
 

--- a/packages/core/src/loop/boringstack/dual-extension-guard.ts
+++ b/packages/core/src/loop/boringstack/dual-extension-guard.ts
@@ -1,0 +1,89 @@
+import { existsSync } from "node:fs";
+import { join } from "node:path";
+import {
+  composeGuards,
+  type EditGuard,
+  type IEditVeto,
+} from "../tools/tool-context";
+import { makeBoringstackEditGuard } from "./i18n-guard";
+
+/**
+ * BoringStack dual-extension guard: veto CREATING a `<base>.test.tsx` when a
+ * `<base>.test.ts` sibling already exists (or vice versa).
+ *
+ * WHY: a same-basename `.ts` + `.tsx` pair in one directory makes TypeScript keep
+ * the `.ts` and DROP the `.tsx` from its program (same-basename resolution), even
+ * when the tsconfig `include` matches both. The type-aware ESLint program then
+ * cannot place the orphaned `.tsx` and reports
+ * `file was not found in any of the provided project(s)` on it, which fans out
+ * across the WHOLE app. This WEDGED a live build for 190+ turns: the collapse token
+ * mislabeled it a syntax break, the model hunted a non-existent `Parsing error`,
+ * and `delete_file` is denied on the build path, so it could never clear the twin.
+ *
+ * PREVENTION over cleanup: an autofix that DELETES the orphan is unsafe — vitest
+ * runs `*.test.tsx` by GLOB (not by TS-project membership), so the `.tsx` may hold
+ * REAL executing tests; deleting it would silently drop coverage (a false green).
+ * Blocking the duplicate at creation loses nothing: the model keeps its tests in the
+ * one existing file. The create-guard reverts the just-written file on veto, so the
+ * twin never lands.
+ */
+
+/** The would-be same-basename twin of a TEST file across the `.ts`/`.tsx` extension,
+ *  or null when `file` is not a test file. `X.test.tsx` → `X.test.ts`, and vice
+ *  versa. Pure — unit-testable. */
+export function twinTestPath(file: string): string | null {
+  if (file.endsWith(".test.tsx")) {
+    return file.slice(0, -1); // ".test.tsx" → ".test.ts"
+  }
+
+  if (file.endsWith(".test.ts")) {
+    return `${file}x`; // ".test.ts" → ".test.tsx"
+  }
+
+  return null;
+}
+
+/** Build the dual-extension edit guard for a build rooted at `cwd` (the clone dir).
+ *  Only a fresh CREATE (empty `before`) of a test file whose extension-twin already
+ *  exists on disk is vetoed — an edit to an existing file, or a lone test file, is
+ *  never blocked. */
+export function makeDualExtensionTestGuard(cwd: string): EditGuard {
+  return (file, before): IEditVeto | null => {
+    // Only a creation (empty before) can introduce the SECOND file of the pair; an
+    // edit to an already-present file is left alone.
+    if (before.trim() !== "") {
+      return null;
+    }
+
+    const twin = twinTestPath(file);
+
+    if (twin === null || !existsSync(join(cwd, twin))) {
+      return null;
+    }
+
+    return {
+      reason: "dual-extension-test",
+      message:
+        `create ${file} REJECTED: ${twin} already exists. A same-basename ` +
+        `.test.ts + .test.tsx PAIR breaks the type-aware lint for the WHOLE app — ` +
+        `TypeScript drops the .tsx from its program, and it cannot be auto-cleared ` +
+        `(the build path can't delete files). Add these tests to the EXISTING ` +
+        `${twin} (one test file per basename). If they need JSX, use a DIFFERENT ` +
+        `basename for the render tests — e.g. a \`.render.test.tsx\` alongside ` +
+        `${twin} — so the two files never share a basename. Do NOT recreate ${file}.`,
+    };
+  };
+}
+
+/** The composed edit guard for a boringstack build: BOTH the i18n-deletion guard
+ *  (vetoes gutting a session-authored translation key / leaving invalid-JSON locale)
+ *  AND the dual-extension guard (vetoes a same-basename `.test.ts`+`.test.tsx` twin).
+ *  Extracted from `headless-build.ts` so the composition is behaviorally testable —
+ *  a test asserts the returned guard vetoes an edit that EACH sub-guard catches, so
+ *  dropping either from the composition fails the test. */
+export function makeBoringstackBuildGuard(cwd: string): EditGuard {
+  return composeGuards(
+    makeBoringstackEditGuard(),
+    makeDualExtensionTestGuard(cwd)
+  );
+}

--- a/packages/core/src/loop/tools/tool-context.ts
+++ b/packages/core/src/loop/tools/tool-context.ts
@@ -55,6 +55,24 @@ export function guardVeto(
     : ctx.editGuard(file, before, after);
 }
 
+/** Combine several edit guards into one: run them in order and return the FIRST
+ *  veto (short-circuit), or null if all accept. Lets a stack overlay stack multiple
+ *  independent rules (e.g. boringstack's i18n-deletion guard AND its dual-extension
+ *  guard) into the single `editGuard` slot without either knowing about the other. */
+export function composeGuards(...guards: readonly EditGuard[]): EditGuard {
+  return (file, before, after) => {
+    for (const guard of guards) {
+      const veto = guard(file, before, after);
+
+      if (veto !== null) {
+        return veto;
+      }
+    }
+
+    return null;
+  };
+}
+
 export interface IToolContext {
   cwd: string;
   /** Editable scope — `edit`/`create` outside it are rejected. */

--- a/packages/core/tests/dual-extension-guard.test.ts
+++ b/packages/core/tests/dual-extension-guard.test.ts
@@ -1,0 +1,236 @@
+import { test, expect, describe } from "bun:test";
+import { existsSync } from "node:fs";
+import { mkdtemp, rm, mkdir, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { IProvider } from "../src/inference";
+import { Session } from "../src/loop";
+import {
+  twinTestPath,
+  makeDualExtensionTestGuard,
+  makeBoringstackBuildGuard,
+} from "../src/loop/boringstack/dual-extension-guard";
+import { composeGuards, type EditGuard } from "../src/loop/tools/tool-context";
+
+describe("twinTestPath", () => {
+  test("maps .test.tsx ↔ .test.ts, and returns null for non-test files", () => {
+    expect(twinTestPath("src/x/A.test.tsx")).toBe("src/x/A.test.ts");
+    expect(twinTestPath("src/x/A.test.ts")).toBe("src/x/A.test.tsx");
+    expect(twinTestPath("src/x/A.tsx")).toBeNull(); // component, not a test
+    expect(twinTestPath("src/x/A.ts")).toBeNull();
+    expect(twinTestPath("src/x/A.test.js")).toBeNull();
+  });
+});
+
+describe("makeDualExtensionTestGuard", () => {
+  async function withCwd(
+    run: (cwd: string, guard: EditGuard) => Promise<void>
+  ): Promise<void> {
+    const cwd = await mkdtemp(join(tmpdir(), "dualext-"));
+
+    try {
+      await run(cwd, makeDualExtensionTestGuard(cwd));
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  }
+
+  test("vetoes creating a .test.tsx when the .test.ts twin exists on disk", async () => {
+    await withCwd(async (cwd, guard) => {
+      const dir = join(cwd, "src/features/x");
+
+      await mkdir(dir, { recursive: true });
+      await writeFile(join(dir, "X.mutations.test.ts"), "//ts");
+
+      const veto = guard(
+        "src/features/x/X.mutations.test.tsx",
+        "", // empty before → a create
+        "test content"
+      );
+
+      expect(veto?.reason).toBe("dual-extension-test");
+      expect(veto?.message).toContain("X.mutations.test.ts");
+    });
+  });
+
+  test("vetoes the reverse too — creating a .test.ts when the .test.tsx twin exists", async () => {
+    await withCwd(async (cwd, guard) => {
+      const dir = join(cwd, "src/features/x");
+
+      await mkdir(dir, { recursive: true });
+      await writeFile(join(dir, "X.hooks.test.tsx"), "//tsx");
+
+      const veto = guard("src/features/x/X.hooks.test.ts", "", "content");
+
+      expect(veto?.reason).toBe("dual-extension-test");
+    });
+  });
+
+  test("allows a LONE test create (no twin on disk)", async () => {
+    await withCwd(async (cwd, guard) => {
+      await mkdir(join(cwd, "src/features/x"), { recursive: true });
+
+      expect(guard("src/features/x/X.page.test.tsx", "", "content")).toBeNull();
+    });
+  });
+
+  test("allows an EDIT (non-empty before) even when the twin exists — only creates block", async () => {
+    await withCwd(async (cwd, guard) => {
+      const dir = join(cwd, "src/features/x");
+
+      await mkdir(dir, { recursive: true });
+      await writeFile(join(dir, "X.mutations.test.ts"), "//ts");
+
+      // Editing the .tsx (before is non-empty) is not the create that forms the pair.
+      expect(
+        guard(
+          "src/features/x/X.mutations.test.tsx",
+          "existing content",
+          "new content"
+        )
+      ).toBeNull();
+    });
+  });
+
+  test("ignores non-test files entirely", async () => {
+    await withCwd(async (cwd, guard) => {
+      const dir = join(cwd, "src/features/x");
+
+      await mkdir(dir, { recursive: true });
+      await writeFile(join(dir, "Widget.ts"), "//logic");
+
+      expect(guard("src/features/x/Widget.tsx", "", "component")).toBeNull();
+    });
+  });
+});
+
+describe("composeGuards", () => {
+  const veto: EditGuard = () => ({ reason: "a", message: "blocked by A" });
+  const accept: EditGuard = () => null;
+
+  test("returns the FIRST veto and short-circuits", () => {
+    expect(composeGuards(accept, veto, accept)("f", "", "x")?.reason).toBe("a");
+  });
+
+  test("returns null when every guard accepts", () => {
+    expect(composeGuards(accept, accept)("f", "", "x")).toBeNull();
+  });
+});
+
+/** A provider that emits ONE `create` of the shadowed `.test.tsx`, then reports done. */
+function scriptedCreateProvider(file: string): IProvider {
+  let turn = 0;
+
+  return {
+    async complete() {
+      turn += 1;
+
+      if (turn === 1) {
+        return {
+          content: "",
+          toolCalls: [
+            {
+              id: "1",
+              name: "create",
+              arguments: { file, content: "// duplicate test\n" },
+            },
+          ],
+        };
+      }
+
+      return { content: "done", toolCalls: [] };
+    },
+  };
+}
+
+// The reviewer's concern: the guard must actually reach the CREATE tool path and
+// revert the just-written file — not merely be correct as a pure function. This
+// drives a real Session whose model creates the shadowing `.test.tsx`, and asserts
+// it never lands on disk.
+describe("dual-extension guard through the real create tool", () => {
+  const twin = "apps/ui/src/features/x/X.mutations.test.ts";
+  const shadow = "apps/ui/src/features/x/X.mutations.test.tsx";
+
+  test("a Session wired with the guard reverts the shadowing .test.tsx create", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "tsforge-dualext-"));
+
+    await Bun.write(join(dir, twin), "// existing unit tests\n");
+
+    try {
+      const session = await Session.create({
+        provider: scriptedCreateProvider(shadow),
+        cwd: dir,
+        files: ["**/*"],
+        editGuard: makeDualExtensionTestGuard(dir),
+      });
+
+      await session.send("add a duplicate .tsx test");
+
+      // The guard fired through the real create path and reverted the write.
+      expect(existsSync(join(dir, shadow))).toBe(false);
+      // The pre-existing twin is untouched.
+      expect(existsSync(join(dir, twin))).toBe(true);
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  test("without the guard the same .test.tsx create IS written (guard is the cause)", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "tsforge-dualext-"));
+
+    await Bun.write(join(dir, twin), "// existing unit tests\n");
+
+    try {
+      const session = await Session.create({
+        provider: scriptedCreateProvider(shadow),
+        cwd: dir,
+        files: ["**/*"],
+      });
+
+      await session.send("add a duplicate .tsx test");
+
+      // No guard → the shadow lands (control that isolates the guard's effect).
+      expect(existsSync(join(dir, shadow))).toBe(true);
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+});
+
+// The panel's finding: the COMPOSITION wired into the build (makeBoringstackBuildGuard,
+// used by headless-build.ts) must be tested, so dropping EITHER sub-guard fails a test.
+describe("makeBoringstackBuildGuard (composed build guard)", () => {
+  test("vetoes BOTH a dual-extension .test.tsx twin AND an invalid-JSON locale edit", async () => {
+    const cwd = await mkdtemp(join(tmpdir(), "bs-guard-"));
+
+    try {
+      const feat = join(cwd, "apps/ui/src/features/x");
+
+      await mkdir(feat, { recursive: true });
+      await writeFile(join(feat, "X.mutations.test.ts"), "//ts");
+
+      const guard = makeBoringstackBuildGuard(cwd);
+
+      // (1) dual-extension guard is present: creating the shadowing .test.tsx is vetoed.
+      const dualVeto = guard(
+        "apps/ui/src/features/x/X.mutations.test.tsx",
+        "",
+        "content"
+      );
+
+      expect(dualVeto?.reason).toBe("dual-extension-test");
+
+      // (2) i18n guard is present: an edit that leaves a locale common.json as invalid
+      // JSON is vetoed. (Drop either sub-guard from the composition → one of these fails.)
+      const i18nVeto = guard(
+        "apps/ui/src/lib/i18n/locales/en/common.json",
+        '{"features":{"x":{"title":"X"}}}',
+        "not valid json"
+      );
+
+      expect(i18nVeto?.reason).toBe("i18n-invalid-json");
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+});


### PR DESCRIPTION
The build-wedging 'cascade' (panel diagnose 3/4) is really dual-extension orphan test files: the model creates X.test.ts AND X.test.tsx (same basename); TypeScript drops the .tsx from its program, so the type-aware ESLint program reports 'file was not found in any of the provided project(s)' and fans out across the whole app. The collapse token mislabels it a syntax break; the model hunts a non-existent Parsing error for 70+ turns, finds the orphans — and delete_file is denied on the build path, so it can never clear them. A live build wedged 190+ turns and never reached the judge.

PREVENTION, not deletion (auto-deleting the orphan is unsafe — vitest runs *.test.tsx by glob, so it may hold real tests → false green). A composed edit guard blocks creating the SECOND file of a same-basename .test pair at create time (the create guard reverts the just-written file), so the twin never lands. Guidance points the model to a distinct basename for JSX render tests. Panel-approved. Tests: twinTestPath, both directions, lone/edit/non-test pass-through, the real create-tool round-trip (+ no-guard control), and makeBoringstackBuildGuard proving BOTH sub-guards (i18n + dual-extension) are wired so dropping either fails.