### PR TITLE
fix(boringstack): steer discrete parse errors to a full-file rewrite

### DIFF
--- a/packages/core/src/loop/boringstack/gate-stages.ts
+++ b/packages/core/src/loop/boringstack/gate-stages.ts
@@ -111,11 +111,19 @@ export function signatureToError(sig: string): IErrorItem {
     // re-breaks its braces/generics/JSX, so it grinds at the SAME error for turns (observed
     // live: stuck at 2 `'>' expected` for 40min). Steer it to REWRITE THE WHOLE FILE, and flag
     // the JSX-in-`.ts` case (a `.ts` can't hold JSX → `<X>` reads as a generic wanting `>`).
-    const isParse =
-      /parsing error|['`][^'`]*['`] expected|unexpected token/iu.test(message);
+    // Match the whole tsc/eslint syntax-error family: `Parsing error`, `Unexpected token`, and
+    // any `… expected.` (quoted `';' expected` OR bare `Expression/Declaration/Identifier/Type
+    // expected`). The trailing-`expected` form is anchored so it doesn't catch type errors that
+    // merely contain the word mid-sentence.
+    const isParse = /parsing error|unexpected token|expected\.?\s*$/iu.test(
+      message
+    );
+    // The `.tsx` root-cause tip is ONLY valid for the JSX/generic `'>' expected` class — appended
+    // elsewhere it invents a wrong cause and can push a rename detour for a plain `';' expected`.
+    const isJsxGenericParse = /['`]>['`]\s+expected/iu.test(message);
     const parseSteer =
-      file.endsWith(".ts") && !file.endsWith(".d.ts")
-        ? " If this file contains JSX it must be a `.tsx` — a `.ts` parses `<X>` as a generic and demands `>`."
+      isJsxGenericParse && file.endsWith(".ts") && !file.endsWith(".d.ts")
+        ? " This `'>' expected` in a `.ts` is usually JSX in a non-JSX file — if it contains JSX, it must be a `.tsx` (a `.ts` parses `<X>` as a generic and demands `>`)."
         : "";
 
     return {

--- a/packages/core/src/loop/boringstack/gate-stages.ts
+++ b/packages/core/src/loop/boringstack/gate-stages.ts
@@ -106,13 +106,27 @@ export function signatureToError(sig: string): IErrorItem {
     const message = decodeURIComponent(structured[4] ?? "");
     const phase = phaseForFile(file);
 
+    // A syntax/parse error (`'>' expected`, `Parsing error`, `Unexpected token`) is the one
+    // class the model can't fix by surgical patch — a patch on an already-broken file usually
+    // re-breaks its braces/generics/JSX, so it grinds at the SAME error for turns (observed
+    // live: stuck at 2 `'>' expected` for 40min). Steer it to REWRITE THE WHOLE FILE, and flag
+    // the JSX-in-`.ts` case (a `.ts` can't hold JSX → `<X>` reads as a generic wanting `>`).
+    const isParse =
+      /parsing error|['`][^'`]*['`] expected|unexpected token/iu.test(message);
+    const parseSteer =
+      file.endsWith(".ts") && !file.endsWith(".d.ts")
+        ? " If this file contains JSX it must be a `.tsx` — a `.ts` parses `<X>` as a generic and demands `>`."
+        : "";
+
     return {
       key: sig,
       file,
       ...(lineText === "" ? {} : { line: Number(lineText) }),
       rule,
       ...(phase === undefined ? {} : { phase }),
-      message,
+      message: isParse
+        ? `${message}\n↳ SYNTAX/PARSE error — do NOT surgically patch it (a patch on a broken-parse file re-breaks its braces/generics/JSX). REWRITE THE WHOLE FILE \`${file}\` cleanly in one pass; once it parses, downstream errors clear.${parseSteer}`
+        : message,
     };
   }
 

