### PR TITLE
fix(reviewers): sandbox reviewer-binary CWD (root cause of the repo corruption)

### DIFF
--- a/packages/core/src/cli/harness-review-mode.ts
+++ b/packages/core/src/cli/harness-review-mode.ts
@@ -1,4 +1,4 @@
-import { mkdir, readFile, writeFile, rm } from "node:fs/promises";
+import { mkdir, mkdtemp, readFile, writeFile, rm } from "node:fs/promises";
 import { join } from "node:path";
 import { createHash, randomUUID } from "node:crypto";
 import { tmpdir } from "node:os";
@@ -133,8 +133,17 @@ export async function runBinary(
     await writeFile(tmpPath, stdin, "utf-8");
   }
 
+  // SANDBOX the reviewer's working directory. The binary reviewers (grok, codex) receive the diff
+  // to review via stdin/tempfile — they never need the real repo as their CWD. But an AGENTIC
+  // reviewer (codex "can read further on its own") will run shell/git in whatever CWD it inherits,
+  // and if that's the repo root it mutates the live checkout: observed corruption included junk
+  // `git commit -m init` fixtures (a.ts/discount.ts) written onto the working branch, `user` reset
+  // to `t/t@t.t`, and `core.bare` flipped true — which then propagated into pushes. Spawning each
+  // reviewer in a throwaway temp dir confines every side effect there; the real repo is untouchable.
+  const sandbox = await mkdtemp(join(tmpdir(), "tsforge-review-sandbox-"));
   const invocation = buildBinaryInvocation(r, stdin, tmpPath);
   const proc = Bun.spawn(invocation.cmd, {
+    cwd: sandbox,
     stdin: invocation.stdinBytes,
     stdout: "pipe",
     stderr: "ignore",
@@ -154,6 +163,8 @@ export async function runBinary(
     if (tmpPath !== undefined) {
       await rm(tmpPath, { force: true });
     }
+
+    await rm(sandbox, { recursive: true, force: true });
   }
 }
 

--- a/packages/core/tests/reviewers-runbinary.test.ts
+++ b/packages/core/tests/reviewers-runbinary.test.ts
@@ -115,3 +115,41 @@ describe("runBinary with tempfile mode", () => {
     expect(result.stdout).toContain("stdin mode test");
   });
 });
+
+describe("runBinary sandboxes the reviewer's working directory", () => {
+  test("the reviewer runs in a throwaway temp dir, NOT the repo/process cwd", async () => {
+    const result = await runBinary(
+      { argv: ["sh", "-c", "pwd"], input: "stdin", timeoutMs: 5000 },
+      ""
+    );
+    const cwd = result.stdout.trim();
+
+    expect(result.ok).toBe(true);
+    expect(cwd.includes("tsforge-review-sandbox-")).toBe(true);
+    expect(cwd).not.toBe(process.cwd());
+  });
+
+  test("a file the reviewer creates lands in the sandbox (repo untouched) and is cleaned up", async () => {
+    // The exact failure this guards: an agentic reviewer writing into its CWD. If the CWD were the
+    // repo, this probe file would appear in the repo root (the class of pollution that corrupted
+    // main). It must land in the sandbox instead, and the sandbox must be gone after the run.
+    const probeInRepo = join(process.cwd(), "reviewer-pollution-probe.txt");
+    const before = existsSync(probeInRepo);
+
+    const result = await runBinary(
+      {
+        argv: ["sh", "-c", "touch reviewer-pollution-probe.txt && pwd"],
+        input: "stdin",
+        timeoutMs: 5000,
+      },
+      ""
+    );
+    const sandbox = result.stdout.trim();
+
+    expect(result.ok).toBe(true);
+    // The repo cwd is unchanged — the probe did NOT leak into it.
+    expect(existsSync(probeInRepo)).toBe(before);
+    // The sandbox where it actually went is removed after the run.
+    expect(existsSync(sandbox)).toBe(false);
+  });
+});


### PR DESCRIPTION
**Root cause of tonight's repo corruption.** `runBinary` (harness-review-mode.ts) spawned reviewer binaries (grok/codex) with **no `cwd`**, so they inherited the repo root. An agentic reviewer (codex 'can read further on its own' — harness-review.ts:141) then ran shell/git in the live checkout, producing:
- junk `git commit -q -m init` fixture commits (`a.ts`/`discount.ts`) on the working branch
- `git config user` reset to `t/t@t.t`
- `core.bare` flipped to `true`

…which propagated into pushes and wrecked `main`.

**Fix:** reviewers receive the diff via stdin/tempfile and never need the repo as CWD, so each binary is now spawned in a throwaway `mkdtemp` sandbox (removed in `finally`). Every reviewer side effect is confined there; the real repo is untouchable. This should also un-break the panel (reviewers were erroring because their git setup failed in the polluted live repo).

**Tests:** reviewer runs in the sandbox (not `process.cwd()`); a file it creates never leaks into the repo and the sandbox is cleaned up. Full suite 2835/0, typecheck + lint + format green.