### PR TITLE
fix(boringstack): extractFailures parses lint:meta i18n violations on .json locale files

### DIFF
--- a/packages/core/src/loop/boringstack/extract-failures.ts
+++ b/packages/core/src/loop/boringstack/extract-failures.ts
@@ -430,7 +430,13 @@ function structuredFailure(
 function sourceFileFromLine(line: string, app: string): string | null {
   const withoutColon = line.endsWith(":") ? line.slice(0, -1) : line;
 
-  if (!/^\S+\.[cm]?[jt]sx?$/u.test(withoutColon.trim())) {
+  // JS/TS source files AND `.json` — the latter because meta-rules like
+  // `i18n-locale-keys-used` report their file HEADER as an i18n locale `.json`. Without
+  // `.json` here, `consumeLintMeta` never sets `currentFile` for such a violation, drops
+  // it, and the whole apps/ui gate falls through to opaqueGateError — which hid a lone
+  // unused-locale-key from the structured error path (so #61's completion-phase couldn't
+  // see it and WS-B reverted the model's wiring). A bare path-only line is unambiguous.
+  if (!/^\S+\.([cm]?[jt]sx?|json)$/u.test(withoutColon.trim())) {
     return null;
   }
 

--- a/packages/core/tests/boringstack-extract-failures.test.ts
+++ b/packages/core/tests/boringstack-extract-failures.test.ts
@@ -61,6 +61,32 @@ error: script "lint:meta" exited with code 1`;
     ).toBe(true);
   });
 
+  test("captures a lint-meta violation whose file header is a .json locale file (i18n-locale-keys-used)", () => {
+    // build10 trap: the ONLY failure was an unused i18n key, whose lint:meta file header is a
+    // `.json` locale file. sourceFileFromLine matched only JS/TS, so currentFile never set →
+    // the violation was dropped → the whole apps/ui gate fell to opaqueGateError → #61's
+    // completion-phase couldn't see rule=i18n-locale-keys-used and WS-B reverted the wiring.
+    const cwd = "/private/tmp/clone";
+    const out = `::tsforge-app apps/ui::
+[generate:api] Wrote src/lib/api/schema.d.ts
+::tsforge-eslint-json apps/ui::
+[{"filePath":"${cwd}/apps/ui/x.tsx","messages":[],"errorCount":0,"warningCount":0}]
+::tsforge-eslint-json-end::
+[lint:meta] 1 violation(s):
+
+  ${cwd}/apps/ui/src/lib/i18n/locales/en/common.json
+    i18n-locale-keys-used: Locale key \`features.supplier.loadError\` is defined but never referenced in src — dead translation surface (remove it from every locale, or wire it up).
+
+error: script "lint:meta" exited with code 1`;
+    const sigs = extractFailures(out, cwd);
+
+    expect(sigs.size).toBe(1);
+    const sig = [...sigs][0] ?? "";
+
+    expect(sig).toContain("i18n-locale-keys-used");
+    expect(sig).toContain("common.json");
+  });
+
   test("carries the preceding eslint file header into the failure signature", () => {
     const cwd = "/tmp/clone";
     const out = `${cwd}/apps/api/tests/api/note/note.routes.test.ts


### PR DESCRIPTION
Stacked on #147. build10 trapped at 1 error because a standalone `i18n-locale-keys-used` violation whose file header is a `.json` locale file fell to opaqueGateError (sourceFileFromLine rejected .json + leading whitespace). Now parsed → structured error with rule set. Validated: build11 reached the i18n wall as an actionable error. Panel-approved; 49 tests.