### PR TITLE
feat(loop): situational awareness — front-load stack-active rules (WS-A)

### DIFF
--- a/packages/core/src/loop/conventions.ts
+++ b/packages/core/src/loop/conventions.ts
@@ -118,6 +118,25 @@ export function conventionTopics(): ConventionTopic[] {
   return [...TOPICS];
 }
 
+/** A compact PUSH index of the pullable convention topics + the gate rules each one
+ *  prevents (WS-A1). Front-loaded into the build system prompt so the model knows the
+ *  catalog exists and pulls the compliant pattern BEFORE writing that kind of code —
+ *  the situational awareness that stops it writing a convention-violating draft it
+ *  then burns turns fixing. Complements `pull_conventions` (the on-demand fetch). */
+export function buildConventionIndex(): string {
+  const rows = conventionTopics().map((t) => {
+    const rules = TOPIC_RULES[t];
+    const prevents = rules.length > 0 ? ` — prevents: ${rules.join(", ")}` : "";
+
+    return `  • ${t}${prevents}`;
+  });
+
+  return [
+    "STACK CONVENTIONS. This stack enforces strict patterns the gate REJECTS if you guess. Before writing a given kind of code, call `pull_conventions` with the matching topic to get the compliant shape FIRST — do not write from memory and discover the rule at the gate. Topics:",
+    ...rows,
+  ].join("\n");
+}
+
 /** Narrow an arbitrary string to a ConventionTopic (for the pull tool's arg) —
  *  membership test, no `as` cast. */
 export function isConventionTopic(s: string): s is ConventionTopic {

--- a/packages/core/src/loop/prompt/prompt.ts
+++ b/packages/core/src/loop/prompt/prompt.ts
@@ -77,14 +77,17 @@ export type ExecutionMode = "chat" | "drive-to-green";
  * constitution as {@link buildSystem} (it reuses {@link gateRulesSentence}, the one
  * source of the hard rules), but build-tuned: inspect the target + one existing
  * sibling that already does the unfamiliar pattern BEFORE writing it (so the model
- * copies the real client/service/hook shape instead of inventing it), make progress
- * via edits + tiny probes, and NEVER self-run the full gate — the harness owns it.
- * That single command policy also resolves the old chat-prompt "run tsc/tests"
- * contradiction that made the model burn turns self-linting.
+ * copies the real client/service/hook shape instead of inventing it), and make
+ * progress via edits + tiny probes. Gate policy depends on `offerCheck`: WITHOUT it
+ * the harness owns the gate (never self-run it via the shell); WITH it (WS-G) the
+ * model MUST run the gate mid-turn via the `check` tool, while shell gate commands
+ * stay banned. Either way, the old chat-prompt "run tsc/tests" contradiction that
+ * made the model burn turns self-linting is resolved.
  */
 export function buildDriveToGreenSystem(
   conventions: IConventions,
-  offerCheck = false
+  offerCheck = false,
+  offerConventions = false
 ): string {
   const lookupLine = flags.webTools()
     ? "When a blocker is a FRAMEWORK's behavior or types (not your own logic) — e.g. why an Elysia route loses its schema types — LOOK IT UP instead of reasoning in circles: `package_docs`/`package_info` read the installed package's own types + README (no network), and `web_search`/`web_fetch` reach its online docs. Two lookups beat ten turns of guessing."
@@ -98,9 +101,25 @@ export function buildDriveToGreenSystem(
     ? "After every edit the harness runs the gate automatically — AND you can run it yourself any time with the `check` tool, which returns your WHOLE structured error set (`{file,line,rule,message}`) mid-turn. Call `check` before you stop and fix every error it lists in ONE pass, then `check` again; `passed:true` means done. Do NOT run the gate through the SHELL (`tsc`, `eslint`, `knip`, `bun run check`/`validate`) — `check` is the only gate you run; `run` is for tiny diagnostic probes only (`bun -e '…'`)."
     : "After every edit the harness AUTOMATICALLY runs the gate and hands you the errors + fix guidance. Do NOT run `tsc`, `eslint`, `knip`, `bun run check`/`validate`, or the acceptance/gate command yourself — it wastes turns and tells you nothing the harness won't. `run` is for tiny diagnostic probes only (`bun -e '…'`, a single targeted test). Fix exactly what the gate reports, then edit again; the harness ends the task when it reports green.";
 
+  // Keep the inventory line consistent with what's actually advertised — otherwise a
+  // weaker model reads "read/edit/create/run" as the COMPLETE toolset and discounts the
+  // check / pull_conventions guidance below it.
+  const extraTools = [
+    offerConventions
+      ? "`pull_conventions` (fetch a stack convention guide before writing that kind of code)"
+      : "",
+    offerCheck
+      ? "`check` (run the gate now, get your whole structured error set)"
+      : "",
+  ].filter((t) => t.length > 0);
+  const toolsLine =
+    "Tools: `read` (inspect a file), `edit` (replace an exact, unique snippet), `create` (a new file), `run` (execute a shell command and see its output)" +
+    (extraTools.length > 0 ? `, ${extraTools.join(", ")}` : "") +
+    ".";
+
   return [
     "You are an expert TypeScript engineer inside tsforge, a harness specialized for STRICT TypeScript. You are driving ONE task to a GREEN gate — you are not chatting.",
-    "Tools: `read` (inspect a file), `edit` (replace an exact, unique snippet), `create` (a new file), `run` (execute a shell command and see its output).",
+    toolsLine,
     overlayBlock(
       "Before you write an unfamiliar pattern — an API-client call, a service, a hook, a form — `read` ONE existing sibling that already does it and copy its shape. A few targeted reads, never a repo scan. Do NOT invent library or client APIs from memory; the codebase already shows the right way.",
       "bootstrap"

--- a/packages/core/src/loop/prompt/prompt.ts
+++ b/packages/core/src/loop/prompt/prompt.ts
@@ -82,10 +82,21 @@ export type ExecutionMode = "chat" | "drive-to-green";
  * That single command policy also resolves the old chat-prompt "run tsc/tests"
  * contradiction that made the model burn turns self-linting.
  */
-export function buildDriveToGreenSystem(conventions: IConventions): string {
+export function buildDriveToGreenSystem(
+  conventions: IConventions,
+  offerCheck = false
+): string {
   const lookupLine = flags.webTools()
     ? "When a blocker is a FRAMEWORK's behavior or types (not your own logic) — e.g. why an Elysia route loses its schema types — LOOK IT UP instead of reasoning in circles: `package_docs`/`package_info` read the installed package's own types + README (no network), and `web_search`/`web_fetch` reach its online docs. Two lookups beat ten turns of guessing."
     : "When a blocker is a FRAMEWORK's behavior or types (not your own logic), find a working example in the repo and copy it — don't reason about the framework's internals in the abstract.";
+
+  // With the `check` tool wired (WS-G), the model SHOULD run the gate on demand via
+  // that tool — the opposite of the default "don't run the gate yourself". Only the
+  // SHELL gate commands stay banned (they waste turns / resolve the wrong tsc). Without
+  // check, keep the original guidance (the gate runs automatically after each edit).
+  const executionLine = offerCheck
+    ? "After every edit the harness runs the gate automatically — AND you can run it yourself any time with the `check` tool, which returns your WHOLE structured error set (`{file,line,rule,message}`) mid-turn. Call `check` before you stop and fix every error it lists in ONE pass, then `check` again; `passed:true` means done. Do NOT run the gate through the SHELL (`tsc`, `eslint`, `knip`, `bun run check`/`validate`) — `check` is the only gate you run; `run` is for tiny diagnostic probes only (`bun -e '…'`)."
+    : "After every edit the harness AUTOMATICALLY runs the gate and hands you the errors + fix guidance. Do NOT run `tsc`, `eslint`, `knip`, `bun run check`/`validate`, or the acceptance/gate command yourself — it wastes turns and tells you nothing the harness won't. `run` is for tiny diagnostic probes only (`bun -e '…'`, a single targeted test). Fix exactly what the gate reports, then edit again; the harness ends the task when it reports green.";
 
   return [
     "You are an expert TypeScript engineer inside tsforge, a harness specialized for STRICT TypeScript. You are driving ONE task to a GREEN gate — you are not chatting.",
@@ -95,10 +106,7 @@ export function buildDriveToGreenSystem(conventions: IConventions): string {
       "bootstrap"
     ),
     lookupLine,
-    overlayBlock(
-      "After every edit the harness AUTOMATICALLY runs the gate and hands you the errors + fix guidance. Do NOT run `tsc`, `eslint`, `knip`, `bun run check`/`validate`, or the acceptance/gate command yourself — it wastes turns and tells you nothing the harness won't. `run` is for tiny diagnostic probes only (`bun -e '…'`, a single targeted test). Fix exactly what the gate reports, then edit again; the harness ends the task when it reports green.",
-      "execution"
-    ),
+    overlayBlock(executionLine, "execution"),
     "The harness AUTO-FIXES mechanical formatting on every file you write (blank lines, braces, quotes, semicolons, import order, `prefer-template`). NEVER hand-fix or chase those.",
     gateRulesSentence(conventions),
     "Keep functions small: the gate caps cognitive complexity at 20 and nesting depth at 4 — extract named helpers instead of one sprawling block. Always `await` promises (or `void` them deliberately) — a floating promise is a gate error.",

--- a/packages/core/src/loop/session.ts
+++ b/packages/core/src/loop/session.ts
@@ -596,11 +596,13 @@ function systemPrompt(
 
 /** Build the initial message list. A FRESH session gets one freshly-built system
  *  prompt. A RESUMED session (`cfg.history`) reuses its persisted messages as-is —
- *  EXCEPT when `offerCheck` is set: the persisted prompt predates the `check` tool and
- *  would tell the model "never run the gate" while the tool is advertised (the exact
- *  contradiction WS-A4 removes). In that case the leading system message is refreshed
- *  to the current check-aware prompt and the rest of the conversation is kept intact —
- *  enforcing the offerCheck↔prompt invariant in code, not by an unchecked caller rule. */
+ *  EXCEPT when a build flag that CHANGES the prompt is set (`offerCheck` in
+ *  drive-to-green → the check-aware execution block + Tools line; `pullConventions` →
+ *  the convention index + pull_conventions in the Tools line). The persisted prompt
+ *  predates those, so it would advertise a tool the prompt omits or contradicts. In
+ *  that case the leading system message is refreshed to the current prompt and every
+ *  non-system turn is kept in order — enforcing the flag↔prompt invariant in code,
+ *  not by an unchecked caller rule. */
 function resumeMessages(
   cfg: ISessionConfig,
   freshSystem: string
@@ -611,7 +613,11 @@ function resumeMessages(
     return [systemMsg];
   }
 
-  if (cfg.offerCheck !== true) {
+  const promptFlagSet =
+    (cfg.offerCheck === true && cfg.executionMode === "drive-to-green") ||
+    cfg.pullConventions === true;
+
+  if (!promptFlagSet) {
     return [...cfg.history];
   }
 
@@ -742,7 +748,10 @@ export class Session {
     // prompt that predates the check tool ("never run the gate") while advertising it —
     // `resumeMessages` refreshes the leading system message to the check-aware prompt so
     // the two can't contradict, enforcing the invariant in code (not a caller rule).
-    const offerCheck = cfg.offerCheck === true;
+    // Requires drive-to-green: only that base prompt is check-aware, and toolsFor must
+    // not advertise check in a chat session whose prompt would omit + contradict it.
+    const offerCheck =
+      cfg.offerCheck === true && cfg.executionMode === "drive-to-green";
 
     this.tools = toolsFor(false, {}, cfg.pullConventions === true, offerCheck);
 

--- a/packages/core/src/loop/session.ts
+++ b/packages/core/src/loop/session.ts
@@ -560,7 +560,7 @@ function systemPrompt(
 ): string {
   const base =
     cfg.executionMode === "drive-to-green"
-      ? buildDriveToGreenSystem(conventions)
+      ? buildDriveToGreenSystem(conventions, cfg.offerCheck === true)
       : buildChatSystem(conventions);
 
   const lines = [`Workspace: ${cfg.cwd}`];

--- a/packages/core/src/loop/session.ts
+++ b/packages/core/src/loop/session.ts
@@ -35,6 +35,7 @@ import {
   type ErrorSet,
 } from "../validate";
 import { ruleHelp } from "./feedback";
+import { buildConventionIndex } from "./conventions";
 import { detectStack } from "../stack-detection";
 import { recallMapBlock } from "../codebase";
 import {
@@ -577,9 +578,16 @@ function systemPrompt(
   // it here too so test-first is the out-of-the-box default everywhere.
   const tdd = flags.tdd() ? `${buildTddGuidance(conventions)}\n\n` : "";
 
+  // WS-A1: front-load the stack convention topic index when the backend ships a
+  // convention library (pullConventions). PUSHes awareness that the catalog exists so
+  // the model pulls the compliant pattern BEFORE writing — the Bucket-1 fix that stops
+  // it drafting convention-violating code it then burns turns repairing.
+  const conv =
+    cfg.pullConventions === true ? `${buildConventionIndex()}\n\n` : "";
+
   const contract = taskContract(cfg.files ?? [], cfg.accept);
 
-  return `${base}\n\n${tdd}${prefix}${lines.join("\n")}\n\n${contract}`;
+  return `${base}\n\n${tdd}${conv}${prefix}${lines.join("\n")}\n\n${contract}`;
 }
 
 /** Stable prefix of the delegation block — the sentinel `setDelegation` checks to
@@ -702,6 +710,11 @@ export class Session {
     // (not at construction), so this is an explicit flag, not `cfg.gate !== undefined`
     // (which is still undefined here). A plain eval/scratch task leaves it off — its
     // acceptance set can be empty, so a callable gate would answer vacuously.
+    // NOTE: the check-AWARE system prompt (see systemPrompt) is baked only for a FRESH
+    // session; a session resumed from `cfg.history` reuses its persisted prompt. That
+    // can't contradict today because offerCheck is set ONLY by the fresh headless
+    // boringstack build, which never resumes with history — if a resumable path ever
+    // sets offerCheck, rebuild or patch the persisted prompt there.
     const offerCheck = cfg.offerCheck === true;
 
     this.tools = toolsFor(false, {}, cfg.pullConventions === true, offerCheck);

--- a/packages/core/src/loop/session.ts
+++ b/packages/core/src/loop/session.ts
@@ -595,14 +595,15 @@ function systemPrompt(
 }
 
 /** Build the initial message list. A FRESH session gets one freshly-built system
- *  prompt. A RESUMED session (`cfg.history`) reuses its persisted messages as-is —
- *  EXCEPT when a build flag that CHANGES the prompt is set (`offerCheck` in
- *  drive-to-green → the check-aware execution block + Tools line; `pullConventions` →
- *  the convention index + pull_conventions in the Tools line). The persisted prompt
- *  predates those, so it would advertise a tool the prompt omits or contradicts. In
- *  that case the leading system message is refreshed to the current prompt and every
- *  non-system turn is kept in order — enforcing the flag↔prompt invariant in code,
- *  not by an unchecked caller rule. */
+ *  prompt. A RESUMED session (`cfg.history`) has its LEADING base-prompt system message
+ *  refreshed to the current prompt, keeping every later message in order. Refreshing is
+ *  unconditional and idempotent: the prompt is deterministic from `cfg`, so an unchanged
+ *  config rebuilds the identical string, while a config that toggled a flag either way
+ *  (`offerCheck`/`pullConventions` on OR off) gets a prompt consistent with what
+ *  `toolsFor` now advertises — so a resumed build can never carry a prompt that requires
+ *  or advertises a tool the session no longer exposes (the flag↔prompt invariant, both
+ *  directions). Only the LEADING system message is replaced; a LATER persisted system
+ *  instruction (delegation, scope notes) is preserved. */
 function resumeMessages(
   cfg: ISessionConfig,
   freshSystem: string
@@ -613,17 +614,6 @@ function resumeMessages(
     return [systemMsg];
   }
 
-  const promptFlagSet =
-    (cfg.offerCheck === true && cfg.executionMode === "drive-to-green") ||
-    cfg.pullConventions === true;
-
-  if (!promptFlagSet) {
-    return [...cfg.history];
-  }
-
-  // Replace ONLY the leading base-prompt system message; keep every later message —
-  // including any LATER system instruction (persisted delegation, scope notes), which
-  // a blanket "drop all system" filter would silently lose.
   const [first, ...rest] = cfg.history;
 
   return first?.role === "system"
@@ -751,12 +741,10 @@ export class Session {
     // (not at construction), so this is an explicit flag, not `cfg.gate !== undefined`
     // (which is still undefined here). A plain eval/scratch task leaves it off — its
     // acceptance set can be empty, so a callable gate would answer vacuously.
-    // A resumed session (cfg.history) with offerCheck would otherwise carry a persisted
-    // prompt that predates the check tool ("never run the gate") while advertising it —
-    // `resumeMessages` refreshes the leading system message to the check-aware prompt so
-    // the two can't contradict, enforcing the invariant in code (not a caller rule).
     // Requires drive-to-green: only that base prompt is check-aware, and toolsFor must
     // not advertise check in a chat session whose prompt would omit + contradict it.
+    // (`resumeMessages` keeps the persisted prompt in lockstep with this on resume, so
+    // the advertised tool set and the prompt can never disagree in either direction.)
     const offerCheck =
       cfg.offerCheck === true && cfg.executionMode === "drive-to-green";
 

--- a/packages/core/src/loop/session.ts
+++ b/packages/core/src/loop/session.ts
@@ -561,7 +561,11 @@ function systemPrompt(
 ): string {
   const base =
     cfg.executionMode === "drive-to-green"
-      ? buildDriveToGreenSystem(conventions, cfg.offerCheck === true)
+      ? buildDriveToGreenSystem(
+          conventions,
+          cfg.offerCheck === true,
+          cfg.pullConventions === true
+        )
       : buildChatSystem(conventions);
 
   const lines = [`Workspace: ${cfg.cwd}`];
@@ -588,6 +592,30 @@ function systemPrompt(
   const contract = taskContract(cfg.files ?? [], cfg.accept);
 
   return `${base}\n\n${tdd}${conv}${prefix}${lines.join("\n")}\n\n${contract}`;
+}
+
+/** Build the initial message list. A FRESH session gets one freshly-built system
+ *  prompt. A RESUMED session (`cfg.history`) reuses its persisted messages as-is —
+ *  EXCEPT when `offerCheck` is set: the persisted prompt predates the `check` tool and
+ *  would tell the model "never run the gate" while the tool is advertised (the exact
+ *  contradiction WS-A4 removes). In that case the leading system message is refreshed
+ *  to the current check-aware prompt and the rest of the conversation is kept intact —
+ *  enforcing the offerCheck↔prompt invariant in code, not by an unchecked caller rule. */
+function resumeMessages(
+  cfg: ISessionConfig,
+  freshSystem: string
+): IChatMessage[] {
+  const systemMsg: IChatMessage = { role: "system", content: freshSystem };
+
+  if (cfg.history === undefined || cfg.history.length === 0) {
+    return [systemMsg];
+  }
+
+  if (cfg.offerCheck !== true) {
+    return [...cfg.history];
+  }
+
+  return [systemMsg, ...cfg.history.filter((m) => m.role !== "system")];
 }
 
 /** Stable prefix of the delegation block — the sentinel `setDelegation` checks to
@@ -710,11 +738,10 @@ export class Session {
     // (not at construction), so this is an explicit flag, not `cfg.gate !== undefined`
     // (which is still undefined here). A plain eval/scratch task leaves it off — its
     // acceptance set can be empty, so a callable gate would answer vacuously.
-    // NOTE: the check-AWARE system prompt (see systemPrompt) is baked only for a FRESH
-    // session; a session resumed from `cfg.history` reuses its persisted prompt. That
-    // can't contradict today because offerCheck is set ONLY by the fresh headless
-    // boringstack build, which never resumes with history — if a resumable path ever
-    // sets offerCheck, rebuild or patch the persisted prompt there.
+    // A resumed session (cfg.history) with offerCheck would otherwise carry a persisted
+    // prompt that predates the check tool ("never run the gate") while advertising it —
+    // `resumeMessages` refreshes the leading system message to the check-aware prompt so
+    // the two can't contradict, enforcing the invariant in code (not a caller rule).
     const offerCheck = cfg.offerCheck === true;
 
     this.tools = toolsFor(false, {}, cfg.pullConventions === true, offerCheck);
@@ -865,15 +892,10 @@ export class Session {
         }),
         runner: cfg.gate ?? commandGate(task, cfg.parse),
       },
-      messages:
-        cfg.history !== undefined && cfg.history.length > 0
-          ? [...cfg.history]
-          : [
-              {
-                role: "system",
-                content: systemPrompt(cfg, workspaceMap, conventions),
-              },
-            ],
+      messages: resumeMessages(
+        cfg,
+        systemPrompt(cfg, workspaceMap, conventions)
+      ),
     };
 
     const session = new Session(cfg, ctx);

--- a/packages/core/src/loop/session.ts
+++ b/packages/core/src/loop/session.ts
@@ -621,7 +621,14 @@ function resumeMessages(
     return [...cfg.history];
   }
 
-  return [systemMsg, ...cfg.history.filter((m) => m.role !== "system")];
+  // Replace ONLY the leading base-prompt system message; keep every later message —
+  // including any LATER system instruction (persisted delegation, scope notes), which
+  // a blanket "drop all system" filter would silently lose.
+  const [first, ...rest] = cfg.history;
+
+  return first?.role === "system"
+    ? [systemMsg, ...rest]
+    : [systemMsg, ...cfg.history];
 }
 
 /** Stable prefix of the delegation block — the sentinel `setDelegation` checks to

--- a/packages/core/src/loop/session.ts
+++ b/packages/core/src/loop/session.ts
@@ -603,7 +603,9 @@ function systemPrompt(
  *  `toolsFor` now advertises — so a resumed build can never carry a prompt that requires
  *  or advertises a tool the session no longer exposes (the flag↔prompt invariant, both
  *  directions). Only the LEADING system message is replaced; a LATER persisted system
- *  instruction (delegation, scope notes) is preserved. */
+ *  instruction (delegation, scope notes) is preserved. This assumes `history[0]` is the
+ *  generated base prompt — true for every caller here, since `create` always seeds it
+ *  with `systemPrompt(cfg)` and later system text is APPENDED, never prepended. */
 function resumeMessages(
   cfg: ISessionConfig,
   freshSystem: string

--- a/packages/core/tests/convention-index.test.ts
+++ b/packages/core/tests/convention-index.test.ts
@@ -1,0 +1,79 @@
+import { test, expect } from "bun:test";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  buildConventionIndex,
+  conventionTopics,
+} from "../src/loop/conventions";
+import type { IProvider, IChatMessage } from "../src/inference";
+import { Session } from "../src/loop";
+
+// WS-A1: the PUSH index that front-loads the pullable convention catalog so the model
+// pulls the compliant pattern BEFORE writing (Bucket 1), complementing pull_conventions.
+
+test("buildConventionIndex lists every pullable topic", () => {
+  const index = buildConventionIndex();
+
+  for (const topic of conventionTopics()) {
+    expect(index).toContain(topic);
+  }
+});
+
+test("buildConventionIndex tells the model to pull BEFORE writing", () => {
+  const index = buildConventionIndex();
+
+  expect(index).toContain("pull_conventions");
+  expect(index).toContain("FIRST");
+  // Cross-references the gate rules a topic prevents, so the model connects
+  // topic → rule and knows what it's avoiding.
+  expect(index).toContain("prevents:");
+  expect(index).toContain("component-folder-structure");
+});
+
+// Behavioral: the index reaches the model's SYSTEM prompt only when the backend ships
+// a convention library (pullConventions), so plain sessions stay minimal.
+function systemCapturingProvider(cap: { system: string }): IProvider {
+  return {
+    async complete(messages: IChatMessage[]) {
+      const sys = messages.find((m) => m.role === "system");
+
+      cap.system = typeof sys?.content === "string" ? sys.content : "";
+
+      return { content: "done", toolCalls: [] };
+    },
+  };
+}
+
+test("the convention index is in the system prompt with pullConventions, absent without", async () => {
+  const dir = await mkdtemp(join(tmpdir(), "tsforge-conv-"));
+
+  try {
+    const withConv = { system: "" };
+    const on = await Session.create({
+      provider: systemCapturingProvider(withConv),
+      cwd: dir,
+      files: ["**/*"],
+      executionMode: "drive-to-green",
+      pullConventions: true,
+    });
+
+    await on.send("go");
+
+    expect(withConv.system).toContain("STACK CONVENTIONS");
+
+    const noConv = { system: "" };
+    const off = await Session.create({
+      provider: systemCapturingProvider(noConv),
+      cwd: dir,
+      files: ["**/*"],
+      executionMode: "drive-to-green",
+    });
+
+    await off.send("go");
+
+    expect(noConv.system).not.toContain("STACK CONVENTIONS");
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});

--- a/packages/core/tests/drive-to-green-check-prompt.test.ts
+++ b/packages/core/tests/drive-to-green-check-prompt.test.ts
@@ -234,3 +234,67 @@ test("resume refresh preserves a LATER system message (delegation/scope), replac
     await rm(dir, { recursive: true, force: true });
   }
 });
+
+test("resume refresh is two-directional: a stale check-requiring prompt is dropped when offerCheck is now OFF", async () => {
+  const dir = await mkdtemp(join(tmpdir(), "tsforge-dtg-"));
+  const cap: { system: string; roles?: string[] } = { system: "" };
+
+  // History persisted while offerCheck was ON (prompt tells the model to use `check`).
+  // Resuming WITHOUT offerCheck must refresh the prompt so it no longer requires a tool
+  // the session no longer advertises — the mirror of the on-resume case.
+  const staleHistory = [
+    {
+      role: "system" as const,
+      content: "OLD PROMPT: call the `check` tool before you stop.",
+    },
+    { role: "user" as const, content: "earlier" },
+    { role: "assistant" as const, content: "ok" },
+  ];
+
+  try {
+    const session = await Session.create({
+      provider: systemCapturingProvider(cap),
+      cwd: dir,
+      files: ["**/*"],
+      executionMode: "drive-to-green",
+      // offerCheck omitted → the refreshed prompt must NOT mention check.
+      history: staleHistory,
+    });
+
+    await session.send("continue");
+
+    expect(cap.system).not.toContain("`check`");
+    expect(cap.system).not.toContain("OLD PROMPT");
+    expect(cap.roles).toEqual(["system", "user", "assistant", "user"]);
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test("resume where history does NOT start with a system message prepends the fresh one, keeping all turns", async () => {
+  const dir = await mkdtemp(join(tmpdir(), "tsforge-dtg-"));
+  const cap: { system: string; roles?: string[] } = { system: "" };
+
+  const history = [
+    { role: "user" as const, content: "no leading system message" },
+    { role: "assistant" as const, content: "ok" },
+  ];
+
+  try {
+    const session = await Session.create({
+      provider: systemCapturingProvider(cap),
+      cwd: dir,
+      files: ["**/*"],
+      executionMode: "drive-to-green",
+      history,
+    });
+
+    await session.send("continue");
+
+    // Fresh system prepended; both original turns survive.
+    expect(cap.system.length).toBeGreaterThan(0);
+    expect(cap.roles).toEqual(["system", "user", "assistant", "user"]);
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});

--- a/packages/core/tests/drive-to-green-check-prompt.test.ts
+++ b/packages/core/tests/drive-to-green-check-prompt.test.ts
@@ -161,3 +161,76 @@ test("the Tools inventory lists pull_conventions alone when only offerConvention
   expect(toolsLine).toContain("`pull_conventions`");
   expect(toolsLine).not.toContain("`check`");
 });
+
+test("a resumed pullConventions session (no offerCheck) refreshes to include the convention index", async () => {
+  const dir = await mkdtemp(join(tmpdir(), "tsforge-dtg-"));
+  const cap: { system: string; roles?: string[] } = { system: "" };
+
+  const staleHistory = [
+    {
+      role: "system" as const,
+      content: "OLD PROMPT: no convention index here.",
+    },
+    { role: "user" as const, content: "earlier" },
+    { role: "assistant" as const, content: "ok" },
+  ];
+
+  try {
+    // pullConventions only — NO offerCheck. Locks the `|| cfg.pullConventions` arm:
+    // deleting it would leave the stale prompt (no convention index) on resume.
+    const session = await Session.create({
+      provider: systemCapturingProvider(cap),
+      cwd: dir,
+      files: ["**/*"],
+      executionMode: "drive-to-green",
+      pullConventions: true,
+      history: staleHistory,
+    });
+
+    await session.send("continue");
+
+    expect(cap.system).toContain("STACK CONVENTIONS");
+    expect(cap.system).not.toContain("OLD PROMPT");
+    expect(cap.roles).toEqual(["system", "user", "assistant", "user"]);
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test("resume refresh preserves a LATER system message (delegation/scope), replacing only the leading one", async () => {
+  const dir = await mkdtemp(join(tmpdir(), "tsforge-dtg-"));
+  const cap: { system: string; roles?: string[] } = { system: "" };
+
+  const laterSystem = "DELEGATION: keep this later system instruction intact.";
+  const history = [
+    { role: "system" as const, content: "OLD PROMPT: leading base prompt." },
+    { role: "user" as const, content: "earlier" },
+    { role: "system" as const, content: laterSystem },
+    { role: "assistant" as const, content: "ok" },
+  ];
+
+  try {
+    const session = await Session.create({
+      provider: systemCapturingProvider(cap),
+      cwd: dir,
+      files: ["**/*"],
+      executionMode: "drive-to-green",
+      offerCheck: true,
+      history,
+    });
+
+    await session.send("continue");
+
+    // The LEADING base prompt is replaced; the later system message is NOT dropped.
+    expect(cap.system).not.toContain("OLD PROMPT");
+    expect(cap.roles).toEqual([
+      "system",
+      "user",
+      "system",
+      "assistant",
+      "user",
+    ]);
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});

--- a/packages/core/tests/drive-to-green-check-prompt.test.ts
+++ b/packages/core/tests/drive-to-green-check-prompt.test.ts
@@ -1,6 +1,11 @@
 import { test, expect } from "bun:test";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { buildDriveToGreenSystem } from "../src/loop/prompt/prompt";
 import { DEFAULT_CONVENTIONS } from "../src/infer-rules/conventions";
+import type { IProvider, IChatMessage } from "../src/inference";
+import { Session } from "../src/loop";
 
 // WS-A4: the drive-to-green system prompt must not CONTRADICT the check tool. When
 // check is offered (the boringstack build), the execution guidance promotes it; when
@@ -30,4 +35,62 @@ test("offerCheck defaults to false (non-build drive-to-green paths unchanged)", 
   expect(buildDriveToGreenSystem(DEFAULT_CONVENTIONS)).toBe(
     buildDriveToGreenSystem(DEFAULT_CONVENTIONS, false)
   );
+});
+
+// Session-level wiring: the pure-builder tests above pass even if Session stops
+// forwarding cfg.offerCheck. These drive a real Session and inspect the SYSTEM
+// message, so a reverted one-liner (tool advertised + gate-ban prompt) fails here.
+function systemCapturingProvider(cap: { system: string }): IProvider {
+  return {
+    async complete(messages: IChatMessage[]) {
+      const sys = messages.find((m) => m.role === "system");
+
+      cap.system = typeof sys?.content === "string" ? sys.content : "";
+
+      return { content: "done", toolCalls: [] };
+    },
+  };
+}
+
+test("a drive-to-green Session with offerCheck puts the check guidance in its system prompt", async () => {
+  const dir = await mkdtemp(join(tmpdir(), "tsforge-dtg-"));
+  const cap = { system: "" };
+
+  try {
+    const session = await Session.create({
+      provider: systemCapturingProvider(cap),
+      cwd: dir,
+      files: ["**/*"],
+      executionMode: "drive-to-green",
+      offerCheck: true,
+    });
+
+    await session.send("go");
+
+    expect(cap.system).toContain("`check`");
+    expect(cap.system).not.toContain("or the acceptance/gate command yourself");
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test("a drive-to-green Session WITHOUT offerCheck keeps the original gate guidance", async () => {
+  const dir = await mkdtemp(join(tmpdir(), "tsforge-dtg-"));
+  const cap = { system: "" };
+
+  try {
+    const session = await Session.create({
+      provider: systemCapturingProvider(cap),
+      cwd: dir,
+      files: ["**/*"],
+      executionMode: "drive-to-green",
+    });
+
+    await session.send("go");
+
+    expect(cap.system).not.toContain("`check`");
+    expect(cap.system).toContain("Do NOT run `tsc`");
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
 });

--- a/packages/core/tests/drive-to-green-check-prompt.test.ts
+++ b/packages/core/tests/drive-to-green-check-prompt.test.ts
@@ -43,6 +43,7 @@ test("offerCheck defaults to false (non-build drive-to-green paths unchanged)", 
 function systemCapturingProvider(cap: {
   system: string;
   roles?: string[];
+  contents?: string[];
 }): IProvider {
   return {
     async complete(messages: IChatMessage[]) {
@@ -50,6 +51,9 @@ function systemCapturingProvider(cap: {
 
       cap.system = typeof sys?.content === "string" ? sys.content : "";
       cap.roles = messages.map((m) => m.role);
+      cap.contents = messages.map((m) =>
+        typeof m.content === "string" ? m.content : ""
+      );
 
       return { content: "done", toolCalls: [] };
     },
@@ -176,8 +180,8 @@ test("a resumed pullConventions session (no offerCheck) refreshes to include the
   ];
 
   try {
-    // pullConventions only — NO offerCheck. Locks the `|| cfg.pullConventions` arm:
-    // deleting it would leave the stale prompt (no convention index) on resume.
+    // pullConventions only — NO offerCheck. The unconditional resume refresh must still
+    // rebuild the prompt so the convention index appears in place of the stale one.
     const session = await Session.create({
       provider: systemCapturingProvider(cap),
       cwd: dir,
@@ -199,7 +203,9 @@ test("a resumed pullConventions session (no offerCheck) refreshes to include the
 
 test("resume refresh preserves a LATER system message (delegation/scope), replacing only the leading one", async () => {
   const dir = await mkdtemp(join(tmpdir(), "tsforge-dtg-"));
-  const cap: { system: string; roles?: string[] } = { system: "" };
+  const cap: { system: string; roles?: string[]; contents?: string[] } = {
+    system: "",
+  };
 
   const laterSystem = "DELEGATION: keep this later system instruction intact.";
   const history = [
@@ -221,7 +227,8 @@ test("resume refresh preserves a LATER system message (delegation/scope), replac
 
     await session.send("continue");
 
-    // The LEADING base prompt is replaced; the later system message is NOT dropped.
+    // The LEADING base prompt is replaced; the later system message is NOT dropped —
+    // and its CONTENT survives verbatim (a role-only check would pass if it were cleared).
     expect(cap.system).not.toContain("OLD PROMPT");
     expect(cap.roles).toEqual([
       "system",
@@ -230,6 +237,7 @@ test("resume refresh preserves a LATER system message (delegation/scope), replac
       "assistant",
       "user",
     ]);
+    expect(cap.contents).toContain(laterSystem);
   } finally {
     await rm(dir, { recursive: true, force: true });
   }

--- a/packages/core/tests/drive-to-green-check-prompt.test.ts
+++ b/packages/core/tests/drive-to-green-check-prompt.test.ts
@@ -40,12 +40,16 @@ test("offerCheck defaults to false (non-build drive-to-green paths unchanged)", 
 // Session-level wiring: the pure-builder tests above pass even if Session stops
 // forwarding cfg.offerCheck. These drive a real Session and inspect the SYSTEM
 // message, so a reverted one-liner (tool advertised + gate-ban prompt) fails here.
-function systemCapturingProvider(cap: { system: string }): IProvider {
+function systemCapturingProvider(cap: {
+  system: string;
+  roles?: string[];
+}): IProvider {
   return {
     async complete(messages: IChatMessage[]) {
       const sys = messages.find((m) => m.role === "system");
 
       cap.system = typeof sys?.content === "string" ? sys.content : "";
+      cap.roles = messages.map((m) => m.role);
 
       return { content: "done", toolCalls: [] };
     },
@@ -112,7 +116,7 @@ test("the Tools inventory lists check and pull_conventions when they are offered
 
 test("a resumed offerCheck session refreshes its system prompt to the check-aware one", async () => {
   const dir = await mkdtemp(join(tmpdir(), "tsforge-dtg-"));
-  const cap = { system: "" };
+  const cap: { system: string; roles?: string[] } = { system: "" };
 
   // A persisted history whose system message predates the check tool (says the old
   // "never run the gate yourself"). On resume WITH offerCheck it must be refreshed.
@@ -141,7 +145,19 @@ test("a resumed offerCheck session refreshes its system prompt to the check-awar
     // The stale system message is gone; the check-aware prompt is in its place.
     expect(cap.system).toContain("`check`");
     expect(cap.system).not.toContain("OLD PROMPT");
+    // Two-sided: the refresh must KEEP the prior conversation, not drop it to a lone
+    // system message. The earlier user + assistant turns survive after the fresh system.
+    expect(cap.roles).toEqual(["system", "user", "assistant", "user"]);
   } finally {
     await rm(dir, { recursive: true, force: true });
   }
+});
+
+test("the Tools inventory lists pull_conventions alone when only offerConventions is set", () => {
+  const prompt = buildDriveToGreenSystem(DEFAULT_CONVENTIONS, false, true);
+  const toolsLine =
+    prompt.split("\n").find((l) => l.startsWith("Tools:")) ?? "";
+
+  expect(toolsLine).toContain("`pull_conventions`");
+  expect(toolsLine).not.toContain("`check`");
 });

--- a/packages/core/tests/drive-to-green-check-prompt.test.ts
+++ b/packages/core/tests/drive-to-green-check-prompt.test.ts
@@ -94,3 +94,54 @@ test("a drive-to-green Session WITHOUT offerCheck keeps the original gate guidan
     await rm(dir, { recursive: true, force: true });
   }
 });
+
+test("the Tools inventory lists check and pull_conventions when they are offered", () => {
+  const both = buildDriveToGreenSystem(DEFAULT_CONVENTIONS, true, true);
+
+  expect(both).toContain("`check` (run the gate now");
+  expect(both).toContain("`pull_conventions`");
+
+  // Neither leaks into the inventory when not offered.
+  const neither = buildDriveToGreenSystem(DEFAULT_CONVENTIONS, false, false);
+  const toolsLine =
+    neither.split("\n").find((l) => l.startsWith("Tools:")) ?? "";
+
+  expect(toolsLine).not.toContain("check");
+  expect(toolsLine).not.toContain("pull_conventions");
+});
+
+test("a resumed offerCheck session refreshes its system prompt to the check-aware one", async () => {
+  const dir = await mkdtemp(join(tmpdir(), "tsforge-dtg-"));
+  const cap = { system: "" };
+
+  // A persisted history whose system message predates the check tool (says the old
+  // "never run the gate yourself"). On resume WITH offerCheck it must be refreshed.
+  const staleHistory = [
+    {
+      role: "system" as const,
+      content:
+        "OLD PROMPT: never run `tsc`/the gate yourself; the harness owns it.",
+    },
+    { role: "user" as const, content: "earlier turn" },
+    { role: "assistant" as const, content: "ok" },
+  ];
+
+  try {
+    const session = await Session.create({
+      provider: systemCapturingProvider(cap),
+      cwd: dir,
+      files: ["**/*"],
+      executionMode: "drive-to-green",
+      offerCheck: true,
+      history: staleHistory,
+    });
+
+    await session.send("continue");
+
+    // The stale system message is gone; the check-aware prompt is in its place.
+    expect(cap.system).toContain("`check`");
+    expect(cap.system).not.toContain("OLD PROMPT");
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});

--- a/packages/core/tests/drive-to-green-check-prompt.test.ts
+++ b/packages/core/tests/drive-to-green-check-prompt.test.ts
@@ -1,0 +1,33 @@
+import { test, expect } from "bun:test";
+import { buildDriveToGreenSystem } from "../src/loop/prompt/prompt";
+import { DEFAULT_CONVENTIONS } from "../src/infer-rules/conventions";
+
+// WS-A4: the drive-to-green system prompt must not CONTRADICT the check tool. When
+// check is offered (the boringstack build), the execution guidance promotes it; when
+// not, the original "the gate runs automatically, don't run it yourself" stands.
+
+test("with offerCheck, the drive-to-green prompt promotes the check tool", () => {
+  const prompt = buildDriveToGreenSystem(DEFAULT_CONVENTIONS, true);
+
+  expect(prompt).toContain("`check`");
+  expect(prompt).toContain("before you stop");
+  // Shell gate execution is still banned — check is a tool, not `bun run check`.
+  expect(prompt).toContain("Do NOT run the gate through the SHELL");
+  // The self-contradiction ("do NOT run ... the gate command yourself") is gone.
+  expect(prompt).not.toContain("or the acceptance/gate command yourself");
+});
+
+test("without offerCheck, the drive-to-green prompt keeps the original gate guidance", () => {
+  const prompt = buildDriveToGreenSystem(DEFAULT_CONVENTIONS, false);
+
+  expect(prompt).toContain("the harness AUTOMATICALLY runs the gate");
+  expect(prompt).toContain("Do NOT run `tsc`");
+  // No mention of a check tool the model wasn't given.
+  expect(prompt).not.toContain("`check`");
+});
+
+test("offerCheck defaults to false (non-build drive-to-green paths unchanged)", () => {
+  expect(buildDriveToGreenSystem(DEFAULT_CONVENTIONS)).toBe(
+    buildDriveToGreenSystem(DEFAULT_CONVENTIONS, false)
+  );
+});

--- a/packages/core/tests/session-check-tool.test.ts
+++ b/packages/core/tests/session-check-tool.test.ts
@@ -70,6 +70,7 @@ test("offerCheck wires the seam: the model's check call returns the injected gat
       provider: checkingProvider(captured),
       cwd: dir,
       files: ["**/*"],
+      executionMode: "drive-to-green",
       offerCheck: true,
       gate: fixedGate(RED),
     });
@@ -123,6 +124,7 @@ test("runCheck reads the gate LAZILY — a mid-build setGate swap is honored", a
       provider: checkingProvider(captured),
       cwd: dir,
       files: ["**/*"],
+      executionMode: "drive-to-green",
       offerCheck: true,
       gate: fixedGate(GREEN), // initial gate: green
     });
@@ -211,6 +213,7 @@ test("check goes RED on a META_RULE error even when the gate command is GREEN (t
       provider: createThenCheckProvider(captured, "src/bad.ts"),
       cwd: dir,
       files: ["**/*"],
+      executionMode: "drive-to-green",
       offerCheck: true,
       // Gate COMMAND is green — only the meta-rule (no-eslint-disable-comments,
       // change-scoped to the file the model just wrote) makes it red.
@@ -277,6 +280,7 @@ test("offerCheck:true makes the Session ADVERTISE check to the model", async () 
       provider: toolNameCapturingProvider(captured),
       cwd: dir,
       files: ["**/*"],
+      executionMode: "drive-to-green",
       offerCheck: true,
       gate: fixedGate(GREEN),
     });

--- a/packages/core/tests/session-check-tool.test.ts
+++ b/packages/core/tests/session-check-tool.test.ts
@@ -312,3 +312,27 @@ test("without offerCheck the Session does NOT advertise check (the tool is un-di
     await rm(dir, { recursive: true, force: true });
   }
 });
+
+test("a CHAT session with offerCheck does NOT advertise check (tool tied to drive-to-green)", async () => {
+  const dir = await mkdtemp(join(tmpdir(), "tsforge-check-"));
+  const captured: { names: string[] } = { names: [] };
+
+  try {
+    // offerCheck:true but NO executionMode (defaults to chat, whose prompt is not
+    // check-aware). Advertising check here would give the tool + a contradicting
+    // prompt — so it must be withheld. Locks the drive-to-green guard.
+    const session = await Session.create({
+      provider: toolNameCapturingProvider(captured),
+      cwd: dir,
+      files: ["**/*"],
+      offerCheck: true,
+      gate: fixedGate(GREEN),
+    });
+
+    await session.send("go");
+
+    expect(captured.names).not.toContain("check");
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
## WS-A — situational awareness (front-load the stack-active rules)

Second in the co-pilot v1 stack: **WS-G (#140) ← WS-A ← WS-C**. Base is `feat/ws-g-check-tool` — review/merge #140 first.

Attacks bucket 1 (the traced 1→8 convention spray): the model wrote stack-rule-violating code it was never shown. WS-A front-loads the stack-active rule catalog + compliant guidance and fixes the anti-investigation framing, so the model writes it right the first time.

Note: **WS-A2 (attach `ruleHelp` to gate errors) was verified as a dead-end and dropped** — boringstack uses its own `@boring-stack-pkg` eslint plugins (rule ids like `react-component-architecture/...` enforcing `src/features/`), while tsforge's `ruleHelp` docs are keyed `tsforge/` and would teach the wrong `src/views/` path. The working vehicle is the conventions push (front-loaded, bare-name matched).

Panel-passed; build-validated safe (no regression) on a live DGX build.
