### PR TITLE
fix(loop): WS-B — don't trap the model in the hollow-app state (completion-phase flag)

### DIFF
--- a/packages/core/src/loop/near-green-checkpoint.ts
+++ b/packages/core/src/loop/near-green-checkpoint.ts
@@ -51,18 +51,20 @@ export interface INearGreenCheckpoint {
   readonly depFiles: ReadonlyMap<string, Uint8Array>;
 }
 
-/** Gate errors that clear ONLY by ADDING code — wiring the i18n keys the feature declared
- *  (`i18n-locale-keys-used`), making the feature reachable (`reachability`), or passing the
- *  hollow-app quality `judge`. They are NOT fixable in the current files. A near-green state
- *  whose remaining errors are all of this class is a HOLLOW state (e.g. a list-only page with
- *  unused create/edit/delete translations): reaching green REQUIRES the model to add the
- *  form + buttons + toasts, which transiently spikes the error count. WS-B's count-only spray
- *  detection can't tell that legitimate completion edit from a bad convention spray, so
- *  checkpointing this state and reverting to it traps the model in the hollow app. */
+/** Gate errors that in THIS stack clear ONLY by ADDING code — wiring the i18n keys the feature
+ *  declared (`i18n-locale-keys-used`; the i18n-destructive-delete guard forbids the removal
+ *  shortcut, so the model MUST add the UI that references them), or making the feature reachable
+ *  (`reachability`; add the route/mount). A near-green state whose remaining errors are all of
+ *  this class is a HOLLOW state (e.g. a list-only page with unused create/edit/delete
+ *  translations): reaching green REQUIRES the model to add the form + buttons + toasts, which
+ *  transiently spikes the error count. WS-B's count-only spray detection can't tell that
+ *  legitimate completion edit from a bad convention spray, so checkpointing this state and
+ *  reverting to it traps the model in the hollow app. NOTE: `judge` is deliberately EXCLUDED —
+ *  the quality judge can reject defects in EXISTING code (fixable in place), not only
+ *  hollowness, so it is not a reliable add-only signal. */
 const COMPLETION_CLASS_RULES: ReadonlySet<string> = new Set([
   "reachability",
   "i18n-locale-keys-used",
-  "judge",
 ]);
 
 /** Whether a gate error clears only by adding code (see COMPLETION_CLASS_RULES). Matches the

--- a/packages/core/src/loop/near-green-checkpoint.ts
+++ b/packages/core/src/loop/near-green-checkpoint.ts
@@ -82,6 +82,26 @@ export function allCompletionClass(errors: readonly IErrorItem[]): boolean {
   return errors.length > 0 && errors.every(isCompletionClass);
 }
 
+/** Advance the persistent completion-phase flag. ENTER when every error is completion-class (a
+ *  hollow state); STAY while ANY completion error remains (the MIXED spike as the model wires
+ *  the keys — a per-cycle all-completion check would flip false here and re-arm the rollback +
+ *  "undo" banner mid-add); EXIT when no completion error remains (the model finished wiring →
+ *  only fixable errors left → WS-B re-engages) or when green (no errors). */
+export function nextCompletionPhase(
+  prev: boolean,
+  errors: readonly IErrorItem[]
+): boolean {
+  if (allCompletionClass(errors)) {
+    return true;
+  }
+
+  if (!errors.some(isCompletionClass)) {
+    return false;
+  }
+
+  return prev;
+}
+
 /** Whether a fresh gate result should be CHECKPOINTED: it's a new all-time low, it's near
  *  green (1..N), and not zero (zero means the build just went green — nothing to protect).
  *  `isNewLow` is the loop's own genuine-progress signal, passed in so this stays pure. */

--- a/packages/core/src/loop/near-green-checkpoint.ts
+++ b/packages/core/src/loop/near-green-checkpoint.ts
@@ -51,6 +51,35 @@ export interface INearGreenCheckpoint {
   readonly depFiles: ReadonlyMap<string, Uint8Array>;
 }
 
