### PR TITLE
fix(conventions+gate): Readable<SuccessResponse> is a CONSUMER unwrap, not a route fix (build15 wall)

### DIFF
--- a/packages/core/src/loop/boringstack/gate-stages.ts
+++ b/packages/core/src/loop/boringstack/gate-stages.ts
@@ -106,49 +106,56 @@ export function signatureToError(sig: string): IErrorItem {
     const message = decodeURIComponent(structured[4] ?? "");
     const phase = phaseForFile(file);
 
-    // A syntax/parse error (`'>' expected`, `Parsing error`, `Unexpected token`) is the one
-    // class the model can't fix by surgical patch — a patch on an already-broken file usually
-    // re-breaks its braces/generics/JSX, so it grinds at the SAME error for turns (observed
-    // live: stuck at 2 `'>' expected` for 40min). Steer it to REWRITE THE WHOLE FILE, and flag
-    // the JSX-in-`.ts` case (a `.ts` can't hold JSX → `<X>` reads as a generic wanting `>`).
-    // Match the whole tsc/eslint syntax-error family: `Parsing error`, `Unexpected token`, and
-    // any `… expected.` (quoted `';' expected` OR bare `Expression/Declaration/Identifier/Type
-    // expected`). The trailing-`expected` form is anchored so it doesn't catch type errors that
-    // merely contain the word mid-sentence.
-    const isParse = /parsing error|unexpected token|expected\.?\s*$/iu.test(
-      message
-    );
-    // The `.tsx` root-cause tip is ONLY valid for the JSX/generic `'>' expected` class — appended
-    // elsewhere it invents a wrong cause and can push a rename detour for a plain `';' expected`.
-    const isJsxGenericParse = /['`]>['`]\s+expected/iu.test(message);
-    const parseSteer =
-      isJsxGenericParse && file.endsWith(".ts") && !file.endsWith(".d.ts")
-        ? " This `'>' expected` in a `.ts` is usually JSX in a non-JSX file — if it contains JSX, it must be a `.tsx` (a `.ts` parses `<X>` as a generic and demands `>`)."
-        : "";
-
-    // The api-client's types are GENERATED from the OpenAPI spec. A `PathsWithMethod<paths, …>`
-    // error means the path STRING doesn't match any generated key — which has TWO causes, and
-    // the steer must name both (observed live: build12's model used `/api/supplier` — a wrong
-    // CALL-SITE string, the route `/api/v1/supplier/{id}` was already in the spec — yet re-ran
-    // generate:api 5× because the old steer only ever said "route not in spec"). Cause 1 (check
-    // FIRST, cheaper): the path literal is wrong. Cause 2: the route genuinely isn't registered.
-    const isPathsWithMethod = message.includes("PathsWithMethod");
-
     return {
       key: sig,
       file,
       ...(lineText === "" ? {} : { line: Number(lineText) }),
       rule,
       ...(phase === undefined ? {} : { phase }),
-      message: isParse
-        ? `${message}\n↳ SYNTAX/PARSE error — do NOT surgically patch it (a patch on a broken-parse file re-breaks its braces/generics/JSX). REWRITE THE WHOLE FILE \`${file}\` cleanly in one pass; once it parses, downstream errors clear.${parseSteer}`
-        : isPathsWithMethod
-          ? `${message}\n↳ \`PathsWithMethod<…, "<verb>">\` means no generated key matches this path AND method. Three causes — check the call site FIRST (generate:api fixes NEITHER of the first two): (1) WRONG PATH string — the literal must EXACTLY match a generated key: the COLLECTION root carries a TRAILING SLASH (list/create are \`/api/v1/<resource>/\`, e.g. \`POST "/api/v1/<resource>/"\` — a POST/GET to \`/api/v1/<resource>\` WITHOUT the slash is the usual cause here; ADD it), while by-id is \`/api/v1/<resource>/{id}\` (no trailing slash) with a literal \`{id}\` segment, value via \`{ params: { path: { id } } }\`, never interpolated; \`/api/x\` or \`/x\` (missing the \`/api/v1/\` prefix) is also wrong; (2) WRONG VERB — the path exists but doesn't support this method (e.g. a GET-only path called with POST); call the method the route actually defines; (3) ONLY if path AND verb are already right is the route genuinely unregistered — ensure it exists AND is mounted (shows in /swagger/json), then the gate re-runs generate:api and the type appears. Do NOT re-run generate:api for a call-site (path/verb) bug.`
-          : message,
+      message: structuredSteerMessage(message, file),
     };
   }
 
   return { key: sig, message: sig };