--- a/packages/core/tests/boringstack-gate-stages.test.ts
+++ b/packages/core/tests/boringstack-gate-stages.test.ts
@@ -114,13 +114,16 @@ describe("signatureToError", () => {
 
   test("a discrete PARSE error is steered to a full rewrite (not a surgical patch)", () => {
     // The class the model can't fix by patching — observed live stuck at 2 `'>' expected`.
-    const sig =
-      "failure:apps%2Fui%2Fsrc%2Ffeatures%2Fx%2FX.tsx:5::Parsing%20error%3A%20'%3E'%20expected.";
-    const err = signatureToError(sig);
+    const err = signatureToError(
+      "failure:apps%2Fui%2Fsrc%2Ffeatures%2Fx%2FX.tsx:5::Parsing%20error%3A%20'%3E'%20expected."
+    );
 
     expect(err.file).toBe("apps/ui/src/features/x/X.tsx");
     expect(err.message).toContain("SYNTAX/PARSE error");
     expect(err.message).toContain("REWRITE THE WHOLE FILE");
+    // A .tsx file already holds JSX — it must NOT get the "must be a `.tsx`" rename tip.
+    expect(err.message).not.toContain("must be a `.tsx`");
+
     // A non-parse error is left untouched (no rewrite steer).
     const plain = signatureToError(
       "failure:apps%2Fui%2Fsrc%2Fx.ts:3:no-unused-vars:'y'%20is%20defined%20but%20never%20used."
@@ -129,12 +132,30 @@ describe("signatureToError", () => {
     expect(plain.message).not.toContain("REWRITE THE WHOLE FILE");
   });
 
-  test("a parse error in a .ts file flags the JSX-must-be-.tsx cause", () => {
-    const sig =
-      "failure:apps%2Fui%2Fsrc%2Ffeatures%2Fx%2FX.hooks.ts:9::'%3E'%20expected.";
-    const err = signatureToError(sig);
+  test("an UNQUOTED parse diagnostic still gets the rewrite steer", () => {
+    // `Expression expected.` / `Declaration or statement expected.` carry no quoted token.
+    const err = signatureToError(
+      "failure:apps%2Fapi%2Fsrc%2Fx.ts:2::Expression%20expected."
+    );
 
-    expect(err.message).toContain("must be a `.tsx`");
+    expect(err.message).toContain("REWRITE THE WHOLE FILE");
+  });
+
+  test("a `'>' expected` in a .ts flags the JSX-must-be-.tsx cause; other .ts parse errors do NOT", () => {
+    // The one class the .tsx tip is valid for.
+    const jsx = signatureToError(
+      "failure:apps%2Fui%2Fsrc%2Ffeatures%2Fx%2FX.hooks.ts:9::'%3E'%20expected."
+    );
+
+    expect(jsx.message).toContain("must be a `.tsx`");
+
+    // A plain `';' expected` in a .ts is NOT a JSX problem — must not suggest a rename detour.
+    const semi = signatureToError(
+      "failure:apps%2Fapi%2Fsrc%2Fx.ts:4::';'%20expected."
+    );
+
+    expect(semi.message).toContain("REWRITE THE WHOLE FILE");
+    expect(semi.message).not.toContain("must be a `.tsx`");
   });
 });
 

--- a/packages/core/tests/boringstack-gate-stages.test.ts
+++ b/packages/core/tests/boringstack-gate-stages.test.ts
@@ -111,6 +111,31 @@ describe("signatureToError", () => {
     expect(err.message).toContain("ONE broken file");
     expect(err.message).toContain("REWRITE IT IN FULL");
   });
+
+  test("a discrete PARSE error is steered to a full rewrite (not a surgical patch)", () => {
+    // The class the model can't fix by patching — observed live stuck at 2 `'>' expected`.
+    const sig =
+      "failure:apps%2Fui%2Fsrc%2Ffeatures%2Fx%2FX.tsx:5::Parsing%20error%3A%20'%3E'%20expected.";
+    const err = signatureToError(sig);
+
+    expect(err.file).toBe("apps/ui/src/features/x/X.tsx");
+    expect(err.message).toContain("SYNTAX/PARSE error");
+    expect(err.message).toContain("REWRITE THE WHOLE FILE");
+    // A non-parse error is left untouched (no rewrite steer).
+    const plain = signatureToError(
+      "failure:apps%2Fui%2Fsrc%2Fx.ts:3:no-unused-vars:'y'%20is%20defined%20but%20never%20used."
+    );
+
+    expect(plain.message).not.toContain("REWRITE THE WHOLE FILE");
+  });
+
+  test("a parse error in a .ts file flags the JSX-must-be-.tsx cause", () => {
+    const sig =
+      "failure:apps%2Fui%2Fsrc%2Ffeatures%2Fx%2FX.hooks.ts:9::'%3E'%20expected.";
+    const err = signatureToError(sig);
+
+    expect(err.message).toContain("must be a `.tsx`");
+  });
 });
 
 describe("reachabilityStage", () => {


### PR DESCRIPTION
Live-proven wall: a build plateaued 40min on 2 `'>' expected` parse errors — the model surgically patched a broken-parse file, re-breaking its generics/JSX, grinding the same error. The existing rewrite steer only fired on a full parserOptions.project cascade, not discrete 1-2 parse errors.

signatureToError now attaches to ANY parse diagnostic (Parsing error / Unexpected token / trailing '… expected', quoted or unquoted): 'do NOT patch — REWRITE THE WHOLE FILE'. The JSX '.tsx' root-cause tip is scoped to the `'>' expected` class only (so a plain ';' expected doesn't trigger a wrong rename detour).

Panel: PASS 4/4. Tests: parse→rewrite, unquoted→rewrite, .tsx→no-tip, .ts ';' →no-tip, .ts '>' →tip. typecheck 0, full validate green.