### PR TITLE
fix(ws-a): front-load the actual convention guides, not just a topic index

### DIFF
--- a/packages/core/src/agent/agent.constants.ts
+++ b/packages/core/src/agent/agent.constants.ts
@@ -350,7 +350,7 @@ export const PULL_CONVENTIONS_TOOL = {
   function: {
     name: TOOL_NAME.pullConventions,
     description:
-      "Pull the boringstack HOW-TO guide for a topic BEFORE you write that kind of code — so you write it right the first time instead of getting a gate error. Call it when you're about to create a component, write JSX, place state, add a route/form, or hit a rule you're unsure how to satisfy. Returns the exact pattern the gate enforces.",
+      "Re-fetch the boringstack HOW-TO guide for a topic on demand. The core guides are ALREADY front-loaded in your system prompt — use this to re-read one you need again, or for a rule you're still unsure how to satisfy. Returns the exact pattern the gate enforces.",
     parameters: {
       type: "object",
       properties: {
@@ -364,9 +364,10 @@ export const PULL_CONVENTIONS_TOOL = {
             "no-casts",
             "routing",
             "forms",
+            "data-fetching",
           ],
           description:
-            "which guide: component-anatomy (where a component lives + one-per-file), file-layout (no inline types/constants/helpers), jsx (no computation in markup), state (hooks, not component body), no-casts (type guards instead of `as`/`!`), routing (thin route files), forms.",
+            "which guide: component-anatomy (where a component lives + one-per-file), file-layout (no inline types/constants/helpers), jsx (no computation in markup), state (hooks, not component body), no-casts (type guards instead of `as`/`!`), routing (thin route files), forms, data-fetching (api-client, never raw fetch).",
         },
       },
       required: ["topic"],

--- a/packages/core/src/agent/agent.constants.ts
+++ b/packages/core/src/agent/agent.constants.ts
@@ -365,9 +365,10 @@ export const PULL_CONVENTIONS_TOOL = {
             "routing",
             "forms",
             "data-fetching",
+            "lint-gotchas",
           ],
           description:
-            "which guide: component-anatomy (where a component lives + one-per-file), file-layout (no inline types/constants/helpers), jsx (no computation in markup), state (hooks, not component body), no-casts (type guards instead of `as`/`!`), routing (thin route files), forms, data-fetching (api-client, never raw fetch).",
+            "which guide: component-anatomy (where a component lives + one-per-file), file-layout (no inline types/constants/helpers), jsx (no computation in markup), state (hooks, not component body), no-casts (type guards instead of `as`/`!`), routing (thin route files), forms, data-fetching (api-client, never raw fetch), lint-gotchas (await promises, no void-expr values, no stringified errors, no duplicate strings).",
         },
       },
       required: ["topic"],

