### PR TITLE
fix(#63): eliminate the ~2s whole-repo TS-service build in AgentRunner tests (pre-validate false-BLOCK)

### DIFF
--- a/packages/core/tests/agent-runner.test.ts
+++ b/packages/core/tests/agent-runner.test.ts
@@ -187,7 +187,13 @@ describe("AgentRunner (read-only loop against this repo)", () => {
     const result = await new AgentRunner({
       id: "structured",
       outputMode: "structured",
-    }).run({ provider, cwd: REPO, parentTaskId: "r", task: "t" });
+    }).run({
+      provider,
+      cwd: REPO,
+      tsService: null,
+      parentTaskId: "r",
+      task: "t",
+    });
 
     expect(seenTools()).toContain("agent_result");
     expect(result.status).toBe("done");
@@ -212,7 +218,13 @@ describe("AgentRunner (read-only loop against this repo)", () => {
       id: "structured",
       outputMode: "structured",
       tools: [],
-    }).run({ provider, cwd: REPO, parentTaskId: "r", task: "t" });
+    }).run({
+      provider,
+      cwd: REPO,
+      tsService: null,
+      parentTaskId: "r",
+      task: "t",
+    });
 
     expect(result.status).toBe("done");
     expect(result.output).toBe("answer");

--- a/packages/core/tests/agent-runner.test.ts
+++ b/packages/core/tests/agent-runner.test.ts
@@ -1,4 +1,4 @@
-import { test, expect, describe } from "bun:test";
+import { test, expect, describe, setDefaultTimeout } from "bun:test";
 import { existsSync } from "node:fs";
 import { join } from "node:path";
 import type { IProvider, IModelResponse } from "../src/inference";
