### PR TITLE
feat(conventions): i18n locale-key discipline guide (build11 dead-key park fix)

### DIFF
--- a/packages/core/src/agent/agent.constants.ts
+++ b/packages/core/src/agent/agent.constants.ts
@@ -366,9 +366,10 @@ export const PULL_CONVENTIONS_TOOL = {
             "forms",
             "data-fetching",
             "lint-gotchas",
+            "testing",
           ],
           description:
-            "which guide: component-anatomy (where a component lives + one-per-file), file-layout (no inline types/constants/helpers), jsx (no computation in markup), state (hooks, not component body), no-casts (type guards instead of `as`/`!`), routing (thin route files), forms, data-fetching (api-client, never raw fetch), lint-gotchas (await promises, no void-expr values, no stringified errors, no duplicate strings).",
+            "which guide: component-anatomy (where a component lives + one-per-file), file-layout (no inline types/constants/helpers), jsx (no computation in markup), state (hooks, not component body), no-casts (type guards instead of `as`/`!`), routing (thin route files), forms, data-fetching (api-client, never raw fetch), lint-gotchas (await promises, no void-expr values, no stringified errors, no duplicate strings), testing (.test.ts vs .test.tsx, the vi.hoisted api-client mock, createApp/app.handle route tests, enforced test rules).",
         },
       },
       required: ["topic"],

--- a/packages/core/src/agent/agent.constants.ts
+++ b/packages/core/src/agent/agent.constants.ts
@@ -367,9 +367,10 @@ export const PULL_CONVENTIONS_TOOL = {
             "data-fetching",
             "lint-gotchas",
             "testing",
+            "api-service",
           ],
           description:
-            "which guide: component-anatomy (where a component lives + one-per-file), file-layout (no inline types/constants/helpers), jsx (no computation in markup), state (hooks, not component body), no-casts (type guards instead of `as`/`!`), routing (thin route files), forms, data-fetching (api-client, never raw fetch), lint-gotchas (await promises, no void-expr values, no stringified errors, no duplicate strings), testing (.test.ts vs .test.tsx, the vi.hoisted api-client mock, createApp/app.handle route tests, enforced test rules).",
+            "which guide: component-anatomy (where a component lives + one-per-file), file-layout (no inline types/constants/helpers), jsx (no computation in markup), state (hooks, not component body), no-casts (type guards instead of `as`/`!`), routing (thin route files), forms, data-fetching (api-client, never raw fetch), lint-gotchas (await promises, no void-expr values, no stringified errors, no duplicate strings), testing (.test.ts vs .test.tsx, the vi.hoisted api-client mock, createApp/app.handle route tests, enforced test rules), api-service (mutating service methods record an audit event; throw ApiError).",
         },
       },
       required: ["topic"],

--- a/packages/core/src/agent/agent.constants.ts
+++ b/packages/core/src/agent/agent.constants.ts
@@ -368,9 +368,10 @@ export const PULL_CONVENTIONS_TOOL = {
             "lint-gotchas",
             "testing",
             "api-service",
+            "i18n",
           ],
           description:
-            "which guide: component-anatomy (where a component lives + one-per-file), file-layout (no inline types/constants/helpers), jsx (no computation in markup), state (hooks, not component body), no-casts (type guards instead of `as`/`!`), routing (thin route files), forms, data-fetching (api-client, never raw fetch), lint-gotchas (await promises, no void-expr values, no stringified errors, no duplicate strings), testing (.test.ts vs .test.tsx, the vi.hoisted api-client mock, createApp/app.handle route tests, enforced test rules), api-service (mutating service methods record an audit event; throw ApiError).",
+            'which guide: component-anatomy (where a component lives + one-per-file), file-layout (no inline types/constants/helpers), jsx (no computation in markup), state (hooks, not component body), no-casts (type guards instead of `as`/`!`), routing (thin route files), forms, data-fetching (api-client, never raw fetch), lint-gotchas (await promises, no void-expr values, no stringified errors, no duplicate strings), testing (.test.ts vs .test.tsx, the vi.hoisted api-client mock, createApp/app.handle route tests, enforced test rules), api-service (mutating service methods record an audit event; throw ApiError), i18n (add a locale key only when you reference it via t("key") — never pre-declare, or it\'s a dead-key error).',
         },
       },
       required: ["topic"],

--- a/packages/core/src/loop/boringstack/gate-stages.ts
+++ b/packages/core/src/loop/boringstack/gate-stages.ts
@@ -126,6 +126,14 @@ export function signatureToError(sig: string): IErrorItem {
         ? " This `'>' expected` in a `.ts` is usually JSX in a non-JSX file — if it contains JSX, it must be a `.tsx` (a `.ts` parses `<X>` as a generic and demands `>`)."
         : "";
 
+    // The api-client's types are GENERATED from the OpenAPI spec. Calling
+    // `apiClient.<M>("/api/v1/x")` for a path not yet in the spec fails typing with
+    // `PathsWithMethod<paths, …>` — the tell that the UI was written BEFORE the API route
+    // was registered + the client regenerated, NOT a UI-type bug to fight in the component.
+    // Steer to fix the ORDER, not the call site (observed: model ground on this + the
+    // coupled test-sibling for 20+ turns instead of touching the route).
+    const isPathsWithMethod = message.includes("PathsWithMethod");
+
     return {
       key: sig,
       file,
@@ -134,7 +142,9 @@ export function signatureToError(sig: string): IErrorItem {
       ...(phase === undefined ? {} : { phase }),
       message: isParse
         ? `${message}\n↳ SYNTAX/PARSE error — do NOT surgically patch it (a patch on a broken-parse file re-breaks its braces/generics/JSX). REWRITE THE WHOLE FILE \`${file}\` cleanly in one pass; once it parses, downstream errors clear.${parseSteer}`
-        : message,
+        : isPathsWithMethod
+          ? `${message}\n↳ This path is NOT in the OpenAPI spec yet — the api-client types are GENERATED from it, so don't fight the UI types. Make sure the API route exists AND is registered/mounted (so it shows in /swagger/json), then let the gate run — it re-runs generate:api and the path type appears. A \`/api/v1/…\` literal rejected by \`PathsWithMethod\` means the route isn't in the spec; fix the route/registration, not the call site.`
+          : message,
     };
   }
 

--- a/packages/core/src/loop/conventions.ts
+++ b/packages/core/src/loop/conventions.ts
@@ -170,6 +170,12 @@ const GUIDES: Readonly<Record<ConventionTopic, string>> = {
     "hook in a `QueryClient` with `retry:false` via `renderHook(() => useX(), { wrapper })` and " +
     "assert with `await waitFor(() => …)`. Imports: `vitest` (`describe, it, expect, vi, beforeEach`) " +
     "+ `@testing-library/react` (`renderHook, waitFor, act`) + `@tanstack/react-query`.\n" +
+    "• API tests (apps/api) run under `bun:test`, NOT vitest — `import { describe, expect, test } " +
+    'from "bun:test"` (vitest + `vi.*` are UI-only; using them in an apps/api test fails to resolve). ' +
+    "For a `*.service.ts` whose function hits the DB (Drizzle), do NOT unit-test it in isolation — you'll " +
+    "fight `string | SQLWrapper` types and need a live DB. Its behaviour is covered by the route test " +
+    "below; the `*.service.test.ts` only needs to satisfy the test-sibling floor with a minimal smoke " +
+    'test (e.g. `expect(typeof myServiceFn).toBe("function")`). Put the real assertions in the route test.\n' +
     "• API route tests (`apps/api/tests/**/*.routes.test.ts`, pure `.ts`) — handle the app in-process, " +
     "never a real network (no-real-network-in-unit-tests):\n" +
     '    const app = createApp(); // from "../../../src/config/app"\n' +

--- a/packages/core/src/loop/conventions.ts
+++ b/packages/core/src/loop/conventions.ts
@@ -23,6 +23,7 @@ const TOPICS = [
   "forms",
   "data-fetching",
   "lint-gotchas",
+  "testing",
 ] as const;
 
 export type ConventionTopic = (typeof TOPICS)[number];
@@ -59,6 +60,18 @@ export const TOPIC_RULES: Readonly<Record<ConventionTopic, readonly string[]>> =
       "no-confusing-void-expression",
       "no-error-stringify",
       "no-duplicate-string",
+    ],
+    // Tests were 61% of the edits on a live CRUD build (measured) — the model doesn't
+    // know the stack's test idioms so it flails: guesses .test.ts vs .test.tsx (and makes
+    // BOTH), reinvents the api-client mock (getting `any`-typed `data`), uses the wrong
+    // vi mock method. These rules fire on those mistakes; the guide teaches the idiom.
+    testing: [
+      "test-sibling-required",
+      "test-file-mirrors-source",
+      "no-focused-tests",
+      "no-conditional-expect",
+      "no-real-network-in-unit-tests",
+      "fake-timers-must-be-restored",
     ],
   };
 