--- a/packages/core/src/loop/conventions.ts
+++ b/packages/core/src/loop/conventions.ts
@@ -127,7 +127,7 @@ export function conventionTopics(): ConventionTopic[] {
  *  long tail, not the primary teaching. */
 export function buildConventionGuides(): string {
   return [
-    "HOW THIS STACK WRITES CODE — read this BEFORE you write, not after the gate rejects you. These are the exact compliant patterns the gate enforces; write your FIRST draft this way instead of guessing from memory and burning turns repairing. (Each guide names the rules it satisfies; `pull_conventions` fetches any of these again on demand.)",
+    "HOW THIS STACK WRITES CODE — read this BEFORE you write, not after the gate rejects you. These are the exact compliant patterns the gate enforces; write your FIRST draft this way instead of guessing from memory and burning turns repairing. (`pull_conventions` re-fetches any of these on demand.)",
     "",
     ...conventionTopics().map((t) => conventionGuide(t)),
   ].join("\n\n");

--- a/packages/core/src/loop/conventions.ts
+++ b/packages/core/src/loop/conventions.ts
@@ -131,7 +131,7 @@ const GUIDES: Readonly<Record<ConventionTopic, string>> = {
     "a BLOCK body: `onClick={() => { setOpen(true); }}`, not `() => setOpen(true)`.\n" +
     "• NEVER stringify an error into a log — pass the error object: " +
     '`log.error({ err }, "failed")`, never `` log.error(`${err}`) `` or `String(err)`.\n' +
-    "• HOIST repeated string literals — the same literal 3+ times is a no-duplicate-string " +
+    "• HOIST heavily-repeated string literals — the same literal 5+ times is a no-duplicate-string " +
     "error; pull it into a `const` (or `<Feature>.constants.ts`) and reference that.",
 };
 

--- a/packages/core/src/loop/conventions.ts
+++ b/packages/core/src/loop/conventions.ts
@@ -122,9 +122,10 @@ const GUIDES: Readonly<Record<ConventionTopic, string>> = {
   "lint-gotchas":
     "STRICT-LINT GOTCHAS (boringstack). The gate is eslint with EVERY rule an error; a fresh " +
     "feature trips these most, so write them right up front:\n" +
-    "• AWAIT every promise — an async call you don't await is a floating-promise / " +
-    "await-thenable error. Write `await doX()`; only `void doX()` if you deliberately " +
-    "fire-and-forget.\n" +
+    "• AWAIT the promises you use — an un-awaited async call is a no-floating-promises error; " +
+    "write `await doX()` (or `void doX()` to deliberately fire-and-forget).\n" +
+    "• …but do NOT await non-promises — `await` on a plain value or a sync function's result is " +
+    "an await-thenable error; drop the `await`.\n" +
     "• NO value out of a void expression — never `return foo.forEach(...)` or " +
     "`const x = setState(v)`; call the void thing, then return/act separately. For handlers use " +
     "a BLOCK body: `onClick={() => { setOpen(true); }}`, not `() => setOpen(true)`.\n" +

--- a/packages/core/src/loop/conventions.ts
+++ b/packages/core/src/loop/conventions.ts
@@ -76,7 +76,8 @@ const GUIDES: Readonly<Record<ConventionTopic, string>> = {
   state:
     "STATE (boringstack). ALL `useState`/`useReducer`/`useEffect`/`useMemo`/" +
     "`useCallback` live in `<feature>.hooks.ts`, never in a component body. Server " +
-    "data → a hook using react-query/fetch that narrows the response. A hooks file " +
+    "data → a hook using react-query over the generated api-client (NEVER raw `fetch` — " +
+    "see data-fetching) that narrows the response. A hooks file " +
     "exporting too many hooks splits into focused modules (e.g. `*.queries.ts` + " +
     "`*.mutations.ts`).",
   "no-casts":

--- a/packages/core/src/loop/conventions.ts
+++ b/packages/core/src/loop/conventions.ts
@@ -22,6 +22,7 @@ const TOPICS = [
   "routing",
   "forms",
   "data-fetching",
+  "lint-gotchas",
 ] as const;
 
 export type ConventionTopic = (typeof TOPICS)[number];
@@ -48,6 +49,17 @@ export const TOPIC_RULES: Readonly<Record<ConventionTopic, readonly string[]>> =
     // guarded `response.error` — this stack throws on errors, so that guard is dead.
     // Mapping it here pushes the data-fetching guide on the FIRST such red.
     "data-fetching": ["no-unnecessary-condition"],
+    // The strict-lint rules a fresh feature trips most (measured on a live build): floating/
+    // un-awaited promises, void-returning expressions used as values, errors stringified into
+    // logs, and repeated string literals. None are structural — they're write-time habits the
+    // model gets wrong then grinds down one gate at a time.
+    "lint-gotchas": [
+      "await-thenable",
+      "no-floating-promises",
+      "no-confusing-void-expression",
+      "no-error-stringify",
+      "no-duplicate-string",
+    ],
   };
 
 const GUIDES: Readonly<Record<ConventionTopic, string>> = {
@@ -107,6 +119,19 @@ const GUIDES: Readonly<Record<ConventionTopic, string>> = {
     "a dead `no-unnecessary-condition` gate error. Just read `data`. Put queries in " +
     "`<Feature>.queries.ts` and mutations in `<Feature>.mutations.ts`. If a path isn't " +
     "in the spec yet, add the API route first, then `bun run generate:api`.",
+  "lint-gotchas":
+    "STRICT-LINT GOTCHAS (boringstack). The gate is eslint with EVERY rule an error; a fresh " +
+    "feature trips these most, so write them right up front:\n" +
+    "• AWAIT every promise — an async call you don't await is a floating-promise / " +
+    "await-thenable error. Write `await doX()`; only `void doX()` if you deliberately " +
+    "fire-and-forget.\n" +
+    "• NO value out of a void expression — never `return foo.forEach(...)` or " +
+    "`const x = setState(v)`; call the void thing, then return/act separately. For handlers use " +
+    "a BLOCK body: `onClick={() => { setOpen(true); }}`, not `() => setOpen(true)`.\n" +
+    "• NEVER stringify an error into a log — pass the error object: " +
+    '`log.error({ err }, "failed")`, never `` log.error(`${err}`) `` or `String(err)`.\n' +
+    "• HOIST repeated string literals — the same literal 3+ times is a no-duplicate-string " +
+    "error; pull it into a `const` (or `<Feature>.constants.ts`) and reference that.",
 };
 
 /** The guide for a topic (the exact string pushed or pulled). */

--- a/packages/core/src/loop/conventions.ts
+++ b/packages/core/src/loop/conventions.ts
@@ -123,18 +123,12 @@ export function conventionTopics(): ConventionTopic[] {
  *  catalog exists and pulls the compliant pattern BEFORE writing that kind of code —
  *  the situational awareness that stops it writing a convention-violating draft it
  *  then burns turns fixing. Complements `pull_conventions` (the on-demand fetch). */
-export function buildConventionIndex(): string {
-  const rows = conventionTopics().map((t) => {
-    const rules = TOPIC_RULES[t];
-    const prevents = rules.length > 0 ? ` — prevents: ${rules.join(", ")}` : "";
-
-    return `  • ${t}${prevents}`;
-  });
-
+export function buildConventionGuides(): string {
   return [
-    "STACK CONVENTIONS. This stack enforces strict patterns the gate REJECTS if you guess. Before writing a given kind of code, call `pull_conventions` with the matching topic to get the compliant shape FIRST — do not write from memory and discover the rule at the gate. Topics:",
-    ...rows,
-  ].join("\n");
+    "HOW THIS STACK WRITES CODE — read this BEFORE you write, not after the gate rejects you. These are the exact compliant patterns the gate enforces; write your FIRST draft this way instead of guessing from memory and burning turns repairing. (Each guide names the rules it satisfies; `pull_conventions` fetches any of these again on demand.)",
+    "",
+    ...conventionTopics().map((t) => conventionGuide(t)),
+  ].join("\n\n");
 }
 
 /** Narrow an arbitrary string to a ConventionTopic (for the pull tool's arg) —

--- a/packages/core/src/loop/conventions.ts
+++ b/packages/core/src/loop/conventions.ts
@@ -118,11 +118,12 @@ export function conventionTopics(): ConventionTopic[] {
   return [...TOPICS];
 }
 
-/** A compact PUSH index of the pullable convention topics + the gate rules each one
- *  prevents (WS-A1). Front-loaded into the build system prompt so the model knows the
- *  catalog exists and pulls the compliant pattern BEFORE writing that kind of code —
- *  the situational awareness that stops it writing a convention-violating draft it
- *  then burns turns fixing. Complements `pull_conventions` (the on-demand fetch). */
+/** The full PUSH body of every stack convention GUIDE (not just a topic index), joined for the
+ *  build system prompt (WS-A1). Front-loading the actual compliant patterns — the exact shape
+ *  for components, state, JSX, casts, data-fetching, etc. — lets the model write it right on the
+ *  FIRST draft instead of guessing from memory and burning turns at the gate. The reactive PUSH
+ *  (`unseenGuidesForErrors`) and `pull_conventions` remain fallbacks for reinforcement and the
+ *  long tail, not the primary teaching. */
 export function buildConventionGuides(): string {
   return [
     "HOW THIS STACK WRITES CODE — read this BEFORE you write, not after the gate rejects you. These are the exact compliant patterns the gate enforces; write your FIRST draft this way instead of guessing from memory and burning turns repairing. (Each guide names the rules it satisfies; `pull_conventions` fetches any of these again on demand.)",

--- a/packages/core/src/loop/prompt/prompt.ts
+++ b/packages/core/src/loop/prompt/prompt.ts
@@ -106,7 +106,7 @@ export function buildDriveToGreenSystem(
   // check / pull_conventions guidance below it.
   const extraTools = [
     offerConventions
-      ? "`pull_conventions` (fetch a stack convention guide before writing that kind of code)"
+      ? "`pull_conventions` (re-fetch a stack convention guide on demand — the core guides are already in this prompt)"
       : "",
     offerCheck
       ? "`check` (run the gate now, get your whole structured error set)"

--- a/packages/core/src/loop/session.ts
+++ b/packages/core/src/loop/session.ts
@@ -35,7 +35,7 @@ import {
   type ErrorSet,
 } from "../validate";
 import { ruleHelp } from "./feedback";
-import { buildConventionIndex } from "./conventions";
+import { buildConventionGuides } from "./conventions";
 import { detectStack } from "../stack-detection";
 import { recallMapBlock } from "../codebase";
 import {
@@ -603,12 +603,13 @@ function systemPrompt(
   // it here too so test-first is the out-of-the-box default everywhere.
   const tdd = flags.tdd() ? `${buildTddGuidance(conventions)}\n\n` : "";
 
-  // WS-A1: front-load the stack convention topic index when the backend ships a
-  // convention library (pullConventions). PUSHes awareness that the catalog exists so
-  // the model pulls the compliant pattern BEFORE writing — the Bucket-1 fix that stops
-  // it drafting convention-violating code it then burns turns repairing.
+  // WS-A1: front-load the actual stack convention GUIDES (not just a topic index) when the
+  // backend ships a convention library (pullConventions). The compliant pattern for every core
+  // topic is in the prompt UP FRONT, so the model writes it right the FIRST time — the Bucket-1
+  // fix. The reactive PUSH (unseenGuidesForErrors) and `pull_conventions` remain as fallbacks
+  // for reinforcement and the long tail, not the primary teaching.
   const conv =
-    cfg.pullConventions === true ? `${buildConventionIndex()}\n\n` : "";
+    cfg.pullConventions === true ? `${buildConventionGuides()}\n\n` : "";
 
   const contract = taskContract(cfg.files ?? [], cfg.accept);
 

--- a/packages/core/tests/convention-index.test.ts
+++ b/packages/core/tests/convention-index.test.ts
@@ -6,6 +6,7 @@ import {
   buildConventionGuides,
   conventionGuide,
   conventionTopics,
+  topicForRule,
 } from "../src/loop/conventions";
 import { PULL_CONVENTIONS_TOOL } from "../src/agent/agent.constants";
 import type { IProvider, IChatMessage } from "../src/inference";
@@ -115,8 +116,26 @@ test("the STATE guide routes server data through the api-client, not raw fetch",
 test("the lint-gotchas guide covers the top strict-lint offenders", () => {
   const g = conventionGuide("lint-gotchas");
 
-  expect(g).toContain("AWAIT");
   expect(g).toContain("void expression");
   expect(g).toContain("stringify an error");
   expect(g).toContain("repeated string literals");
+  // await-thenable and no-floating-promises are OPPOSITE rules — the guide must teach BOTH
+  // directions (add await for a floating promise; DROP await on a non-promise), not conflate them.
+  expect(g).toContain("no-floating-promises");
+  expect(g).toContain("await-thenable");
+  expect(g).toContain("drop the `await`");
+});
+
+// Lock the rule→lint-gotchas mapping so unseenGuidesForErrors re-injects this guide on exactly
+// these rules (and a renamed/removed rule fails the test rather than silently un-mapping).
+test("the strict-lint rules map to the lint-gotchas guide", () => {
+  for (const rule of [
+    "await-thenable",
+    "no-floating-promises",
+    "no-confusing-void-expression",
+    "no-error-stringify",
+    "no-duplicate-string",
+  ]) {
+    expect(topicForRule(rule)).toBe("lint-gotchas");
+  }
 });

--- a/packages/core/tests/convention-index.test.ts
+++ b/packages/core/tests/convention-index.test.ts
@@ -7,6 +7,7 @@ import {
   conventionGuide,
   conventionTopics,
 } from "../src/loop/conventions";
+import { PULL_CONVENTIONS_TOOL } from "../src/agent/agent.constants";
 import type { IProvider, IChatMessage } from "../src/inference";
 import { Session } from "../src/loop";
 
@@ -87,4 +88,24 @@ test("the convention guides are in the system prompt with pullConventions, absen
   } finally {
     await rm(dir, { recursive: true, force: true });
   }
+});
+
+// The pull_conventions tool enum is a hand-maintained duplicate of TOPICS — this locks it to
+// conventionTopics() so a new topic (or a dropped one, like data-fetching was) can't silently
+// diverge, leaving a guide the model can't actually pull.
+test("PULL_CONVENTIONS_TOOL enum stays in sync with conventionTopics()", () => {
+  const enumTopics =
+    PULL_CONVENTIONS_TOOL.function.parameters.properties.topic.enum;
+
+  expect([...enumTopics].sort()).toEqual([...conventionTopics()].sort());
+});
+
+// The STATE guide must NOT tell the model to use raw fetch (it contradicts DATA-FETCHING's
+// fetch ban) — the aggregate front-load test can't catch this because the data-fetching guide
+// separately contains the api-client string.
+test("the STATE guide routes server data through the api-client, not raw fetch", () => {
+  const state = conventionGuide("state");
+
+  expect(state).toContain("api-client");
+  expect(state).not.toContain("react-query/fetch");
 });

--- a/packages/core/tests/convention-index.test.ts
+++ b/packages/core/tests/convention-index.test.ts
@@ -3,36 +3,45 @@ import { mkdtemp, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import {
-  buildConventionIndex,
+  buildConventionGuides,
+  conventionGuide,
   conventionTopics,
 } from "../src/loop/conventions";
 import type { IProvider, IChatMessage } from "../src/inference";
 import { Session } from "../src/loop";
 
-// WS-A1: the PUSH index that front-loads the pullable convention catalog so the model
-// pulls the compliant pattern BEFORE writing (Bucket 1), complementing pull_conventions.
+// WS-A1: front-load the actual convention GUIDES (the compliant patterns), not merely a
+// topic index — so the model writes it right the FIRST time (Bucket 1) instead of pulling
+// only reactively after the gate rejects it.
 
-test("buildConventionIndex lists every pullable topic", () => {
-  const index = buildConventionIndex();
+test("buildConventionGuides front-loads the actual guide CONTENT for every topic", () => {
+  const guides = buildConventionGuides();
 
+  // The full compliant pattern for each topic is present — not just its name.
   for (const topic of conventionTopics()) {
-    expect(index).toContain(topic);
+    expect(guides).toContain(conventionGuide(topic));
   }
 });
 
-test("buildConventionIndex tells the model to pull BEFORE writing", () => {
-  const index = buildConventionIndex();
+test("buildConventionGuides carries the concrete patterns that prevent the traced sprays", () => {
+  const guides = buildConventionGuides();
 
-  expect(index).toContain("pull_conventions");
-  expect(index).toContain("FIRST");
-  // Cross-references the gate rules a topic prevents, so the model connects
-  // topic → rule and knows what it's avoiding.
-  expect(index).toContain("prevents:");
-  expect(index).toContain("component-folder-structure");
+  // The exact idioms the model was guessing wrong (the inv157 1→8 spray classes):
+  expect(guides).toContain("@/lib/api/client"); // data-fetching (no fetch/axios)
+  expect(guides).toContain("src/features/"); // component anatomy / layout
+  expect(guides).toContain("TYPE GUARD"); // no-casts (no `as`/`!`)
+  expect(guides).toContain("hooks.ts"); // state lives in hooks, not the body
 });
 
-// Behavioral: the index reaches the model's SYSTEM prompt only when the backend ships
-// a convention library (pullConventions), so plain sessions stay minimal.
+test("buildConventionGuides tells the model to write it right BEFORE the gate", () => {
+  const guides = buildConventionGuides();
+
+  expect(guides).toContain("BEFORE you write");
+  expect(guides).toContain("FIRST");
+});
+
+// Behavioral: the guides reach the model's SYSTEM prompt only when the backend ships a
+// convention library (pullConventions), so plain sessions stay minimal.
 function systemCapturingProvider(cap: { system: string }): IProvider {
   return {
     async complete(messages: IChatMessage[]) {
@@ -45,7 +54,7 @@ function systemCapturingProvider(cap: { system: string }): IProvider {
   };
 }
 
-test("the convention index is in the system prompt with pullConventions, absent without", async () => {
+test("the convention guides are in the system prompt with pullConventions, absent without", async () => {
   const dir = await mkdtemp(join(tmpdir(), "tsforge-conv-"));
 
   try {
@@ -60,7 +69,9 @@ test("the convention index is in the system prompt with pullConventions, absent 
 
     await on.send("go");
 
-    expect(withConv.system).toContain("STACK CONVENTIONS");
+    expect(withConv.system).toContain("HOW THIS STACK WRITES CODE");
+    // The actual pattern is inline, not just a menu entry.
+    expect(withConv.system).toContain("@/lib/api/client");
 
     const noConv = { system: "" };
     const off = await Session.create({
@@ -72,7 +83,7 @@ test("the convention index is in the system prompt with pullConventions, absent 
 
     await off.send("go");
 
-    expect(noConv.system).not.toContain("STACK CONVENTIONS");
+    expect(noConv.system).not.toContain("HOW THIS STACK WRITES CODE");
   } finally {
     await rm(dir, { recursive: true, force: true });
   }

--- a/packages/core/tests/convention-index.test.ts
+++ b/packages/core/tests/convention-index.test.ts
@@ -109,3 +109,14 @@ test("the STATE guide routes server data through the api-client, not raw fetch",
   expect(state).toContain("api-client");
   expect(state).not.toContain("react-query/fetch");
 });
+
+// The lint-gotchas guide targets the strict rules a fresh feature trips most (measured live):
+// await-thenable, no-confusing-void-expression, no-error-stringify, no-duplicate-string.
+test("the lint-gotchas guide covers the top strict-lint offenders", () => {
+  const g = conventionGuide("lint-gotchas");
+
+  expect(g).toContain("AWAIT");
+  expect(g).toContain("void expression");
+  expect(g).toContain("stringify an error");
+  expect(g).toContain("repeated string literals");
+});

--- a/packages/core/tests/drive-to-green-check-prompt.test.ts
+++ b/packages/core/tests/drive-to-green-check-prompt.test.ts
@@ -181,7 +181,7 @@ test("a resumed pullConventions session (no offerCheck) refreshes to include the
 
   try {
     // pullConventions only — NO offerCheck. The unconditional resume refresh must still
-    // rebuild the prompt so the convention index appears in place of the stale one.
+    // rebuild the prompt so the convention guides appear in place of the stale one.
     const session = await Session.create({
       provider: systemCapturingProvider(cap),
       cwd: dir,
@@ -193,7 +193,7 @@ test("a resumed pullConventions session (no offerCheck) refreshes to include the
 
     await session.send("continue");
 
-    expect(cap.system).toContain("STACK CONVENTIONS");
+    expect(cap.system).toContain("HOW THIS STACK WRITES CODE");
     expect(cap.system).not.toContain("OLD PROMPT");
     expect(cap.roles).toEqual(["system", "user", "assistant", "user"]);
   } finally {


### PR DESCRIPTION
WS-A1 under-delivered: it front-loaded only a topic INDEX and told the model to pull_conventions. Live build showed 9 REACTIVE pulls, ~0 upfront adoption. This front-loads the 8 actual guide bodies (~57 lines) so the model writes it right the first time. Reactive PUSH + pull_conventions remain fallbacks. Tests assert the guide CONTENT (apiClient, src/features/, TYPE GUARD, hooks.ts) is inline in the system prompt.