@@ -50,6 +50,16 @@ function scripted(queue: IModelResponse[]): {
 
 // The tsforge repo itself is the read-only workspace under test.
 const REPO = join(import.meta.dir, "..", "..", "..");
+
+// #63: every test here constructs `new AgentRunner(...).run({ cwd: REPO })`, which pays a fixed
+// ~2s startup cost against the real repo (even the immediate-abort / no-op cases). In isolation the
+// file runs ~1.9s/test — well under bun's 5000ms default — but under the FULL suite's 273-file
+// concurrency, CPU contention inflates that startup past 5s and the tests spuriously time out,
+// which false-BLOCKs the harness-review pre-validate gate. Raise the ceiling for THIS FILE ONLY
+// (setDefaultTimeout is module-scoped) so the 5s fail-fast default — and its infinite-loop
+// detection — stays intact for the other 272 files. 15s = generous margin over the real ~2s work
+// under contention, while still failing a genuine hang here.
+setDefaultTimeout(15_000);
 
 describe("parseAgentSpec", () => {
   test("accepts a well-formed spec and keeps only valid fields", () => {

--- a/packages/core/tests/agent-runner.test.ts
+++ b/packages/core/tests/agent-runner.test.ts
@@ -1,4 +1,4 @@
-import { test, expect, describe, setDefaultTimeout } from "bun:test";
+import { test, expect, describe } from "bun:test";
 import { existsSync } from "node:fs";
 import { join } from "node:path";
 import type { IProvider, IModelResponse } from "../src/inference";
@@ -47,16 +47,14 @@ function scripted(queue: IModelResponse[]): {
 // The tsforge repo itself is the read-only workspace under test.
 const REPO = join(import.meta.dir, "..", "..", "..");
 
-// #63: EVERY test in this file constructs `new AgentRunner(...).run({ cwd: REPO })`, which pays a
-// fixed ~2s startup cost against the real repo (even the immediate-abort / no-op cases). In
-// isolation the file runs ~1.9s/test — well under bun's 5000ms default — but under the FULL suite's
-// concurrency, CPU contention inflates that startup past 5s and the tests spuriously time out,
-// which false-BLOCKs the harness-review pre-validate gate. Raise the ceiling for THIS FILE ONLY
-// (setDefaultTimeout is module-scoped) so the 5s fail-fast default — and its infinite-loop
-// detection — stays intact for every other test file. 15s = generous margin over the real ~2s work
-// under contention, while still failing a genuine hang here. The pure parseAgentSpec/loadAgentSpecs
-// config tests do NOT construct AgentRunner and live in agent-specs.test.ts, keeping the 5s default.
-setDefaultTimeout(15_000);
+// #63: every run below passes `tsService: null`. Without it, AgentRunner.run calls
+// buildTsService(cwd) — building a TypeScript service over the ENTIRE tsforge repo (cwd: REPO) —
+// which costs ~2s per test. In isolation that's tolerable, but under the full suite's concurrency
+// the CPU contention inflated it past bun's 5000ms default and the tests spuriously timed out,
+// false-BLOCKing the harness-review pre-validate gate. These read-only tests exercise tool-gating /
+// events / maxTurns / abort / policy — none use the type-aware tools (type_at/diagnostics) — so a
+// null service is faithful AND removes the cost at the ROOT, keeping every test well under the 5s
+// fail-fast default (no timeout raise needed). Matches the many sibling tests that pass tsService: null.
 
 describe("AgentRunner (read-only loop against this repo)", () => {
   test("tool turn then final text; events are agentId-tagged", async () => {
@@ -73,6 +71,7 @@ describe("AgentRunner (read-only loop against this repo)", () => {
     const result = await runner.run({
       provider,
       cwd: REPO,
+      tsService: null,
       parentTaskId: "run-1",
       task: "What package is this?",
     });
@@ -105,6 +104,7 @@ describe("AgentRunner (read-only loop against this repo)", () => {
     const result = await new AgentRunner({ id: "explore" }).run({
       provider,
       cwd: REPO,
+      tsService: null,
       parentTaskId: "run-1",
       task: "try to write",
     });
@@ -128,6 +128,7 @@ describe("AgentRunner (read-only loop against this repo)", () => {
     await new AgentRunner({ id: "narrow", tools: ["read"] }).run({
       provider,
       cwd: REPO,
+      tsService: null,
       parentTaskId: "r",
       task: "t",
     });
@@ -147,6 +148,7 @@ describe("AgentRunner (read-only loop against this repo)", () => {
     const result = await new AgentRunner({ id: "loopy", maxTurns: 3 }).run({
       provider,
       cwd: REPO,
+      tsService: null,
       parentTaskId: "r",
       task: "loop forever",
     });
@@ -222,6 +224,7 @@ describe("AgentRunner (read-only loop against this repo)", () => {
     const result = await new AgentRunner({ id: "img", kind: "generate" }).run({
       provider,
       cwd: REPO,
+      tsService: null,
       parentTaskId: "r",
     });
 
@@ -244,6 +247,7 @@ describe("review-round regressions", () => {
     const result = await new AgentRunner({ id: "explore" }).run({
       provider,
       cwd: REPO,
+      tsService: null,
       parentTaskId: "r",
       task: "read the manifest",
       policyMode: "default",
@@ -273,6 +277,7 @@ describe("review-round regressions", () => {
     const result = await new AgentRunner({ id: "explore" }).run({
       provider: aborting,
       cwd: REPO,
+      tsService: null,
       parentTaskId: "r",
       task: "t",
       signal: ctrl.signal,
@@ -294,6 +299,7 @@ describe("review-round regressions", () => {
     await new AgentRunner({ id: "bare", tools: [] }).run({
       provider,
       cwd: REPO,
+      tsService: null,
       parentTaskId: "r",
       task: "t",
     });
@@ -306,6 +312,7 @@ describe("review-round regressions", () => {
     const result = await new AgentRunner({ id: "x" }).run({
       provider,
       cwd: REPO,
+      tsService: null,
       parentTaskId: "r",
       task: "t",
       report: () => {

--- a/packages/core/tests/agent-runner.test.ts
+++ b/packages/core/tests/agent-runner.test.ts
@@ -3,10 +3,6 @@ import { existsSync } from "node:fs";
 import { join } from "node:path";
 import type { IProvider, IModelResponse } from "../src/inference";
 import { AgentRunner, AGENT_LIMITS } from "../src/agent/agent-runner";
-import {
-  parseAgentSpec,
-  unrecognizedAgentKeys,
-} from "../src/config/agent-specs";
 
 /** A provider that replays a fixed queue of responses (repeats the last one). */
 function scripted(queue: IModelResponse[]): {
@@ -51,45 +47,16 @@ function scripted(queue: IModelResponse[]): {
 // The tsforge repo itself is the read-only workspace under test.
 const REPO = join(import.meta.dir, "..", "..", "..");
 
-// #63: every test here constructs `new AgentRunner(...).run({ cwd: REPO })`, which pays a fixed
-// ~2s startup cost against the real repo (even the immediate-abort / no-op cases). In isolation the
-// file runs ~1.9s/test — well under bun's 5000ms default — but under the FULL suite's 273-file
+// #63: EVERY test in this file constructs `new AgentRunner(...).run({ cwd: REPO })`, which pays a
+// fixed ~2s startup cost against the real repo (even the immediate-abort / no-op cases). In
+// isolation the file runs ~1.9s/test — well under bun's 5000ms default — but under the FULL suite's
 // concurrency, CPU contention inflates that startup past 5s and the tests spuriously time out,
 // which false-BLOCKs the harness-review pre-validate gate. Raise the ceiling for THIS FILE ONLY
 // (setDefaultTimeout is module-scoped) so the 5s fail-fast default — and its infinite-loop
-// detection — stays intact for the other 272 files. 15s = generous margin over the real ~2s work
-// under contention, while still failing a genuine hang here.
+// detection — stays intact for every other test file. 15s = generous margin over the real ~2s work
+// under contention, while still failing a genuine hang here. The pure parseAgentSpec/loadAgentSpecs
+// config tests do NOT construct AgentRunner and live in agent-specs.test.ts, keeping the 5s default.
 setDefaultTimeout(15_000);
-
-describe("parseAgentSpec", () => {
-  test("accepts a well-formed spec and keeps only valid fields", () => {
-    const spec = parseAgentSpec({
-      id: "explore",
-      description: "map a subsystem",
-      model: "qwen3-coder",
-      kind: "chat",
-      tools: ["read", "search", 42],
-      maxTurns: 6,
-      outputMode: "structured",
-      bogus: true,
-    });
-
-    expect(spec?.id).toBe("explore");
-    expect(spec?.tools).toEqual(["read", "search"]);
-    expect(spec?.maxTurns).toBe(6);
-    expect(spec?.outputMode).toBe("structured");
-    expect(unrecognizedAgentKeys({ id: "x", bogus: true })).toEqual(["bogus"]);
-  });
-
-  test("rejects a missing/non-kebab id and drops invalid enums", () => {
-    expect(parseAgentSpec({ model: "m" })).toBeNull();
-    expect(parseAgentSpec({ id: "Has Space" })).toBeNull();
-    expect(parseAgentSpec({ id: "x", kind: "psychic" })?.kind).toBeUndefined();
-    expect(
-      parseAgentSpec({ id: "x", outputMode: "yaml" })?.outputMode
-    ).toBeUndefined();
-  });
-});
 
 describe("AgentRunner (read-only loop against this repo)", () => {
   test("tool turn then final text; events are agentId-tagged", async () => {
@@ -260,56 +227,6 @@ describe("AgentRunner (read-only loop against this repo)", () => {
 
     expect(result.status).toBe("error");
     expect(result.output).toContain("generate");
-  });
-});
-
-describe("loadAgentSpecs", () => {
-  test("project spec overrides global on id collision", async () => {
-    const { mkdtemp, mkdir, writeFile, rm } = await import("node:fs/promises");
-    const { tmpdir } = await import("node:os");
-    const { loadAgentSpecs } = await import("../src/config/agent-specs");
-    const home = await mkdtemp(join(tmpdir(), "tsforge-agents-home-"));
-    const cwd = await mkdtemp(join(tmpdir(), "tsforge-agents-proj-"));
-    const prev = process.env.TSFORGE_HOME;
-
-    try {
-      process.env.TSFORGE_HOME = home;
-      await mkdir(join(home, ".tsforge", "agents"), { recursive: true });
-      await mkdir(join(cwd, ".tsforge", "agents"), { recursive: true });
-      await writeFile(
-        join(home, ".tsforge/agents/explore.json"),
-        JSON.stringify({ id: "explore", model: "global-model" })
-      );
-      await writeFile(
-        join(cwd, ".tsforge/agents/explore.json"),
-        JSON.stringify({ id: "explore", model: "project-model", bogus: 1 })
-      );
-      await writeFile(join(cwd, ".tsforge/agents/broken.json"), "{ nope");
-
-      const reports: string[] = [];
-      const specs = await loadAgentSpecs(cwd, (m) => reports.push(m));
-      const ids = specs.map((s) => s.id);
-
-      // The user's project `explore.json` overrides BOTH the global one and the
-      // built-in of the same id (project wins; built-in < global < project).
-      expect(ids).toContain("explore");
-      expect(specs.find((s) => s.id === "explore")?.model).toBe(
-        "project-model"
-      );
-      // Built-in specialists are always present (delegation works out of the box).
-      expect(ids).toContain("research");
-      expect(reports.some((m) => m.includes("broken.json"))).toBe(true);
-      expect(reports.some((m) => m.includes("bogus"))).toBe(true);
-    } finally {
-      if (prev === undefined) {
-        delete process.env.TSFORGE_HOME;
-      } else {
-        process.env.TSFORGE_HOME = prev;
-      }
-
-      await rm(home, { recursive: true, force: true });
-      await rm(cwd, { recursive: true, force: true });
-    }
   });
 });
 

--- a/packages/core/tests/agent-specs.test.ts
+++ b/packages/core/tests/agent-specs.test.ts
@@ -1,0 +1,90 @@
+import { test, expect, describe } from "bun:test";
+import { join } from "node:path";
+import {
+  parseAgentSpec,
+  unrecognizedAgentKeys,
+} from "../src/config/agent-specs";
+
+// Pure agent-SPEC config tests (parse + load). Split out of agent-runner.test.ts (#63): those tests
+// construct AgentRunner against the real repo and need a raised per-file timeout, but these do not —
+// keeping them here preserves bun's 5s fail-fast default for this fast, hermetic config suite.
+
+describe("parseAgentSpec", () => {
+  test("accepts a well-formed spec and keeps only valid fields", () => {
+    const spec = parseAgentSpec({
+      id: "explore",
+      description: "map a subsystem",
+      model: "qwen3-coder",
+      kind: "chat",
+      tools: ["read", "search", 42],
+      maxTurns: 6,
+      outputMode: "structured",
+      bogus: true,
+    });
+
+    expect(spec?.id).toBe("explore");
+    expect(spec?.tools).toEqual(["read", "search"]);
+    expect(spec?.maxTurns).toBe(6);
+    expect(spec?.outputMode).toBe("structured");
+    expect(unrecognizedAgentKeys({ id: "x", bogus: true })).toEqual(["bogus"]);
+  });
+
+  test("rejects a missing/non-kebab id and drops invalid enums", () => {
+    expect(parseAgentSpec({ model: "m" })).toBeNull();
+    expect(parseAgentSpec({ id: "Has Space" })).toBeNull();
+    expect(parseAgentSpec({ id: "x", kind: "psychic" })?.kind).toBeUndefined();
+    expect(
+      parseAgentSpec({ id: "x", outputMode: "yaml" })?.outputMode
+    ).toBeUndefined();
+  });
+});
+
+describe("loadAgentSpecs", () => {
+  test("project spec overrides global on id collision", async () => {
+    const { mkdtemp, mkdir, writeFile, rm } = await import("node:fs/promises");
+    const { tmpdir } = await import("node:os");
+    const { loadAgentSpecs } = await import("../src/config/agent-specs");
+    const home = await mkdtemp(join(tmpdir(), "tsforge-agents-home-"));
+    const cwd = await mkdtemp(join(tmpdir(), "tsforge-agents-proj-"));
+    const prev = process.env.TSFORGE_HOME;
+
+    try {
+      process.env.TSFORGE_HOME = home;
+      await mkdir(join(home, ".tsforge", "agents"), { recursive: true });
+      await mkdir(join(cwd, ".tsforge", "agents"), { recursive: true });
+      await writeFile(
+        join(home, ".tsforge/agents/explore.json"),
+        JSON.stringify({ id: "explore", model: "global-model" })
+      );
+      await writeFile(
+        join(cwd, ".tsforge/agents/explore.json"),
+        JSON.stringify({ id: "explore", model: "project-model", bogus: 1 })
+      );
+      await writeFile(join(cwd, ".tsforge/agents/broken.json"), "{ nope");
+
+      const reports: string[] = [];
+      const specs = await loadAgentSpecs(cwd, (m) => reports.push(m));
+      const ids = specs.map((s) => s.id);
+
+      // The user's project `explore.json` overrides BOTH the global one and the
+      // built-in of the same id (project wins; built-in < global < project).
+      expect(ids).toContain("explore");
+      expect(specs.find((s) => s.id === "explore")?.model).toBe(
+        "project-model"
+      );
+      // Built-in specialists are always present (delegation works out of the box).
+      expect(ids).toContain("research");
+      expect(reports.some((m) => m.includes("broken.json"))).toBe(true);
+      expect(reports.some((m) => m.includes("bogus"))).toBe(true);
+    } finally {
+      if (prev === undefined) {
+        delete process.env.TSFORGE_HOME;
+      } else {
+        process.env.TSFORGE_HOME = prev;
+      }
+
+      await rm(home, { recursive: true, force: true });
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+});

--- a/packages/core/tests/agent-specs.test.ts
+++ b/packages/core/tests/agent-specs.test.ts
@@ -6,8 +6,8 @@ import {
 } from "../src/config/agent-specs";
 
 // Pure agent-SPEC config tests (parse + load). Split out of agent-runner.test.ts (#63): those tests
-// construct AgentRunner against the real repo and need a raised per-file timeout, but these do not —
-// keeping them here preserves bun's 5s fail-fast default for this fast, hermetic config suite.
+// construct AgentRunner against the real repo (slow whole-repo TS-service build, since fixed by
+// passing tsService: null); these pure config tests don't, so they belong in their own fast file.
 
 describe("parseAgentSpec", () => {
   test("accepts a well-formed spec and keeps only valid fields", () => {


### PR DESCRIPTION
## What

The `harness-review` pre-review gate runs the full `bun run validate` and BLOCKs review on any non-zero exit. Under full-suite concurrency its `bun test packages` phase spuriously timed out, false-BLOCKing **every** review — even a twice-PASSed diff (observed on PR #170's branch: 9 timeout "fails" blocked a clean change). This is issue #63.

## Root cause

`AgentRunner.run` calls `buildTsService(cwd)` when no `tsService` is passed. `agent-runner.test.ts` runs the agent against the **whole tsforge repo** (`cwd: REPO`), so every test built a TypeScript service over the entire project — **~2s per test**, even the immediate-abort / no-op cases. In isolation the file ran ~24.6s (~1.8s/test), under bun's 5000ms default; under 273-file CPU contention that startup inflated past 5s → spurious timeouts.

## Fix (at the root — no gate change)

- Pass `tsService: null` on **every** `run()` in `agent-runner.test.ts` (as many sibling tests already do). These read-only tests exercise tool-gating / events / maxTurns / abort / policy / structured-mode — **none use the type-aware tools** (`type_at`/`diagnostics`) — so a null service is faithful and removes the cost at the source. File drops **~24.6s → ~0.4s**; every test is far under the 5s default.
- Split the pure `parseAgentSpec`/`loadAgentSpecs` config tests into `agent-specs.test.ts` (they don't construct `AgentRunner`; they belong in their own fast file).

**No timeout was raised** — `setDefaultTimeout` is not used. Nothing is relaxed; bun's 5s fail-fast default and its infinite-loop detection stay intact for every file. The full `bun run validate` gate is unchanged.

## Review

- **harness-review panel: PASS, 4/4 reviewers, zero findings.** The panel earned its keep across the iteration: it rejected two earlier gate-*relaxing* attempts (a global `--timeout` bump, then a file-scoped one) and caught an incomplete `replace_all` that left two structured-mode runs unstubbed — all fixed here.
- 14 tests unchanged (11 AgentRunner + 3 config), all green; typecheck / lint / format clean.