### PR TITLE
fix(boringstack): steer PathsWithMethod errors to register the route (not fight UI types)

### DIFF
--- a/packages/core/src/loop/boringstack/gate-stages.ts
+++ b/packages/core/src/loop/boringstack/gate-stages.ts
@@ -126,6 +126,14 @@ export function signatureToError(sig: string): IErrorItem {
         ? " This `'>' expected` in a `.ts` is usually JSX in a non-JSX file — if it contains JSX, it must be a `.tsx` (a `.ts` parses `<X>` as a generic and demands `>`)."
         : "";
 
+    // The api-client's types are GENERATED from the OpenAPI spec. Calling
+    // `apiClient.<M>("/api/v1/x")` for a path not yet in the spec fails typing with
+    // `PathsWithMethod<paths, …>` — the tell that the UI was written BEFORE the API route
+    // was registered + the client regenerated, NOT a UI-type bug to fight in the component.
+    // Steer to fix the ORDER, not the call site (observed: model ground on this + the
+    // coupled test-sibling for 20+ turns instead of touching the route).
+    const isPathsWithMethod = message.includes("PathsWithMethod");
+
     return {
       key: sig,
       file,
@@ -134,7 +142,9 @@ export function signatureToError(sig: string): IErrorItem {
       ...(phase === undefined ? {} : { phase }),
       message: isParse
         ? `${message}\n↳ SYNTAX/PARSE error — do NOT surgically patch it (a patch on a broken-parse file re-breaks its braces/generics/JSX). REWRITE THE WHOLE FILE \`${file}\` cleanly in one pass; once it parses, downstream errors clear.${parseSteer}`
-        : message,
+        : isPathsWithMethod
+          ? `${message}\n↳ This path is NOT in the OpenAPI spec yet — the api-client types are GENERATED from it, so don't fight the UI types. Make sure the API route exists AND is registered/mounted (so it shows in /swagger/json), then let the gate run — it re-runs generate:api and the path type appears. A \`/api/v1/…\` literal rejected by \`PathsWithMethod\` means the route isn't in the spec; fix the route/registration, not the call site.`
+          : message,
     };
   }
 

--- a/packages/core/tests/boringstack-gate-stages.test.ts
+++ b/packages/core/tests/boringstack-gate-stages.test.ts
@@ -141,6 +141,26 @@ describe("signatureToError", () => {
     expect(err.message).toContain("REWRITE THE WHOLE FILE");
   });
 
+  test("a PathsWithMethod type error steers to REGISTER the route (not fight the UI types)", () => {
+    // Observed live (build6): model called apiClient.POST('/api/v1/supplier') before the
+    // route was in the OpenAPI spec → fought the UI types + coupled test-sibling for 20+ turns.
+    const msg =
+      "Argument of type '\"/api/v1/supplier\"' is not assignable to parameter of type 'PathsWithMethod<paths, \"post\">'.";
+    const err = signatureToError(
+      `failure:apps%2Fui%2Fsrc%2Ffeatures%2Fsupplier%2FSupplier.mutations.ts:12:no-unsafe:${encodeURIComponent(msg)}`
+    );
+
+    expect(err.message).toContain("NOT in the OpenAPI spec");
+    expect(err.message).toContain("register");
+    expect(err.message).toContain("generate:api");
+    // A plain type error (no PathsWithMethod) is left untouched.
+    const plain = signatureToError(
+      "failure:apps%2Fui%2Fsrc%2Fx.ts:3:no-unsafe:Type%20'string'%20is%20not%20assignable%20to%20'number'."
+    );
+
+    expect(plain.message).not.toContain("NOT in the OpenAPI spec");
+  });
+
   test("a `'>' expected` in a .ts flags the JSX-must-be-.tsx cause; other .ts parse errors do NOT", () => {
     // The one class the .tsx tip is valid for.
     const jsx = signatureToError(


### PR DESCRIPTION
build6 residual: the model wrote UI calling `apiClient.<M>('/api/v1/x')` before the API route was in the OpenAPI spec → `not assignable to PathsWithMethod<paths,…>` → it fought the UI types + coupled test-sibling for 20+ turns. Enriches that error class in `signatureToError`: a PathsWithMethod rejection means the route isn't in the spec — register/mount it, let the gate regenerate the client, then the type exists. Same seam as the parse-steer. Unit-tested.