+}
+
+/** Enrich a structured gate error's raw message with the actionable steer for the failure
+ *  classes the model chronically mis-fixes (each observed live). Extracted from
+ *  signatureToError to keep that function's branching under the cognitive-complexity cap. */
+function structuredSteerMessage(message: string, file: string): string {
+  // A syntax/parse error (`'>' expected`, `Parsing error`, `Unexpected token`) is the one class
+  // the model can't fix by surgical patch — a patch on an already-broken file usually re-breaks
+  // its braces/generics/JSX, so it grinds at the SAME error for turns (observed live: stuck at 2
+  // `'>' expected` for 40min). Steer it to REWRITE THE WHOLE FILE, and flag the JSX-in-`.ts` case.
+  const isParse = /parsing error|unexpected token|expected\.?\s*$/iu.test(
+    message
+  );
+
+  if (isParse) {
+    // The `.tsx` tip is ONLY valid for the JSX/generic `'>' expected` class.
+    const isJsxGenericParse = /['`]>['`]\s+expected/iu.test(message);
+    const parseSteer =
+      isJsxGenericParse && file.endsWith(".ts") && !file.endsWith(".d.ts")
+        ? " This `'>' expected` in a `.ts` is usually JSX in a non-JSX file — if it contains JSX, it must be a `.tsx` (a `.ts` parses `<X>` as a generic and demands `>`)."
+        : "";
+
+    return `${message}\n↳ SYNTAX/PARSE error — do NOT surgically patch it (a patch on a broken-parse file re-breaks its braces/generics/JSX). REWRITE THE WHOLE FILE \`${file}\` cleanly in one pass; once it parses, downstream errors clear.${parseSteer}`;
+  }
+
+  // `Readable<SuccessResponse<…>>` is Elysia+openapi-fetch's UNIVERSAL response type (swagger
+  // emits json+multipart+text for EVERY route, scaffold ones included) — NOT a route/schema bug.
+  // The model burned ~60 turns (build15) chasing it on the API side; steer to the consumer.
+  if (message.includes("Readable<SuccessResponse")) {
+    return `${message}\n↳ \`Readable<SuccessResponse<…>>\` is the api-client's NORMAL, UNIVERSAL response type — Elysia's swagger emits three media types (json/multipart/text) for EVERY route (the scaffold's own auth/dashboard routes are identical), so you CANNOT remove it by editing the route or the \`response:\` schema — do NOT try. Fix it on the CONSUMER: the 'not assignable to Promise<IEntity>' error means you annotated the \`.queries.ts\`/\`.mutations.ts\` fn \`: Promise<IEntity>\` and did a bare \`return data\` — the fix is to REMOVE that return-type annotation and let TS INFER it (never \`as\`-cast). Then return the payload for THIS route's response shape: if it wraps \`{ data: … }\` (scaffold auth pattern) read \`data?.data\`; if it returns the object/array directly, just \`return data\` — match your \`response:\` schema, don't blindly add \`.data\`.`;
+  }
+
+  // A `PathsWithMethod<paths, …>` error means the path STRING doesn't match any generated key —
+  // three causes, call-site first (build12/build14 evidence in the message below).
+  if (message.includes("PathsWithMethod")) {
+    return `${message}\n↳ \`PathsWithMethod<…, "<verb>">\` means no generated key matches this path AND method. Three causes — check the call site FIRST (generate:api fixes NEITHER of the first two): (1) WRONG PATH string — the literal must EXACTLY match a generated key: the COLLECTION root carries a TRAILING SLASH (list/create are \`/api/v1/<resource>/\`, e.g. \`POST "/api/v1/<resource>/"\` — a POST/GET to \`/api/v1/<resource>\` WITHOUT the slash is the usual cause here; ADD it), while by-id is \`/api/v1/<resource>/{id}\` (no trailing slash) with a literal \`{id}\` segment, value via \`{ params: { path: { id } } }\`, never interpolated; \`/api/x\` or \`/x\` (missing the \`/api/v1/\` prefix) is also wrong; (2) WRONG VERB — the path exists but doesn't support this method (e.g. a GET-only path called with POST); call the method the route actually defines; (3) ONLY if path AND verb are already right is the route genuinely unregistered — ensure it exists AND is mounted (shows in /swagger/json), then the gate re-runs generate:api and the type appears. Do NOT re-run generate:api for a call-site (path/verb) bug.`;
+  }
+
+  return message;
 }
 
 /** Preserve the failing app's section when an unfamiliar tool format defeats the

--- a/packages/core/src/loop/conventions.ts
+++ b/packages/core/src/loop/conventions.ts
@@ -181,11 +181,19 @@ const GUIDES: Readonly<Record<ConventionTopic, string>> = {
     "passing body as a THIRD argument is an arity error: 'Expected 2 arguments, but got 3'). Errors THROW automatically via the " +
     "client's `throwOnError` middleware (TanStack Query catches them) — so NEVER check " +
     "`response.error`: it is typed `undefined`, so the guard is a dead `no-unnecessary-condition` " +
-    "gate error. Just read `data`; let TS infer its type (do NOT annotate a return type or `as`-cast " +
-    "it — index into it with a null-narrow, e.g. `data?.items ?? []`, to satisfy strict undefined " +
-    "checks). If `data` types as `Readable<SuccessResponse<…>>` instead of the JSON body, the API " +
-    "ROUTE is missing a single-content-type `response:` schema — fix the route (see api-service), " +
-    "not the consumer. Put queries in `<Feature>.queries.ts` and mutations in " +
+    "gate error. `data` is typed `Readable<SuccessResponse<…>>` (a read-only type helper, NOT a " +
+    "stream) for EVERY route — Elysia's swagger emits three media types (json/multipart/text) so " +
+    "openapi-fetch unions them. This is EXPECTED and UNIVERSAL (the scaffold's own auth/dashboard " +
+    "routes are identical); you CANNOT remove it from the route/response schema, so do NOT try. FIX " +
+    "IT ON THE CONSUMER. The error `Readable<…> not assignable to Promise<IEntity>` means you " +
+    "annotated the query/mutation fn `: Promise<IEntity>` and did a bare `return data` — the " +
+    "UNIVERSAL fix is to REMOVE that return-type annotation and let TS INFER it (never `as`-cast). " +
+    "Then return the payload for YOUR route's response SHAPE: if the response wraps `{ data: … }` " +
+    '(the scaffold auth pattern), read `data?.data` — `const { data } = await apiClient.GET("/api/v1/' +
+    'supplier/"); return data?.data ?? [];`; if the route returns the object/array DIRECTLY (no ' +
+    "`data` envelope), just `return data` — match what your `response:` schema actually declares, " +
+    "don't blindly add `.data`. Put " +
+    "queries in `<Feature>.queries.ts` and mutations in " +
     "`<Feature>.mutations.ts`. If a path genuinely isn't in the spec yet, add the API route first, " +
     "then `bun run generate:api` ONCE — if the error persists after one regen, the path STRING or " +
     "call shape is wrong, not the spec.",
@@ -257,12 +265,13 @@ const GUIDES: Readonly<Record<ConventionTopic, string>> = {
     "`void auditLogService.record({ userId, action: AUDIT_ACTIONS.<ENTITY_ACTION>, metadata: { … } })` " +
     "(the `void` satisfies no-floating-promises). Read-only methods (get/list) don't need it. Surface " +
     "failures by THROWING an `ApiError` (e.g. 404/409), not by returning an error envelope — the route " +
-    "layer maps thrown ApiErrors to responses. Every ROUTE must declare a single-content-type " +
-    "`response:` schema (`.get(path, handler, { response: <Entity>ResponseSchema })`) — the UI's " +
-    "api-client is generated from this. If a route omits `response:` (or allows multiple content " +
-    "types), openapi-fetch types the UI's `data` as `Readable<SuccessResponse<…>>` instead of the " +
-    "JSON body, and the UI can't consume it (a persistent 'not assignable to …' error you canNOT fix " +
-    "on the UI side — fix the ROUTE's response schema).",
+    "layer maps thrown ApiErrors to responses. Every ROUTE should declare a `response:` schema " +
+    "(`.get(path, handler, { response: <Entity>ResponseSchema })`) so the body TYPE is generated — " +
+    "define it like the scaffold's `AccountResponse` (a plain `t.Object({…})`, NO `headers`). NOTE: a " +
+    "`response:` schema does NOT collapse the media types — Elysia's swagger always emits " +
+    "json+multipart+text, so the UI's `data` is ALWAYS `Readable<SuccessResponse<…>>` (true for the " +
+    "scaffold's own routes too). That is NORMAL and is handled on the CONSUMER via `data?.data` (see " +
+    "data-fetching), NOT by changing this route — do not chase it from the API side.",
   i18n:
     "I18N LOCALE KEYS (boringstack). Every user-facing string is a translation key, and the gate " +
     'enforces BOTH directions: a `t("key")` with no locale entry fails (used→defined), AND a key ' +

--- a/packages/core/tests/boringstack-conventions.test.ts
+++ b/packages/core/tests/boringstack-conventions.test.ts
@@ -58,9 +58,14 @@ describe("convention registry", () => {
     // Mutations only; reads exempt; throw ApiError (not error envelopes).
     expect(g).toContain("create/update/delete");
     expect(g).toContain("ApiError");
-    // Panel-diagnosed root cause of the Readable<SuccessResponse> UI residual: route response schema.
+    // response: schema is for the body TYPE, define it like AccountResponse (no headers)…
     expect(g).toContain("response:");
+    expect(g).toContain("AccountResponse");
+    // …but build15 proved Readable<SuccessResponse> is NOT a route fix — the guide must say so
+    // (Elysia always emits multi media types; the consumer handles it via data?.data).
     expect(g).toContain("Readable<SuccessResponse");
+    expect(g).toContain("does NOT collapse the media types");
+    expect(g).toContain("data?.data");
   });
 
   test("i18n guide bans pre-declaring keys — the dominant near-green thrash (build11: 19× dead-key)", () => {
@@ -152,8 +157,17 @@ describe("convention registry", () => {
     // generate:api is the WRONG lever for a consumer/usage error (model reran it 5×).
     expect(g).toContain("generate:api");
     expect(g).toContain("usage bug, not a stale-spec bug");
-    // The Readable wrapper is a ROUTE response-schema problem, not a consumer fix.
+    // Readable<SuccessResponse> is UNIVERSAL + EXPECTED (build15) — consumed via data?.data,
+    // NOT fixed on the route. The guide must teach the consumer unwrap + infer-not-annotate.
     expect(g).toContain("Readable<SuccessResponse");
+    expect(g).toContain("data?.data");
+    expect(g).toContain("EXPECTED and UNIVERSAL");
+    expect(g).toContain("not assignable to Promise<IEntity>");
+    // The UNIVERSAL fix is infer-don't-annotate; data?.data is SHAPE-CONDITIONAL (panel: not
+    // every response is {data:…} — a raw object/array returns `data` directly), so the guide
+    // must NOT categorically prescribe .data.
+    expect(g).toContain("let TS INFER");
+    expect(g).toContain("don't blindly add");
   });
 
   test("testing guide teaches the exact idioms the model kept failing (extension, hoisted mock, route tests, rules)", () => {

--- a/packages/core/tests/boringstack-gate-stages.test.ts
+++ b/packages/core/tests/boringstack-gate-stages.test.ts
@@ -170,6 +170,23 @@ describe("signatureToError", () => {
     expect(plain.message).not.toContain("call site");
   });
 
+  test("a Readable<SuccessResponse> error steers to the CONSUMER unwrap, not a route/schema fix (build15 wall)", () => {
+    const msg =
+      "Type 'Readable<SuccessResponse<{ 200: {} }>>' is not assignable to type 'Promise<ISupplierItem>'.";
+    const err = signatureToError(
+      `failure:apps%2Fui%2Fsrc%2Ffeatures%2Fsupplier%2FSupplier.mutations.ts:20:no-unsafe:${encodeURIComponent(msg)}`
+    );
+
+    // Steer names it universal/expected and points at the consumer fix (infer, then unwrap).
+    expect(err.message).toContain("UNIVERSAL");
+    expect(err.message).toContain("CONSUMER");
+    // Universal move is infer-don't-annotate; unwrap is shape-conditional (not blind .data).
+    expect(err.message).toContain("let TS INFER");
+    expect(err.message).toContain("don't blindly add");
+    // Must NOT tell the model to fix the route/schema for this.
+    expect(err.message).toContain("CANNOT remove it by editing the route");
+  });
+
   test("a `'>' expected` in a .ts flags the JSX-must-be-.tsx cause; other .ts parse errors do NOT", () => {
     // The one class the .tsx tip is valid for.
     const jsx = signatureToError(


### PR DESCRIPTION
Stacked on #155. build15 parked at 3 on Readable<SuccessResponse> — my earlier guide WRONGLY said fix-the-route. harness-diagnose 4/4 + grok (reproduced): @elysiajs/swagger emits json+multipart+text for EVERY route (unfixable at route); the real error is annotating the fn Promise<IEntity> + bare return data. Fix: infer-don't-annotate (universal) + unwrap by response shape (data?.data if enveloped, else data — NOT categorical); corrected data-fetching+api-service guides + new gate-stages Readable steer. Panel PASS.