+/** Gate errors that clear ONLY by ADDING code — wiring the i18n keys the feature declared
+ *  (`i18n-locale-keys-used`), making the feature reachable (`reachability`), or passing the
+ *  hollow-app quality `judge`. They are NOT fixable in the current files. A near-green state
+ *  whose remaining errors are all of this class is a HOLLOW state (e.g. a list-only page with
+ *  unused create/edit/delete translations): reaching green REQUIRES the model to add the
+ *  form + buttons + toasts, which transiently spikes the error count. WS-B's count-only spray
+ *  detection can't tell that legitimate completion edit from a bad convention spray, so
+ *  checkpointing this state and reverting to it traps the model in the hollow app. */
+const COMPLETION_CLASS_RULES: ReadonlySet<string> = new Set([
+  "reachability",
+  "i18n-locale-keys-used",
+  "judge",
+]);
+
+/** Whether a gate error clears only by adding code (see COMPLETION_CLASS_RULES). Matches the
+ *  bare rule id so a plugin-prefixed form (`plugin/i18n-locale-keys-used`) still classifies. */
+export function isCompletionClass(error: IErrorItem): boolean {
+  const rule = error.rule ?? "";
+  const bare = rule.split("/").pop() ?? rule;
+
+  return COMPLETION_CLASS_RULES.has(bare);
+}
+
+/** True when EVERY remaining gate error is completion-class — the hollow near-green state WS-B
+ *  must not protect. Empty is false (green is handled elsewhere; nothing to classify). */
+export function allCompletionClass(errors: readonly IErrorItem[]): boolean {
+  return errors.length > 0 && errors.every(isCompletionClass);
+}
+
 /** Whether a fresh gate result should be CHECKPOINTED: it's a new all-time low, it's near
  *  green (1..N), and not zero (zero means the build just went green — nothing to protect).
  *  `isNewLow` is the loop's own genuine-progress signal, passed in so this stays pure. */

--- a/packages/core/src/loop/session.ts
+++ b/packages/core/src/loop/session.ts
@@ -424,6 +424,7 @@ export function resetDriveConvergence(state: ILoopState): void {
   delete state.nearGreenCheckpoint;
   delete state.nearGreenBest;
   delete state.nearGreenRollbacks;
+  delete state.completionPhase;
 }
 
 /** How many times a send recovers from a repetition loop before giving up. */

--- a/packages/core/src/loop/turn.ts
+++ b/packages/core/src/loop/turn.ts
@@ -29,7 +29,7 @@ import { unseenGuidesForErrors } from "./conventions";
 import {
   shouldCheckpoint,
   shouldRollback,
-  allCompletionClass,
+  nextCompletionPhase,
   MAX_NEAR_GREEN_ROLLBACKS,
   type INearGreenCheckpoint,
 } from "./near-green-checkpoint";