@@ -133,6 +146,44 @@ const GUIDES: Readonly<Record<ConventionTopic, string>> = {
     '`log.error({ err }, "failed")`, never `` log.error(`${err}`) `` or `String(err)`.\n' +
     "• HOIST heavily-repeated string literals — the same literal 5+ times is a no-duplicate-string " +
     "error; pull it into a `const` (or `<Feature>.constants.ts`) and reference that.",
+  testing:
+    "TESTING (boringstack). Every logic file needs a co-located test (test-sibling-required), " +
+    "and tests are where builds waste the MOST turns — because the model guesses the idioms. " +
+    "Write them right the first time:\n" +
+    "• EXTENSION — pick ONE, never both: `.test.tsx` ONLY if the test renders JSX (`renderHook` " +
+    "with a wrapper, `render`, any `<X/>`); `.test.ts` for pure logic (schemas, utils, services, " +
+    "API route tests). The sibling check accepts EITHER, so if you create both, the unused twin " +
+    "becomes a knip `unused file` error. A `<X>` inside a `.test.ts` parses as a generic and fails " +
+    "with `'>' expected` — that means the file must be `.test.tsx`.\n" +
+    "• UI query/mutation/hook tests (`.test.tsx`) — mock the api-client HOISTED at the top, exactly " +
+    "this shape:\n" +
+    "    const apiMock = vi.hoisted(() => ({ GET: vi.fn(), POST: vi.fn(), PATCH: vi.fn(), PUT: vi.fn(), DELETE: vi.fn() }));\n" +
+    '    vi.mock("@/lib/api/client", () => ({ apiClient: apiMock }));\n' +
+    "  Return a CONCRETE typed object from the mock — `apiMock.POST.mockResolvedValueOnce({ data: { " +
+    "...the real response shape... } })`. A concrete literal keeps `data` typed; a bare `vi.fn()` " +
+    "return is `any`, which then trips no-unsafe/no-unnecessary-condition in the code under test " +
+    "(do NOT try to fix that by casting or changing production code). Use `mockResolvedValueOnce` " +
+    "per call; use `mockResolvedValue` only for a call that retries (e.g. a GET-me loop). RESET the " +
+    "mocks between tests — `beforeEach(() => { apiMock.GET.mockReset(); apiMock.POST.mockReset(); … })` " +
+    "(or `vi.clearAllMocks()`) — or a leftover `mockResolvedValue` leaks into the next test (it passes " +
+    "alone but fails in the suite). Wrap the " +
+    "hook in a `QueryClient` with `retry:false` via `renderHook(() => useX(), { wrapper })` and " +
+    "assert with `await waitFor(() => …)`. Imports: `vitest` (`describe, it, expect, vi, beforeEach`) " +
+    "+ `@testing-library/react` (`renderHook, waitFor, act`) + `@tanstack/react-query`.\n" +
+    "• API route tests (`apps/api/tests/**/*.routes.test.ts`, pure `.ts`) — handle the app in-process, " +
+    "never a real network (no-real-network-in-unit-tests):\n" +
+    '    const app = createApp(); // from "../../../src/config/app"\n' +
+    '    const res = await app.handle(new Request("http://localhost/api/v1/<path>", { method, headers, body }));\n' +
+    "    expect(res.status).toBe(200);\n" +
+    "  Read the body as `unknown` then TYPE-GUARD it (`const isX = (v: unknown): v is {…} => …; if " +
+    "(!isX(body)) throw new Error(…)`) — never `as`. For an authed route, define a local `loginCookie` " +
+    "helper (copy it verbatim from an existing `*.routes.test.ts`) and pass the returned cookie in headers.\n" +
+    "• RULES the gate enforces: no `.only`/`.skip` (no-focused-tests); never put `expect` inside an " +
+    "`if`/`try`/`catch` (no-conditional-expect); if you use fake timers, restore them in `afterEach` " +
+    "(fake-timers-must-be-restored); the test path/name mirrors its source (test-file-mirrors-source).\n" +
+    "• After you write a test the harness AUTO-FORMATS it (imports reordered, quotes/commas normalized), " +
+    "so your next `edit` oldString won't match — RE-READ the file and copy oldString from its current " +
+    "content; do NOT recreate the whole file.",
 };
 
 /** The guide for a topic (the exact string pushed or pulled). */

