### PR TITLE
feat(loop): callable structured `check` tool (WS-G)

### DIFF
--- a/packages/core/scripts/headless-build.ts
+++ b/packages/core/scripts/headless-build.ts
@@ -251,6 +251,11 @@ async function driveBuild(
     // BoringStack ships a convention library — offer pull_conventions so the model
     // can fetch its how-to patterns on demand (decoupled from any flag).
     pullConventions: true,
+    // WS-G: offer the callable, structured `check` tool. The per-slice gate is
+    // injected via setGate inside runBoringstackBuild, and check runs THAT gate on
+    // demand — so the model sees its whole error set mid-turn (fix all in one pass)
+    // instead of discovering them one-per-turn after it stops.
+    offerCheck: true,
     // BoringStack overlay: veto deletion of a feature translation key the model
     // authored earlier this build (its lazy "clear the unused-key check" shortcut
     // that ships a hollow app). Stateful → one instance per build.

--- a/packages/core/scripts/headless-build.ts
+++ b/packages/core/scripts/headless-build.ts
@@ -12,9 +12,9 @@ import { appendFileSync, existsSync, mkdirSync, realpathSync } from "node:fs";
 import { join } from "node:path";
 import { OpenAICompatibleProvider, PROVIDER_LIMITS } from "../src/inference";
 import { resolveActiveModel, resolveApiKey } from "../src/models-config";
-import { Session, LOOP_LIMITS, type Reporter } from "../src/loop";
+import { LOOP_LIMITS, type Reporter } from "../src/loop";
 import { runBoringstackBuild } from "../src/loop/boringstack/build";
-import { BORINGSTACK_BUILD_SESSION } from "../src/loop/boringstack/build-config";
+import { createBoringstackHostSession } from "../src/loop/boringstack/build-session";
 import { makeBoringstackEditGuard } from "../src/loop/boringstack/i18n-guard";
 import type { Exec } from "../src/loop/boringstack/exec";
 import { detectContextWindow } from "../src/cli/model-setup";
@@ -233,21 +233,17 @@ async function driveBuild(
     await boringstackExec(["bun", "run", "format"], { cwd: join(dir, app) });
   }
 
-  const host = await Session.create({
+  // The SINGLE constructor for the boringstack host session — carries the fixed build
+  // flags (drive-to-green, guidance, pull_conventions, the WS-G `check` tool) and is
+  // unit-tested to advertise `check`, so this wiring can't silently regress. The i18n
+  // editGuard is stateful (one per build) so it's supplied here, not in the flags.
+  const host = await createBoringstackHostSession({
     provider,
     cwd: dir,
-    files: ["**/*"],
     contextWindow,
     maxTurns: LOOP_LIMITS.webMaxTurns,
-    // The BoringStack build's fixed Session flags (drive-to-green, guidance,
-    // pull_conventions, offer the `check` tool) — extracted + unit-tested so a
-    // dropped flag can't silently un-offer a tool. See build-config.ts.
-    ...BORINGSTACK_BUILD_SESSION,
-    // BoringStack overlay: veto deletion of a feature translation key the model
-    // authored earlier this build (its lazy "clear the unused-key check" shortcut
-    // that ships a hollow app). Stateful → one instance per build.
-    editGuard: makeBoringstackEditGuard(),
     report,
+    editGuard: makeBoringstackEditGuard(),
   });
 
   const result = await runBoringstackBuild({

--- a/packages/core/scripts/headless-build.ts
+++ b/packages/core/scripts/headless-build.ts
@@ -14,6 +14,7 @@ import { OpenAICompatibleProvider, PROVIDER_LIMITS } from "../src/inference";
 import { resolveActiveModel, resolveApiKey } from "../src/models-config";
 import { Session, LOOP_LIMITS, type Reporter } from "../src/loop";
 import { runBoringstackBuild } from "../src/loop/boringstack/build";
+import { BORINGSTACK_BUILD_SESSION } from "../src/loop/boringstack/build-config";
 import { makeBoringstackEditGuard } from "../src/loop/boringstack/i18n-guard";
 import type { Exec } from "../src/loop/boringstack/exec";
 import { detectContextWindow } from "../src/cli/model-setup";
@@ -238,24 +239,10 @@ async function driveBuild(
     files: ["**/*"],
     contextWindow,
     maxTurns: LOOP_LIMITS.webMaxTurns,
-    // Autonomous build → the strict expert-TS implement contract is in force from the
-    // first token (not the soft chat prompt), and the per-write eslint moat is wired
-    // from the detected stack so `as`/`!`/`any` surface as the file is written.
-    executionMode: "drive-to-green",
-    guidance:
-      "You are filling in ONE BoringStack resource at a time. The API resource " +
-      "files (schemas/service/types) and its UI feature are already generated and " +
-      "wired; edit ONLY the files named in the task, add real domain fields + logic " +
-      "(never an `as` cast), and write the required test siblings. Everything else " +
-      "is locked.",
-    // BoringStack ships a convention library — offer pull_conventions so the model
-    // can fetch its how-to patterns on demand (decoupled from any flag).
-    pullConventions: true,
-    // WS-G: offer the callable, structured `check` tool. The per-slice gate is
-    // injected via setGate inside runBoringstackBuild, and check runs THAT gate on
-    // demand — so the model sees its whole error set mid-turn (fix all in one pass)
-    // instead of discovering them one-per-turn after it stops.
-    offerCheck: true,
+    // The BoringStack build's fixed Session flags (drive-to-green, guidance,
+    // pull_conventions, offer the `check` tool) — extracted + unit-tested so a
+    // dropped flag can't silently un-offer a tool. See build-config.ts.
+    ...BORINGSTACK_BUILD_SESSION,
     // BoringStack overlay: veto deletion of a feature translation key the model
     // authored earlier this build (its lazy "clear the unused-key check" shortcut
     // that ships a hollow app). Stateful → one instance per build.

--- a/packages/core/src/agent/agent.constants.ts
+++ b/packages/core/src/agent/agent.constants.ts
@@ -33,6 +33,7 @@ export const TOOL_NAME = {
   spawnAgent: "spawn_agent",
   readImage: "read_image",
   generateImage: "generate_image",
+  check: "check",
 } as const;
 
 /** Per-tool capability flags — the single source of truth the plan-mode set and
@@ -91,6 +92,10 @@ export const TOOL_SPECS: Readonly<Record<ToolName, IToolSpec>> = {
   // backend (see toolsFor). Not script-exposable initially (network + I/O heavy).
   [TOOL_NAME.readImage]: { readOnly: true, scriptExposable: false },
   [TOOL_NAME.generateImage]: { readOnly: false, scriptExposable: false },
+  // `check` runs the gate, which applies the workspace's deterministic auto-fixes
+  // (prettier / eslint --fix) — so it can mutate → NOT plan-mode-safe. Not script-
+  // exposable: the gate is heavy and already runs at end-of-turn.
+  [TOOL_NAME.check]: { readOnly: false, scriptExposable: false },
 };
 
 function toolNamesWhere(
@@ -676,6 +681,19 @@ export const GENERATE_IMAGE_TOOL = {
     },
   },
 };
+
+export const CHECK_TOOL = {
+  type: "function",
+  function: {
+    name: TOOL_NAME.check,
+    description:
+      "Run the fast acceptance gate NOW and get back ALL current errors as structured JSON ({file, line, rule, message}). Call it before you stop — see and fix your whole error set in ONE pass instead of discovering errors one at a time on later turns. Takes no arguments. Returns {passed:true} when clean.",
+    parameters: {
+      type: "object",
+      properties: {},
+    },
+  },
+} as const;
 
 /**
  * The model-invoked delegation tool (like Claude Code's Task tool). The

--- a/packages/core/src/agent/agent.constants.ts
+++ b/packages/core/src/agent/agent.constants.ts
@@ -687,7 +687,7 @@ export const CHECK_TOOL = {
   function: {
     name: TOOL_NAME.check,
     description:
-      "Run the fast acceptance gate NOW and get back ALL current errors as structured JSON ({file, line, rule, message}). Call it before you stop — see and fix your whole error set in ONE pass instead of discovering errors one at a time on later turns. Takes no arguments. Returns {passed:true} when clean.",
+      "Run the fast acceptance gate NOW and get back ALL current errors as structured JSON ({file, line, rule, message}). Call it before you stop — see and fix your whole error set in ONE pass instead of discovering errors one at a time on later turns. Takes no arguments. Returns {passed:true} when clean. If the result has an `autoFixed` list, the gate reformatted those files on disk this run — RE-READ them before your next edit (their content and line anchors changed); do NOT redo that formatting by hand.",
     parameters: {
       type: "object",
       properties: {},

--- a/packages/core/src/loop/boringstack/build-config.ts
+++ b/packages/core/src/loop/boringstack/build-config.ts
@@ -1,0 +1,30 @@
+import type { ExecutionMode } from "../prompt";
+
+/**
+ * The BoringStack build's fixed Session flags — spread into `Session.create` by the
+ * headless build driver. Extracted here (domain content belongs in loop/boringstack,
+ * not the script) so the wiring is UNIT-TESTABLE: dropping a flag silently un-offers
+ * a tool, and a Session/advertisement test alone can't catch a headless regression.
+ *
+ * - `executionMode`: the strict expert-TS drive-to-green contract from the first token.
+ * - `guidance`: the per-resource framing (edit only the named files; real domain logic).
+ * - `pullConventions`: offer the convention library the model can fetch on demand.
+ * - `offerCheck`: offer the callable, structured `check` tool (WS-G) — the per-slice
+ *   gate is injected via setGate, and check runs THAT gate mid-turn.
+ */
+export const BORINGSTACK_BUILD_SESSION: {
+  readonly executionMode: ExecutionMode;
+  readonly guidance: string;
+  readonly pullConventions: true;
+  readonly offerCheck: true;
+} = {
+  executionMode: "drive-to-green",
+  guidance:
+    "You are filling in ONE BoringStack resource at a time. The API resource " +
+    "files (schemas/service/types) and its UI feature are already generated and " +
+    "wired; edit ONLY the files named in the task, add real domain fields + logic " +
+    "(never an `as` cast), and write the required test siblings. Everything else " +
+    "is locked.",
+  pullConventions: true,
+  offerCheck: true,
+};

--- a/packages/core/src/loop/boringstack/build-session.ts
+++ b/packages/core/src/loop/boringstack/build-session.ts
@@ -1,0 +1,38 @@
+import type { IProvider } from "../../inference";
+import type { Reporter } from "../loop.types";
+import type { EditGuard } from "../tools";
+import { Session } from "../session";
+import { BORINGSTACK_BUILD_SESSION } from "./build-config";
+
+/** Runtime inputs the caller (the headless driver) supplies; the fixed BoringStack
+ *  build flags come from {@link BORINGSTACK_BUILD_SESSION}. */
+export interface IBoringstackHostDeps {
+  provider: IProvider;
+  cwd: string;
+  contextWindow: number;
+  maxTurns: number;
+  report: Reporter;
+  editGuard: EditGuard;
+}
+
+/**
+ * The SINGLE constructor for the BoringStack build's host Session. The headless
+ * driver calls exactly this — so the fixed build flags (drive-to-green, guidance,
+ * pull_conventions, and the WS-G `check` tool) can't drift or be silently dropped by
+ * a re-inlined `Session.create`, and a test can assert the resulting session actually
+ * advertises `check` (closing the gap a Session-only test or a const-only pin leaves).
+ */
+export function createBoringstackHostSession(
+  deps: IBoringstackHostDeps
+): Promise<Session> {
+  return Session.create({
+    provider: deps.provider,
+    cwd: deps.cwd,
+    files: ["**/*"],
+    contextWindow: deps.contextWindow,
+    maxTurns: deps.maxTurns,
+    ...BORINGSTACK_BUILD_SESSION,
+    editGuard: deps.editGuard,
+    report: deps.report,
+  });
+}

--- a/packages/core/src/loop/boringstack/refine-prompt.ts
+++ b/packages/core/src/loop/boringstack/refine-prompt.ts
@@ -202,14 +202,18 @@ If you need to make a change elsewhere, the build has already locked it. Rebase 
 
 ---
 
-## Do NOT run the gate yourself
-The harness runs the full gate (typecheck, lint, meta-rules, knip, tests) after your
-edits and hands you the exact errors. Do NOT run \`tsc\`, \`eslint\`, \`knip\`,
-\`bun run check\`/\`validate\`/\`typecheck\`, or \`scripts/stack-check.sh\` yourself —
-it wastes turns and tells you nothing the harness won't. Just edit; the gate report
-is your feedback. And NEVER use \`npx\` (or \`npm\`/\`yarn\`) — this stack is bun-only,
-and \`npx tsc\` resolves a WRONG package that prints "This is not the tsc command you
-are looking for". If you ever must run something, use the project's \`bun run <script>\`.
+## Use the \`check\` tool to see ALL your errors before you stop
+Call the \`check\` tool to run the gate (typecheck, lint, meta-rules, knip) NOW and get
+back your WHOLE structured error set (\`{file, line, rule, message}\`) mid-turn. Fix every
+error it lists in ONE pass, then \`check\` again — do NOT fix one, stop, and discover the
+rest next turn. When \`check\` returns \`passed: true\`, you are done.
+
+Do NOT run the gate through the shell — no \`tsc\`, \`eslint\`, \`knip\`,
+\`bun run check\`/\`validate\`/\`typecheck\`, or \`scripts/stack-check.sh\`. The \`check\`
+tool is the ONLY gate you run; the shell versions waste turns and, via \`npx\`, resolve a
+WRONG \`tsc\` that prints "This is not the tsc command you are looking for". NEVER use
+\`npx\`/\`npm\`/\`yarn\` — this stack is bun-only. If you ever must run something else, use
+the project's \`bun run <script>\`.
 
 ---
 

--- a/packages/core/src/loop/boringstack/refine-prompt.ts
+++ b/packages/core/src/loop/boringstack/refine-prompt.ts
@@ -203,8 +203,10 @@ If you need to make a change elsewhere, the build has already locked it. Rebase 
 ---
 
 ## Use the \`check\` tool to see ALL your errors before you stop
-Call the \`check\` tool to run the gate (typecheck, lint, meta-rules, knip) NOW and get
-back your WHOLE structured error set (\`{file, line, rule, message}\`) mid-turn. Fix every
+Call the \`check\` tool to run the gate (typecheck, lint, meta-rules, knip, AND the API +
+UI feature test suites) NOW and get back your WHOLE structured error set
+(\`{file, line, rule, message}\`) mid-turn. A failing test reds the gate just like a type
+error, so your test siblings must actually PASS — not merely exist. Fix every
 error it lists in ONE pass, then \`check\` again — do NOT fix one, stop, and discover the
 rest next turn. When \`check\` returns \`passed: true\`, you are done.
 

--- a/packages/core/src/loop/session.ts
+++ b/packages/core/src/loop/session.ts
@@ -169,9 +169,11 @@ export interface ISessionConfig {
   pullConventions?: boolean;
   /** Offer the callable, structured `check` tool (WS-G) — set by a build BACKEND
    *  whose gate is authoritative (e.g. boringstack, which injects its gate per-slice
-   *  via `setGate`). The tool runs `ctx.gate.runner` on demand and returns the whole
-   *  structured error set MID-TURN, so the model fixes every error in one pass. Left
-   *  off for plain eval/scratch tasks (their acceptance set can be empty ⇒ vacuous). */
+   *  via `setGate`). The tool runs the SAME full evaluation `settleGate` does
+   *  (`runCheckGate` → autofix + gate command + META_RULES combined — NOT the gate
+   *  runner alone) and returns the whole structured error set MID-TURN, so the model
+   *  fixes every error in one pass. Left off for plain eval/scratch tasks (their
+   *  acceptance set can be empty ⇒ vacuous). */
   offerCheck?: boolean;
   /** Composed gate the session's loop checks each cycle. Defaults to a command
    *  gate from `accept`. Use `setGate` to swap it per unit mid-build. */

--- a/packages/core/src/loop/session.ts
+++ b/packages/core/src/loop/session.ts
@@ -166,6 +166,12 @@ export interface ISessionConfig {
    *  a convention library (e.g. boringstack) so the model can fetch its how-to
    *  patterns on demand. Decoupled from any flag: a plain session leaves it off. */
   pullConventions?: boolean;
+  /** Offer the callable, structured `check` tool (WS-G) — set by a build BACKEND
+   *  whose gate is authoritative (e.g. boringstack, which injects its gate per-slice
+   *  via `setGate`). The tool runs `ctx.gate.runner` on demand and returns the whole
+   *  structured error set MID-TURN, so the model fixes every error in one pass. Left
+   *  off for plain eval/scratch tasks (their acceptance set can be empty ⇒ vacuous). */
+  offerCheck?: boolean;
   /** Composed gate the session's loop checks each cycle. Defaults to a command
    *  gate from `accept`. Use `setGate` to swap it per unit mid-build. */
   gate?: IGate;
@@ -688,9 +694,25 @@ export class Session {
     // no tsconfig, and is the plan-mode explorer's main tool besides `read`.
     // Headless/eval sessions keep the measured base set (see
     // lsp-tools-regress-scratch: nav tools hurt from-scratch builds).
-    this.tools = toolsFor(false, {}, cfg.pullConventions === true);
+    // `check` (WS-G): offered only when the build BACKEND opts in (`cfg.offerCheck`).
+    // The boringstack build injects its authoritative gate per-slice via `setGate`
+    // (not at construction), so this is an explicit flag, not `cfg.gate !== undefined`
+    // (which is still undefined here). A plain eval/scratch task leaves it off — its
+    // acceptance set can be empty, so a callable gate would answer vacuously.
+    const offerCheck = cfg.offerCheck === true;
+
+    this.tools = toolsFor(false, {}, cfg.pullConventions === true, offerCheck);
 
     this.ctx = ctx;
+
+    // Wire the `check` tool's runCheck seam to the SAME gate settleGate runs
+    // (`ctx.gate.runner`), read LAZILY so a mid-build `setGate` swap is honored, and
+    // never `validate(accept)` (empty for an injected gate — see the vacuous-recheck
+    // trap). Absent ⇒ the tool isn't offered and reports it isn't available.
+    if (offerCheck) {
+      this.ctx.tool.runCheck = () => this.ctx.gate.runner.run(this.ctx.cwd);
+    }
+
     // create() already resolved the base mode (CLI > config > default) onto ctx.
     this.baseMode = ctx.tool.policyMode ?? "default";
     this.ctx.tool.policyMode = this.planMode ? "plan" : this.baseMode;

--- a/packages/core/src/loop/session.ts
+++ b/packages/core/src/loop/session.ts
@@ -81,6 +81,7 @@ import {
   type ILoopState,
   isPhantomRouteError,
   NO_TOOL_CALL_NUDGE,
+  runCheckGate,
   runToolCalls,
   settleGate,
   toolsFor,
@@ -705,12 +706,14 @@ export class Session {
 
     this.ctx = ctx;
 
-    // Wire the `check` tool's runCheck seam to the SAME gate settleGate runs
-    // (`ctx.gate.runner`), read LAZILY so a mid-build `setGate` swap is honored, and
-    // never `validate(accept)` (empty for an injected gate — see the vacuous-recheck
-    // trap). Absent ⇒ the tool isn't offered and reports it isn't available.
+    // Wire the `check` tool's runCheck seam to `runCheckGate` — the SAME full
+    // evaluation `settleGate` runs (autofix → gate command → META_RULES combined),
+    // so `check` can never report green while the end-of-turn settle is red. Reads
+    // `this.ctx` LAZILY so a mid-build `setGate` swap is honored, and never
+    // `validate(accept)` (empty for an injected gate — the vacuous-recheck trap).
+    // Absent ⇒ the tool isn't offered and reports it isn't available.
     if (offerCheck) {
-      this.ctx.tool.runCheck = () => this.ctx.gate.runner.run(this.ctx.cwd);
+      this.ctx.tool.runCheck = () => runCheckGate(this.ctx);
     }
 
     // create() already resolved the base mode (CLI > config > default) onto ctx.

--- a/packages/core/src/loop/tools/check-tool.ts
+++ b/packages/core/src/loop/tools/check-tool.ts
@@ -1,0 +1,81 @@
+import type { IToolContext } from "./tool-context";
+import type { IErrorItem } from "../../validate/validate.types";
+
+/** Cap the error list so a huge failure set can't blow the turn's context budget. */
+const MAX_ERRORS = 200;
+
+/** One structured error as the model sees it — the actionable fields only. */
+interface ICheckError {
+  file?: string;
+  line?: number;
+  rule?: string;
+  message: string;
+}
+
+function toStruct(e: IErrorItem): ICheckError {
+  return {
+    ...(e.file === undefined ? {} : { file: e.file }),
+    ...(e.line === undefined ? {} : { line: e.line }),
+    ...(e.rule === undefined ? {} : { rule: e.rule }),
+    message: e.message,
+  };
+}
+
+/** Drop duplicate diagnostics by their stable `key` (same file/line/rule), keeping
+ *  first-seen order — repeated `check` calls and dual-format gate output stay clean. */
+function dedupe(errors: readonly IErrorItem[]): IErrorItem[] {
+  const seen = new Set<string>();
+  const out: IErrorItem[] = [];
+
+  for (const e of errors) {
+    if (!seen.has(e.key)) {
+      seen.add(e.key);
+      out.push(e);
+    }
+  }
+
+  return out;
+}
+
+/**
+ * The `check` tool: run the fast acceptance gate NOW and hand the model its whole
+ * STRUCTURED error set (`{file,line,rule,message}`) mid-turn — so it fixes every
+ * error in one pass instead of discovering them one-per-turn (the model's own #1
+ * ask; a primary driver of near-green turn-waste). The gate runner is injected
+ * (`ctx.runCheck`) so the core tool stays stack-agnostic; absent ⇒ it says so
+ * rather than pretending. Returns compact JSON the model can act on directly.
+ */
+export async function doCheck(
+  _args: Record<string, unknown>,
+  ctx: IToolContext
+): Promise<string> {
+  if (ctx.runCheck === undefined) {
+    return (
+      "check is not available in this session (no gate is wired here). Stop " +
+      "calling tools and the gate will run automatically."
+    );
+  }
+
+  ctx.report({
+    kind: "tool",
+    task: ctx.task,
+    message: "check: running the gate",
+  });
+
+  const result = await ctx.runCheck();
+
+  if (result.passed) {
+    return JSON.stringify({ passed: true, errors: [] });
+  }
+
+  const deduped = dedupe(result.errors);
+  const shown = deduped.slice(0, MAX_ERRORS).map(toStruct);
+  const omitted = deduped.length - shown.length;
+
+  return JSON.stringify({
+    passed: false,
+    errorCount: deduped.length,
+    ...(omitted > 0 ? { omitted } : {}),
+    errors: shown,
+  });
+}

--- a/packages/core/src/loop/tools/check-tool.ts
+++ b/packages/core/src/loop/tools/check-tool.ts
@@ -4,9 +4,14 @@ import type { IErrorItem } from "../../validate/validate.types";
 /** Cap the error list so a huge failure set can't blow the turn's context budget. */
 const MAX_ERRORS = 200;
 
-/** Cap raw gate output (surfaced only when the gate failed but parsed NO structured
- *  errors) so an unparsed failure blob can't blow the turn's context budget. */
+/** Raw-output cap when the gate failed but parsed NO structured errors — the output
+ *  IS the only diagnostic, so keep a big tail. */
 const MAX_OUTPUT_CHARS = 4000;
+
+/** Raw-output cap when structured errors ARE present — the errors are the distilled
+ *  signal; a short tail only needs to catch a trailing unparsed crash without
+ *  re-dumping the whole gate log (which extract-failures already condensed). */
+const MAX_OUTPUT_WITH_ERRORS = 600;
 
 /** One structured error as the model sees it — the actionable fields only. */
 interface ICheckError {
@@ -25,23 +30,26 @@ function toStruct(e: IErrorItem): ICheckError {
   };
 }
 
-/** Cap raw gate output to its last {@link MAX_OUTPUT_CHARS} chars — the TAIL, where
- *  a crash's actionable error usually sits — and disclose the cut (`outputTruncated`
- *  + `outputOmittedChars`) so a cut-off log never reads as the whole failure
- *  (no-silent-truncation house rule). Under the cap ⇒ just `{output}`. */
-function capOutput(output: string): {
+/** Cap raw gate output to its last `max` chars — the TAIL, where a crash's actionable
+ *  error usually sits — and disclose the cut (`outputTruncated` + `outputOmittedChars`)
+ *  so a cut-off log never reads as the whole failure (no-silent-truncation house rule).
+ *  Under the cap ⇒ just `{output}`. */
+function capOutput(
+  output: string,
+  max: number
+): {
   output: string;
   outputTruncated?: true;
   outputOmittedChars?: number;
 } {
-  if (output.length <= MAX_OUTPUT_CHARS) {
+  if (output.length <= max) {
     return { output };
   }
 
   return {
-    output: output.slice(output.length - MAX_OUTPUT_CHARS),
+    output: output.slice(output.length - max),
     outputTruncated: true,
-    outputOmittedChars: output.length - MAX_OUTPUT_CHARS,
+    outputOmittedChars: output.length - max,
   };
 }
 
@@ -68,6 +76,12 @@ function dedupe(errors: readonly IErrorItem[]): IErrorItem[] {
  * ask; a primary driver of near-green turn-waste). The gate runner is injected
  * (`ctx.runCheck`) so the core tool stays stack-agnostic; absent ⇒ it says so
  * rather than pretending. Returns compact JSON the model can act on directly.
+ *
+ * ORDERING: check runs the gate's autofix (mutates on-disk source), so its result is
+ * only authoritative if no edit runs concurrently. It relies on `runToolCalls`, which
+ * executes every non-`spawn_agent` tool SEQUENTIALLY as an ordering barrier — an
+ * `edit` and a `check` in one model response never overlap. If that executor ever
+ * parallelizes non-spawn tools, check would need its own serialization.
  */
 export async function doCheck(
   _args: Record<string, unknown>,
@@ -102,13 +116,17 @@ export async function doCheck(
   const shown = deduped.slice(0, MAX_ERRORS).map(toStruct);
   const omitted = deduped.length - shown.length;
 
-  // A gate can fail with NO parseable errors (a command crashed in an unrecognized
-  // format). Empty `errors` would leave the model blind, so surface the raw output
-  // as the only diagnostic it has — keeping the TAIL (a crash's actionable error is
-  // usually last) and DISCLOSING the cut, per the no-silent-truncation house rule.
+  // Surface the raw gate output on EVERY failure — not only when zero errors parsed.
+  // A partial parse (some lint errors PLUS an unrecognized crash line) would otherwise
+  // hide the crash while the response looks complete. Big tail when errors are empty
+  // (output is the ONLY signal); short tail when errors are present (they're the
+  // distilled signal — just catch a trailing crash). Always DISCLOSE any cut.
   const rawOutput =
-    deduped.length === 0 && result.output.trim().length > 0
-      ? capOutput(result.output)
+    result.output.trim().length > 0
+      ? capOutput(
+          result.output,
+          deduped.length === 0 ? MAX_OUTPUT_CHARS : MAX_OUTPUT_WITH_ERRORS
+        )
       : {};
 
   return JSON.stringify({

--- a/packages/core/src/loop/tools/check-tool.ts
+++ b/packages/core/src/loop/tools/check-tool.ts
@@ -25,6 +25,26 @@ function toStruct(e: IErrorItem): ICheckError {
   };
 }
 
+/** Cap raw gate output to its last {@link MAX_OUTPUT_CHARS} chars — the TAIL, where
+ *  a crash's actionable error usually sits — and disclose the cut (`outputTruncated`
+ *  + `outputOmittedChars`) so a cut-off log never reads as the whole failure
+ *  (no-silent-truncation house rule). Under the cap ⇒ just `{output}`. */
+function capOutput(output: string): {
+  output: string;
+  outputTruncated?: true;
+  outputOmittedChars?: number;
+} {
+  if (output.length <= MAX_OUTPUT_CHARS) {
+    return { output };
+  }
+
+  return {
+    output: output.slice(output.length - MAX_OUTPUT_CHARS),
+    outputTruncated: true,
+    outputOmittedChars: output.length - MAX_OUTPUT_CHARS,
+  };
+}
+
 /** Drop duplicate diagnostics by their stable `key` (same file/line/rule), keeping
  *  first-seen order — repeated `check` calls and dual-format gate output stay clean. */
 function dedupe(errors: readonly IErrorItem[]): IErrorItem[] {
@@ -84,10 +104,11 @@ export async function doCheck(
 
   // A gate can fail with NO parseable errors (a command crashed in an unrecognized
   // format). Empty `errors` would leave the model blind, so surface the raw output
-  // (capped) as the only diagnostic it has.
+  // as the only diagnostic it has — keeping the TAIL (a crash's actionable error is
+  // usually last) and DISCLOSING the cut, per the no-silent-truncation house rule.
   const rawOutput =
     deduped.length === 0 && result.output.trim().length > 0
-      ? { output: result.output.slice(0, MAX_OUTPUT_CHARS) }
+      ? capOutput(result.output)
       : {};
 
   return JSON.stringify({

--- a/packages/core/src/loop/tools/check-tool.ts
+++ b/packages/core/src/loop/tools/check-tool.ts
@@ -53,15 +53,20 @@ function capOutput(
   };
 }
 
-/** Drop duplicate diagnostics by their stable `key` (same file/line/rule), keeping
- *  first-seen order — repeated `check` calls and dual-format gate output stay clean. */
+/** Drop only diagnostics identical in EVERY reported field (file, line, rule, message),
+ *  keeping first-seen order — so a dual-format re-emission of the same error is removed,
+ *  but two DISTINCT diagnostics that merely share the coarse `key` (e.g. two meta
+ *  violations of one rule in one file, whose key is only `file:ruleId`) both survive.
+ *  Deduping on `e.key` alone would silently under-report errorCount. */
 function dedupe(errors: readonly IErrorItem[]): IErrorItem[] {
   const seen = new Set<string>();
   const out: IErrorItem[] = [];
 
   for (const e of errors) {
-    if (!seen.has(e.key)) {
-      seen.add(e.key);
+    const identity = JSON.stringify([e.file, e.line, e.rule, e.message]);
+
+    if (!seen.has(identity)) {
+      seen.add(identity);
       out.push(e);
     }
   }

--- a/packages/core/src/loop/tools/check-tool.ts
+++ b/packages/core/src/loop/tools/check-tool.ts
@@ -4,6 +4,10 @@ import type { IErrorItem } from "../../validate/validate.types";
 /** Cap the error list so a huge failure set can't blow the turn's context budget. */
 const MAX_ERRORS = 200;
 
+/** Cap raw gate output (surfaced only when the gate failed but parsed NO structured
+ *  errors) so an unparsed failure blob can't blow the turn's context budget. */
+const MAX_OUTPUT_CHARS = 4000;
+
 /** One structured error as the model sees it — the actionable fields only. */
 interface ICheckError {
   file?: string;
@@ -64,18 +68,34 @@ export async function doCheck(
 
   const result = await ctx.runCheck();
 
+  // Files the gate's autofix reformatted/rewrote this run — the model must re-read
+  // them before editing again (their on-disk content + anchors changed). Surfaced
+  // on BOTH pass and fail, mirroring settleGate's autofix notice.
+  const autoFixed =
+    result.autoFixed.length > 0 ? { autoFixed: result.autoFixed } : {};
+
   if (result.passed) {
-    return JSON.stringify({ passed: true, errors: [] });
+    return JSON.stringify({ passed: true, errors: [], ...autoFixed });
   }
 
   const deduped = dedupe(result.errors);
   const shown = deduped.slice(0, MAX_ERRORS).map(toStruct);
   const omitted = deduped.length - shown.length;
 
+  // A gate can fail with NO parseable errors (a command crashed in an unrecognized
+  // format). Empty `errors` would leave the model blind, so surface the raw output
+  // (capped) as the only diagnostic it has.
+  const rawOutput =
+    deduped.length === 0 && result.output.trim().length > 0
+      ? { output: result.output.slice(0, MAX_OUTPUT_CHARS) }
+      : {};
+
   return JSON.stringify({
     passed: false,
     errorCount: deduped.length,
     ...(omitted > 0 ? { omitted } : {}),
     errors: shown,
+    ...rawOutput,
+    ...autoFixed,
   });
 }

--- a/packages/core/src/loop/tools/execute-tool.ts
+++ b/packages/core/src/loop/tools/execute-tool.ts
@@ -13,6 +13,7 @@ import { doPackageInfo, doPackageDocs } from "./package-info";
 import { doScript } from "./script-tool";
 import { doSpawnAgent } from "./spawn-agent";
 import { doReadImage, doGenerateImage } from "./image-tools";
+import { doCheck } from "./check-tool";
 import { reject, type IToolContext } from "./tool-context";
 import {
   classifyAction,
@@ -58,6 +59,7 @@ const HANDLERS: Record<ToolName, ToolHandler> = {
   [TOOL_NAME.spawnAgent]: doSpawnAgent,
   [TOOL_NAME.readImage]: doReadImage,
   [TOOL_NAME.generateImage]: doGenerateImage,
+  [TOOL_NAME.check]: doCheck,
 };
 
 function isToolName(name: string): name is ToolName {

--- a/packages/core/src/loop/tools/index.ts
+++ b/packages/core/src/loop/tools/index.ts
@@ -4,4 +4,6 @@ export type {
   SpawnAgentFn,
   EditGuard,
   IEditVeto,
+  RunCheck,
+  ICheckOutcome,
 } from "./tool-context";

--- a/packages/core/src/loop/tools/tool-context.ts
+++ b/packages/core/src/loop/tools/tool-context.ts
@@ -4,6 +4,15 @@ import type { Reporter } from "../loop.types";
 import type { SessionSnapshotStore } from "../../files/hashline";
 import type { McpRegistry } from "../../mcp";
 import type { PolicyMode, IPolicyRules } from "../../policy";
+import type { IValidateResult } from "../../validate/validate.types";
+
+/** Run the workspace's fast acceptance gate on demand and return its STRUCTURED
+ *  result (errors as `{file,line,rule,message}`), so the `check` tool can hand the
+ *  model its whole error set MID-TURN instead of only at end-of-turn. A generic
+ *  injected seam (like {@link EditGuard}): the core tool knows nothing about which
+ *  gate runs — a stack overlay (the boringstack build) wires the real runner.
+ *  Absent ⇒ `check` reports it isn't available here. */
+export type RunCheck = () => Promise<IValidateResult>;
 
 /** One model-invoked delegation to a read-only specialist subagent (the
  *  `spawn_agent` tool). Wired by the CLI/session, which owns model resolution,
@@ -109,6 +118,9 @@ export interface IToolContext {
     base64: string;
     mimeType: string;
   }) => void;
+  /** Run the fast acceptance gate on demand for the `check` tool (see {@link RunCheck}).
+   *  Wired by the build overlay; absent ⇒ `check` says it isn't available here. */
+  runCheck?: RunCheck;
 }
 
 /** A required string arg, or "" if missing/wrong-type. */

--- a/packages/core/src/loop/tools/tool-context.ts
+++ b/packages/core/src/loop/tools/tool-context.ts
@@ -6,13 +6,22 @@ import type { McpRegistry } from "../../mcp";
 import type { PolicyMode, IPolicyRules } from "../../policy";
 import type { IValidateResult } from "../../validate/validate.types";
 
+/** What one on-demand gate run produced for the `check` tool: the standard
+ *  validate result PLUS the files the gate's autofix reformatted/rewrote on disk
+ *  this run. The model MUST re-read those before its next edit — their on-disk
+ *  content (and hashline anchors) changed underneath it, exactly as `settleGate`
+ *  warns via its autofix notice. */
+export interface ICheckOutcome extends IValidateResult {
+  autoFixed: string[];
+}
+
 /** Run the workspace's fast acceptance gate on demand and return its STRUCTURED
- *  result (errors as `{file,line,rule,message}`), so the `check` tool can hand the
- *  model its whole error set MID-TURN instead of only at end-of-turn. A generic
- *  injected seam (like {@link EditGuard}): the core tool knows nothing about which
- *  gate runs — a stack overlay (the boringstack build) wires the real runner.
- *  Absent ⇒ `check` reports it isn't available here. */
-export type RunCheck = () => Promise<IValidateResult>;
+ *  result (errors as `{file,line,rule,message}` + the autofixed file list), so the
+ *  `check` tool can hand the model its whole error set MID-TURN instead of only at
+ *  end-of-turn. A generic injected seam (like {@link EditGuard}): the core tool
+ *  knows nothing about which gate runs — a stack overlay (the boringstack build)
+ *  wires the real runner. Absent ⇒ `check` reports it isn't available here. */
+export type RunCheck = () => Promise<ICheckOutcome>;
 
 /** One model-invoked delegation to a read-only specialist subagent (the
  *  `spawn_agent` tool). Wired by the CLI/session, which owns model resolution,

--- a/packages/core/src/loop/turn.ts
+++ b/packages/core/src/loop/turn.ts
@@ -8,6 +8,7 @@ import {
   type ErrorParser,
   type ErrorSet,
   type IErrorItem,
+  type IValidateResult,
 } from "../validate";
 import { TOOL_NAME } from "../agent/agent.constants";
 import { isInScope } from "../lib/scope";
@@ -1183,6 +1184,57 @@ function runMetaRulesStep(ctx: ILoopCtx): IMetaRuleViolation[] {
   }
 }
 
+/** The FULL gate evaluation — autofix, then the gate command, then the harness
+ *  meta-rules — combined into ONE pass/fail with the union error set. This is the
+ *  authoritative "is it green?" answer; `settleGate` (the end-of-turn settle) and
+ *  the callable `check` tool (WS-G, mid-turn) BOTH go through here so they can never
+ *  disagree — the model can't see `check` say green while the settle path is red
+ *  (e.g. a `test-sibling-required` meta-error the gate command alone doesn't emit).
+ *  Signal-forwarding and gate streaming come for free via `runGateStep`. */
+export async function evaluateGate(
+  ctx: ILoopCtx,
+  turn: number
+): Promise<{
+  passed: boolean;
+  errors: IErrorItem[];
+  output: string;
+  metaViolations: IMetaRuleViolation[];
+  autoFixed: string[];
+}> {
+  const autoFixed = await autoFixStep(ctx);
+  const gate = await runGateStep(ctx, turn);
+  const metaViolations = runMetaRulesStep(ctx);
+
+  const metaErrors = metaViolations.filter((v) => v.severity === "error");
+  const errors = gate.errors.concat(
+    metaErrors.map((v) => ({
+      key: `${v.file}:${v.ruleId}`,
+      file: v.file,
+      rule: v.ruleId,
+      message: v.message,
+    }))
+  );
+
+  return {
+    // Green only when BOTH the gate command AND the meta-rules are clean.
+    passed: gate.passed && metaErrors.length === 0,
+    errors,
+    output: gate.output,
+    metaViolations,
+    autoFixed,
+  };
+}
+
+/** The callable-gate seam the `check` tool (WS-G) runs: the SAME full evaluation
+ *  `settleGate` uses, projected to the {@link IValidateResult} the tool returns.
+ *  Wired onto the tool context by the build overlay (Session). `turn` is 0 — a
+ *  mid-turn check is not a settle cycle; it only affects a cosmetic progress line. */
+export async function runCheckGate(ctx: ILoopCtx): Promise<IValidateResult> {
+  const { passed, errors, output } = await evaluateGate(ctx, 0);
+
+  return { passed, errors, output };
+}
+
 /** Pure helper: derive the handoff ask string from the final steer message and
  *  persisting error set. Produces a non-empty, informative ask for human/stronger-model
  *  handoff. */
@@ -1913,28 +1965,20 @@ export async function settleGate(
   turn: number
 ): Promise<IRunResult | null> {
   const { task, report } = ctx;
-  const autoFixed = await autoFixStep(ctx);
-  const gate = await runGateStep(ctx, turn);
-  const metaViolations = runMetaRulesStep(ctx);
-
-  const metaErrors = metaViolations.filter((v) => v.severity === "error");
-  const gateErrors = gate.errors.concat(
-    metaErrors.map((v) => ({
-      key: `${v.file}:${v.ruleId}`,
-      file: v.file,
-      rule: v.ruleId,
-      message: v.message,
-    }))
-  );
+  // The FULL evaluation (autofix → gate command → meta-rules), shared verbatim with
+  // the `check` tool via evaluateGate so the two never disagree.
+  const {
+    passed: gatePassed,
+    errors: gateErrors,
+    metaViolations,
+    autoFixed,
+  } = await evaluateGate(ctx, turn);
 
   if (state.lastGateCount >= 0 && gateErrors.length > state.lastGateCount) {
     state.regressions += 1;
   }
 
   state.lastGateCount = gateErrors.length;
-
-  // Determine pass/fail: the gate passes only if BOTH gate command AND meta-rules are clean
-  const gatePassed = gate.passed && metaErrors.length === 0;
 
   // On red, surface the ACTUAL errors (codes + messages) into the event — so the
   // log records WHAT failed at the gate, not just a count (the analysis substrate

--- a/packages/core/src/loop/turn.ts
+++ b/packages/core/src/loop/turn.ts
@@ -8,7 +8,6 @@ import {
   type ErrorParser,
   type ErrorSet,
   type IErrorItem,
-  type IValidateResult,
 } from "../validate";
 import { TOOL_NAME } from "../agent/agent.constants";
 import { isInScope } from "../lib/scope";
@@ -38,7 +37,12 @@ import {
   resolveStuckFile,
   type ExpertAsk,
 } from "./expert-handoff";
-import { executeTool, type SpawnAgentFn, type IToolContext } from "./tools";
+import {
+  executeTool,
+  type SpawnAgentFn,
+  type IToolContext,
+  type ICheckOutcome,
+} from "./tools";
 import {
   astGrepFix,
   dropRedundantAnnotations,
@@ -1226,13 +1230,15 @@ export async function evaluateGate(
 }
 
 /** The callable-gate seam the `check` tool (WS-G) runs: the SAME full evaluation
- *  `settleGate` uses, projected to the {@link IValidateResult} the tool returns.
+ *  `settleGate` uses, projected to the {@link ICheckOutcome} the tool returns —
+ *  including `autoFixed`, so `check` can warn the model that mid-turn autofix
+ *  rewrote files (the desync guard `settleGate` gives via its autofix notice).
  *  Wired onto the tool context by the build overlay (Session). `turn` is 0 — a
  *  mid-turn check is not a settle cycle; it only affects a cosmetic progress line. */
-export async function runCheckGate(ctx: ILoopCtx): Promise<IValidateResult> {
-  const { passed, errors, output } = await evaluateGate(ctx, 0);
+export async function runCheckGate(ctx: ILoopCtx): Promise<ICheckOutcome> {
+  const { passed, errors, output, autoFixed } = await evaluateGate(ctx, 0);
 
-  return { passed, errors, output };
+  return { passed, errors, output, autoFixed };
 }
 
 /** Pure helper: derive the handoff ask string from the final steer message and

--- a/packages/core/src/loop/turn.ts
+++ b/packages/core/src/loop/turn.ts
@@ -1212,7 +1212,11 @@ export async function evaluateGate(
   const metaErrors = metaViolations.filter((v) => v.severity === "error");
   const errors = gate.errors.concat(
     metaErrors.map((v) => ({
-      key: `${v.file}:${v.ruleId}`,
+      // Include the message so two DISTINCT violations of the same rule in one file
+      // (IMetaRuleViolation has no line) get distinct keys — else the `check` tool's
+      // key-dedupe collapses them and under-reports errorCount. Message is stable
+      // per violation, so settleGate's cross-cycle age/fingerprint tracking is safe.
+      key: `${v.file}:${v.ruleId}:${v.message}`,
       file: v.file,
       rule: v.ruleId,
       message: v.message,

--- a/packages/core/src/loop/turn.ts
+++ b/packages/core/src/loop/turn.ts
@@ -60,6 +60,7 @@ import {
   GIT_CONTEXT_TOOL,
   READ_IMAGE_TOOL,
   GENERATE_IMAGE_TOOL,
+  CHECK_TOOL,
 } from "../agent";
 import { TsService } from "../lsp";
 import type { McpRegistry } from "../mcp";
@@ -114,7 +115,8 @@ type AdvertisedTool =
   | typeof SCRIPT_TOOL
   | typeof GIT_CONTEXT_TOOL
   | typeof READ_IMAGE_TOOL
-  | typeof GENERATE_IMAGE_TOOL;
+  | typeof GENERATE_IMAGE_TOOL
+  | typeof CHECK_TOOL;
 
 /** Which extra capability backends are configured this run — decides whether the
  *  image tools are advertised. Resolved once by the driver (run.ts) so
@@ -166,12 +168,19 @@ function imageTools(caps: ICapabilityFlags): AdvertisedTool[] {
 export function toolsFor(
   hasExistingCode: boolean,
   caps: ICapabilityFlags = {},
-  offerConventions = false
+  offerConventions = false,
+  offerCheck = false
 ): AdvertisedTool[] {
   const web = webTools();
   const git = gitTools(hasExistingCode);
   const script = scriptTools();
   const image = imageTools(caps);
+
+  // check — the callable, structured acceptance gate. Offered ONLY when the caller
+  // wires a `runCheck` seam on the tool context (the boringstack build does); a
+  // plain scratch/logic task leaves it off so the base set stays minimal. Same
+  // per-backend opt-in shape as pull_conventions — decoupled from every flag.
+  const check: AdvertisedTool[] = offerCheck ? [CHECK_TOOL] : [];
 
   // pull_conventions — a read-only knowledge tool the model calls to fetch the
   // BoringStack how-to BEFORE writing that kind of code (the PULL complement to the
@@ -189,6 +198,7 @@ export function toolsFor(
       ...BASE_TOOLS,
       ...HASHLINE_TOOLS,
       ...conventions,
+      ...check,
       ...web,
       ...git,
       ...script,
@@ -201,6 +211,7 @@ export function toolsFor(
     ...BASE_TOOLS,
     ...HASHLINE_TOOLS,
     ...conventions,
+    ...check,
     ...LSP_TOOLS,
     ...web,
     ...git,
@@ -263,6 +274,10 @@ export interface ILoopCtxTool {
    *  destructive edit. Threaded into the tool context so `edit`/`edit_lines`
    *  enforce it; declared here so the seam is typed, not accidental. */
   editGuard?: IToolContext["editGuard"];
+  /** Optional callable-gate runner set by a build backend (WS-G): runs the gate on
+   *  demand for the `check` tool. Threaded into the tool context; declared here so
+   *  the seam is typed, not accidental. Absent ⇒ `check` isn't offered. */
+  runCheck?: IToolContext["runCheck"];
 }
 
 /** Gate/VALIDATION options — what `settleGate` and the write-guard consume. */

--- a/packages/core/src/loop/turn.ts
+++ b/packages/core/src/loop/turn.ts
@@ -1212,11 +1212,11 @@ export async function evaluateGate(
   const metaErrors = metaViolations.filter((v) => v.severity === "error");
   const errors = gate.errors.concat(
     metaErrors.map((v) => ({
-      // Include the message so two DISTINCT violations of the same rule in one file
-      // (IMetaRuleViolation has no line) get distinct keys — else the `check` tool's
-      // key-dedupe collapses them and under-reports errorCount. Message is stable
-      // per violation, so settleGate's cross-cycle age/fingerprint tracking is safe.
-      key: `${v.file}:${v.ruleId}:${v.message}`,
+      // Key stays `file:ruleId` — the R3 escalation focus contract (gateFeedback
+      // filters metaViolations by exactly this) depends on it. Distinct-message
+      // collapse is handled by the `check` tool's dedupe (full-identity), NOT by
+      // widening this key, so the ladder's focus matching is untouched.
+      key: `${v.file}:${v.ruleId}`,
       file: v.file,
       rule: v.ruleId,
       message: v.message,

--- a/packages/core/src/policy/classify.ts
+++ b/packages/core/src/policy/classify.ts
@@ -25,6 +25,12 @@ const KIND_BY_TOOL: Readonly<Record<string, ActionKind>> = {
   // `script` runs a program that can call other tools — classify as shell so the
   // policy treats it like `run` (its stub calls are each re-classified on dispatch).
   [TOOL_NAME.script]: "shell",
+  // `check` (WS-G) runs the acceptance gate on demand (bun/eslint/tsc + meta-rules)
+  // — command execution with side effects, exactly like `run`/`script`, so it's
+  // `shell`: allowed in the build's default mode, and plan mode still blocks it via
+  // executeTool's non-read-only hard guard. WITHOUT this it classifies `unknown` →
+  // deny, and every check call dies before doCheck (the spawn_agent/script regression).
+  [TOOL_NAME.check]: "shell",
   // Delegating to a read-only subagent — its own class so a repo can deny/ask it
   // specifically; the child's tool calls are re-classified as they dispatch.
   [TOOL_NAME.spawnAgent]: "spawn_agent",

--- a/packages/core/tests/boringstack-build-config.test.ts
+++ b/packages/core/tests/boringstack-build-config.test.ts
@@ -7,6 +7,20 @@ import { BORINGSTACK_BUILD_SESSION } from "../src/loop/boringstack/build-config"
 import { createBoringstackHostSession } from "../src/loop/boringstack/build-session";
 import { isRecord } from "../src/lib/guards/guards";
 
+// The headless driver must construct its host session THROUGH the tested constructor,
+// or the whole offerCheck wiring is untested — reverting to an inline Session.create
+// (with or without offerCheck) would leave the behavioral tests below green. This
+// source guard fails on exactly that revert.
+test("headless-build.ts wires its host session via createBoringstackHostSession, not an inline Session.create", async () => {
+  const src = await Bun.file(
+    join(import.meta.dir, "..", "scripts", "headless-build.ts")
+  ).text();
+
+  expect(src).toContain("createBoringstackHostSession({");
+  // A re-inlined host session (the exact regression) would reintroduce Session.create.
+  expect(src).not.toContain("Session.create(");
+});
+
 // createBoringstackHostSession is the SINGLE constructor the headless driver uses, so
 // asserting the session it builds actually advertises `check` closes the real gap:
 // dropping offerCheck from the flags — or bypassing the constructor — regresses here.
@@ -19,7 +33,7 @@ test("the BoringStack build flags keep offerCheck + convention library + drive-t
 
 test("the boringstack host session actually ADVERTISES check to the model", async () => {
   const dir = await mkdtemp(join(tmpdir(), "tsforge-hostcfg-"));
-  const captured = { names: [] as string[] };
+  const captured: { names: string[] } = { names: [] };
 
   const provider: IProvider = {
     async complete(_messages, opts) {

--- a/packages/core/tests/boringstack-build-config.test.ts
+++ b/packages/core/tests/boringstack-build-config.test.ts
@@ -1,0 +1,15 @@
+import { test, expect } from "bun:test";
+import { BORINGSTACK_BUILD_SESSION } from "../src/loop/boringstack/build-config";
+
+// headless-build.ts spreads BORINGSTACK_BUILD_SESSION into Session.create, so these
+// pins are what stops a flag being silently dropped from the production build path —
+// the gap a Session-only advertisement test cannot cover (it bypasses headless-build).
+
+test("the BoringStack build offers the check tool (WS-G) — offerCheck must stay true", () => {
+  expect(BORINGSTACK_BUILD_SESSION.offerCheck).toBe(true);
+});
+
+test("the BoringStack build keeps its convention library + drive-to-green contract", () => {
+  expect(BORINGSTACK_BUILD_SESSION.pullConventions).toBe(true);
+  expect(BORINGSTACK_BUILD_SESSION.executionMode).toBe("drive-to-green");
+});

--- a/packages/core/tests/boringstack-build-config.test.ts
+++ b/packages/core/tests/boringstack-build-config.test.ts
@@ -1,15 +1,58 @@
 import { test, expect } from "bun:test";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { IProvider } from "../src/inference";
 import { BORINGSTACK_BUILD_SESSION } from "../src/loop/boringstack/build-config";
+import { createBoringstackHostSession } from "../src/loop/boringstack/build-session";
+import { isRecord } from "../src/lib/guards/guards";
 
-// headless-build.ts spreads BORINGSTACK_BUILD_SESSION into Session.create, so these
-// pins are what stops a flag being silently dropped from the production build path —
-// the gap a Session-only advertisement test cannot cover (it bypasses headless-build).
+// createBoringstackHostSession is the SINGLE constructor the headless driver uses, so
+// asserting the session it builds actually advertises `check` closes the real gap:
+// dropping offerCheck from the flags — or bypassing the constructor — regresses here.
 
-test("the BoringStack build offers the check tool (WS-G) — offerCheck must stay true", () => {
+test("the BoringStack build flags keep offerCheck + convention library + drive-to-green", () => {
   expect(BORINGSTACK_BUILD_SESSION.offerCheck).toBe(true);
-});
-
-test("the BoringStack build keeps its convention library + drive-to-green contract", () => {
   expect(BORINGSTACK_BUILD_SESSION.pullConventions).toBe(true);
   expect(BORINGSTACK_BUILD_SESSION.executionMode).toBe("drive-to-green");
+});
+
+test("the boringstack host session actually ADVERTISES check to the model", async () => {
+  const dir = await mkdtemp(join(tmpdir(), "tsforge-hostcfg-"));
+  const captured = { names: [] as string[] };
+
+  const provider: IProvider = {
+    async complete(_messages, opts) {
+      const tools = Array.isArray(opts?.tools) ? opts.tools : [];
+
+      captured.names = tools.flatMap((t) => {
+        if (!isRecord(t) || !isRecord(t.function)) {
+          return [];
+        }
+
+        return typeof t.function.name === "string" ? [t.function.name] : [];
+      });
+
+      return { content: "done", toolCalls: [] };
+    },
+  };
+
+  try {
+    const host = await createBoringstackHostSession({
+      provider,
+      cwd: dir,
+      contextWindow: 8000,
+      maxTurns: 1,
+      report: () => undefined,
+      editGuard: () => null,
+    });
+
+    await host.send("go");
+
+    expect(captured.names).toContain("check");
+    // Sibling flags travel with it — a regression in any is visible here too.
+    expect(captured.names).toContain("pull_conventions");
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
 });

--- a/packages/core/tests/boringstack-refine-prompt.test.ts
+++ b/packages/core/tests/boringstack-refine-prompt.test.ts
@@ -412,4 +412,22 @@ describe("refinePrompt", () => {
     expect(p).toContain("the delete mutation fires");
     expect(p).toContain("MUST drive edit and delete from the rendered list");
   });
+
+  it("instructs the model to use the `check` tool and forbids running the gate via shell (WS-G contract)", () => {
+    const feature: IFeature = {
+      id: "Invoice",
+      desc: "Customer billing record",
+      passes: false,
+      attempts: 0,
+    };
+
+    const prompt = refinePrompt(feature);
+
+    // WS-G: the callable gate replaced the old "do NOT run the gate yourself".
+    expect(prompt).toContain("check");
+    expect(prompt).toContain("passed: true");
+    // Shell gate execution is still forbidden (check is a tool, not `npx tsc`).
+    expect(prompt).toContain("Do NOT run the gate through the shell");
+    expect(prompt).not.toContain("Do NOT run the gate yourself");
+  });
 });

--- a/packages/core/tests/check-tool.test.ts
+++ b/packages/core/tests/check-tool.test.ts
@@ -1,0 +1,113 @@
+import { test, expect } from "bun:test";
+import { doCheck } from "../src/loop/tools/check-tool";
+import type { IToolContext } from "../src/loop/tools/tool-context";
+import type {
+  IErrorItem,
+  IValidateResult,
+} from "../src/validate/validate.types";
+
+/** A minimal structural IToolContext — only the fields doCheck reads, plus an
+ *  injectable runCheck. Built structurally (no cast) so the test tracks the real
+ *  interface: a required field going missing breaks compilation. */
+function ctxWith(runCheck?: IToolContext["runCheck"]): IToolContext {
+  return {
+    cwd: "/workspace",
+    files: [],
+    report: () => undefined,
+    task: "check-test",
+    ...(runCheck === undefined ? {} : { runCheck }),
+  };
+}
+
+function err(part: Partial<IErrorItem> & { key: string }): IErrorItem {
+  return { message: "boom", ...part };
+}
+
+function result(errors: IErrorItem[]): IValidateResult {
+  return { passed: errors.length === 0, errors, output: "" };
+}
+
+test("doCheck reports it isn't available when no runCheck is wired", async () => {
+  const out = await doCheck({}, ctxWith());
+
+  expect(out).toContain("not available");
+  // Must NOT masquerade as a passing gate — a missing seam is not "green".
+  expect(out).not.toContain('"passed":true');
+});
+
+test("doCheck returns passed:true with an empty error list on a green gate", async () => {
+  const out = await doCheck(
+    {},
+    ctxWith(async () => result([]))
+  );
+
+  expect(JSON.parse(out)).toEqual({ passed: true, errors: [] });
+});
+
+test("doCheck returns the whole structured error set on a red gate", async () => {
+  const out = await doCheck(
+    {},
+    ctxWith(async () =>
+      result([
+        err({
+          key: "a",
+          file: "src/x.ts",
+          line: 3,
+          rule: "no-unused-vars",
+          message: "'y' is unused",
+        }),
+        err({ key: "b", file: "src/y.ts", message: "type error" }),
+      ])
+    )
+  );
+
+  const parsed = JSON.parse(out);
+
+  expect(parsed.passed).toBe(false);
+  expect(parsed.errorCount).toBe(2);
+  expect(parsed.errors).toEqual([
+    {
+      file: "src/x.ts",
+      line: 3,
+      rule: "no-unused-vars",
+      message: "'y' is unused",
+    },
+    { file: "src/y.ts", message: "type error" },
+  ]);
+  // The model-facing struct must NOT leak the internal dedup `key`.
+  expect(out).not.toContain('"key"');
+});
+
+test("doCheck dedupes by stable key so repeated/dual-format output stays clean", async () => {
+  const out = await doCheck(
+    {},
+    ctxWith(async () =>
+      result([
+        err({ key: "dup", file: "src/x.ts", line: 1, message: "same" }),
+        err({ key: "dup", file: "src/x.ts", line: 1, message: "same" }),
+        err({ key: "other", file: "src/z.ts", line: 9, message: "diff" }),
+      ])
+    )
+  );
+
+  const parsed = JSON.parse(out);
+
+  expect(parsed.errorCount).toBe(2);
+  expect(parsed.errors).toHaveLength(2);
+});
+
+test("doCheck caps the list at 200 and records how many were omitted", async () => {
+  const many = Array.from({ length: 250 }, (_v, i) =>
+    err({ key: `k${String(i)}`, file: `src/f${String(i)}.ts`, message: "e" })
+  );
+
+  const out = await doCheck(
+    {},
+    ctxWith(async () => result(many))
+  );
+  const parsed = JSON.parse(out);
+
+  expect(parsed.errorCount).toBe(250);
+  expect(parsed.errors).toHaveLength(200);
+  expect(parsed.omitted).toBe(50);
+});

--- a/packages/core/tests/check-tool.test.ts
+++ b/packages/core/tests/check-tool.test.ts
@@ -150,19 +150,28 @@ test("doCheck surfaces raw output when the gate failed but parsed NO structured 
   expect(parsed.output).toContain("ENOSPC");
 });
 
-test("doCheck does NOT dump raw output when structured errors are present", async () => {
+test("doCheck surfaces a SHORT output tail when structured errors are present (catches a hidden crash, disclosed)", async () => {
+  // The errors are the distilled signal; output is capped hard (600) so a trailing
+  // unparsed crash is still visible without re-dumping the whole gate log.
+  const head = "lint noise ".repeat(200);
+  const tail = "SEGFAULT after the lint errors";
   const out = await doCheck(
     {},
     ctxWith(async () =>
       result([err({ key: "a", file: "src/x.ts", message: "e" })], {
         passed: false,
-        output: "noisy full gate log that would blow the context budget",
+        output: head + tail,
       })
     )
   );
 
-  expect(out).not.toContain("output");
-  expect(out).not.toContain("noisy full gate log");
+  const parsed = JSON.parse(out);
+
+  expect(parsed.errorCount).toBe(1);
+  // The trailing crash survives; the head is dropped and the cut disclosed.
+  expect(parsed.output).toContain("SEGFAULT after the lint errors");
+  expect(parsed.output.length).toBe(600);
+  expect(parsed.outputTruncated).toBe(true);
 });
 
 test("doCheck discloses the output cap (tail kept, omitted count) — no silent truncation", async () => {

--- a/packages/core/tests/check-tool.test.ts
+++ b/packages/core/tests/check-tool.test.ts
@@ -1,10 +1,10 @@
 import { test, expect } from "bun:test";
 import { doCheck } from "../src/loop/tools/check-tool";
-import type { IToolContext } from "../src/loop/tools/tool-context";
 import type {
-  IErrorItem,
-  IValidateResult,
-} from "../src/validate/validate.types";
+  IToolContext,
+  ICheckOutcome,
+} from "../src/loop/tools/tool-context";
+import type { IErrorItem } from "../src/validate/validate.types";
 
 /** A minimal structural IToolContext — only the fields doCheck reads, plus an
  *  injectable runCheck. Built structurally (no cast) so the test tracks the real
@@ -23,8 +23,17 @@ function err(part: Partial<IErrorItem> & { key: string }): IErrorItem {
   return { message: "boom", ...part };
 }
 
-function result(errors: IErrorItem[]): IValidateResult {
-  return { passed: errors.length === 0, errors, output: "" };
+function result(
+  errors: IErrorItem[],
+  extra: Partial<ICheckOutcome> = {}
+): ICheckOutcome {
+  return {
+    passed: errors.length === 0,
+    errors,
+    output: "",
+    autoFixed: [],
+    ...extra,
+  };
 }
 
 test("doCheck reports it isn't available when no runCheck is wired", async () => {
@@ -110,4 +119,48 @@ test("doCheck caps the list at 200 and records how many were omitted", async () 
   expect(parsed.errorCount).toBe(250);
   expect(parsed.errors).toHaveLength(200);
   expect(parsed.omitted).toBe(50);
+});
+
+test("doCheck surfaces autoFixed files so the model re-reads after a mid-turn rewrite", async () => {
+  const out = await doCheck(
+    {},
+    ctxWith(async () => result([], { autoFixed: ["src/a.ts", "src/b.ts"] }))
+  );
+
+  expect(JSON.parse(out)).toEqual({
+    passed: true,
+    errors: [],
+    autoFixed: ["src/a.ts", "src/b.ts"],
+  });
+});
+
+test("doCheck surfaces raw output when the gate failed but parsed NO structured errors", async () => {
+  const out = await doCheck(
+    {},
+    ctxWith(async () =>
+      result([], { passed: false, output: "Command crashed: ENOSPC\nstack..." })
+    )
+  );
+
+  const parsed = JSON.parse(out);
+
+  expect(parsed.passed).toBe(false);
+  expect(parsed.errorCount).toBe(0);
+  // Without this the model would be blind to why the gate failed.
+  expect(parsed.output).toContain("ENOSPC");
+});
+
+test("doCheck does NOT dump raw output when structured errors are present", async () => {
+  const out = await doCheck(
+    {},
+    ctxWith(async () =>
+      result([err({ key: "a", file: "src/x.ts", message: "e" })], {
+        passed: false,
+        output: "noisy full gate log that would blow the context budget",
+      })
+    )
+  );
+
+  expect(out).not.toContain("output");
+  expect(out).not.toContain("noisy full gate log");
 });

--- a/packages/core/tests/check-tool.test.ts
+++ b/packages/core/tests/check-tool.test.ts
@@ -164,3 +164,35 @@ test("doCheck does NOT dump raw output when structured errors are present", asyn
   expect(out).not.toContain("output");
   expect(out).not.toContain("noisy full gate log");
 });
+
+test("doCheck discloses the output cap (tail kept, omitted count) — no silent truncation", async () => {
+  // Failure detail is usually LAST, so the tail must survive and the cut be disclosed.
+  const head = "x".repeat(5000);
+  const tail = "FATAL: the real error is here";
+  const out = await doCheck(
+    {},
+    ctxWith(async () => result([], { passed: false, output: head + tail }))
+  );
+
+  const parsed = JSON.parse(out);
+
+  expect(parsed.outputTruncated).toBe(true);
+  expect(parsed.outputOmittedChars).toBe(head.length + tail.length - 4000);
+  expect(parsed.output).toContain("FATAL: the real error is here");
+  expect(parsed.output.length).toBe(4000);
+});
+
+test("doCheck does NOT mark truncation when output fits under the cap", async () => {
+  const out = await doCheck(
+    {},
+    ctxWith(async () =>
+      result([], { passed: false, output: "short crash log" })
+    )
+  );
+
+  const parsed = JSON.parse(out);
+
+  expect(parsed.output).toBe("short crash log");
+  expect(parsed.outputTruncated).toBeUndefined();
+  expect(parsed.outputOmittedChars).toBeUndefined();
+});

--- a/packages/core/tests/check-tool.test.ts
+++ b/packages/core/tests/check-tool.test.ts
@@ -87,7 +87,7 @@ test("doCheck returns the whole structured error set on a red gate", async () =>
   expect(out).not.toContain('"key"');
 });
 
-test("doCheck dedupes by stable key so repeated/dual-format output stays clean", async () => {
+test("doCheck drops only fully-identical diagnostics (dual-format re-emission)", async () => {
   const out = await doCheck(
     {},
     ctxWith(async () =>
@@ -95,6 +95,36 @@ test("doCheck dedupes by stable key so repeated/dual-format output stays clean",
         err({ key: "dup", file: "src/x.ts", line: 1, message: "same" }),
         err({ key: "dup", file: "src/x.ts", line: 1, message: "same" }),
         err({ key: "other", file: "src/z.ts", line: 9, message: "diff" }),
+      ])
+    )
+  );
+
+  const parsed = JSON.parse(out);
+
+  expect(parsed.errorCount).toBe(2);
+  expect(parsed.errors).toHaveLength(2);
+});
+
+test("doCheck keeps two DISTINCT diagnostics that share a coarse key but differ in message", async () => {
+  // Meta-rule keys are only `file:ruleId` (no line), so two distinct violations of one
+  // rule in one file share a key. Deduping on key alone would collapse them and
+  // under-report errorCount — the whole-error-set contract must not silently drop one.
+  const out = await doCheck(
+    {},
+    ctxWith(async () =>
+      result([
+        err({
+          key: "src/a.ts:no-eslint-disable-comments",
+          file: "src/a.ts",
+          rule: "no-eslint-disable-comments",
+          message: "disable on line 3",
+        }),
+        err({
+          key: "src/a.ts:no-eslint-disable-comments",
+          file: "src/a.ts",
+          rule: "no-eslint-disable-comments",
+          message: "disable on line 9",
+        }),
       ])
     )
   );

--- a/packages/core/tests/execute-tool.test.ts
+++ b/packages/core/tests/execute-tool.test.ts
@@ -694,3 +694,65 @@ test("edit not-found steers to a surgical edit on current content, never a rewri
     await rm(dir, { recursive: true, force: true });
   }
 });
+
+// ── WS-G: the callable `check` tool must survive the policy layer ──────────────
+// classifyAction/evaluatePolicy run BEFORE dispatch. `check` was born dead once:
+// absent from KIND_BY_TOOL it classified `unknown` → default/non-interactive deny,
+// so every call was rejected before doCheck. These pin the real end-to-end path.
+
+test("check passes policy (default mode) and dispatches to doCheck — structured JSON", async () => {
+  const r = await executeTool(
+    { name: "check", arguments: {} },
+    {
+      cwd: "/workspace",
+      files: [],
+      task: "t",
+      report: () => undefined,
+      runCheck: async () => ({
+        passed: false,
+        errors: [
+          {
+            key: "a",
+            file: "src/x.ts",
+            line: 2,
+            rule: "no-unused-vars",
+            message: "'y' is unused",
+          },
+        ],
+        output: "",
+      }),
+    }
+  );
+
+  // NOT a policy rejection — it reached doCheck and returned its JSON.
+  expect(r).not.toContain("policy");
+  expect(r).not.toContain("unrecognized action");
+  expect(JSON.parse(r)).toEqual({
+    passed: false,
+    errorCount: 1,
+    errors: [
+      {
+        file: "src/x.ts",
+        line: 2,
+        rule: "no-unused-vars",
+        message: "'y' is unused",
+      },
+    ],
+  });
+});
+
+test("check is rejected in PLAN mode (not read-only, not run) — the hard guard holds", async () => {
+  const r = await executeTool(
+    { name: "check", arguments: {} },
+    {
+      cwd: "/workspace",
+      files: [],
+      task: "t",
+      report: () => undefined,
+      readOnly: true,
+      runCheck: async () => ({ passed: true, errors: [], output: "" }),
+    }
+  );
+
+  expect(r).toContain("plan mode");
+});

--- a/packages/core/tests/execute-tool.test.ts
+++ b/packages/core/tests/execute-tool.test.ts
@@ -720,6 +720,7 @@ test("check passes policy (default mode) and dispatches to doCheck — structure
           },
         ],
         output: "",
+        autoFixed: [],
       }),
     }
   );
@@ -750,7 +751,12 @@ test("check is rejected in PLAN mode (not read-only, not run) — the hard guard
       task: "t",
       report: () => undefined,
       readOnly: true,
-      runCheck: async () => ({ passed: true, errors: [], output: "" }),
+      runCheck: async () => ({
+        passed: true,
+        errors: [],
+        output: "",
+        autoFixed: [],
+      }),
     }
   );
 

--- a/packages/core/tests/meta-rule-feedback.test.ts
+++ b/packages/core/tests/meta-rule-feedback.test.ts
@@ -244,3 +244,53 @@ test("meta-rule violations are sorted deterministically", async () => {
     }
   });
 });
+
+// R3 escalation focus contract: gateFeedback filters metaViolations by `file:ruleId`
+// (== IErrorItem.key that evaluateGate builds for a meta error, == focusError R3 sets).
+// This pins that key format — widening it (e.g. adding :message) silently drops the
+// focused project-structure feedback while the build is still red. That regression
+// landed once precisely because this contract was untested.
+test("gateFeedback R3 focus matches a meta violation by file:ruleId (the focusError contract)", async () => {
+  await withDir(async (dir) => {
+    const task: ITask = {
+      id: "1",
+      files: ["a.service.ts"],
+      accept: "tsc -p tsconfig.json",
+      intent: "",
+    };
+
+    const metaViolations: IMetaRuleViolation[] = [
+      {
+        file: "a.service.ts",
+        ruleId: "test-sibling-required",
+        severity: "error",
+        message: "a.service.ts has no test sibling",
+      },
+    ];
+
+    // focusError = `${file}:${ruleId}` — what evaluateGate keys a meta error as, and
+    // what R3 sets focus to. The violation must survive the focus filter.
+    const focused = await gateFeedback(
+      [],
+      task,
+      dir,
+      metaViolations,
+      "a.service.ts:test-sibling-required"
+    );
+
+    expect(focused).toContain("## Project structure");
+    expect(focused).toContain("test-sibling-required");
+
+    // A focusError carrying the message (the reverted-then-rejected key shape) must
+    // NOT match — proving the contract is file:ruleId, nothing wider.
+    const mismatched = await gateFeedback(
+      [],
+      task,
+      dir,
+      metaViolations,
+      "a.service.ts:test-sibling-required:a.service.ts has no test sibling"
+    );
+
+    expect(mismatched).not.toContain("test-sibling-required");
+  });
+});

--- a/packages/core/tests/policy-evaluation.test.ts
+++ b/packages/core/tests/policy-evaluation.test.ts
@@ -47,6 +47,9 @@ describe("classifyAction", () => {
       ["move_file", "write_file"],
       ["run", "shell"],
       ["add_dependency", "shell"],
+      // WS-G: check runs the gate (bun/eslint/tsc) — shell, NOT unknown. Absent from
+      // this table it classified `unknown` → non-interactive deny → every call DOA.
+      ["check", "shell"],
       ["package_info", "network"],
       ["package_docs", "network"],
       ["web_fetch", "network"],

--- a/packages/core/tests/session-check-tool.test.ts
+++ b/packages/core/tests/session-check-tool.test.ts
@@ -231,3 +231,63 @@ test("check goes RED on a META_RULE error even when the gate command is GREEN (t
     await rm(dir, { recursive: true, force: true });
   }
 });
+
+/** Captures the tool NAMES the Session advertised to the model (opts.tools), then
+ *  ends cleanly. Proves offerCheck actually reaches the advertised schema — not just
+ *  that a forced check call happens to dispatch. */
+function toolNameCapturingProvider(captured: { names: string[] }): IProvider {
+  return {
+    async complete(_messages, opts) {
+      const tools = Array.isArray(opts?.tools) ? opts.tools : [];
+
+      captured.names = tools.flatMap((t) => {
+        const name = (t as { function?: { name?: unknown } }).function?.name;
+
+        return typeof name === "string" ? [name] : [];
+      });
+
+      return { content: "done", toolCalls: [] };
+    },
+  };
+}
+
+test("offerCheck:true makes the Session ADVERTISE check to the model", async () => {
+  const dir = await mkdtemp(join(tmpdir(), "tsforge-check-"));
+  const captured = { names: [] as string[] };
+
+  try {
+    const session = await Session.create({
+      provider: toolNameCapturingProvider(captured),
+      cwd: dir,
+      files: ["**/*"],
+      offerCheck: true,
+      gate: fixedGate(GREEN),
+    });
+
+    await session.send("go");
+
+    expect(captured.names).toContain("check");
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test("without offerCheck the Session does NOT advertise check (the tool is un-discoverable)", async () => {
+  const dir = await mkdtemp(join(tmpdir(), "tsforge-check-"));
+  const captured = { names: [] as string[] };
+
+  try {
+    const session = await Session.create({
+      provider: toolNameCapturingProvider(captured),
+      cwd: dir,
+      files: ["**/*"],
+      gate: fixedGate(GREEN),
+    });
+
+    await session.send("go");
+
+    expect(captured.names).not.toContain("check");
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});

--- a/packages/core/tests/session-check-tool.test.ts
+++ b/packages/core/tests/session-check-tool.test.ts
@@ -270,7 +270,7 @@ function toolNameCapturingProvider(captured: { names: string[] }): IProvider {
 
 test("offerCheck:true makes the Session ADVERTISE check to the model", async () => {
   const dir = await mkdtemp(join(tmpdir(), "tsforge-check-"));
-  const captured = { names: [] as string[] };
+  const captured: { names: string[] } = { names: [] };
 
   try {
     const session = await Session.create({
@@ -291,7 +291,7 @@ test("offerCheck:true makes the Session ADVERTISE check to the model", async () 
 
 test("without offerCheck the Session does NOT advertise check (the tool is un-discoverable)", async () => {
   const dir = await mkdtemp(join(tmpdir(), "tsforge-check-"));
-  const captured = { names: [] as string[] };
+  const captured: { names: string[] } = { names: [] };
 
   try {
     const session = await Session.create({

--- a/packages/core/tests/session-check-tool.test.ts
+++ b/packages/core/tests/session-check-tool.test.ts
@@ -6,6 +6,7 @@ import type { IProvider, IChatMessage } from "../src/inference";
 import { Session } from "../src/loop";
 import type { IGate } from "../src/gate/gate-runner";
 import type { IValidateResult } from "../src/validate";
+import { isRecord } from "../src/lib/guards/guards";
 
 // WS-G end-to-end: the `check` tool must reach the tool context executeTool uses,
 // survive the policy layer (it was DOA once — unknown→deny), and run the SAME gate
@@ -232,6 +233,22 @@ test("check goes RED on a META_RULE error even when the gate command is GREEN (t
   }
 });
 
+/** Extract an advertised tool's name via runtime narrowing — no `as` cast (house
+ *  rule), since opts.tools is typed `unknown[]` at the provider boundary. */
+function advertisedName(tool: unknown): string | undefined {
+  if (!isRecord(tool)) {
+    return undefined;
+  }
+
+  const fn = tool.function;
+
+  if (!isRecord(fn) || typeof fn.name !== "string") {
+    return undefined;
+  }
+
+  return fn.name;
+}
+
 /** Captures the tool NAMES the Session advertised to the model (opts.tools), then
  *  ends cleanly. Proves offerCheck actually reaches the advertised schema — not just
  *  that a forced check call happens to dispatch. */
@@ -241,9 +258,9 @@ function toolNameCapturingProvider(captured: { names: string[] }): IProvider {
       const tools = Array.isArray(opts?.tools) ? opts.tools : [];
 
       captured.names = tools.flatMap((t) => {
-        const name = (t as { function?: { name?: unknown } }).function?.name;
+        const name = advertisedName(t);
 
-        return typeof name === "string" ? [name] : [];
+        return name === undefined ? [] : [name];
       });
 
       return { content: "done", toolCalls: [] };

--- a/packages/core/tests/session-check-tool.test.ts
+++ b/packages/core/tests/session-check-tool.test.ts
@@ -140,3 +140,94 @@ test("runCheck reads the gate LAZILY — a mid-build setGate swap is honored", a
     await rm(dir, { recursive: true, force: true });
   }
 });
+
+/** turn 1: create a file with an eslint-disable comment (→ touched, meta-rule red);
+ *  turn 2: check (its result comes back turn 3); turn 3: capture it, then rewrite the
+ *  file CLEAN so the gate greens and the session terminates. A red gate can't be
+ *  "done"-ed out of, so we must actually fix it — and we never overwrite a captured
+ *  result with null (a later compaction drops the tool message). */
+function createThenCheckProvider(
+  captured: { result: string | null },
+  file: string
+): IProvider {
+  let turn = 0;
+
+  return {
+    async complete(messages: IChatMessage[]) {
+      turn += 1;
+
+      if (turn === 1) {
+        return {
+          content: "",
+          toolCalls: [
+            {
+              id: "1",
+              name: "create",
+              arguments: {
+                file,
+                content:
+                  "// eslint-disable-next-line no-console\nconsole.log(1);\n",
+              },
+            },
+          ],
+        };
+      }
+
+      if (turn === 2) {
+        return {
+          content: "",
+          toolCalls: [{ id: "2", name: "check", arguments: {} }],
+        };
+      }
+
+      const toolMsg = [...messages].reverse().find((m) => m.role === "tool");
+
+      if (typeof toolMsg?.content === "string" && captured.result === null) {
+        captured.result = toolMsg.content;
+      }
+
+      // Green the gate (remove the disable comment) so the loop can terminate.
+      return {
+        content: "",
+        toolCalls: [
+          {
+            id: "3",
+            name: "create",
+            arguments: { file, content: "export const x = 1;\n" },
+          },
+        ],
+      };
+    },
+  };
+}
+
+test("check goes RED on a META_RULE error even when the gate command is GREEN (the gate-relaxed fix)", async () => {
+  const dir = await mkdtemp(join(tmpdir(), "tsforge-check-"));
+  const captured: { result: string | null } = { result: null };
+
+  try {
+    const session = await Session.create({
+      provider: createThenCheckProvider(captured, "src/bad.ts"),
+      cwd: dir,
+      files: ["**/*"],
+      offerCheck: true,
+      // Gate COMMAND is green — only the meta-rule (no-eslint-disable-comments,
+      // change-scoped to the file the model just wrote) makes it red.
+      gate: fixedGate(GREEN),
+    });
+
+    await session.send("write a file");
+
+    const parsed: { passed: boolean; errors: { rule?: string }[] } = JSON.parse(
+      captured.result ?? ""
+    );
+
+    // If runCheck had regressed to ctx.gate.runner alone, this would be passed:true.
+    expect(parsed.passed).toBe(false);
+    expect(
+      parsed.errors.some((e) => e.rule === "no-eslint-disable-comments")
+    ).toBe(true);
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});

--- a/packages/core/tests/session-check-tool.test.ts
+++ b/packages/core/tests/session-check-tool.test.ts
@@ -1,0 +1,142 @@
+import { test, expect } from "bun:test";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { IProvider, IChatMessage } from "../src/inference";
+import { Session } from "../src/loop";
+import type { IGate } from "../src/gate/gate-runner";
+import type { IValidateResult } from "../src/validate";
+
+// WS-G end-to-end: the `check` tool must reach the tool context executeTool uses,
+// survive the policy layer (it was DOA once — unknown→deny), and run the SAME gate
+// settleGate runs (via runCheckGate → evaluateGate). These drive real Session turns.
+
+/** A gate that always reports the given result — stands in for the injected
+ *  per-slice boringstack gate so we can assert `check` returns ITS errors. */
+function fixedGate(result: IValidateResult): IGate {
+  return { run: async () => result };
+}
+
+const RED: IValidateResult = {
+  passed: false,
+  errors: [
+    {
+      key: "a",
+      file: "src/x.ts",
+      line: 3,
+      rule: "no-unused-vars",
+      message: "'y' unused",
+    },
+  ],
+  output: "",
+};
+
+const GREEN: IValidateResult = { passed: true, errors: [], output: "" };
+
+/** Emits ONE `check` call on turn 1, captures the tool-result message it gets back
+ *  on turn 2, then reports done. `captured` holds the JSON the model saw. */
+function checkingProvider(captured: { result: string | null }): IProvider {
+  let turn = 0;
+
+  return {
+    async complete(messages: IChatMessage[]) {
+      turn += 1;
+
+      if (turn === 1) {
+        return {
+          content: "",
+          toolCalls: [{ id: "1", name: "check", arguments: {} }],
+        };
+      }
+
+      // Turn 2: the last tool message is the check result.
+      const toolMsg = [...messages].reverse().find((m) => m.role === "tool");
+
+      captured.result =
+        typeof toolMsg?.content === "string" ? toolMsg.content : null;
+
+      return { content: "done", toolCalls: [] };
+    },
+  };
+}
+
+test("offerCheck wires the seam: the model's check call returns the injected gate's structured errors", async () => {
+  const dir = await mkdtemp(join(tmpdir(), "tsforge-check-"));
+  const captured: { result: string | null } = { result: null };
+
+  try {
+    const session = await Session.create({
+      provider: checkingProvider(captured),
+      cwd: dir,
+      files: ["**/*"],
+      offerCheck: true,
+      gate: fixedGate(RED),
+    });
+
+    await session.send("build it");
+
+    expect(captured.result).not.toBeNull();
+    const parsed = JSON.parse(captured.result ?? "");
+
+    expect(parsed.passed).toBe(false);
+    expect(parsed.errorCount).toBe(1);
+    expect(parsed.errors[0]).toEqual({
+      file: "src/x.ts",
+      line: 3,
+      rule: "no-unused-vars",
+      message: "'y' unused",
+    });
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test("without offerCheck the check tool is not wired — doCheck reports it isn't available (seam is the cause)", async () => {
+  const dir = await mkdtemp(join(tmpdir(), "tsforge-check-"));
+  const captured: { result: string | null } = { result: null };
+
+  try {
+    const session = await Session.create({
+      provider: checkingProvider(captured),
+      cwd: dir,
+      files: ["**/*"],
+      // offerCheck omitted → runCheck seam absent
+      gate: fixedGate(RED),
+    });
+
+    await session.send("build it");
+
+    // The call still dispatches (policy allows it) but finds no seam.
+    expect(captured.result ?? "").toContain("not available");
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test("runCheck reads the gate LAZILY — a mid-build setGate swap is honored", async () => {
+  const dir = await mkdtemp(join(tmpdir(), "tsforge-check-"));
+  const captured: { result: string | null } = { result: null };
+
+  try {
+    const session = await Session.create({
+      provider: checkingProvider(captured),
+      cwd: dir,
+      files: ["**/*"],
+      offerCheck: true,
+      gate: fixedGate(GREEN), // initial gate: green
+    });
+
+    // The build swaps in the per-slice gate AFTER construction; check must see it.
+    session.setGate(fixedGate(RED));
+
+    await session.send("build it");
+
+    const parsed = JSON.parse(captured.result ?? "");
+
+    // Saw the NEW (red) gate, not the construction-time green one.
+    expect(parsed.passed).toBe(false);
+    expect(parsed.errorCount).toBe(1);
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});

--- a/packages/core/tests/tool-accounting.test.ts
+++ b/packages/core/tests/tool-accounting.test.ts
@@ -444,11 +444,16 @@ const MUTATING_TOOLS = new Set<string>([
 // script = runs a program whose tool calls (incl. edit/create) re-enter
 // executeTool and report their OWN mutations, so the script call itself accounts
 // for nothing; generate_image writes ONLY to the .tsforge/images artifact dir
-// (not gated source) and reports no mutation, so it triggers no re-gate.
+// (not gated source) and reports no mutation, so it triggers no re-gate;
+// check = runs the acceptance gate on demand (WS-G). The gate's autofix may
+// reformat files, but check reports NO scoped mutation and returns the errors as
+// its result — the loop does not re-gate off it. Not plan-mode-safe (readOnly:false)
+// because that autofix touches source, so it's special-with-reason, not read-only.
 const SPECIAL_TOOLS = new Set<string>([
   TOOL_NAME.run,
   TOOL_NAME.script,
   TOOL_NAME.generateImage,
+  TOOL_NAME.check,
 ]);
 
 test("every registered tool is classified read-only, mutating, or special", () => {

--- a/packages/core/tests/tools-gating.test.ts
+++ b/packages/core/tests/tools-gating.test.ts
@@ -108,6 +108,19 @@ test("pull_conventions is offered per build BACKEND, not per flag", () => {
   expect(names(toolsFor(true, {}, true))).toContain("pull_conventions");
 });
 
+test("check is offered per build BACKEND (offerCheck), not by any flag", () => {
+  // WS-G: the callable structured gate. Off by default on every path (a plain
+  // eval/scratch task has no authoritative injected gate → a callable gate would
+  // answer vacuously). A build backend opts in via the 4th toolsFor arg. Web being
+  // on must NOT drag it in.
+  process.env.TSFORGE_WEB = "1";
+  expect(names(toolsFor(false))).not.toContain("check");
+  expect(names(toolsFor(true))).not.toContain("check");
+
+  expect(names(toolsFor(false, {}, false, true))).toContain("check");
+  expect(names(toolsFor(true, {}, false, true))).toContain("check");
+});
+
 test("the script tool is on by default for scratch and existing code", () => {
   expect(names(toolsFor(true))).toContain("script");
   expect(names(toolsFor(false))).toContain("script");


### PR DESCRIPTION
## What

WS-G — the callable, structured **\`check\`** tool. The build model calls it mid-turn to run the acceptance gate NOW and get back its WHOLE structured error set (\`{file,line,rule,message}\`) as JSON, so it fixes every error in one pass instead of discovering them one-per-turn after it stops (the model's own #1 ask; a primary driver of near-green turn-waste).

This is priority #1 of the co-pilot plan (panel-corrected order: rules + check before the interactive layer).

## How

- **One gate, shared.** Extracted \`evaluateGate\` (autofix → gate command → META_RULES, combined) — both \`settleGate\` (end-of-turn) and \`check\` (\`runCheckGate\`, mid-turn) go through it, so \`check\` can never report green while the settle path is red (e.g. a \`test-sibling-required\` meta error).
- **Stack-agnostic seam.** Generic \`runCheck\` on the tool context (like \`editGuard\`); the boringstack build opts in via \`cfg.offerCheck\`. Off by default everywhere else. Reads the gate lazily so a per-slice \`setGate\` swap is honored.
- **Policy.** \`check\` classified \`shell\` (runs bun/eslint/tsc) — allowed in the build's default mode, blocked in plan mode by the non-read-only hard guard.
- **Honest output.** \`autoFixed\` files surfaced (re-read guidance); raw gate \`output\` surfaced on failure with disclosed truncation (no silent cut); full-identity dedupe so distinct diagnostics never collapse.
- **Prompt.** \`refine-prompt\` pivots "do NOT run the gate yourself" → "use \`check\` before you stop" (shell gate execution still banned), and correctly lists the test suites the gate runs.
- **Wiring pinned.** Single \`createBoringstackHostSession\` constructor + tests that the built session actually advertises \`check\`.

## Review

Hardened over **7 rounds of the 4-model harness-review panel** — which caught, among others, a critical policy DOA (check classified \`unknown\` → denied before dispatch), a gate-relaxed check (skipped META_RULES), an error-undercount in dedupe, and a self-inflicted escalation-focus regression — none of which the local suite caught. Final panel: **PASS, zero findings.**

Full core suite green (2699 pass). Typecheck / lint / format clean.