@@ -432,6 +432,15 @@ export interface ILoopState {
    *  (e.g. 2→1, or 1→1 different error) instead of a spray reverting to a worse/older saved
    *  state. Reset on green and at the drive boundary; lowered as the checkpoint refreshes. */
   nearGreenBest?: number;
+  /** WS-B: the model is in the COMPLETION phase — it reached an all-completion-class state
+   *  (only add-code errors: unused i18n keys / not reachable) and is now building the demanded
+   *  create/edit/delete UI. This PERSISTS across the resulting error spike (which is MIXED —
+   *  new compile errors + the shrinking completion errors), because a per-cycle all-completion
+   *  check flips false the moment the model starts adding code, re-arming the rollback + the
+   *  "undo" banner mid-add. Set when all errors are completion-class; held while ANY completion
+   *  error remains; cleared when none remain (completion done → WS-B re-engages) or on green /
+   *  at the drive boundary. While set, WS-B does not roll back and the banner says "build it". */
+  completionPhase?: boolean;
   /** Guard-specific identity of the current stuck block (canonical, not the raw error
    *  set). Derived from the guard that fired: samePersist → single error key,
    *  gateStuckRepeats → sorted-join of current keys, plateau → normalized count|keys
@@ -2111,7 +2120,7 @@ export async function injectFeedback(
   const banner = nearGreenBanner(
     gateErrors.length,
     state.bestErrorCount,
-    allCompletionClass(gateErrors)
+    state.completionPhase === true
   );
 
   ctx.messages.push({
@@ -2289,6 +2298,13 @@ async function nearGreenRollbackStep(
     return false;
   }
 
+  // During the COMPLETION phase the model is ADDING the demanded UI, so the error spike is
+  // progress, not a spray — never roll it back (this runs before checkpointStep, so the flag,
+  // not a per-cycle all-completion check, is what protects the mixed-error spike).
+  if (state.completionPhase === true) {
+    return false;
+  }
+
   if (
     shouldRollback(
       state.nearGreenCheckpoint,
@@ -2332,14 +2348,13 @@ async function nearGreenCheckpointStep(
     return;
   }
 
-  // Never protect a HOLLOW near-green state — one whose remaining errors ALL clear only by
-  // ADDING code (wiring i18n keys, reachability, the judge). The completeness guards demand
-  // that code; the model's large completion edit transiently spikes the count, and a
-  // checkpoint here would revert it to the hollow app (observed: 1→27 spray reverted to a
-  // list-only page, model re-does it → thrash). CLEAR any checkpoint (drops an earlier
-  // compile-state one too, so the spray isn't reverted to that either) and don't capture;
-  // WS-B resumes once errors are fixable-in-place again.
-  if (allCompletionClass(gateErrors)) {
+  // Never protect a HOLLOW state while in the COMPLETION phase — the model is adding the
+  // demanded create/edit/delete UI (wiring i18n keys / reachability), so a checkpoint here
+  // would revert it to the list-only page (observed: 1→27 spray reverted, model re-does it →
+  // thrash). CLEAR any checkpoint (drops an earlier compile-state one too — its fixable errors
+  // are already resolved, so it's stale) and don't capture; WS-B re-engages when the phase ends
+  // (no completion error remains). completionPhase was advanced at the top of settleGate.
+  if (state.completionPhase === true) {
     state.nearGreenCheckpoint = undefined;
 
     return;
@@ -2377,6 +2392,15 @@ export async function settleGate(
   } = await evaluateGate(ctx, turn);
 
   const curr = gateErrors.length;
+
+  // WS-B: advance the completion-phase flag BEFORE the rollback/banner/checkpoint steps read
+  // it — so the phase set at the hollow state survives the mixed-error spike that follows
+  // (the rollback step runs first, and a per-cycle all-completion check would already be false
+  // there once the model started adding code).
+  state.completionPhase = nextCompletionPhase(
+    state.completionPhase ?? false,
+    gateErrors
+  );
 
   if (state.lastGateCount >= 0 && curr > state.lastGateCount) {
     state.regressions += 1;

--- a/packages/core/src/loop/turn.ts
+++ b/packages/core/src/loop/turn.ts
@@ -29,6 +29,7 @@ import { unseenGuidesForErrors } from "./conventions";
 import {
   shouldCheckpoint,
   shouldRollback,
+  allCompletionClass,
   MAX_NEAR_GREEN_ROLLBACKS,
   type INearGreenCheckpoint,
 } from "./near-green-checkpoint";
@@ -2303,6 +2304,19 @@ async function nearGreenCheckpointStep(
   // fresh checkpoint and a model that sprays→reverts→re-settles could thrash to maxTurns.
   // The escalation ladder now owns the stall.
   if ((state.nearGreenRollbacks ?? 0) >= MAX_NEAR_GREEN_ROLLBACKS) {
+    return;
+  }
+
+  // Never protect a HOLLOW near-green state — one whose remaining errors ALL clear only by
+  // ADDING code (wiring i18n keys, reachability, the judge). The completeness guards demand
+  // that code; the model's large completion edit transiently spikes the count, and a
+  // checkpoint here would revert it to the hollow app (observed: 1→27 spray reverted to a
+  // list-only page, model re-does it → thrash). CLEAR any checkpoint (drops an earlier
+  // compile-state one too, so the spray isn't reverted to that either) and don't capture;
+  // WS-B resumes once errors are fixable-in-place again.
+  if (allCompletionClass(gateErrors)) {
+    state.nearGreenCheckpoint = undefined;
+
     return;
   }
 

--- a/packages/core/src/loop/turn.ts
+++ b/packages/core/src/loop/turn.ts
@@ -1978,12 +1978,31 @@ const NEAR_GREEN_LOCKDOWN = 3;
 /** A lockdown/regression banner for the top of the feedback, or "" when far from
  *  green and not regressing. `total` = open errors this cycle; `best` = the all-time
  *  low (watermark). Regression = this cycle is WORSE than the best already reached. */
-export function nearGreenBanner(total: number, best: number): string {
+export function nearGreenBanner(
+  total: number,
+  best: number,
+  completionOnly = false
+): string {
   const regressed = Number.isFinite(best) && total > best;
   const near = total > 0 && total <= NEAR_GREEN_LOCKDOWN;
 
   if (!near && !regressed) {
     return "";
+  }
+
+  // When EVERY remaining error clears only by ADDING code (unused i18n keys / not reachable —
+  // see allCompletionClass), the normal near-green lockdown ("smallest change, do NOT create
+  // files or add features") is exactly BACKWARDS: it forbids the create/edit/delete UI the
+  // feature must have. Emit the opposite instruction so the model builds it (WS-B has already
+  // stood its checkpoint down for this state, so the resulting spike won't be reverted).
+  if (completionOnly) {
+    return (
+      `⚠ ${String(total)} error(s) left, and they clear only by ADDING the code the feature is ` +
+      "missing — it declared UI it hasn't built (unused i18n keys / not reachable). BUILD the " +
+      "create/edit/delete UI, the success/error toasts that reference those keys, and the route " +
+      "wiring. The error count WILL rise as you add these files — that's expected progress here, " +
+      "NOT a regression to undo. Keep going until the added code references everything.\n\n"
+    );
   }
 
   const lines: string[] = [];
@@ -2086,8 +2105,14 @@ export async function injectFeedback(
   }
 
   // NEAR-GREEN lockdown / regression callout leads everything — the finishing
-  // discipline that stops "spray after best" (the dominant late-run failure).
-  const banner = nearGreenBanner(gateErrors.length, state.bestErrorCount);
+  // discipline that stops "spray after best" (the dominant late-run failure). When the
+  // remaining errors are all completion-class, the banner flips to "build the missing UI"
+  // instead of "don't create files" (else it contradicts the completeness guard).
+  const banner = nearGreenBanner(
+    gateErrors.length,
+    state.bestErrorCount,
+    allCompletionClass(gateErrors)
+  );
 
   ctx.messages.push({
     role: "user",

--- a/packages/core/tests/near-green-banner.test.ts
+++ b/packages/core/tests/near-green-banner.test.ts
@@ -37,4 +37,26 @@ describe("nearGreenBanner (finishing discipline near green)", () => {
   test("at the watermark, far from green → no banner", () => {
     expect(nearGreenBanner(5, 5)).toBe("");
   });
+
+  test("#61: completionOnly flips the banner to BUILD the UI (not the don't-create-files lockdown)", () => {
+    // The remaining error clears only by ADDING code — the normal lockdown would forbid the
+    // create/edit/delete UI the feature needs. The banner must instruct the opposite.
+    const b = nearGreenBanner(1, 1, true);
+
+    expect(b).toContain("ADDING the code");
+    expect(b).toContain("BUILD the");
+    expect(b).toContain("NOT a regression");
+    // The contradictory lockdown text must be GONE for a completion state.
+    expect(b).not.toContain("Do NOT create new files");
+    expect(b).not.toContain("NEAR-GREEN — only");
+  });
+
+  test("#61: completionOnly during a spike (total>best) still says BUILD, not UNDO", () => {
+    // While the model adds the demanded files the count rises; it must not be told to undo.
+    const b = nearGreenBanner(8, 1, true);
+
+    expect(b).toContain("BUILD the");
+    expect(b).not.toContain("REGRESSION");
+    expect(b).not.toContain("UNDO");
+  });
 });

--- a/packages/core/tests/near-green-checkpoint-loop.test.ts
+++ b/packages/core/tests/near-green-checkpoint-loop.test.ts
@@ -10,6 +10,7 @@ import type { ILoopCtx, ILoopState } from "../src/loop/turn";
 import {
   captureNearGreenCheckpoint,
   rollbackNearGreen,
+  settleGate,
 } from "../src/loop/turn";
 import type { IValidateResult } from "../src/validate";
 import { MAX_NEAR_GREEN_ROLLBACKS } from "../src/loop/near-green-checkpoint";
@@ -133,6 +134,78 @@ test("flag ON: a spray past the near-green checkpoint REVERTS the file to the be
 
     expect(final).toContain("GOOD");
     expect(final).not.toContain("BAD");
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+}, 30_000);
+
+test("#61: settleGate does NOT checkpoint a HOLLOW near-green state (all-completion-class errors) and clears any prior one", async () => {
+  const dir = await mkdtemp(join(tmpdir(), "tsforge-nearg-"));
+
+  try {
+    await Bun.write(join(dir, "feature.ts"), "export const GOOD = 1;\n");
+
+    // The gate is near-green with ONE remaining error that clears only by ADDING code (the
+    // feature declared i18n keys it hasn't wired yet). settleGate must NOT lock this hollow
+    // state — else the model's demanded completion edit (which spikes the count) gets reverted.
+    const ctx: ILoopCtx = {
+      task: {
+        id: "t",
+        intent: "test",
+        accept: "",
+        files: ["**/*"],
+        context: [],
+      },
+      cwd: dir,
+      tsService: null,
+      report: () => undefined,
+      messages: [],
+      tool: { touched: new Set(["feature.ts"]) },
+      gate: {
+        parse: undefined,
+        runner: {
+          run: async (): Promise<IValidateResult> => ({
+            passed: false,
+            errors: [
+              {
+                key: "i18n:supplier.createSuccess",
+                rule: "i18n-locale-keys-used",
+                message: "Locale key defined but never referenced",
+              },
+            ],
+            output: "",
+          }),
+        },
+      },
+    };
+
+    // Seed a stale checkpoint from an earlier compile-clean cycle — the guard must CLEAR it,
+    // so a later spray can't be reverted to it either.
+    const stale = await captureNearGreenCheckpoint(ctx, 1, [
+      { key: "old", message: "earlier compile error" },
+    ]);
+    const state: ILoopState = {
+      prevGateErrors: [],
+      gateNoProgress: 0,
+      bestErrorCount: 1,
+      noNewLow: 0,
+      errorAge: new Map(),
+      lastGateCount: 1,
+      edits: 5,
+      regressions: 0,
+      ttsrInterrupts: 0,
+      steerLevel: 0,
+      conventionsEnabled: false,
+      nearGreenCheckpoint: stale,
+      nearGreenBest: 1,
+      nearGreenRollbacks: 0,
+    };
+
+    await settleGate(ctx, state, 10);
+
+    // The hollow state was NOT protected: the checkpoint is cleared (no revert target), so
+    // the model's next completion edit proceeds forward instead of being reverted to hollow.
+    expect(state.nearGreenCheckpoint).toBeUndefined();
   } finally {
     await rm(dir, { recursive: true, force: true });
   }

--- a/packages/core/tests/near-green-checkpoint-loop.test.ts
+++ b/packages/core/tests/near-green-checkpoint-loop.test.ts
@@ -211,6 +211,85 @@ test("#61: settleGate does NOT checkpoint a HOLLOW near-green state (all-complet
   }
 }, 30_000);
 
+test("#61: during the completion phase, a mixed-error SPIKE is NOT rolled back (banner+rollback stand down through the spike)", async () => {
+  const dir = await mkdtemp(join(tmpdir(), "tsforge-nearg-"));
+
+  try {
+    await Bun.write(join(dir, "feature.ts"), "export const GOOD = 1;\n");
+
+    // The model is mid-add: it entered the completion phase last cycle, and this gate shows a
+    // MIXED spike (the shrinking i18n completion error + new compile errors from the half-written
+    // UI) well past the rollback threshold. A per-cycle all-completion check would be FALSE here
+    // and roll back; the persistent completionPhase flag must keep WS-B (and the undo banner) off.
+    const ctx: ILoopCtx = {
+      task: {
+        id: "t",
+        intent: "test",
+        accept: "",
+        files: ["**/*"],
+        context: [],
+      },
+      cwd: dir,
+      tsService: null,
+      report: () => undefined,
+      messages: [],
+      tool: { touched: new Set(["feature.ts"]) },
+      gate: {
+        parse: undefined,
+        runner: {
+          run: async (): Promise<IValidateResult> => ({
+            passed: false,
+            errors: [
+              {
+                key: "i18n:x",
+                rule: "i18n-locale-keys-used",
+                message: "unused key",
+              },
+              { key: "c1", rule: "no-unsafe-argument", message: "unsafe" },
+              { key: "c2", rule: "no-unsafe-argument", message: "unsafe" },
+              { key: "c3", rule: "no-unsafe-argument", message: "unsafe" },
+              { key: "c4", rule: "no-unsafe-argument", message: "unsafe" },
+              { key: "c5", rule: "no-unsafe-argument", message: "unsafe" },
+            ],
+            output: "",
+          }),
+        },
+      },
+    };
+    const cp = await captureNearGreenCheckpoint(ctx, 1, [
+      { key: "i18n:x", rule: "i18n-locale-keys-used", message: "unused key" },
+    ]);
+    const state: ILoopState = {
+      prevGateErrors: [],
+      gateNoProgress: 0,
+      bestErrorCount: 1,
+      noNewLow: 0,
+      errorAge: new Map(),
+      lastGateCount: 1,
+      edits: 5,
+      regressions: 0,
+      ttsrInterrupts: 0,
+      steerLevel: 0,
+      conventionsEnabled: false,
+      completionPhase: true,
+      nearGreenCheckpoint: cp,
+      nearGreenBest: 1,
+      nearGreenRollbacks: 0,
+    };
+
+    await settleGate(ctx, state, 10);
+
+    // 6 errors is > checkpoint(1) + M(3), so WITHOUT the phase flag WS-B would revert. It did NOT:
+    // no rollback was counted, and the phase persisted (a completion error still remains).
+    expect(state.nearGreenRollbacks).toBe(0);
+    expect(state.completionPhase).toBe(true);
+    // feature.ts was NOT reverted (no rollback restored the checkpoint snapshot).
+    expect(await Bun.file(join(dir, "feature.ts")).text()).toContain("GOOD");
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+}, 30_000);
+
 test("rollbackNearGreen resets the convergence guards + tombstones, without touching the ladder", async () => {
   const dir = await mkdtemp(join(tmpdir(), "tsforge-nearg-"));
 

--- a/packages/core/tests/near-green-checkpoint.test.ts
+++ b/packages/core/tests/near-green-checkpoint.test.ts
@@ -16,11 +16,13 @@ import type { IFileSnapshot } from "../src/loop/file-snapshot";
 // reachability, judge) must NOT be checkpointed, or WS-B reverts the demanded completion edit.
 const err = (rule: string): IErrorItem => ({ key: rule, rule, message: rule });
 
-test("isCompletionClass: only add-code rules (reachability/i18n-locale-keys-used/judge), bare or prefixed", () => {
+test("isCompletionClass: only reliable add-code rules (reachability/i18n-locale-keys-used), bare or prefixed", () => {
   expect(isCompletionClass(err("reachability"))).toBe(true);
   expect(isCompletionClass(err("i18n-locale-keys-used"))).toBe(true);
-  expect(isCompletionClass(err("judge"))).toBe(true);
   expect(isCompletionClass(err("plugin/i18n-locale-keys-used"))).toBe(true);
+  // `judge` is EXCLUDED — it can reject defects in existing code, not only hollowness, so it
+  // isn't a reliable add-only signal (would falsely disable WS-B on a fixable judge rejection).
+  expect(isCompletionClass(err("judge"))).toBe(false);
   // Fixable-in-place errors are NOT completion-class (WS-B still protects against those).
   expect(isCompletionClass(err("no-floating-promises"))).toBe(false);
   expect(isCompletionClass(err("@typescript-eslint/no-unsafe-argument"))).toBe(

--- a/packages/core/tests/near-green-checkpoint.test.ts
+++ b/packages/core/tests/near-green-checkpoint.test.ts
@@ -4,6 +4,7 @@ import {
   shouldRollback,
   isCompletionClass,
   allCompletionClass,
+  nextCompletionPhase,
   NEAR_GREEN_N,
   NEAR_GREEN_M,
   MAX_NEAR_GREEN_ROLLBACKS,
@@ -29,6 +30,23 @@ test("isCompletionClass: only reliable add-code rules (reachability/i18n-locale-
     false
   );
   expect(isCompletionClass({ key: "x", message: "no rule" })).toBe(false);
+});
+
+test("nextCompletionPhase: ENTER on all-completion, STAY through the mixed spike, EXIT when no completion error remains", () => {
+  const i18n = err("i18n-locale-keys-used");
+  const compile = err("no-unsafe-argument");
+
+  // ENTER: reached the hollow all-completion state.
+  expect(nextCompletionPhase(false, [i18n])).toBe(true);
+  // STAY: the model started adding the UI → MIXED errors (this is the case a per-cycle
+  // all-completion check got wrong — it would flip false here and re-arm rollback/undo).
+  expect(nextCompletionPhase(true, [i18n, compile, compile])).toBe(true);
+  // EXIT: the keys are now referenced → only fixable errors remain → WS-B re-engages.
+  expect(nextCompletionPhase(true, [compile, compile])).toBe(false);
+  // EXIT on green (no errors at all).
+  expect(nextCompletionPhase(true, [])).toBe(false);
+  // Never enters from a purely-fixable state.
+  expect(nextCompletionPhase(false, [compile])).toBe(false);
 });
 
 test("allCompletionClass: true only when EVERY error is completion-class; empty is false", () => {

--- a/packages/core/tests/near-green-checkpoint.test.ts
+++ b/packages/core/tests/near-green-checkpoint.test.ts
@@ -2,12 +2,45 @@ import { test, expect } from "bun:test";
 import {
   shouldCheckpoint,
   shouldRollback,
+  isCompletionClass,
+  allCompletionClass,
   NEAR_GREEN_N,
   NEAR_GREEN_M,
   MAX_NEAR_GREEN_ROLLBACKS,
   type INearGreenCheckpoint,
 } from "../src/loop/near-green-checkpoint";
+import type { IErrorItem } from "../src/validate/validate.types";
 import type { IFileSnapshot } from "../src/loop/file-snapshot";
+
+// #61: a HOLLOW near-green state (remaining errors clear only by ADDING code — i18n keys,
+// reachability, judge) must NOT be checkpointed, or WS-B reverts the demanded completion edit.
+const err = (rule: string): IErrorItem => ({ key: rule, rule, message: rule });
+
+test("isCompletionClass: only add-code rules (reachability/i18n-locale-keys-used/judge), bare or prefixed", () => {
+  expect(isCompletionClass(err("reachability"))).toBe(true);
+  expect(isCompletionClass(err("i18n-locale-keys-used"))).toBe(true);
+  expect(isCompletionClass(err("judge"))).toBe(true);
+  expect(isCompletionClass(err("plugin/i18n-locale-keys-used"))).toBe(true);
+  // Fixable-in-place errors are NOT completion-class (WS-B still protects against those).
+  expect(isCompletionClass(err("no-floating-promises"))).toBe(false);
+  expect(isCompletionClass(err("@typescript-eslint/no-unsafe-argument"))).toBe(
+    false
+  );
+  expect(isCompletionClass({ key: "x", message: "no rule" })).toBe(false);
+});
+
+test("allCompletionClass: true only when EVERY error is completion-class; empty is false", () => {
+  expect(allCompletionClass([err("i18n-locale-keys-used")])).toBe(true);
+  expect(
+    allCompletionClass([err("reachability"), err("i18n-locale-keys-used")])
+  ).toBe(true);
+  // A single fixable error among completion ones means the state is NOT purely hollow —
+  // WS-B should still protect it (the fixable error is a real revert target).
+  expect(
+    allCompletionClass([err("i18n-locale-keys-used"), err("no-console")])
+  ).toBe(false);
+  expect(allCompletionClass([])).toBe(false);
+});
 
 // WS-B: the pure checkpoint/rollback decision, unit-locked with the Phase 0a thresholds
 // (N=2, M=3) away from the Session's file I/O. Real spray data from inv157/inv156.


### PR DESCRIPTION
WS-B's near-green checkpoint was reverting the model's **legitimate completion work** (building the create/edit/delete UI the completeness guards demand) as if it were a spray — reproduced in 3 live builds (1→22/27/37 error spike → rollback → thrash).

## Fix
A persistent `completionPhase` flag: ENTER when every remaining error is completion-class (unused i18n keys / not reachable — clear only by ADDING code), STAY through the mixed-error spike as the model wires the UI, EXIT when no completion error remains or green. While set: no rollback, the near-green banner flips from 'don't create files' to 'build the missing UI', and no checkpoint is captured. `judge` excluded (can reject existing code). Pure `isCompletionClass`/`nextCompletionPhase` + settleGate integration tests; 31 near-green tests green; existing WS-B behavior unchanged for fixable errors.

## Reviews
3 panel rounds (banner-contradiction + judge-breadth + spike-persistence findings all addressed). Live capstone (build7) pending an OrbStack restart.