--- a/packages/core/src/loop/conventions.ts
+++ b/packages/core/src/loop/conventions.ts
@@ -137,7 +137,13 @@ const GUIDES: Readonly<Record<ConventionTopic, string>> = {
     "error); if you must name the event it is a `BaseSyntheticEvent`, and fire it as " +
     "`void handleSubmit(onSubmit)(event)` (the `void` satisfies no-floating-promises). In the Zod " +
     "schema use the TOP-LEVEL validators — `z.email()`, `z.url()`, `z.uuid()` — NOT the deprecated " +
-    "`z.string().email()`. Map server/validation errors back onto the fields (`setError`); keep " +
+    "`z.string().email()`. RESOLVER TYPES: do NOT put `.optional()`/`.default()` on a form field's " +
+    "schema — it makes the Zod INPUT type differ from the OUTPUT type, so `zodResolver` yields a " +
+    "`Resolver<In, any, Out>` that won't match `useForm`/`SubmitHandler` (a persistent 'Resolver … " +
+    "not assignable' / 'not assignable to SubmitHandler' error). Keep every field required in the " +
+    "schema and supply its initial value in `useForm({ defaultValues })`; type the hook as " +
+    "`useForm<z.infer<typeof schema>>` so onSubmit's input matches `SubmitHandler`. Map " +
+    "server/validation errors back onto the fields (`setError`); keep " +
     "the component rendering the field state the hook returns.",
   "data-fetching":
     "DATA-FETCHING (boringstack). ALL HTTP goes through the generated client " +
@@ -217,7 +223,12 @@ const GUIDES: Readonly<Record<ConventionTopic, string>> = {
     "`void auditLogService.record({ userId, action: AUDIT_ACTIONS.<ENTITY_ACTION>, metadata: { … } })` " +
     "(the `void` satisfies no-floating-promises). Read-only methods (get/list) don't need it. Surface " +
     "failures by THROWING an `ApiError` (e.g. 404/409), not by returning an error envelope — the route " +
-    "layer maps thrown ApiErrors to responses.",
+    "layer maps thrown ApiErrors to responses. Every ROUTE must declare a single-content-type " +
+    "`response:` schema (`.get(path, handler, { response: <Entity>ResponseSchema })`) — the UI's " +
+    "api-client is generated from this. If a route omits `response:` (or allows multiple content " +
+    "types), openapi-fetch types the UI's `data` as `Readable<SuccessResponse<…>>` instead of the " +
+    "JSON body, and the UI can't consume it (a persistent 'not assignable to …' error you canNOT fix " +
+    "on the UI side — fix the ROUTE's response schema).",
 };
 
 /** The guide for a topic (the exact string pushed or pulled). */

--- a/packages/core/src/loop/conventions.ts
+++ b/packages/core/src/loop/conventions.ts
@@ -192,8 +192,9 @@ const GUIDES: Readonly<Record<ConventionTopic, string>> = {
     "(!isX(body)) throw new Error(…)`) — never `as`. For an authed route, define a local `loginCookie` " +
     "helper (copy it verbatim from an existing `*.routes.test.ts`) and pass the returned cookie in headers.\n" +
     "• RULES the gate enforces: no `.only`/`.skip` (no-focused-tests); never put `expect` inside an " +
-    "`if`/`try`/`catch` (no-conditional-expect); if you use fake timers, restore them in `afterEach` " +
-    "(fake-timers-must-be-restored); the test path/name mirrors its source (test-file-mirrors-source).\n" +
+    "`if`/loop/`switch`/ternary — assert unconditionally (no-conditional-expect); if you use fake " +
+    "timers, restore them in `afterEach` (fake-timers-must-be-restored); the test path/name mirrors " +
+    "its source (test-file-mirrors-source).\n" +
     "• After you write a test the harness AUTO-FORMATS it (imports reordered, quotes/commas normalized), " +
     "so your next `edit` oldString won't match — RE-READ the file and copy oldString from its current " +
     "content; do NOT recreate the whole file.",

--- a/packages/core/src/loop/conventions.ts
+++ b/packages/core/src/loop/conventions.ts
@@ -24,6 +24,7 @@ const TOPICS = [
   "data-fetching",
   "lint-gotchas",
   "testing",
+  "api-service",
 ] as const;
 
 export type ConventionTopic = (typeof TOPICS)[number];
@@ -73,6 +74,9 @@ export const TOPIC_RULES: Readonly<Record<ConventionTopic, readonly string[]>> =
       "no-real-network-in-unit-tests",
       "fake-timers-must-be-restored",
     ],
+    // The audit-event rule is a boringstack-OWN eslint rule (not a tsforge meta-rule), so it
+    // isn't keyed here for the reactive PUSH — the front-loaded guide is the delivery path.
+    "api-service": [],
   };
 
 const GUIDES: Readonly<Record<ConventionTopic, string>> = {
@@ -198,6 +202,15 @@ const GUIDES: Readonly<Record<ConventionTopic, string>> = {
     "• After you write a test the harness AUTO-FORMATS it (imports reordered, quotes/commas normalized), " +
     "so your next `edit` oldString won't match — RE-READ the file and copy oldString from its current " +
     "content; do NOT recreate the whole file.",
+  "api-service":
+    "API SERVICE (boringstack). apps/api resource logic lives in `<entity>.service.ts`. Every " +
+    "MUTATING method (create/update/delete) MUST record an audit event — the gate rejects one that " +
+    "doesn't (`Mutating method '…' does not record an audit event`). Import `{ AUDIT_ACTIONS, " +
+    'auditLogService } from "../../lib/audit-log"` and, after the mutation, call ' +
+    "`void auditLogService.record({ userId, action: AUDIT_ACTIONS.<ENTITY_ACTION>, metadata: { … } })` " +
+    "(the `void` satisfies no-floating-promises). Read-only methods (get/list) don't need it. Surface " +
+    "failures by THROWING an `ApiError` (e.g. 404/409), not by returning an error envelope — the route " +
+    "layer maps thrown ApiErrors to responses.",
 };
 
 /** The guide for a topic (the exact string pushed or pulled). */

--- a/packages/core/src/loop/conventions.ts
+++ b/packages/core/src/loop/conventions.ts
@@ -101,7 +101,14 @@ const GUIDES: Readonly<Record<ConventionTopic, string>> = {
     "already-computed values. A derived value → a `useMemo` in `<feature>.hooks.ts`; " +
     "a pure transform → a function in `src/lib`. A simple ternary is fine; a " +
     "`.map()`/`.filter()`/arithmetic/`Object.entries()` in the markup is not (extract " +
-    "it). Every `<button>` needs an explicit `type`.",
+    "it). Every `<button>` needs an explicit `type`. A function passed to a JSX prop " +
+    "(`onClick`, `onChange`, `onSubmit`) must be a STABLE reference — `react/jsx-no-bind` " +
+    "rejects BOTH an inline arrow (`onClick={() => …}`) AND a plain arrow defined in the " +
+    "component body (it's recreated every render). Make it stable: for a list ROW, give " +
+    "the row its own component with an `onEdit(id)`/`onDelete(id)` prop and pass that prop " +
+    "straight to `onClick`; the parent supplies each callback via `useCallback` in " +
+    "`<feature>.hooks.ts`. A handler needing an argument → `useCallback(() => onEdit(id), " +
+    "[onEdit, id])` in the row's hook, not an inline `() => onEdit(id)` in the markup.",
   state:
     "STATE (boringstack). ALL `useState`/`useReducer`/`useEffect`/`useMemo`/" +
     "`useCallback` live in `<feature>.hooks.ts`, never in a component body. Server " +

--- a/packages/core/src/loop/conventions.ts
+++ b/packages/core/src/loop/conventions.ts
@@ -25,6 +25,7 @@ const TOPICS = [
   "lint-gotchas",
   "testing",
   "api-service",
+  "i18n",
 ] as const;
 
 export type ConventionTopic = (typeof TOPICS)[number];
@@ -77,6 +78,12 @@ export const TOPIC_RULES: Readonly<Record<ConventionTopic, readonly string[]>> =
     // The audit-event rule is a boringstack-OWN eslint rule (not a tsforge meta-rule), so it
     // isn't keyed here for the reactive PUSH — the front-loaded guide is the delivery path.
     "api-service": [],
+    // The DOMINANT recurring error on a live near-green build (measured: 19× in one run — it
+    // trapped the model oscillating around 1 error): the model pre-declares locale keys it never
+    // references, so each is a `i18n-locale-keys-used` dead-key error. Both i18n directions map here
+    // so EITHER pushes the guide: `i18n-locale-keys-used` (defined→used, the dead-key trap) and
+    // `static-translation-key-exists` (used→defined, a `t()` whose key isn't in the locale files).
+    i18n: ["i18n-locale-keys-used", "static-translation-key-exists"],
   };
 
 const GUIDES: Readonly<Record<ConventionTopic, string>> = {
@@ -231,6 +238,28 @@ const GUIDES: Readonly<Record<ConventionTopic, string>> = {
     "types), openapi-fetch types the UI's `data` as `Readable<SuccessResponse<…>>` instead of the " +
     "JSON body, and the UI can't consume it (a persistent 'not assignable to …' error you canNOT fix " +
     "on the UI side — fix the ROUTE's response schema).",
+  i18n:
+    "I18N LOCALE KEYS (boringstack). Every user-facing string is a translation key, and the gate " +
+    'enforces BOTH directions: a `t("key")` with no locale entry fails (used→defined), AND a key ' +
+    "defined in the locale files that NO src file references fails as 'dead translation surface' " +
+    "(i18n-locale-keys-used, defined→used). THE TRAP that stalls near-green builds is PRE-DECLARING " +
+    "keys: never add a key to the locale JSON 'for later' or in a batch. Add a key and its single " +
+    '`t("full.dotted.path")` reference in the SAME change — if you are not calling `t()` on it right ' +
+    'now, do not define it. WIRING: `import { useTranslation } from "react-i18next"`, then ' +
+    "`const { t } = useTranslation()` in the component (a hook — it lives in the component body per " +
+    'react-hooks rules, NOT in `.hooks.ts`), and `t("features.<feature>.<key>")` in the JSX. The ' +
+    "reference must ALWAYS be the FULL dotted key as a plain STRING LITERAL — never assemble a key by " +
+    "concatenation or a template (`t(`…${x}`)`): the used→defined check (static-translation-key-exists) " +
+    "only reads string literals, so a dynamic key silently BYPASSES validation and ships missing " +
+    "translations. If a value varies (e.g. a status label), map each concrete case to its own literal " +
+    "key. LOCALE FILES: add the key to EVERY locale — `src/lib/i18n/locales/en/common.json` (the " +
+    "canonical file the rule scans) AND `src/lib/i18n/locales/de/common.json` — nested under the dotted " +
+    "path. FIXING a dead-key (i18n-locale-keys-used) error: WIRE IT UP — add the missing " +
+    '`t("features.<feature>.<key>")` in the component that should display it. This clears by ADDING code, ' +
+    "not removing it. Do NOT delete a key you authored this session to silence the rule: it strips real " +
+    "functionality the feature needs (a hollow list-only page), it's pure churn you'll re-add, and the " +
+    "build's i18n edit-guard VETOES a net deletion of session-authored keys anyway. (Removal is only for " +
+    "a genuinely obsolete pre-existing key, or a balanced rename that adds the replacement in the same edit.)",
 };
 
 /** The guide for a topic (the exact string pushed or pulled). */

--- a/packages/core/src/loop/conventions.ts
+++ b/packages/core/src/loop/conventions.ts
@@ -165,8 +165,9 @@ const GUIDES: Readonly<Record<ConventionTopic, string>> = {
     "(do NOT try to fix that by casting or changing production code). Use `mockResolvedValueOnce` " +
     "per call; use `mockResolvedValue` only for a call that retries (e.g. a GET-me loop). RESET the " +
     "mocks between tests — `beforeEach(() => { apiMock.GET.mockReset(); apiMock.POST.mockReset(); … })` " +
-    "(or `vi.clearAllMocks()`) — or a leftover `mockResolvedValue` leaks into the next test (it passes " +
-    "alone but fails in the suite). Wrap the " +
+    "(or `vi.resetAllMocks()`; NOT `vi.clearAllMocks()`, which clears only call history and leaves " +
+    "queued return values in place) — or a leftover `mockResolvedValue` leaks into the next test (it " +
+    "passes alone but fails in the suite). Wrap the " +
     "hook in a `QueryClient` with `retry:false` via `renderHook(() => useX(), { wrapper })` and " +
     "assert with `await waitFor(() => …)`. Imports: `vitest` (`describe, it, expect, vi, beforeEach`) " +
     "+ `@testing-library/react` (`renderHook, waitFor, act`) + `@tanstack/react-query`.\n" +

--- a/packages/core/src/loop/conventions.ts
+++ b/packages/core/src/loop/conventions.ts
@@ -119,9 +119,15 @@ const GUIDES: Readonly<Record<ConventionTopic, string>> = {
     "router (`src/app/router/routes.tsx`) pointing at `@/features/<feature>` — never " +
     "hand-write a component's body in a route file.",
   forms:
-    "FORMS (boringstack). Use react-hook-form's `useForm` inside `<Component>.hooks.ts` " +
-    "(not the component body). Map server/validation errors back onto the form fields; " +
-    "keep the component rendering the field state the hook returns.",
+    "FORMS (boringstack). Use react-hook-form's `useForm<T>({ resolver: zodResolver(schema) })` " +
+    "(from `react-hook-form` + `@hookform/resolvers/zod`) inside `<Component>.hooks.ts`, not the " +
+    "component body. Submit via the returned `handleSubmit(onSubmit)` — do NOT hand-type the " +
+    "submit handler with React's `FormEvent` (it's the wrong type here and a repeatedly-invented " +
+    "error); if you must name the event it is a `BaseSyntheticEvent`, and fire it as " +
+    "`void handleSubmit(onSubmit)(event)` (the `void` satisfies no-floating-promises). In the Zod " +
+    "schema use the TOP-LEVEL validators — `z.email()`, `z.url()`, `z.uuid()` — NOT the deprecated " +
+    "`z.string().email()`. Map server/validation errors back onto the fields (`setError`); keep " +
+    "the component rendering the field state the hook returns.",
   "data-fetching":
     "DATA-FETCHING (boringstack). ALL HTTP goes through the generated client " +
     "`@/lib/api/client` — never `fetch`/`axios` (lint-banned). Call it as " +

--- a/packages/core/src/loop/conventions.ts
+++ b/packages/core/src/loop/conventions.ts
@@ -82,13 +82,15 @@ export const TOPIC_RULES: Readonly<Record<ConventionTopic, readonly string[]>> =
 const GUIDES: Readonly<Record<ConventionTopic, string>> = {
   "component-anatomy":
     "COMPONENT ANATOMY (boringstack). A feature lives in `src/features/<feature>/`. " +
-    "Components go under `src/features/<feature>/components/<Name>/`: `<Name>.tsx` " +
-    "renders props (it does NOT own state), and `index.ts` re-exports the default — " +
-    "ONE component per file. State/effects/memo live in `<Name>.hooks.ts`, never in " +
-    "the component body — the component imports the hook and consumes its return " +
-    "value. Feature-level files sit at `src/features/<feature>/`: `<Feature>.types.ts`, " +
-    "`<Feature>.constants.ts`, `<Feature>.queries.ts`, `<Feature>.mutations.ts`. shadcn " +
-    "primitives in `src/components/ui/` are exempt.",
+    "Components go under `src/features/<feature>/components/<Name>/`, and component-folder-" +
+    "structure requires the FULL sibling set — create ALL of them or the gate rejects the " +
+    "folder ('missing required siblings'): `<Name>.tsx` (renders props, does NOT own state), " +
+    "`<Name>.hooks.ts` (all state/effects/memo — never in the body), `<Name>.types.ts` (its " +
+    "Props interface), `<Name>.stories.tsx` (a Storybook story — REQUIRED, easy to forget), " +
+    "`<Name>.test.tsx` (or `.test.ts`), and `index.ts` (`export { default as <Name> } from " +
+    '"./<Name>"`). ONE component per file. Feature-level files sit at `src/features/<feature>/`: ' +
+    "`<Feature>.types.ts`, `<Feature>.constants.ts`, `<Feature>.queries.ts`, " +
+    "`<Feature>.mutations.ts`. shadcn primitives in `src/components/ui/` are exempt.",
   "file-layout":
     "FILE PURITY (boringstack). A component `.tsx` holds ONLY imports + the component " +
     "— nothing else atop it. Move each out and import it back: a type → " +

--- a/packages/core/src/loop/near-green-checkpoint.ts
+++ b/packages/core/src/loop/near-green-checkpoint.ts
@@ -51,18 +51,20 @@ export interface INearGreenCheckpoint {
   readonly depFiles: ReadonlyMap<string, Uint8Array>;
 }
 
-/** Gate errors that clear ONLY by ADDING code — wiring the i18n keys the feature declared
- *  (`i18n-locale-keys-used`), making the feature reachable (`reachability`), or passing the
- *  hollow-app quality `judge`. They are NOT fixable in the current files. A near-green state
- *  whose remaining errors are all of this class is a HOLLOW state (e.g. a list-only page with
- *  unused create/edit/delete translations): reaching green REQUIRES the model to add the
- *  form + buttons + toasts, which transiently spikes the error count. WS-B's count-only spray
- *  detection can't tell that legitimate completion edit from a bad convention spray, so
- *  checkpointing this state and reverting to it traps the model in the hollow app. */
+/** Gate errors that in THIS stack clear ONLY by ADDING code — wiring the i18n keys the feature
+ *  declared (`i18n-locale-keys-used`; the i18n-destructive-delete guard forbids the removal
+ *  shortcut, so the model MUST add the UI that references them), or making the feature reachable
+ *  (`reachability`; add the route/mount). A near-green state whose remaining errors are all of
+ *  this class is a HOLLOW state (e.g. a list-only page with unused create/edit/delete
+ *  translations): reaching green REQUIRES the model to add the form + buttons + toasts, which
+ *  transiently spikes the error count. WS-B's count-only spray detection can't tell that
+ *  legitimate completion edit from a bad convention spray, so checkpointing this state and
+ *  reverting to it traps the model in the hollow app. NOTE: `judge` is deliberately EXCLUDED —
+ *  the quality judge can reject defects in EXISTING code (fixable in place), not only
+ *  hollowness, so it is not a reliable add-only signal. */
 const COMPLETION_CLASS_RULES: ReadonlySet<string> = new Set([
   "reachability",
   "i18n-locale-keys-used",
-  "judge",
 ]);
 
 /** Whether a gate error clears only by adding code (see COMPLETION_CLASS_RULES). Matches the

--- a/packages/core/src/loop/near-green-checkpoint.ts
+++ b/packages/core/src/loop/near-green-checkpoint.ts
@@ -82,6 +82,26 @@ export function allCompletionClass(errors: readonly IErrorItem[]): boolean {
   return errors.length > 0 && errors.every(isCompletionClass);
 }
 
+/** Advance the persistent completion-phase flag. ENTER when every error is completion-class (a
+ *  hollow state); STAY while ANY completion error remains (the MIXED spike as the model wires
+ *  the keys — a per-cycle all-completion check would flip false here and re-arm the rollback +
+ *  "undo" banner mid-add); EXIT when no completion error remains (the model finished wiring →
+ *  only fixable errors left → WS-B re-engages) or when green (no errors). */
+export function nextCompletionPhase(
+  prev: boolean,
+  errors: readonly IErrorItem[]
+): boolean {
+  if (allCompletionClass(errors)) {
+    return true;
+  }
+
+  if (!errors.some(isCompletionClass)) {
+    return false;
+  }
+
+  return prev;
+}
+
 /** Whether a fresh gate result should be CHECKPOINTED: it's a new all-time low, it's near
  *  green (1..N), and not zero (zero means the build just went green — nothing to protect).
  *  `isNewLow` is the loop's own genuine-progress signal, passed in so this stays pure. */

--- a/packages/core/src/loop/near-green-checkpoint.ts
+++ b/packages/core/src/loop/near-green-checkpoint.ts
@@ -51,6 +51,35 @@ export interface INearGreenCheckpoint {
   readonly depFiles: ReadonlyMap<string, Uint8Array>;
 }
 
+/** Gate errors that clear ONLY by ADDING code — wiring the i18n keys the feature declared
+ *  (`i18n-locale-keys-used`), making the feature reachable (`reachability`), or passing the
+ *  hollow-app quality `judge`. They are NOT fixable in the current files. A near-green state
+ *  whose remaining errors are all of this class is a HOLLOW state (e.g. a list-only page with
+ *  unused create/edit/delete translations): reaching green REQUIRES the model to add the
+ *  form + buttons + toasts, which transiently spikes the error count. WS-B's count-only spray
+ *  detection can't tell that legitimate completion edit from a bad convention spray, so
+ *  checkpointing this state and reverting to it traps the model in the hollow app. */
+const COMPLETION_CLASS_RULES: ReadonlySet<string> = new Set([
+  "reachability",
+  "i18n-locale-keys-used",
+  "judge",
+]);
+
+/** Whether a gate error clears only by adding code (see COMPLETION_CLASS_RULES). Matches the
+ *  bare rule id so a plugin-prefixed form (`plugin/i18n-locale-keys-used`) still classifies. */
+export function isCompletionClass(error: IErrorItem): boolean {
+  const rule = error.rule ?? "";
+  const bare = rule.split("/").pop() ?? rule;
+
+  return COMPLETION_CLASS_RULES.has(bare);
+}
+
+/** True when EVERY remaining gate error is completion-class — the hollow near-green state WS-B
+ *  must not protect. Empty is false (green is handled elsewhere; nothing to classify). */
+export function allCompletionClass(errors: readonly IErrorItem[]): boolean {
+  return errors.length > 0 && errors.every(isCompletionClass);
+}
+
 /** Whether a fresh gate result should be CHECKPOINTED: it's a new all-time low, it's near
  *  green (1..N), and not zero (zero means the build just went green — nothing to protect).
  *  `isNewLow` is the loop's own genuine-progress signal, passed in so this stays pure. */

--- a/packages/core/src/loop/session.ts
+++ b/packages/core/src/loop/session.ts
@@ -424,6 +424,7 @@ export function resetDriveConvergence(state: ILoopState): void {
   delete state.nearGreenCheckpoint;
   delete state.nearGreenBest;
   delete state.nearGreenRollbacks;
+  delete state.completionPhase;
 }
 
 /** How many times a send recovers from a repetition loop before giving up. */

--- a/packages/core/src/loop/turn.ts
+++ b/packages/core/src/loop/turn.ts
@@ -29,7 +29,7 @@ import { unseenGuidesForErrors } from "./conventions";
 import {
   shouldCheckpoint,
   shouldRollback,
-  allCompletionClass,
+  nextCompletionPhase,
   MAX_NEAR_GREEN_ROLLBACKS,
   type INearGreenCheckpoint,
 } from "./near-green-checkpoint";
@@ -432,6 +432,15 @@ export interface ILoopState {
    *  (e.g. 2→1, or 1→1 different error) instead of a spray reverting to a worse/older saved
    *  state. Reset on green and at the drive boundary; lowered as the checkpoint refreshes. */
   nearGreenBest?: number;
+  /** WS-B: the model is in the COMPLETION phase — it reached an all-completion-class state
+   *  (only add-code errors: unused i18n keys / not reachable) and is now building the demanded
+   *  create/edit/delete UI. This PERSISTS across the resulting error spike (which is MIXED —
+   *  new compile errors + the shrinking completion errors), because a per-cycle all-completion
+   *  check flips false the moment the model starts adding code, re-arming the rollback + the
+   *  "undo" banner mid-add. Set when all errors are completion-class; held while ANY completion
+   *  error remains; cleared when none remain (completion done → WS-B re-engages) or on green /
+   *  at the drive boundary. While set, WS-B does not roll back and the banner says "build it". */
+  completionPhase?: boolean;
   /** Guard-specific identity of the current stuck block (canonical, not the raw error
    *  set). Derived from the guard that fired: samePersist → single error key,
    *  gateStuckRepeats → sorted-join of current keys, plateau → normalized count|keys
@@ -2111,7 +2120,7 @@ export async function injectFeedback(
   const banner = nearGreenBanner(
     gateErrors.length,
     state.bestErrorCount,
-    allCompletionClass(gateErrors)
+    state.completionPhase === true
   );
 
   ctx.messages.push({
@@ -2289,6 +2298,13 @@ async function nearGreenRollbackStep(
     return false;
   }
 
+  // During the COMPLETION phase the model is ADDING the demanded UI, so the error spike is
+  // progress, not a spray — never roll it back (this runs before checkpointStep, so the flag,
+  // not a per-cycle all-completion check, is what protects the mixed-error spike).
+  if (state.completionPhase === true) {
+    return false;
+  }
+
   if (
     shouldRollback(
       state.nearGreenCheckpoint,
@@ -2332,14 +2348,13 @@ async function nearGreenCheckpointStep(
     return;
   }
 
-  // Never protect a HOLLOW near-green state — one whose remaining errors ALL clear only by
-  // ADDING code (wiring i18n keys, reachability, the judge). The completeness guards demand
-  // that code; the model's large completion edit transiently spikes the count, and a
-  // checkpoint here would revert it to the hollow app (observed: 1→27 spray reverted to a
-  // list-only page, model re-does it → thrash). CLEAR any checkpoint (drops an earlier
-  // compile-state one too, so the spray isn't reverted to that either) and don't capture;
-  // WS-B resumes once errors are fixable-in-place again.
-  if (allCompletionClass(gateErrors)) {
+  // Never protect a HOLLOW state while in the COMPLETION phase — the model is adding the
+  // demanded create/edit/delete UI (wiring i18n keys / reachability), so a checkpoint here
+  // would revert it to the list-only page (observed: 1→27 spray reverted, model re-does it →
+  // thrash). CLEAR any checkpoint (drops an earlier compile-state one too — its fixable errors
+  // are already resolved, so it's stale) and don't capture; WS-B re-engages when the phase ends
+  // (no completion error remains). completionPhase was advanced at the top of settleGate.
+  if (state.completionPhase === true) {
     state.nearGreenCheckpoint = undefined;
 
     return;
@@ -2377,6 +2392,15 @@ export async function settleGate(
   } = await evaluateGate(ctx, turn);
 
   const curr = gateErrors.length;
+
+  // WS-B: advance the completion-phase flag BEFORE the rollback/banner/checkpoint steps read
+  // it — so the phase set at the hollow state survives the mixed-error spike that follows
+  // (the rollback step runs first, and a per-cycle all-completion check would already be false
+  // there once the model started adding code).
+  state.completionPhase = nextCompletionPhase(
+    state.completionPhase ?? false,
+    gateErrors
+  );
 
   if (state.lastGateCount >= 0 && curr > state.lastGateCount) {
     state.regressions += 1;

--- a/packages/core/src/loop/turn.ts
+++ b/packages/core/src/loop/turn.ts
@@ -29,6 +29,7 @@ import { unseenGuidesForErrors } from "./conventions";
 import {
   shouldCheckpoint,
   shouldRollback,
+  allCompletionClass,
   MAX_NEAR_GREEN_ROLLBACKS,
   type INearGreenCheckpoint,
 } from "./near-green-checkpoint";
@@ -2303,6 +2304,19 @@ async function nearGreenCheckpointStep(
   // fresh checkpoint and a model that sprays→reverts→re-settles could thrash to maxTurns.
   // The escalation ladder now owns the stall.
   if ((state.nearGreenRollbacks ?? 0) >= MAX_NEAR_GREEN_ROLLBACKS) {
+    return;
+  }
+
+  // Never protect a HOLLOW near-green state — one whose remaining errors ALL clear only by
+  // ADDING code (wiring i18n keys, reachability, the judge). The completeness guards demand
+  // that code; the model's large completion edit transiently spikes the count, and a
+  // checkpoint here would revert it to the hollow app (observed: 1→27 spray reverted to a
+  // list-only page, model re-does it → thrash). CLEAR any checkpoint (drops an earlier
+  // compile-state one too, so the spray isn't reverted to that either) and don't capture;
+  // WS-B resumes once errors are fixable-in-place again.
+  if (allCompletionClass(gateErrors)) {
+    state.nearGreenCheckpoint = undefined;
+
     return;
   }
 

--- a/packages/core/src/loop/turn.ts
+++ b/packages/core/src/loop/turn.ts
@@ -1978,12 +1978,31 @@ const NEAR_GREEN_LOCKDOWN = 3;
 /** A lockdown/regression banner for the top of the feedback, or "" when far from
  *  green and not regressing. `total` = open errors this cycle; `best` = the all-time
  *  low (watermark). Regression = this cycle is WORSE than the best already reached. */
-export function nearGreenBanner(total: number, best: number): string {
+export function nearGreenBanner(
+  total: number,
+  best: number,
+  completionOnly = false
+): string {
   const regressed = Number.isFinite(best) && total > best;
   const near = total > 0 && total <= NEAR_GREEN_LOCKDOWN;
 
   if (!near && !regressed) {
     return "";
+  }
+
+  // When EVERY remaining error clears only by ADDING code (unused i18n keys / not reachable —
+  // see allCompletionClass), the normal near-green lockdown ("smallest change, do NOT create
+  // files or add features") is exactly BACKWARDS: it forbids the create/edit/delete UI the
+  // feature must have. Emit the opposite instruction so the model builds it (WS-B has already
+  // stood its checkpoint down for this state, so the resulting spike won't be reverted).
+  if (completionOnly) {
+    return (
+      `⚠ ${String(total)} error(s) left, and they clear only by ADDING the code the feature is ` +
+      "missing — it declared UI it hasn't built (unused i18n keys / not reachable). BUILD the " +
+      "create/edit/delete UI, the success/error toasts that reference those keys, and the route " +
+      "wiring. The error count WILL rise as you add these files — that's expected progress here, " +
+      "NOT a regression to undo. Keep going until the added code references everything.\n\n"
+    );
   }
 
   const lines: string[] = [];
@@ -2086,8 +2105,14 @@ export async function injectFeedback(
   }
 
   // NEAR-GREEN lockdown / regression callout leads everything — the finishing
-  // discipline that stops "spray after best" (the dominant late-run failure).
-  const banner = nearGreenBanner(gateErrors.length, state.bestErrorCount);
+  // discipline that stops "spray after best" (the dominant late-run failure). When the
+  // remaining errors are all completion-class, the banner flips to "build the missing UI"
+  // instead of "don't create files" (else it contradicts the completeness guard).
+  const banner = nearGreenBanner(
+    gateErrors.length,
+    state.bestErrorCount,
+    allCompletionClass(gateErrors)
+  );
 
   ctx.messages.push({
     role: "user",

--- a/packages/core/tests/boringstack-conventions.test.ts
+++ b/packages/core/tests/boringstack-conventions.test.ts
@@ -3,9 +3,11 @@ import { tmpdir } from "node:os";
 import {
   conventionGuide,
   conventionTopics,
+  isConventionTopic,
   topicForRule,
   unseenGuidesForErrors,
 } from "../src/loop/conventions";
+import { PULL_CONVENTIONS_TOOL } from "../src/agent/agent.constants";
 import { injectFeedback, type ILoopCtx } from "../src/loop/turn";
 import type { ILoopState, ILoopEvent } from "../src/loop";
 import type { IErrorItem } from "../src/validate";
@@ -59,6 +61,45 @@ describe("convention registry", () => {
     // Panel-diagnosed root cause of the Readable<SuccessResponse> UI residual: route response schema.
     expect(g).toContain("response:");
     expect(g).toContain("Readable<SuccessResponse");
+  });
+
+  test("i18n guide bans pre-declaring keys — the dominant near-green thrash (build11: 19× dead-key)", () => {
+    const g = conventionGuide("i18n");
+
+    // The CAUSE: the model pre-declares locale keys it never references. The guide must forbid it
+    // and pin the two-way rule so the model connects the gate error to the fix.
+    expect(g).toContain("PRE-DECLARING");
+    expect(g).toContain("i18n-locale-keys-used");
+    expect(g).toContain("SAME change");
+    // The verified wiring idiom (react-i18next, full dotted literal, both locales).
+    expect(g).toContain("useTranslation");
+    expect(g).toContain("react-i18next");
+    expect(g).toContain("STRING LITERAL");
+    expect(g).toContain("locales/en/common.json");
+    expect(g).toContain("locales/de/common.json");
+    // The fix MUST be the harness-sanctioned one — WIRE IT UP, never delete a session-authored
+    // key (rule-docs.ts + i18n-guard + near-green completion-class all mandate clear-by-adding).
+    // The guide must NOT offer deletion as an equal fix (that re-introduces the #49 churn).
+    expect(g).toContain("WIRE IT UP");
+    expect(g).toContain("Do NOT delete a key you authored");
+    expect(g).toContain("VETOES");
+    expect(g).not.toContain("EXACTLY ONE");
+    // A dynamic template key bypasses the used→defined (static-translation-key-exists) check,
+    // so the guide must forbid it and require a static literal per concrete case.
+    expect(g).toContain("BYPASSES validation");
+  });
+
+  test("i18n is a first-class pullable topic — registry AND pull_conventions enum agree (no drift)", () => {
+    // The three hand-maintained surfaces for a topic must all carry `i18n`, or the model
+    // hits a live guide it can't `pull_conventions` for (enum reject) — the exact drift the
+    // reviewers flagged. convention-index.test.ts locks the full enum↔topics parity; this pins
+    // the NEW topic explicitly in its own change so the guard is visible beside the addition.
+    expect(conventionTopics()).toContain("i18n");
+    expect(isConventionTopic("i18n")).toBe(true);
+    const enumTopics =
+      PULL_CONVENTIONS_TOOL.function.parameters.properties.topic.enum;
+
+    expect(enumTopics).toContain("i18n");
   });
 
   test("forms guide steers away from the invented FormEvent + deprecated z.string().email() (live-build residuals)", () => {
@@ -145,6 +186,13 @@ describe("topicForRule", () => {
     expect(topicForRule("no-restricted-syntax")).toBe("no-casts");
     expect(topicForRule("component-folder-structure")).toBe(
       "component-anatomy"
+    );
+    // BOTH i18n directions must PUSH the i18n guide: the dead-key trap (defined→used, build11)
+    // AND a t() whose key isn't defined (used→defined, plugin-prefixed in the wild).
+    expect(topicForRule("i18n-locale-keys-used")).toBe("i18n");
+    expect(topicForRule("static-translation-key-exists")).toBe("i18n");
+    expect(topicForRule("i18n-keys/static-translation-key-exists")).toBe(
+      "i18n"
     );
   });
 

--- a/packages/core/tests/boringstack-conventions.test.ts
+++ b/packages/core/tests/boringstack-conventions.test.ts
@@ -31,6 +31,9 @@ describe("convention registry", () => {
     expect(g).toContain("src/features/<feature>/components/");
     // The dead UI-only-React `src/views` layout must be gone.
     expect(g).not.toContain("src/views/");
+    // The FULL required sibling set incl the easily-forgotten .stories.tsx (build9 arch wall).
+    expect(g).toContain(".stories.tsx");
+    expect(g).toContain("missing required siblings");
   });
 
   test("jsx guide gives the exact jsx-no-bind fix for list-row handlers (build7 parking residual)", () => {

--- a/packages/core/tests/boringstack-conventions.test.ts
+++ b/packages/core/tests/boringstack-conventions.test.ts
@@ -33,6 +33,17 @@ describe("convention registry", () => {
     expect(g).not.toContain("src/views/");
   });
 
+  test("api-service guide teaches the audit-event idiom on mutating methods (build6 hard-gate residual)", () => {
+    const g = conventionGuide("api-service");
+
+    expect(g).toContain("auditLogService.record");
+    expect(g).toContain("AUDIT_ACTIONS");
+    expect(g).toContain("audit event");
+    // Mutations only; reads exempt; throw ApiError (not error envelopes).
+    expect(g).toContain("create/update/delete");
+    expect(g).toContain("ApiError");
+  });
+
   test("forms guide steers away from the invented FormEvent + deprecated z.string().email() (live-build residuals)", () => {
     const g = conventionGuide("forms");
 

--- a/packages/core/tests/boringstack-conventions.test.ts
+++ b/packages/core/tests/boringstack-conventions.test.ts
@@ -33,6 +33,17 @@ describe("convention registry", () => {
     expect(g).not.toContain("src/views/");
   });
 
+  test("jsx guide gives the exact jsx-no-bind fix for list-row handlers (build7 parking residual)", () => {
+    const g = conventionGuide("jsx");
+
+    expect(g).toContain("react/jsx-no-bind");
+    expect(g).toContain("STABLE reference");
+    // Both an inline arrow AND a body-defined arrow are rejected — the model kept doing the latter.
+    expect(g).toContain("recreated every render");
+    expect(g).toContain("useCallback");
+    expect(g).toContain("onEdit(id)");
+  });
+
   test("api-service guide teaches the audit-event idiom on mutating methods (build6 hard-gate residual)", () => {
     const g = conventionGuide("api-service");
 

--- a/packages/core/tests/boringstack-conventions.test.ts
+++ b/packages/core/tests/boringstack-conventions.test.ts
@@ -53,6 +53,9 @@ describe("convention registry", () => {
     // Mutations only; reads exempt; throw ApiError (not error envelopes).
     expect(g).toContain("create/update/delete");
     expect(g).toContain("ApiError");
+    // Panel-diagnosed root cause of the Readable<SuccessResponse> UI residual: route response schema.
+    expect(g).toContain("response:");
+    expect(g).toContain("Readable<SuccessResponse");
   });
 
   test("forms guide steers away from the invented FormEvent + deprecated z.string().email() (live-build residuals)", () => {
@@ -65,6 +68,9 @@ describe("convention registry", () => {
     expect(g).toContain("z.email()");
     expect(g).toContain("z.string().email()");
     expect(g).toContain("BaseSyntheticEvent");
+    // build8 park (#67): the rhf resolver input≠output type mismatch from .optional()/.default().
+    expect(g).toContain("SubmitHandler");
+    expect(g).toContain("defaultValues");
   });
 
   test("data-fetching guide states the apiClient pattern and forbids response.error", () => {

--- a/packages/core/tests/boringstack-conventions.test.ts
+++ b/packages/core/tests/boringstack-conventions.test.ts
@@ -41,6 +41,41 @@ describe("convention registry", () => {
     expect(g).toContain("response.error");
     expect(g).toContain("throwOnError");
   });
+
+  test("testing guide teaches the exact idioms the model kept failing (extension, hoisted mock, route tests, rules)", () => {
+    const g = conventionGuide("testing");
+
+    // The .test.ts vs .test.tsx decision + the never-both rule (the dual-extension churn).
+    expect(g).toContain(".test.tsx");
+    expect(g).toContain(".test.ts");
+    expect(g).toContain("never both");
+    // The api-client mock idiom the model reinvented 16× (getting `any`-typed data).
+    expect(g).toContain("vi.hoisted");
+    expect(g).toContain('vi.mock("@/lib/api/client"');
+    expect(g).toContain("mockResolvedValueOnce");
+    expect(g).toContain("keeps `data` typed");
+    // Mock reset between tests (deepseek-flagged gap): the pass-alone-fail-in-suite trap.
+    expect(g).toContain("mockReset");
+    expect(g).toContain("fails in the suite");
+    // The API route test idiom from the shipped example.
+    expect(g).toContain("createApp()");
+    expect(g).toContain("app.handle");
+    expect(g).toContain("loginCookie");
+    // The enforced test rules, each named so the model connects error → fix.
+    expect(g).toContain("no-focused-tests");
+    expect(g).toContain("no-conditional-expect");
+    expect(g).toContain("fake-timers-must-be-restored");
+    // The auto-reformat re-read (the not-found edit-reject churn).
+    expect(g).toContain("AUTO-FORMATS");
+  });
+});
+
+describe("topicForRule (testing)", () => {
+  test("a test rule maps to the testing topic so its gate error pushes the guide", () => {
+    expect(topicForRule("test-sibling-required")).toBe("testing");
+    expect(topicForRule("no-real-network-in-unit-tests")).toBe("testing");
+    expect(topicForRule("no-focused-tests")).toBe("testing");
+  });
 });
 
 describe("topicForRule", () => {

--- a/packages/core/tests/boringstack-conventions.test.ts
+++ b/packages/core/tests/boringstack-conventions.test.ts
@@ -92,10 +92,18 @@ describe("convention registry", () => {
 });
 
 describe("topicForRule (testing)", () => {
-  test("a test rule maps to the testing topic so its gate error pushes the guide", () => {
-    expect(topicForRule("test-sibling-required")).toBe("testing");
-    expect(topicForRule("no-real-network-in-unit-tests")).toBe("testing");
-    expect(topicForRule("no-focused-tests")).toBe("testing");
+  test("EVERY testing rule maps to the testing topic so its gate error pushes the guide", () => {
+    // Lock all six — a typo in any would silently disable the reactive PUSH for that error.
+    for (const rule of [
+      "test-sibling-required",
+      "test-file-mirrors-source",
+      "no-focused-tests",
+      "no-conditional-expect",
+      "no-real-network-in-unit-tests",
+      "fake-timers-must-be-restored",
+    ]) {
+      expect(topicForRule(rule)).toBe("testing");
+    }
   });
 });
 

--- a/packages/core/tests/boringstack-conventions.test.ts
+++ b/packages/core/tests/boringstack-conventions.test.ts
@@ -57,6 +57,10 @@ describe("convention registry", () => {
     // Mock reset between tests (deepseek-flagged gap): the pass-alone-fail-in-suite trap.
     expect(g).toContain("mockReset");
     expect(g).toContain("fails in the suite");
+    // The correct global reset is resetAllMocks (resets queued return values); clearAllMocks
+    // only clears call history and would NOT prevent the leak — the guide must steer away from it.
+    expect(g).toContain("resetAllMocks");
+    expect(g).toContain("NOT `vi.clearAllMocks()`");
     // The API route test idiom from the shipped example.
     expect(g).toContain("createApp()");
     expect(g).toContain("app.handle");

--- a/packages/core/tests/boringstack-conventions.test.ts
+++ b/packages/core/tests/boringstack-conventions.test.ts
@@ -33,6 +33,18 @@ describe("convention registry", () => {
     expect(g).not.toContain("src/views/");
   });
 
+  test("forms guide steers away from the invented FormEvent + deprecated z.string().email() (live-build residuals)", () => {
+    const g = conventionGuide("forms");
+
+    expect(g).toContain("zodResolver");
+    expect(g).toContain("handleSubmit");
+    // The model repeatedly invented React's FormEvent and used the deprecated Zod string email.
+    expect(g).toContain("FormEvent");
+    expect(g).toContain("z.email()");
+    expect(g).toContain("z.string().email()");
+    expect(g).toContain("BaseSyntheticEvent");
+  });
+
   test("data-fetching guide states the apiClient pattern and forbids response.error", () => {
     const g = conventionGuide("data-fetching");
 

--- a/packages/core/tests/boringstack-conventions.test.ts
+++ b/packages/core/tests/boringstack-conventions.test.ts
@@ -61,6 +61,11 @@ describe("convention registry", () => {
     expect(g).toContain("createApp()");
     expect(g).toContain("app.handle");
     expect(g).toContain("loginCookie");
+    // API runner is bun:test (not vitest) + the service-test smoke idiom (build4 residual:
+    // 14 edits grinding a DB-hitting supplier.service.test.ts against Drizzle types).
+    expect(g).toContain('from "bun:test"');
+    expect(g).toContain("smoke");
+    expect(g).toContain('expect(typeof myServiceFn).toBe("function")');
     // The enforced test rules, each named so the model connects error → fix.
     expect(g).toContain("no-focused-tests");
     expect(g).toContain("no-conditional-expect");

--- a/packages/core/tests/boringstack-gate-stages.test.ts
+++ b/packages/core/tests/boringstack-gate-stages.test.ts
@@ -141,6 +141,26 @@ describe("signatureToError", () => {
     expect(err.message).toContain("REWRITE THE WHOLE FILE");
   });
 
+  test("a PathsWithMethod type error steers to REGISTER the route (not fight the UI types)", () => {
+    // Observed live (build6): model called apiClient.POST('/api/v1/supplier') before the
+    // route was in the OpenAPI spec → fought the UI types + coupled test-sibling for 20+ turns.
+    const msg =
+      "Argument of type '\"/api/v1/supplier\"' is not assignable to parameter of type 'PathsWithMethod<paths, \"post\">'.";
+    const err = signatureToError(
+      `failure:apps%2Fui%2Fsrc%2Ffeatures%2Fsupplier%2FSupplier.mutations.ts:12:no-unsafe:${encodeURIComponent(msg)}`
+    );
+
+    expect(err.message).toContain("NOT in the OpenAPI spec");
+    expect(err.message).toContain("register");
+    expect(err.message).toContain("generate:api");
+    // A plain type error (no PathsWithMethod) is left untouched.
+    const plain = signatureToError(
+      "failure:apps%2Fui%2Fsrc%2Fx.ts:3:no-unsafe:Type%20'string'%20is%20not%20assignable%20to%20'number'."
+    );
+
+    expect(plain.message).not.toContain("NOT in the OpenAPI spec");
+  });
+
   test("a `'>' expected` in a .ts flags the JSX-must-be-.tsx cause; other .ts parse errors do NOT", () => {
     // The one class the .tsx tip is valid for.
     const jsx = signatureToError(

--- a/packages/core/tests/near-green-banner.test.ts
+++ b/packages/core/tests/near-green-banner.test.ts
@@ -37,4 +37,26 @@ describe("nearGreenBanner (finishing discipline near green)", () => {
   test("at the watermark, far from green → no banner", () => {
     expect(nearGreenBanner(5, 5)).toBe("");
   });
+
+  test("#61: completionOnly flips the banner to BUILD the UI (not the don't-create-files lockdown)", () => {
+    // The remaining error clears only by ADDING code — the normal lockdown would forbid the
+    // create/edit/delete UI the feature needs. The banner must instruct the opposite.
+    const b = nearGreenBanner(1, 1, true);
+
+    expect(b).toContain("ADDING the code");
+    expect(b).toContain("BUILD the");
+    expect(b).toContain("NOT a regression");
+    // The contradictory lockdown text must be GONE for a completion state.
+    expect(b).not.toContain("Do NOT create new files");
+    expect(b).not.toContain("NEAR-GREEN — only");
+  });
+
+  test("#61: completionOnly during a spike (total>best) still says BUILD, not UNDO", () => {
+    // While the model adds the demanded files the count rises; it must not be told to undo.
+    const b = nearGreenBanner(8, 1, true);
+
+    expect(b).toContain("BUILD the");
+    expect(b).not.toContain("REGRESSION");
+    expect(b).not.toContain("UNDO");
+  });
 });

--- a/packages/core/tests/near-green-checkpoint-loop.test.ts
+++ b/packages/core/tests/near-green-checkpoint-loop.test.ts
@@ -10,6 +10,7 @@ import type { ILoopCtx, ILoopState } from "../src/loop/turn";
 import {
   captureNearGreenCheckpoint,
   rollbackNearGreen,
+  settleGate,
 } from "../src/loop/turn";
 import type { IValidateResult } from "../src/validate";
 import { MAX_NEAR_GREEN_ROLLBACKS } from "../src/loop/near-green-checkpoint";
@@ -133,6 +134,78 @@ test("flag ON: a spray past the near-green checkpoint REVERTS the file to the be
 
     expect(final).toContain("GOOD");
     expect(final).not.toContain("BAD");
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+}, 30_000);
+
+test("#61: settleGate does NOT checkpoint a HOLLOW near-green state (all-completion-class errors) and clears any prior one", async () => {
+  const dir = await mkdtemp(join(tmpdir(), "tsforge-nearg-"));
+
+  try {
+    await Bun.write(join(dir, "feature.ts"), "export const GOOD = 1;\n");
+
+    // The gate is near-green with ONE remaining error that clears only by ADDING code (the
+    // feature declared i18n keys it hasn't wired yet). settleGate must NOT lock this hollow
+    // state — else the model's demanded completion edit (which spikes the count) gets reverted.
+    const ctx: ILoopCtx = {
+      task: {
+        id: "t",
+        intent: "test",
+        accept: "",
+        files: ["**/*"],
+        context: [],
+      },
+      cwd: dir,
+      tsService: null,
+      report: () => undefined,
+      messages: [],
+      tool: { touched: new Set(["feature.ts"]) },
+      gate: {
+        parse: undefined,
+        runner: {
+          run: async (): Promise<IValidateResult> => ({
+            passed: false,
+            errors: [
+              {
+                key: "i18n:supplier.createSuccess",
+                rule: "i18n-locale-keys-used",
+                message: "Locale key defined but never referenced",
+              },
+            ],
+            output: "",
+          }),
+        },
+      },
+    };
+
+    // Seed a stale checkpoint from an earlier compile-clean cycle — the guard must CLEAR it,
+    // so a later spray can't be reverted to it either.
+    const stale = await captureNearGreenCheckpoint(ctx, 1, [
+      { key: "old", message: "earlier compile error" },
+    ]);
+    const state: ILoopState = {
+      prevGateErrors: [],
+      gateNoProgress: 0,
+      bestErrorCount: 1,
+      noNewLow: 0,
+      errorAge: new Map(),
+      lastGateCount: 1,
+      edits: 5,
+      regressions: 0,
+      ttsrInterrupts: 0,
+      steerLevel: 0,
+      conventionsEnabled: false,
+      nearGreenCheckpoint: stale,
+      nearGreenBest: 1,
+      nearGreenRollbacks: 0,
+    };
+
+    await settleGate(ctx, state, 10);
+
+    // The hollow state was NOT protected: the checkpoint is cleared (no revert target), so
+    // the model's next completion edit proceeds forward instead of being reverted to hollow.
+    expect(state.nearGreenCheckpoint).toBeUndefined();
   } finally {
     await rm(dir, { recursive: true, force: true });
   }

--- a/packages/core/tests/near-green-checkpoint-loop.test.ts
+++ b/packages/core/tests/near-green-checkpoint-loop.test.ts
@@ -211,6 +211,85 @@ test("#61: settleGate does NOT checkpoint a HOLLOW near-green state (all-complet
   }
 }, 30_000);
 
+test("#61: during the completion phase, a mixed-error SPIKE is NOT rolled back (banner+rollback stand down through the spike)", async () => {
+  const dir = await mkdtemp(join(tmpdir(), "tsforge-nearg-"));
+
+  try {
+    await Bun.write(join(dir, "feature.ts"), "export const GOOD = 1;\n");
+
+    // The model is mid-add: it entered the completion phase last cycle, and this gate shows a
+    // MIXED spike (the shrinking i18n completion error + new compile errors from the half-written
+    // UI) well past the rollback threshold. A per-cycle all-completion check would be FALSE here
+    // and roll back; the persistent completionPhase flag must keep WS-B (and the undo banner) off.
+    const ctx: ILoopCtx = {
+      task: {
+        id: "t",
+        intent: "test",
+        accept: "",
+        files: ["**/*"],
+        context: [],
+      },
+      cwd: dir,
+      tsService: null,
+      report: () => undefined,
+      messages: [],
+      tool: { touched: new Set(["feature.ts"]) },
+      gate: {
+        parse: undefined,
+        runner: {
+          run: async (): Promise<IValidateResult> => ({
+            passed: false,
+            errors: [
+              {
+                key: "i18n:x",
+                rule: "i18n-locale-keys-used",
+                message: "unused key",
+              },
+              { key: "c1", rule: "no-unsafe-argument", message: "unsafe" },
+              { key: "c2", rule: "no-unsafe-argument", message: "unsafe" },
+              { key: "c3", rule: "no-unsafe-argument", message: "unsafe" },
+              { key: "c4", rule: "no-unsafe-argument", message: "unsafe" },
+              { key: "c5", rule: "no-unsafe-argument", message: "unsafe" },
+            ],
+            output: "",
+          }),
+        },
+      },
+    };
+    const cp = await captureNearGreenCheckpoint(ctx, 1, [
+      { key: "i18n:x", rule: "i18n-locale-keys-used", message: "unused key" },
+    ]);
+    const state: ILoopState = {
+      prevGateErrors: [],
+      gateNoProgress: 0,
+      bestErrorCount: 1,
+      noNewLow: 0,
+      errorAge: new Map(),
+      lastGateCount: 1,
+      edits: 5,
+      regressions: 0,
+      ttsrInterrupts: 0,
+      steerLevel: 0,
+      conventionsEnabled: false,
+      completionPhase: true,
+      nearGreenCheckpoint: cp,
+      nearGreenBest: 1,
+      nearGreenRollbacks: 0,
+    };
+
+    await settleGate(ctx, state, 10);
+
+    // 6 errors is > checkpoint(1) + M(3), so WITHOUT the phase flag WS-B would revert. It did NOT:
+    // no rollback was counted, and the phase persisted (a completion error still remains).
+    expect(state.nearGreenRollbacks).toBe(0);
+    expect(state.completionPhase).toBe(true);
+    // feature.ts was NOT reverted (no rollback restored the checkpoint snapshot).
+    expect(await Bun.file(join(dir, "feature.ts")).text()).toContain("GOOD");
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+}, 30_000);
+
 test("rollbackNearGreen resets the convergence guards + tombstones, without touching the ladder", async () => {
   const dir = await mkdtemp(join(tmpdir(), "tsforge-nearg-"));
 

--- a/packages/core/tests/near-green-checkpoint.test.ts
+++ b/packages/core/tests/near-green-checkpoint.test.ts
@@ -16,11 +16,13 @@ import type { IFileSnapshot } from "../src/loop/file-snapshot";
 // reachability, judge) must NOT be checkpointed, or WS-B reverts the demanded completion edit.
 const err = (rule: string): IErrorItem => ({ key: rule, rule, message: rule });
 
-test("isCompletionClass: only add-code rules (reachability/i18n-locale-keys-used/judge), bare or prefixed", () => {
+test("isCompletionClass: only reliable add-code rules (reachability/i18n-locale-keys-used), bare or prefixed", () => {
   expect(isCompletionClass(err("reachability"))).toBe(true);
   expect(isCompletionClass(err("i18n-locale-keys-used"))).toBe(true);
-  expect(isCompletionClass(err("judge"))).toBe(true);
   expect(isCompletionClass(err("plugin/i18n-locale-keys-used"))).toBe(true);
+  // `judge` is EXCLUDED — it can reject defects in existing code, not only hollowness, so it
+  // isn't a reliable add-only signal (would falsely disable WS-B on a fixable judge rejection).
+  expect(isCompletionClass(err("judge"))).toBe(false);
   // Fixable-in-place errors are NOT completion-class (WS-B still protects against those).
   expect(isCompletionClass(err("no-floating-promises"))).toBe(false);
   expect(isCompletionClass(err("@typescript-eslint/no-unsafe-argument"))).toBe(

--- a/packages/core/tests/near-green-checkpoint.test.ts
+++ b/packages/core/tests/near-green-checkpoint.test.ts
@@ -4,6 +4,7 @@ import {
   shouldRollback,
   isCompletionClass,
   allCompletionClass,
+  nextCompletionPhase,
   NEAR_GREEN_N,
   NEAR_GREEN_M,
   MAX_NEAR_GREEN_ROLLBACKS,
@@ -29,6 +30,23 @@ test("isCompletionClass: only reliable add-code rules (reachability/i18n-locale-
     false
   );
   expect(isCompletionClass({ key: "x", message: "no rule" })).toBe(false);
+});
+
+test("nextCompletionPhase: ENTER on all-completion, STAY through the mixed spike, EXIT when no completion error remains", () => {
+  const i18n = err("i18n-locale-keys-used");
+  const compile = err("no-unsafe-argument");
+
+  // ENTER: reached the hollow all-completion state.
+  expect(nextCompletionPhase(false, [i18n])).toBe(true);
+  // STAY: the model started adding the UI → MIXED errors (this is the case a per-cycle
+  // all-completion check got wrong — it would flip false here and re-arm rollback/undo).
+  expect(nextCompletionPhase(true, [i18n, compile, compile])).toBe(true);
+  // EXIT: the keys are now referenced → only fixable errors remain → WS-B re-engages.
+  expect(nextCompletionPhase(true, [compile, compile])).toBe(false);
+  // EXIT on green (no errors at all).
+  expect(nextCompletionPhase(true, [])).toBe(false);
+  // Never enters from a purely-fixable state.
+  expect(nextCompletionPhase(false, [compile])).toBe(false);
 });
 
 test("allCompletionClass: true only when EVERY error is completion-class; empty is false", () => {

--- a/packages/core/tests/near-green-checkpoint.test.ts
+++ b/packages/core/tests/near-green-checkpoint.test.ts
@@ -2,12 +2,45 @@ import { test, expect } from "bun:test";
 import {
   shouldCheckpoint,
   shouldRollback,
+  isCompletionClass,
+  allCompletionClass,
   NEAR_GREEN_N,
   NEAR_GREEN_M,
   MAX_NEAR_GREEN_ROLLBACKS,
   type INearGreenCheckpoint,
 } from "../src/loop/near-green-checkpoint";
+import type { IErrorItem } from "../src/validate/validate.types";
 import type { IFileSnapshot } from "../src/loop/file-snapshot";
+
+// #61: a HOLLOW near-green state (remaining errors clear only by ADDING code — i18n keys,
+// reachability, judge) must NOT be checkpointed, or WS-B reverts the demanded completion edit.
+const err = (rule: string): IErrorItem => ({ key: rule, rule, message: rule });
+
+test("isCompletionClass: only add-code rules (reachability/i18n-locale-keys-used/judge), bare or prefixed", () => {
+  expect(isCompletionClass(err("reachability"))).toBe(true);
+  expect(isCompletionClass(err("i18n-locale-keys-used"))).toBe(true);
+  expect(isCompletionClass(err("judge"))).toBe(true);
+  expect(isCompletionClass(err("plugin/i18n-locale-keys-used"))).toBe(true);
+  // Fixable-in-place errors are NOT completion-class (WS-B still protects against those).
+  expect(isCompletionClass(err("no-floating-promises"))).toBe(false);
+  expect(isCompletionClass(err("@typescript-eslint/no-unsafe-argument"))).toBe(
+    false
+  );
+  expect(isCompletionClass({ key: "x", message: "no rule" })).toBe(false);
+});
+
+test("allCompletionClass: true only when EVERY error is completion-class; empty is false", () => {
+  expect(allCompletionClass([err("i18n-locale-keys-used")])).toBe(true);
+  expect(
+    allCompletionClass([err("reachability"), err("i18n-locale-keys-used")])
+  ).toBe(true);
+  // A single fixable error among completion ones means the state is NOT purely hollow —
+  // WS-B should still protect it (the fixable error is a real revert target).
+  expect(
+    allCompletionClass([err("i18n-locale-keys-used"), err("no-console")])
+  ).toBe(false);
+  expect(allCompletionClass([])).toBe(false);
+});
 
 // WS-B: the pure checkpoint/rollback decision, unit-locked with the Phase 0a thresholds
 // (N=2, M=3) away from the Session's file I/O. Real spray data from inv157/inv156.


### PR DESCRIPTION
Stacked on extract-failures PR. build11 PARKED oscillating on i18n-locale-keys-used (19× loadError): model pre-declares locale keys it never wires. New `i18n` guide: never pre-declare (add key + t() literal same change); WIRE IT UP never delete (aligns rule-docs/i18n-guard/completion-class); static literals only. Panel 3 rounds → PASS (caught a delete-vs-#49 contradiction + a dynamic-key validation bypass). VALIDATED: build12 eliminated the wall (0 dead-key events).