### PR TITLE
fix(gate): name the broken file behind an eslint-program-unparsable cascade (append-only, feature-owned, panel-clean)

### DIFF
--- a/packages/core/src/loop/boringstack/build.ts
+++ b/packages/core/src/loop/boringstack/build.ts
@@ -389,7 +389,10 @@ export function boringstackDeps(opts: {
       // model then fills the domain INSIDE the loop, checked by the live gate.
       await generate(cwd, feature.id, exec);
       await genUi(cwd, feature.id, exec);
-      host.setScope(scopeFor(feature.id));
+
+      const scopeGlobs = scopeFor(feature.id);
+
+      host.setScope(scopeGlobs);
       // The editable file the expert repairs if a stall's errors are all out of
       // scope (locked consumers of this feature's types) — its service file.
       host.setExpertRescueTarget((await rescueFileFor(cwd, feature)) ?? "");
@@ -428,6 +431,7 @@ export function boringstackDeps(opts: {
           feature,
           entity,
           siblingEntities,
+          scopeGlobs,
         })
       );
 

--- a/packages/core/src/loop/boringstack/build.ts
+++ b/packages/core/src/loop/boringstack/build.ts
@@ -127,13 +127,26 @@ export const APP_ROUTES_FILE = "apps/ui/src/app/router/routes.tsx";
 export const APP_SIDEBAR_TEST_FILE =
   "apps/ui/src/components/core/AppSidebar/AppSidebar.test.tsx";
 
-export function scopeFor(name: string): string[] {
+/**
+ * The feature-EXCLUSIVE directories the model may FULLY REWRITE — its own API resource, its API
+ * tests, and its UI feature. These are safe rewrite targets because no other feature owns them.
+ * Distinct from the shared ADD-ONLY files (schema/locale/sidebar/routes/sidebar-test) that
+ * `scopeFor` also grants edit access to: those are add-only and must NEVER be named for a wholesale
+ * rewrite (it would clobber sibling features), so the parse-error locator uses ONLY these globs.
+ */
+export function featureOwnedGlobs(name: string): string[] {
   const camel = toCamelCase(name);
 
   return [
     `apps/api/src/api/${camel}/**`,
     `apps/api/tests/api/${camel}/**`,
     `apps/ui/src/features/${camel}/**`,
+  ];
+}
+
+export function scopeFor(name: string): string[] {
+  return [
+    ...featureOwnedGlobs(name),
     // The entity's table + columns live in the shared app schema (not the resource
     // dir), so a greenfield build must let the model add its domain columns there.
     APP_SCHEMA_FILE,
@@ -390,9 +403,7 @@ export function boringstackDeps(opts: {
       await generate(cwd, feature.id, exec);
       await genUi(cwd, feature.id, exec);
 
-      const scopeGlobs = scopeFor(feature.id);
-
-      host.setScope(scopeGlobs);
+      host.setScope(scopeFor(feature.id));
       // The editable file the expert repairs if a stall's errors are all out of
       // scope (locked consumers of this feature's types) — its service file.
       host.setExpertRescueTarget((await rescueFileFor(cwd, feature)) ?? "");
@@ -431,7 +442,6 @@ export function boringstackDeps(opts: {
           feature,
           entity,
           siblingEntities,
-          scopeGlobs,
         })
       );
 

--- a/packages/core/src/loop/boringstack/gate-stages.ts
+++ b/packages/core/src/loop/boringstack/gate-stages.ts
@@ -275,89 +275,129 @@ function fileInScope(file: string, scopeGlobs: readonly string[]): boolean {
   return scopeGlobs.some((glob) => new Bun.Glob(glob).match(file));
 }
 
+/** First syntax error in one file, or null — swallowing ANY throw (unreadable file, parser/program
+ *  error) so a single bad file skips ONLY itself and the scan keeps going to later files. */
+async function safeFirstSyntaxError(
+  absPath: string,
+  fileName: string
+): Promise<string | null> {
+  try {
+    return firstSyntaxError(await Bun.file(absPath).text(), fileName);
+  } catch {
+    return null;
+  }
+}
+
+/** Which app section(s) of the composed-gate output actually show the `parserOptions.project`
+ *  cascade — so the locator scans the app that FAILED, not blindly apps/api then apps/ui. The
+ *  output echoes `::tsforge-app <app>::` before each app's stages (see gate.ts). Empty when no
+ *  section matches → the caller falls back to scanning both. */
+function appsWithParseCascade(output: string): string[] {
+  const parts = output.split(/::tsforge-app (\S+)::/u);
+  const apps: string[] = [];
+
+  // split with a capture group yields [pre, app1, body1, app2, body2, …].
+  for (let i = 1; i + 1 < parts.length; i += 2) {
+    const app = parts[i] ?? "";
+    const body = parts[i + 1] ?? "";
+
+    if (
+      (app === "apps/api" || app === "apps/ui") &&
+      /parserOptions\.project|ESLint was configured to run on/u.test(body)
+    ) {
+      apps.push(app);
+    }
+  }
+
+  return apps;
+}
+
 /**
  * Pinpoint the ONE file with a real syntax error behind an `eslint-program-unparsable` cascade.
  * The type-aware ESLint program fails to build off a single broken file yet fans a
- * `parserOptions.project` parse error across EVERY .tsx, so its output can't say which file is
+ * `parserOptions.project` parse error across EVERY file, so its output can't say which file is
  * actually broken — and the model thrashes near-green hunting for it. Re-parse each source file
  * in ISOLATION with the TypeScript parser (`firstSyntaxError`) and return the first genuinely
  * malformed one (repo-relative) + its located message. Same parser as the lint, so it cannot
- * mis-name a healthy file. Because there are no false positives, the apps/api-before-ui scan
- * order is harmless — if both apps hold a real syntax error, either is a correct thing to fix.
- * Best-effort and fast (only runs on the rare cascade). Never throws.
+ * mis-name a healthy file. `appsToScan` is the app(s) whose gate section actually showed the
+ * cascade — so a UI cascade is never mis-attributed to an unrelated API syntax error. Scans
+ * `{src,tests}` (the editable scope includes `apps/api/tests/…`). Best-effort; never throws.
  */
 export async function locateParseError(
-  cwd: string
+  cwd: string,
+  appsToScan: readonly string[]
 ): Promise<{ file: string; detail: string } | null> {
-  for (const app of ["apps/api", "apps/ui"]) {
+  for (const app of appsToScan) {
     const root = join(cwd, app);
 
     try {
-      // `src` AND `tests` — the editable scope includes `apps/api/tests/api/<feature>/**`, and
-      // a syntax error in a test file breaks the type-aware program just the same, so it must be
-      // locatable too (else the feature silently falls back to the file-less guidance).
       const glob = new Bun.Glob("{src,tests}/**/*.{ts,tsx}");
 
       for await (const rel of glob.scan({ cwd: root })) {
-        let code: string;
-
-        try {
-          code = await Bun.file(join(root, rel)).text();
-        } catch {
-          continue;
-        }
-
-        const detail = firstSyntaxError(code, rel);
+        const detail = await safeFirstSyntaxError(join(root, rel), rel);
 
         if (detail !== null) {
           return { file: `${app}/${rel}`, detail };
         }
       }
     } catch {
-      // glob/scan failure is non-fatal — the base message still guides the model.
+      // glob/scan setup failure is non-fatal — enrichUnparsable still fails safe below.
     }
   }
 
   return null;
 }
 
+const UNPARSABLE_PREAMBLE =
+  "The TypeScript-aware lint could not build its program: ONE file has a real syntax/parse " +
+  "error, which makes ESLint report a `parserOptions.project` error on every file. This is " +
+  "ONE broken file, not many — do NOT chase the per-file parse errors.";
+
 /**
- * REPLACE the file-less `eslint-program-unparsable` message once the real broken file is located.
- * A file the parser rejects necessarily breaks the SHARED type-aware program (typescript-eslint
- * parses the same files with the same parser), so naming any real syntax error is a sound fix
- * target; if none is found — a config/`include` failure, not a syntax cascade — the message is
- * left unchanged (no fabricated pointer). The message is REPLACED (not appended) so the base
- * text's generic "REWRITE IT IN FULL" directive can't contradict the out-of-scope "do NOT edit"
- * guidance. The guidance is SCOPE-AWARE and FAIL-CLOSED: only a file CONFIRMED in the model's
- * editable scope gets a rewrite instruction; a file outside scope — or when scope is unknown —
- * is flagged as blocked, never a rewrite that would bypass ownership.
+ * REPLACE the file-less `eslint-program-unparsable` message with precise, non-contradictory
+ * guidance. The message is REPLACED (never appended) so the base text's generic "REWRITE IT IN
+ * FULL" can't co-exist with an out-of-scope "do NOT edit". FAIL-CLOSED in every branch — a rewrite
+ * instruction is issued ONLY for a file CONFIRMED in the model's editable scope:
+ *   • located + in scope → fix that file (and set `.file` so stuck-file/expert consumers agree);
+ *   • located + out of scope → named as info + flagged blocked, never a rewrite;
+ *   • NOT located (incl. a swallowed scan failure) → no in-scope rewrite target is asserted; the
+ *     model is told to check the files it just edited, else report blocked.
+ * A file the parser rejects necessarily breaks the SHARED type-aware program (same parser as the
+ * lint), so naming any real syntax error in the failing app is a sound fix target.
  */
 async function enrichUnparsable(
   unparsable: IErrorItem,
   cwd: string,
-  scopeGlobs: readonly string[]
+  scopeGlobs: readonly string[],
+  appsToScan: readonly string[]
 ): Promise<void> {
-  const located = await locateParseError(cwd);
+  const located = await locateParseError(cwd, appsToScan);
 
   if (located === null) {
+    unparsable.message =
+      `${UNPARSABLE_PREAMBLE} It could not be pinpointed automatically — inspect the files you ` +
+      `edited this cycle for an unterminated brace/generic/JSX and rewrite the offending file ` +
+      `cleanly. If you cannot find it among files you own, report this as blocked.`;
+
     return;
   }
 
-  const preamble =
-    "The TypeScript-aware lint could not build its program: ONE file has a real syntax/parse " +
-    "error, which makes ESLint report a `parserOptions.project` error on every file. This is " +
-    "ONE broken file, not many — do NOT chase the per-file parse errors.";
   const head = `The parse failure is in \`${located.file}\` (${located.detail}).`;
-  const editable =
-    scopeGlobs.length > 0 && fileInScope(located.file, scopeGlobs);
 
-  // FAIL-CLOSED: only a CONFIRMED-editable file gets a rewrite instruction. Anything else
-  // (out of scope, or scope unknown) is named as info + flagged blocked — never a rewrite.
-  unparsable.message = editable
-    ? `${preamble} ${head} Fix the syntax error there — rewrite that file in full if the cause ` +
-      `is not obvious. Once it parses, the whole cascade clears at once.`
-    : `${preamble} ${head} That file is OUTSIDE your editable scope (a shared/scaffold file) — ` +
-      `do NOT try to edit it. Report this as blocked.`;
+  if (scopeGlobs.length > 0 && fileInScope(located.file, scopeGlobs)) {
+    unparsable.message =
+      `${UNPARSABLE_PREAMBLE} ${head} Fix the syntax error there — rewrite that file in full if ` +
+      `the cause is not obvious. Once it parses, the whole cascade clears at once.`;
+    // Structured consumers (stuck-file/expert/phase) now agree with the prose. Safe because the
+    // file is CONFIRMED in scope — an out-of-scope file stays file-less so it can't be hidden.
+    unparsable.file = located.file;
+
+    return;
+  }
+
+  unparsable.message =
+    `${UNPARSABLE_PREAMBLE} ${head} That file is OUTSIDE your editable scope (a shared/scaffold ` +
+    `file) — do NOT try to edit it. Report this as blocked.`;
 }
 
 export function boringstackCommandStage(
@@ -391,7 +431,13 @@ export function boringstackCommandStage(
       );
 
       if (unparsable !== undefined) {
-        await enrichUnparsable(unparsable, cwd, scopeGlobs);
+        // Scan only the app(s) whose gate section showed the cascade — never mis-attribute a UI
+        // cascade to an unrelated API syntax error. Fall back to both if the section is unclear.
+        const failing = appsWithParseCascade(result.output);
+        const appsToScan =
+          failing.length > 0 ? failing : ["apps/api", "apps/ui"];
+
+        await enrichUnparsable(unparsable, cwd, scopeGlobs, appsToScan);
       }
 
       return { passed: false, errors, output: result.output };
@@ -597,9 +643,10 @@ export function composeBoringstackGate(opts: {
   /** The OTHER features/entities in this build, so the judge scopes to this
    *  feature's own responsibilities and never demands a link to an unbuilt slice. */
   siblingEntities?: readonly string[];
-  /** The globs the model may edit this feature — so a located parse error outside them is
-   *  flagged as blocked rather than issued as a rewrite instruction that bypasses ownership. */
-  scopeGlobs?: readonly string[];
+  /** The globs the model may edit for this feature — so a located parse error outside them is
+   *  flagged as blocked rather than issued as a rewrite instruction that bypasses ownership.
+   *  REQUIRED: dropping it at the call site is a compile error, not a silently-green test. */
+  scopeGlobs: readonly string[];
 }): IGate {
   const { cwd, exec, evaluator, baseline, feature, entity } = opts;
   const e2eAcceptanceDisabled =
@@ -607,7 +654,7 @@ export function composeBoringstackGate(opts: {
 
   return composeGate([
     differentialStage(
-      boringstackCommandStage(cwd, exec, opts.scopeGlobs ?? []),
+      boringstackCommandStage(cwd, exec, opts.scopeGlobs),
       baseline
     ),
     reachabilityStage(cwd, feature.id),

--- a/packages/core/src/loop/boringstack/gate-stages.ts
+++ b/packages/core/src/loop/boringstack/gate-stages.ts
@@ -97,13 +97,13 @@ export function signatureToError(sig: string): IErrorItem {
       rule: "eslint-program-unparsable",
       phase: 2,
       message:
-        "The TypeScript-aware lint could not build its program: ONE file has a real " +
-        "syntax/parse error (`Parsing error: … expected`), which makes ESLint report a " +
-        "`parserOptions.project` parse error on EVERY .tsx file. This is ONE broken " +
-        "file, not many separate errors — do NOT chase the per-file parse errors. Find " +
-        "the file with the actual `Parsing error: … expected` and REWRITE IT IN FULL " +
-        "(a surgical patch on an already-broken file usually re-breaks its braces/" +
-        "generics). Once that file parses, the whole cascade clears at once.",
+        "The TypeScript-aware lint could not build its program: one or more source files have a " +
+        "real syntax/parse error (`Parsing error: … expected`), which makes ESLint report a " +
+        "`parserOptions.project` parse error on many files at once — do NOT chase the per-file " +
+        "cascade. Find the genuine syntax error(s) in the files YOU OWN (your feature's own dirs) " +
+        "and fix each cleanly; a `.ts` file that contains JSX must be renamed to `.tsx` (a `.ts` " +
+        "parses `<X>` as a generic and demands `>`). Do NOT wholesale-rewrite shared files. Every " +
+        "broken file must parse before the cascade clears.",
     };
   }
 

--- a/packages/core/src/loop/boringstack/gate-stages.ts
+++ b/packages/core/src/loop/boringstack/gate-stages.ts
@@ -199,6 +199,52 @@ function opaqueGateError(output: string, cwd: string): IErrorItem {
  * becomes an `IErrorItem` whose `key` IS the signature — so the differential
  * wrapper can suppress baseline signatures and `checkStuck` can fingerprint them.
  */
+/**
+ * Pinpoint the ONE file with a real syntax error behind an `eslint-program-unparsable` cascade.
+ * The type-aware ESLint program fails to build off a single broken file yet fans a
+ * `parserOptions.project` parse error across EVERY .tsx, so its output can't say which file is
+ * actually broken — and the model thrashes near-green hunting for it. Transpile each source file
+ * in ISOLATION (Bun's transpiler builds no cross-file program, so only the genuinely-malformed
+ * file throws); return the first broken one (repo-relative) + the parser's first message line.
+ * Best-effort and fast (sub-ms/file, only runs on the rare cascade). Never throws.
+ */
+export async function locateParseError(
+  cwd: string
+): Promise<{ file: string; detail: string } | null> {
+  for (const app of ["apps/api", "apps/ui"]) {
+    const root = join(cwd, app);
+
+    try {
+      const glob = new Bun.Glob("src/**/*.{ts,tsx}");
+
+      for await (const rel of glob.scan({ cwd: root })) {
+        const loader = rel.endsWith(".tsx") ? "tsx" : "ts";
+        let code: string;
+
+        try {
+          code = await Bun.file(join(root, rel)).text();
+        } catch {
+          continue;
+        }
+
+        try {
+          new Bun.Transpiler({ loader }).transformSync(code);
+        } catch (e) {
+          const detail = (e instanceof Error ? e.message : String(e))
+            .split("\n")[0]
+            ?.slice(0, 200);
+
+          return { file: `${app}/${rel}`, detail: detail ?? "syntax error" };
+        }
+      }
+    } catch {
+      // glob/scan failure is non-fatal — the base message still guides the model.
+    }
+  }
+
+  return null;
+}
+
 export function boringstackCommandStage(cwd: string, exec: Exec): IStage {
   return {
     async run(): Promise<IValidateResult> {
@@ -218,6 +264,22 @@ export function boringstackCommandStage(cwd: string, exec: Exec): IStage {
         signatures.length > 0
           ? signatures.map(signatureToError)
           : [opaqueGateError(result.output, cwd)];
+
+      // If the whole type-aware program failed to parse, name the actual broken file (ESLint's
+      // cascade can't) so the model rewrites THAT file instead of thrashing near-green hunting it.
+      const unparsable = errors.find(
+        (e) => e.rule === "eslint-program-unparsable"
+      );
+
+      if (unparsable !== undefined) {
+        const located = await locateParseError(cwd);
+
+        if (located !== null) {
+          unparsable.message +=
+            ` → The broken file is \`${located.file}\` (${located.detail}). ` +
+            `REWRITE \`${located.file}\` IN FULL — do not surgically patch it.`;
+        }
+      }
 
       return { passed: false, errors, output: result.output };
     },

--- a/packages/core/src/loop/boringstack/gate-stages.ts
+++ b/packages/core/src/loop/boringstack/gate-stages.ts
@@ -348,22 +348,19 @@ export async function locateParseError(
   return null;
 }
 
-const UNPARSABLE_PREAMBLE =
-  "The TypeScript-aware lint could not build its program: ONE file has a real syntax/parse " +
-  "error, which makes ESLint report a `parserOptions.project` error on every file. This is " +
-  "ONE broken file, not many — do NOT chase the per-file parse errors.";
-
 /**
- * REPLACE the file-less `eslint-program-unparsable` message with precise, non-contradictory
- * guidance. The message is REPLACED (never appended) so the base text's generic "REWRITE IT IN
- * FULL" can't co-exist with an out-of-scope "do NOT edit". FAIL-CLOSED in every branch — a rewrite
- * instruction is issued ONLY for a file CONFIRMED in the model's editable scope:
- *   • located + in scope → fix that file (and set `.file` so stuck-file/expert consumers agree);
- *   • located + out of scope → named as info + flagged blocked, never a rewrite;
- *   • NOT located (incl. a swallowed scan failure) → no in-scope rewrite target is asserted; the
- *     model is told to check the files it just edited, else report blocked.
- * A file the parser rejects necessarily breaks the SHARED type-aware program (same parser as the
- * lint), so naming any real syntax error in the failing app is a sound fix target.
+ * APPEND a high-confidence pointer to the file-less `eslint-program-unparsable` message — and ONLY
+ * a high-confidence one. We do NOT try to reconstruct ESLint's project graph; we add a hint only
+ * when all of these hold, otherwise we stay silent and leave the (generic) base message intact:
+ *   • the cascade was attributed to a specific failing app (`appsToScan` non-empty), AND
+ *   • a file in that app has a GENUINE syntax error (getSyntacticDiagnostics — never a config/
+ *     inclusion error, so a `parserOptions.project` message that is really a TSConfig problem is
+ *     never mis-labelled a syntax error), AND
+ *   • that file is in the model's editable scope.
+ * The hint is APPEND-ONLY and AGREES with the base ("find the broken file and rewrite it"), so it
+ * can never contradict it; it never names an out-of-scope file (no ownership bypass); and it never
+ * mutates `.file`/phase (no file-vs-phase disagreement for downstream stuck/frontier logic). When
+ * any condition fails the base message stands unchanged — a safe, silent no-op.
  */
 async function enrichUnparsable(
   unparsable: IErrorItem,
@@ -371,33 +368,19 @@ async function enrichUnparsable(
   scopeGlobs: readonly string[],
   appsToScan: readonly string[]
 ): Promise<void> {
+  if (appsToScan.length === 0 || scopeGlobs.length === 0) {
+    return;
+  }
+
   const located = await locateParseError(cwd, appsToScan);
 
-  if (located === null) {
-    unparsable.message =
-      `${UNPARSABLE_PREAMBLE} It could not be pinpointed automatically — inspect the files you ` +
-      `edited this cycle for an unterminated brace/generic/JSX and rewrite the offending file ` +
-      `cleanly. If you cannot find it among files you own, report this as blocked.`;
-
+  if (located === null || !fileInScope(located.file, scopeGlobs)) {
     return;
   }
 
-  const head = `The parse failure is in \`${located.file}\` (${located.detail}).`;
-
-  if (scopeGlobs.length > 0 && fileInScope(located.file, scopeGlobs)) {
-    unparsable.message =
-      `${UNPARSABLE_PREAMBLE} ${head} Fix the syntax error there — rewrite that file in full if ` +
-      `the cause is not obvious. Once it parses, the whole cascade clears at once.`;
-    // Structured consumers (stuck-file/expert/phase) now agree with the prose. Safe because the
-    // file is CONFIRMED in scope — an out-of-scope file stays file-less so it can't be hidden.
-    unparsable.file = located.file;
-
-    return;
-  }
-
-  unparsable.message =
-    `${UNPARSABLE_PREAMBLE} ${head} That file is OUTSIDE your editable scope (a shared/scaffold ` +
-    `file) — do NOT try to edit it. Report this as blocked.`;
+  unparsable.message +=
+    ` → A real syntax error was found in \`${located.file}\` (${located.detail}) — that is the ` +
+    `ONE file to rewrite; once it parses, the whole cascade clears at once.`;
 }
 
 export function boringstackCommandStage(
@@ -431,13 +414,16 @@ export function boringstackCommandStage(
       );
 
       if (unparsable !== undefined) {
-        // Scan only the app(s) whose gate section showed the cascade — never mis-attribute a UI
-        // cascade to an unrelated API syntax error. Fall back to both if the section is unclear.
-        const failing = appsWithParseCascade(result.output);
-        const appsToScan =
-          failing.length > 0 ? failing : ["apps/api", "apps/ui"];
-
-        await enrichUnparsable(unparsable, cwd, scopeGlobs, appsToScan);
+        // Scan ONLY the app(s) whose gate section showed the cascade — never mis-attribute a UI
+        // cascade to an unrelated API syntax error. If we can't attribute it to an app, we do NOT
+        // guess (no both-apps fallback): enrichUnparsable stays a silent no-op and the base
+        // guidance stands.
+        await enrichUnparsable(
+          unparsable,
+          cwd,
+          scopeGlobs,
+          appsWithParseCascade(result.output)
+        );
       }
 
       return { passed: false, errors, output: result.output };

--- a/packages/core/src/loop/boringstack/gate-stages.ts
+++ b/packages/core/src/loop/boringstack/gate-stages.ts
@@ -293,7 +293,10 @@ export async function locateParseError(
     const root = join(cwd, app);
 
     try {
-      const glob = new Bun.Glob("src/**/*.{ts,tsx}");
+      // `src` AND `tests` — the editable scope includes `apps/api/tests/api/<feature>/**`, and
+      // a syntax error in a test file breaks the type-aware program just the same, so it must be
+      // locatable too (else the feature silently falls back to the file-less guidance).
+      const glob = new Bun.Glob("{src,tests}/**/*.{ts,tsx}");
 
       for await (const rel of glob.scan({ cwd: root })) {
         let code: string;
@@ -319,13 +322,15 @@ export async function locateParseError(
 }
 
 /**
- * Append a located-parse-error pointer to the file-less `eslint-program-unparsable` error.
+ * REPLACE the file-less `eslint-program-unparsable` message once the real broken file is located.
  * A file the parser rejects necessarily breaks the SHARED type-aware program (typescript-eslint
  * parses the same files with the same parser), so naming any real syntax error is a sound fix
  * target; if none is found — a config/`include` failure, not a syntax cascade — the message is
- * left unchanged (no fabricated pointer). The guidance is SCOPE-AWARE: an in-scope file is
- * actionable ("fix it"); a file the model cannot edit is flagged as blocked, never a rewrite
- * instruction that would bypass ownership.
+ * left unchanged (no fabricated pointer). The message is REPLACED (not appended) so the base
+ * text's generic "REWRITE IT IN FULL" directive can't contradict the out-of-scope "do NOT edit"
+ * guidance. The guidance is SCOPE-AWARE and FAIL-CLOSED: only a file CONFIRMED in the model's
+ * editable scope gets a rewrite instruction; a file outside scope — or when scope is unknown —
+ * is flagged as blocked, never a rewrite that would bypass ownership.
  */
 async function enrichUnparsable(
   unparsable: IErrorItem,
@@ -338,17 +343,21 @@ async function enrichUnparsable(
     return;
   }
 
-  const head = ` → The parse failure is in \`${located.file}\` (${located.detail}).`;
+  const preamble =
+    "The TypeScript-aware lint could not build its program: ONE file has a real syntax/parse " +
+    "error, which makes ESLint report a `parserOptions.project` error on every file. This is " +
+    "ONE broken file, not many — do NOT chase the per-file parse errors.";
+  const head = `The parse failure is in \`${located.file}\` (${located.detail}).`;
+  const editable =
+    scopeGlobs.length > 0 && fileInScope(located.file, scopeGlobs);
 
-  // No scope info (e.g. a direct caller) OR the file is editable → actionable fix.
-  // A located file outside the model's scope is a shared/scaffold file it cannot edit —
-  // flag it as blocked rather than issuing a rewrite instruction that bypasses ownership.
-  unparsable.message +=
-    scopeGlobs.length === 0 || fileInScope(located.file, scopeGlobs)
-      ? `${head} Fix the syntax error there — rewrite that file in full if the cause is not obvious. ` +
-        `It is the one file blocking the whole type-aware gate.`
-      : `${head} That file is OUTSIDE your editable scope (a shared/scaffold file) — do NOT try to ` +
-        `edit it. Report this as blocked.`;
+  // FAIL-CLOSED: only a CONFIRMED-editable file gets a rewrite instruction. Anything else
+  // (out of scope, or scope unknown) is named as info + flagged blocked — never a rewrite.
+  unparsable.message = editable
+    ? `${preamble} ${head} Fix the syntax error there — rewrite that file in full if the cause ` +
+      `is not obvious. Once it parses, the whole cascade clears at once.`
+    : `${preamble} ${head} That file is OUTSIDE your editable scope (a shared/scaffold file) — ` +
+      `do NOT try to edit it. Report this as blocked.`;
 }
 
 export function boringstackCommandStage(

--- a/packages/core/src/loop/boringstack/gate-stages.ts
+++ b/packages/core/src/loop/boringstack/gate-stages.ts
@@ -205,32 +205,57 @@ const PARSE_DETAIL_CAP = 200;
 const PARSE_TRUNCATION_MARKER = "…(truncated)";
 
 /**
- * Report the FIRST genuine syntax error in one source file, or null if it parses.
- * Uses the TypeScript compiler's own parser (`transpileModule`, syntax-only — it does NO
- * type-checking) so this agrees with typescript-eslint's parser: a file that is valid TS is
- * NEVER falsely fingered. Global option diagnostics (no `file`) are ignored — only located,
- * in-file parse errors count. Returns `line L:C — <message>` (truncation-marked, never silent).
+ * Report the FIRST genuine SYNTAX error in one source file, or null if it parses.
+ *
+ * Uses `Program.getSyntacticDiagnostics` — syntax-only BY CONTRACT (no type-checking, no
+ * semantic/`isolatedModules` diagnostics), so it agrees exactly with what typescript-eslint's
+ * parser reports as a "Parsing error". A file that is valid TypeScript — `const enum`,
+ * `import type`, a `<T,>` generic — is NEVER falsely fingered (`transpileModule` would flag
+ * some of these; the parser will not). The program is single-file and in-memory (`noLib` +
+ * `noResolve`), so no lib/type resolution runs. Returns `line L:C — <message>`, truncation-marked.
  */
 function firstSyntaxError(code: string, fileName: string): string | null {
-  const out = ts.transpileModule(code, {
-    reportDiagnostics: true,
+  const scriptKind = fileName.endsWith(".tsx")
+    ? ts.ScriptKind.TSX
+    : ts.ScriptKind.TS;
+  const sourceFile = ts.createSourceFile(
     fileName,
-    compilerOptions: {
+    code,
+    ts.ScriptTarget.Latest,
+    /*setParentNodes*/ true,
+    scriptKind
+  );
+
+  const host: ts.CompilerHost = {
+    getSourceFile: (name) => (name === fileName ? sourceFile : undefined),
+    getDefaultLibFileName: () => "lib.d.ts",
+    writeFile: () => undefined,
+    getCurrentDirectory: () => "",
+    getDirectories: () => [],
+    getCanonicalFileName: (name) => name,
+    useCaseSensitiveFileNames: () => true,
+    getNewLine: () => "\n",
+    fileExists: (name) => name === fileName,
+    readFile: () => undefined,
+  };
+
+  const program = ts.createProgram(
+    [fileName],
+    {
       jsx: ts.JsxEmit.Preserve,
       target: ts.ScriptTarget.Latest,
       module: ts.ModuleKind.ESNext,
-      isolatedModules: true,
+      noLib: true,
+      noResolve: true,
     },
-  });
-
-  const diag = (out.diagnostics ?? []).find(
-    (d) =>
-      d.category === ts.DiagnosticCategory.Error &&
-      d.file !== undefined &&
-      d.start !== undefined
+    host
   );
 
-  if (diag?.file === undefined || diag.start === undefined) {
+  // getSyntacticDiagnostics returns DiagnosticWithLocation (file + start guaranteed) and is
+  // syntax-only by contract — the first entry, if any, is the genuine parse error.
+  const diag = program.getSyntacticDiagnostics(sourceFile)[0];
+
+  if (diag === undefined) {
     return null;
   }
 
@@ -243,6 +268,11 @@ function firstSyntaxError(code: string, fileName: string): string | null {
   return detail.length > PARSE_DETAIL_CAP
     ? `${detail.slice(0, PARSE_DETAIL_CAP)}${PARSE_TRUNCATION_MARKER}`
     : detail;
+}
+
+/** True if `file` (repo-relative) falls under any of the scope globs the model may edit. */
+function fileInScope(file: string, scopeGlobs: readonly string[]): boolean {
+  return scopeGlobs.some((glob) => new Bun.Glob(glob).match(file));
 }
 
 /**
@@ -288,7 +318,44 @@ export async function locateParseError(
   return null;
 }
 
-export function boringstackCommandStage(cwd: string, exec: Exec): IStage {
+/**
+ * Append a located-parse-error pointer to the file-less `eslint-program-unparsable` error.
+ * A file the parser rejects necessarily breaks the SHARED type-aware program (typescript-eslint
+ * parses the same files with the same parser), so naming any real syntax error is a sound fix
+ * target; if none is found — a config/`include` failure, not a syntax cascade — the message is
+ * left unchanged (no fabricated pointer). The guidance is SCOPE-AWARE: an in-scope file is
+ * actionable ("fix it"); a file the model cannot edit is flagged as blocked, never a rewrite
+ * instruction that would bypass ownership.
+ */
+async function enrichUnparsable(
+  unparsable: IErrorItem,
+  cwd: string,
+  scopeGlobs: readonly string[]
+): Promise<void> {
+  const located = await locateParseError(cwd);
+
+  if (located === null) {
+    return;
+  }
+
+  const head = ` → The parse failure is in \`${located.file}\` (${located.detail}).`;
+
+  // No scope info (e.g. a direct caller) OR the file is editable → actionable fix.
+  // A located file outside the model's scope is a shared/scaffold file it cannot edit —
+  // flag it as blocked rather than issuing a rewrite instruction that bypasses ownership.
+  unparsable.message +=
+    scopeGlobs.length === 0 || fileInScope(located.file, scopeGlobs)
+      ? `${head} Fix the syntax error there — rewrite that file in full if the cause is not obvious. ` +
+        `It is the one file blocking the whole type-aware gate.`
+      : `${head} That file is OUTSIDE your editable scope (a shared/scaffold file) — do NOT try to ` +
+        `edit it. Report this as blocked.`;
+}
+
+export function boringstackCommandStage(
+  cwd: string,
+  exec: Exec,
+  scopeGlobs: readonly string[] = []
+): IStage {
   return {
     async run(): Promise<IValidateResult> {
       await autofixApps(cwd, exec);
@@ -315,15 +382,7 @@ export function boringstackCommandStage(cwd: string, exec: Exec): IStage {
       );
 
       if (unparsable !== undefined) {
-        const located = await locateParseError(cwd);
-
-        if (located !== null) {
-          unparsable.message +=
-            ` → The parse failure is in \`${located.file}\` (${located.detail}). ` +
-            `Fix the syntax error there — rewrite that file in full if the cause is not obvious. ` +
-            `This is the one file blocking the whole type-aware gate; if it is outside your ` +
-            `current feature, it is still the file to fix.`;
-        }
+        await enrichUnparsable(unparsable, cwd, scopeGlobs);
       }
 
       return { passed: false, errors, output: result.output };
@@ -529,13 +588,19 @@ export function composeBoringstackGate(opts: {
   /** The OTHER features/entities in this build, so the judge scopes to this
    *  feature's own responsibilities and never demands a link to an unbuilt slice. */
   siblingEntities?: readonly string[];
+  /** The globs the model may edit this feature — so a located parse error outside them is
+   *  flagged as blocked rather than issued as a rewrite instruction that bypasses ownership. */
+  scopeGlobs?: readonly string[];
 }): IGate {
   const { cwd, exec, evaluator, baseline, feature, entity } = opts;
   const e2eAcceptanceDisabled =
     process.env[ENV_FLAG.noE2eAcceptance] === FLAG_ON;
 
   return composeGate([
-    differentialStage(boringstackCommandStage(cwd, exec), baseline),
+    differentialStage(
+      boringstackCommandStage(cwd, exec, opts.scopeGlobs ?? []),
+      baseline
+    ),
     reachabilityStage(cwd, feature.id),
     ...(entity !== undefined && !e2eAcceptanceDisabled
       ? [testIdStage(cwd, entity)]

--- a/packages/core/src/loop/boringstack/gate-stages.ts
+++ b/packages/core/src/loop/boringstack/gate-stages.ts
@@ -11,7 +11,12 @@ import { runBoringstackGate } from "./gate";
 import { extractFailures, ESLINT_PROGRAM_UNPARSABLE } from "./extract-failures";
 import { verifyFeatureReachable } from "./reachability";
 import { judgeFeature } from "../greenfield/judge";
-import { autofixApps, readResourceCode, rescueFileFor } from "./build";
+import {
+  autofixApps,
+  featureOwnedGlobs,
+  readResourceCode,
+  rescueFileFor,
+} from "./build";
 import type { IEntityAcceptance } from "../acceptance/acceptance.types";
 import { checkTestIds } from "./acceptance/testid-contract";
 import { FLAG_ON, ENV_FLAG } from "../../config/config.constants";
@@ -291,7 +296,8 @@ async function safeFirstSyntaxError(
 /** Which app section(s) of the composed-gate output actually show the `parserOptions.project`
  *  cascade — so the locator scans the app that FAILED, not blindly apps/api then apps/ui. The
  *  output echoes `::tsforge-app <app>::` before each app's stages (see gate.ts). Empty when no
- *  section matches → the caller falls back to scanning both. */
+ *  section matches → enrichUnparsable stays a silent no-op (there is NO both-apps fallback: we do
+ *  not guess an app the output didn't implicate). */
 function appsWithParseCascade(output: string): string[] {
   const parts = output.split(/::tsforge-app (\S+)::/u);
   const apps: string[] = [];
@@ -318,14 +324,17 @@ function appsWithParseCascade(output: string): string[] {
  * `parserOptions.project` parse error across EVERY file, so its output can't say which file is
  * actually broken — and the model thrashes near-green hunting for it. Re-parse each source file
  * in ISOLATION with the TypeScript parser (`firstSyntaxError`) and return the first genuinely
- * malformed one (repo-relative) + its located message. Same parser as the lint, so it cannot
- * mis-name a healthy file. `appsToScan` is the app(s) whose gate section actually showed the
- * cascade — so a UI cascade is never mis-attributed to an unrelated API syntax error. Scans
- * `{src,tests}` (the editable scope includes `apps/api/tests/…`). Best-effort; never throws.
+ * malformed one that PASSES `isRewritable` (repo-relative) + its located message. Same parser as
+ * the lint, so it cannot mis-name a healthy file. `appsToScan` is the app(s) whose gate section
+ * actually showed the cascade — so a UI cascade is never mis-attributed to an unrelated API syntax
+ * error. `isRewritable` is applied DURING the scan (not to a single first hit): a broken file the
+ * model can't rewrite is skipped and the scan continues, so a later rewritable broken file is still
+ * found. Scans `{src,tests}` (feature scope includes `apps/api/tests/…`). Best-effort; never throws.
  */
 export async function locateParseError(
   cwd: string,
-  appsToScan: readonly string[]
+  appsToScan: readonly string[],
+  isRewritable: (repoRelPath: string) => boolean
 ): Promise<{ file: string; detail: string } | null> {
   for (const app of appsToScan) {
     const root = join(cwd, app);
@@ -334,10 +343,16 @@ export async function locateParseError(
       const glob = new Bun.Glob("{src,tests}/**/*.{ts,tsx}");
 
       for await (const rel of glob.scan({ cwd: root })) {
+        const file = `${app}/${rel}`;
+
+        if (!isRewritable(file)) {
+          continue;
+        }
+
         const detail = await safeFirstSyntaxError(join(root, rel), rel);
 
         if (detail !== null) {
-          return { file: `${app}/${rel}`, detail };
+          return { file, detail };
         }
       }
     } catch {
@@ -353,40 +368,44 @@ export async function locateParseError(
  * a high-confidence one. We do NOT try to reconstruct ESLint's project graph; we add a hint only
  * when all of these hold, otherwise we stay silent and leave the (generic) base message intact:
  *   • the cascade was attributed to a specific failing app (`appsToScan` non-empty), AND
- *   • a file in that app has a GENUINE syntax error (getSyntacticDiagnostics — never a config/
- *     inclusion error, so a `parserOptions.project` message that is really a TSConfig problem is
- *     never mis-labelled a syntax error), AND
- *   • that file is in the model's editable scope.
+ *   • a FEATURE-OWNED file (a dir the model may fully rewrite — never a shared add-only file) in
+ *     that app has a GENUINE syntax error (getSyntacticDiagnostics — never a config/inclusion
+ *     error, so a `parserOptions.project` message that is really a TSConfig problem is never
+ *     mis-labelled a syntax error).
  * The hint is APPEND-ONLY and AGREES with the base ("find the broken file and rewrite it"), so it
- * can never contradict it; it never names an out-of-scope file (no ownership bypass); and it never
- * mutates `.file`/phase (no file-vs-phase disagreement for downstream stuck/frontier logic). When
- * any condition fails the base message stands unchanged — a safe, silent no-op.
+ * can never contradict it; it names only a feature-owned file (no ownership bypass, no shared-file
+ * clobber); it never mutates `.file`/phase (no file-vs-phase disagreement). The wording makes NO
+ * "this is the only broken file / the cascade will fully clear" claim — with two or more broken
+ * files that would mis-steer — it states the true, useful fact: this owned file has a real syntax
+ * error and must be fixed (and there may be more). When any condition fails, the base stands.
  */
 async function enrichUnparsable(
   unparsable: IErrorItem,
   cwd: string,
-  scopeGlobs: readonly string[],
+  rewritableGlobs: readonly string[],
   appsToScan: readonly string[]
 ): Promise<void> {
-  if (appsToScan.length === 0 || scopeGlobs.length === 0) {
+  if (appsToScan.length === 0 || rewritableGlobs.length === 0) {
     return;
   }
 
-  const located = await locateParseError(cwd, appsToScan);
+  const located = await locateParseError(cwd, appsToScan, (file) =>
+    fileInScope(file, rewritableGlobs)
+  );
 
-  if (located === null || !fileInScope(located.file, scopeGlobs)) {
+  if (located === null) {
     return;
   }
 
   unparsable.message +=
-    ` → A real syntax error was found in \`${located.file}\` (${located.detail}) — that is the ` +
-    `ONE file to rewrite; once it parses, the whole cascade clears at once.`;
+    ` → A real syntax error is in \`${located.file}\` (${located.detail}), a file you own — fix ` +
+    `it (there may be more than one broken file; every one must parse before the cascade clears).`;
 }
 
 export function boringstackCommandStage(
   cwd: string,
   exec: Exec,
-  scopeGlobs: readonly string[] = []
+  rewritableGlobs: readonly string[] = []
 ): IStage {
   return {
     async run(): Promise<IValidateResult> {
@@ -421,7 +440,7 @@ export function boringstackCommandStage(
         await enrichUnparsable(
           unparsable,
           cwd,
-          scopeGlobs,
+          rewritableGlobs,
           appsWithParseCascade(result.output)
         );
       }
@@ -629,18 +648,19 @@ export function composeBoringstackGate(opts: {
   /** The OTHER features/entities in this build, so the judge scopes to this
    *  feature's own responsibilities and never demands a link to an unbuilt slice. */
   siblingEntities?: readonly string[];
-  /** The globs the model may edit for this feature — so a located parse error outside them is
-   *  flagged as blocked rather than issued as a rewrite instruction that bypasses ownership.
-   *  REQUIRED: dropping it at the call site is a compile error, not a silently-green test. */
-  scopeGlobs: readonly string[];
 }): IGate {
   const { cwd, exec, evaluator, baseline, feature, entity } = opts;
   const e2eAcceptanceDisabled =
     process.env[ENV_FLAG.noE2eAcceptance] === FLAG_ON;
 
+  // The parse-error locator may only name a file the model can FULLY rewrite — its feature-owned
+  // dirs, NOT the shared add-only files (schema/locale/sidebar/routes). Derived here from the
+  // feature (no wiring to forget, no shared-file clobber).
+  const rewritableGlobs = featureOwnedGlobs(feature.id);
+
   return composeGate([
     differentialStage(
-      boringstackCommandStage(cwd, exec, opts.scopeGlobs),
+      boringstackCommandStage(cwd, exec, rewritableGlobs),
       baseline
     ),
     reachabilityStage(cwd, feature.id),

--- a/packages/core/src/loop/boringstack/gate-stages.ts
+++ b/packages/core/src/loop/boringstack/gate-stages.ts
@@ -1,5 +1,6 @@
 import { join } from "node:path";
 import { readdir, readFile } from "node:fs/promises";
+import ts from "typescript";
 import type { IGate, IStage } from "../../gate/gate-runner";
 import { composeGate, differentialStage } from "../../gate/gate-runner";
 import type { IValidateResult, IErrorItem } from "../../validate";
@@ -199,14 +200,61 @@ function opaqueGateError(output: string, cwd: string): IErrorItem {
  * becomes an `IErrorItem` whose `key` IS the signature — so the differential
  * wrapper can suppress baseline signatures and `checkStuck` can fingerprint them.
  */
+/** Cap the pinpoint detail; longer messages get an explicit truncation marker (never silent). */
+const PARSE_DETAIL_CAP = 200;
+const PARSE_TRUNCATION_MARKER = "…(truncated)";
+
+/**
+ * Report the FIRST genuine syntax error in one source file, or null if it parses.
+ * Uses the TypeScript compiler's own parser (`transpileModule`, syntax-only — it does NO
+ * type-checking) so this agrees with typescript-eslint's parser: a file that is valid TS is
+ * NEVER falsely fingered. Global option diagnostics (no `file`) are ignored — only located,
+ * in-file parse errors count. Returns `line L:C — <message>` (truncation-marked, never silent).
+ */
+function firstSyntaxError(code: string, fileName: string): string | null {
+  const out = ts.transpileModule(code, {
+    reportDiagnostics: true,
+    fileName,
+    compilerOptions: {
+      jsx: ts.JsxEmit.Preserve,
+      target: ts.ScriptTarget.Latest,
+      module: ts.ModuleKind.ESNext,
+      isolatedModules: true,
+    },
+  });
+
+  const diag = (out.diagnostics ?? []).find(
+    (d) =>
+      d.category === ts.DiagnosticCategory.Error &&
+      d.file !== undefined &&
+      d.start !== undefined
+  );
+
+  if (diag?.file === undefined || diag.start === undefined) {
+    return null;
+  }
+
+  const { line, character } = diag.file.getLineAndCharacterOfPosition(
+    diag.start
+  );
+  const message = ts.flattenDiagnosticMessageText(diag.messageText, " ");
+  const detail = `line ${line + 1}:${character + 1} — ${message}`;
+
+  return detail.length > PARSE_DETAIL_CAP
+    ? `${detail.slice(0, PARSE_DETAIL_CAP)}${PARSE_TRUNCATION_MARKER}`
+    : detail;
+}
+
 /**
  * Pinpoint the ONE file with a real syntax error behind an `eslint-program-unparsable` cascade.
  * The type-aware ESLint program fails to build off a single broken file yet fans a
  * `parserOptions.project` parse error across EVERY .tsx, so its output can't say which file is
- * actually broken — and the model thrashes near-green hunting for it. Transpile each source file
- * in ISOLATION (Bun's transpiler builds no cross-file program, so only the genuinely-malformed
- * file throws); return the first broken one (repo-relative) + the parser's first message line.
- * Best-effort and fast (sub-ms/file, only runs on the rare cascade). Never throws.
+ * actually broken — and the model thrashes near-green hunting for it. Re-parse each source file
+ * in ISOLATION with the TypeScript parser (`firstSyntaxError`) and return the first genuinely
+ * malformed one (repo-relative) + its located message. Same parser as the lint, so it cannot
+ * mis-name a healthy file. Because there are no false positives, the apps/api-before-ui scan
+ * order is harmless — if both apps hold a real syntax error, either is a correct thing to fix.
+ * Best-effort and fast (only runs on the rare cascade). Never throws.
  */
 export async function locateParseError(
   cwd: string
@@ -218,7 +266,6 @@ export async function locateParseError(
       const glob = new Bun.Glob("src/**/*.{ts,tsx}");
 
       for await (const rel of glob.scan({ cwd: root })) {
-        const loader = rel.endsWith(".tsx") ? "tsx" : "ts";
         let code: string;
 
         try {
@@ -227,14 +274,10 @@ export async function locateParseError(
           continue;
         }
 
-        try {
-          new Bun.Transpiler({ loader }).transformSync(code);
-        } catch (e) {
-          const detail = (e instanceof Error ? e.message : String(e))
-            .split("\n")[0]
-            ?.slice(0, 200);
+        const detail = firstSyntaxError(code, rel);
 
-          return { file: `${app}/${rel}`, detail: detail ?? "syntax error" };
+        if (detail !== null) {
+          return { file: `${app}/${rel}`, detail };
         }
       }
     } catch {
@@ -276,8 +319,10 @@ export function boringstackCommandStage(cwd: string, exec: Exec): IStage {
 
         if (located !== null) {
           unparsable.message +=
-            ` → The broken file is \`${located.file}\` (${located.detail}). ` +
-            `REWRITE \`${located.file}\` IN FULL — do not surgically patch it.`;
+            ` → The parse failure is in \`${located.file}\` (${located.detail}). ` +
+            `Fix the syntax error there — rewrite that file in full if the cause is not obvious. ` +
+            `This is the one file blocking the whole type-aware gate; if it is outside your ` +
+            `current feature, it is still the file to fix.`;
         }
       }
 

--- a/packages/core/tests/boringstack-acceptance-wiring.test.ts
+++ b/packages/core/tests/boringstack-acceptance-wiring.test.ts
@@ -345,7 +345,6 @@ test("testIdStage: respects the e2e acceptance flag when disabled", async () => 
       baseline: new Set(),
       feature: mockFeature,
       entity: mockEntity,
-      scopeGlobs: [],
     });
 
     // Gate should exist but testIdStage should not be included
@@ -376,7 +375,6 @@ test("testIdStage: runs when e2e acceptance is enabled", async () => {
       baseline: new Set(),
       feature: mockFeature,
       entity: mockEntity,
-      scopeGlobs: [],
     });
 
     // Gate should exist

--- a/packages/core/tests/boringstack-acceptance-wiring.test.ts
+++ b/packages/core/tests/boringstack-acceptance-wiring.test.ts
@@ -345,6 +345,7 @@ test("testIdStage: respects the e2e acceptance flag when disabled", async () => 
       baseline: new Set(),
       feature: mockFeature,
       entity: mockEntity,
+      scopeGlobs: [],
     });
 
     // Gate should exist but testIdStage should not be included
@@ -375,6 +376,7 @@ test("testIdStage: runs when e2e acceptance is enabled", async () => {
       baseline: new Set(),
       feature: mockFeature,
       entity: mockEntity,
+      scopeGlobs: [],
     });
 
     // Gate should exist

--- a/packages/core/tests/boringstack-gate-stages.test.ts
+++ b/packages/core/tests/boringstack-gate-stages.test.ts
@@ -1,9 +1,13 @@
 import { test, expect, describe } from "bun:test";
+import { mkdtemp, mkdir, writeFile, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import {
   boringstackCommandStage,
   reachabilityStage,
   judgeStage,
   signatureToError,
+  locateParseError,
 } from "../src/loop/boringstack/gate-stages";
 import type { Exec } from "../src/loop/boringstack/exec";
 import type { IFeature } from "../src/loop/greenfield/greenfield.types";
@@ -269,5 +273,56 @@ describe("judgeStage", () => {
     const stage = judgeStage(providerWithPass, "/tmp/clone", feature);
 
     expect((await stage.run("/tmp/clone")).passed).toBe(true);
+  });
+});
+
+describe("locateParseError", () => {
+  test("names the ONE file with a real syntax error among good files (disambiguates the cascade)", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "tsforge-parse-"));
+
+    try {
+      await mkdir(join(dir, "apps/ui/src/features/company"), {
+        recursive: true,
+      });
+      await mkdir(join(dir, "apps/api/src"), { recursive: true });
+      // Good files (must NOT be fingered)
+      await writeFile(
+        join(dir, "apps/api/src/ok.ts"),
+        "export const n: number = 1;\n"
+      );
+      await writeFile(
+        join(dir, "apps/ui/src/features/company/Good.tsx"),
+        "export const G = () => <div className='x'>hi</div>;\n"
+      );
+      // The ONE broken file — malformed JSX ('>' expected)
+      await writeFile(
+        join(dir, "apps/ui/src/features/company/Broken.tsx"),
+        "export const B = () => <div className='x' hi</div>;\n"
+      );
+
+      const located = await locateParseError(dir);
+
+      expect(located).not.toBeNull();
+      expect(located?.file).toBe("apps/ui/src/features/company/Broken.tsx");
+      expect(located?.detail.length).toBeGreaterThan(0);
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  test("returns null when every source file parses cleanly", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "tsforge-parse-ok-"));
+
+    try {
+      await mkdir(join(dir, "apps/ui/src"), { recursive: true });
+      await writeFile(
+        join(dir, "apps/ui/src/Ok.tsx"),
+        "export const G = () => <span>ok</span>;\n"
+      );
+
+      expect(await locateParseError(dir)).toBeNull();
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
   });
 });

--- a/packages/core/tests/boringstack-gate-stages.test.ts
+++ b/packages/core/tests/boringstack-gate-stages.test.ts
@@ -4,11 +4,13 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import {
   boringstackCommandStage,
+  composeBoringstackGate,
   reachabilityStage,
   judgeStage,
   signatureToError,
   locateParseError,
 } from "../src/loop/boringstack/gate-stages";
+import { scopeFor } from "../src/loop/boringstack/build";
 import type { Exec } from "../src/loop/boringstack/exec";
 import type { IFeature } from "../src/loop/greenfield/greenfield.types";
 import type { IProvider } from "../src/inference";
@@ -175,6 +177,10 @@ describe("boringstackCommandStage", () => {
       expect(unparsable?.message).toContain("OUTSIDE your editable scope");
       expect(unparsable?.message).toContain("Report this as blocked");
       expect(unparsable?.message).not.toContain("Fix the syntax error there");
+      // The message is REPLACED, so the base "REWRITE IT IN FULL" directive must be GONE — else
+      // the model gets "rewrite this file" AND "do not edit it" (the contradiction the panel flagged).
+      expect(unparsable?.message).not.toContain("REWRITE IT IN FULL");
+      expect(unparsable?.message).not.toContain("rewrite that file in full");
     } finally {
       await rm(dir, { recursive: true, force: true });
     }
@@ -493,5 +499,127 @@ describe("locateParseError", () => {
     } finally {
       await rm(dir, { recursive: true, force: true });
     }
+  });
+
+  test("locates a syntax error in an API TEST file (apps/api/tests is editable scope, so it must be scannable)", async () => {
+    // The editable scope includes `apps/api/tests/api/<feature>/**`; a parse error there breaks the
+    // type-aware program the same way, so it must be locatable — not silently missed.
+    const dir = await mkdtemp(join(tmpdir(), "tsforge-parse-apitests-"));
+
+    try {
+      await mkdir(join(dir, "apps/api/tests/api/company"), { recursive: true });
+      await writeFile(
+        join(dir, "apps/api/tests/api/company/company.route.test.ts"),
+        "export const bad: = 1;\n"
+      );
+
+      const located = await locateParseError(dir);
+
+      expect(located?.file).toBe(
+        "apps/api/tests/api/company/company.route.test.ts"
+      );
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+});
+
+describe("composeBoringstackGate scope wiring", () => {
+  const passthroughJudge: IProvider = {
+    complete: async () => ({
+      content: '{"pass":true,"notes":"ok"}',
+      toolCalls: [],
+    }),
+  };
+  const cascade = (dir: string): string =>
+    [
+      join(dir, "apps/ui/src/features/company/Company.tsx"),
+      "  1:29 error Parsing error: parserOptions.project has been set for @typescript-eslint/parser",
+      "",
+      "✖ 1 problem (1 error, 0 warnings)",
+    ].join("\n");
+
+  const runComposed = async (
+    dir: string,
+    scopeGlobs: readonly string[]
+  ): Promise<string> => {
+    const gate = composeBoringstackGate({
+      cwd: dir,
+      exec: execWith(1, cascade(dir)),
+      evaluator: passthroughJudge,
+      baseline: new Set<string>(),
+      feature,
+      scopeGlobs,
+    });
+    const result = await gate.run(dir);
+    const unparsable = result.errors.find(
+      (e) => e.rule === "eslint-program-unparsable"
+    );
+
+    return unparsable?.message ?? "";
+  };
+
+  test("scopeGlobs flow through composeBoringstackGate → the located file is treated as editable when in scope", async () => {
+    // The panel's wiring finding: forwarding scopeGlobs from composeBoringstackGate into the command
+    // stage must be exercised — otherwise the stage-level tests stay green even if compose stops
+    // forwarding. A REAL scopeFor("company") glob set proves the production path.
+    const dir = await mkdtemp(join(tmpdir(), "tsforge-compose-in-"));
+
+    try {
+      await mkdir(join(dir, "apps/ui/src/features/company"), {
+        recursive: true,
+      });
+      await writeFile(
+        join(dir, "apps/ui/src/features/company/Company.tsx"),
+        "export const B = () => <div className='x' hi</div>;\n"
+      );
+
+      const message = await runComposed(dir, scopeFor("company"));
+
+      expect(message).toContain("apps/ui/src/features/company/Company.tsx");
+      expect(message).toContain("Fix the syntax error there");
+      expect(message).not.toContain("OUTSIDE your editable scope");
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  test("scopeGlobs flow through composeBoringstackGate → an out-of-scope located file is flagged blocked", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "tsforge-compose-out-"));
+
+    try {
+      // A broken file in ANOTHER feature's dir — not covered by scopeFor("company").
+      await mkdir(join(dir, "apps/ui/src/features/contact"), {
+        recursive: true,
+      });
+      await writeFile(
+        join(dir, "apps/ui/src/features/contact/Contact.tsx"),
+        "export const B = () => <div className='x' hi</div>;\n"
+      );
+
+      const message = await runComposed(dir, scopeFor("company"));
+
+      expect(message).toContain("apps/ui/src/features/contact/Contact.tsx");
+      expect(message).toContain("OUTSIDE your editable scope");
+      expect(message).not.toContain("Fix the syntax error there");
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+});
+
+describe("scopeFor", () => {
+  test("covers the feature's UI/API source AND its API test dir (so a parse error in either is in-scope)", () => {
+    const globs = scopeFor("company");
+    const inScope = (file: string): boolean =>
+      globs.some((g) => new Bun.Glob(g).match(file));
+
+    expect(inScope("apps/ui/src/features/company/Company.tsx")).toBe(true);
+    expect(inScope("apps/api/src/api/company/company.service.ts")).toBe(true);
+    expect(inScope("apps/api/tests/api/company/company.route.test.ts")).toBe(
+      true
+    );
+    // Another feature's file is NOT in scope.
+    expect(inScope("apps/ui/src/features/contact/Contact.tsx")).toBe(false);
   });
 });

--- a/packages/core/tests/boringstack-gate-stages.test.ts
+++ b/packages/core/tests/boringstack-gate-stages.test.ts
@@ -10,7 +10,7 @@ import {
   signatureToError,
   locateParseError,
 } from "../src/loop/boringstack/gate-stages";
-import { scopeFor } from "../src/loop/boringstack/build";
+import { scopeFor, featureOwnedGlobs } from "../src/loop/boringstack/build";
 import type { Exec } from "../src/loop/boringstack/exec";
 import type { IFeature } from "../src/loop/greenfield/greenfield.types";
 import type { IProvider } from "../src/inference";
@@ -133,13 +133,12 @@ describe("boringstackCommandStage", () => {
 
       expect(unparsable).toBeDefined();
       // The enrichment appended a hint that NAMES the real broken file the cascade hid,
-      expect(unparsable?.message).toContain("A real syntax error was found in");
+      expect(unparsable?.message).toContain("A real syntax error is in");
       expect(unparsable?.message).toContain(
         "apps/ui/src/features/company/Company.tsx"
       );
       // with the located line/col detail and the fix framing,
       expect(unparsable?.message).toContain("line 1:");
-      expect(unparsable?.message).toContain("ONE file to rewrite");
       // and it did NOT falsely finger ANY valid-TS sibling (the whole point of the parser fix).
       expect(unparsable?.message).not.toContain("Enum.ts");
       expect(unparsable?.message).not.toContain("Types.ts");
@@ -177,9 +176,7 @@ describe("boringstackCommandStage", () => {
 
       expect(unparsable).toBeDefined();
       // No append: the out-of-scope file is never named nor directed for a rewrite.
-      expect(unparsable?.message).not.toContain(
-        "A real syntax error was found in"
-      );
+      expect(unparsable?.message).not.toContain("A real syntax error is in");
       expect(unparsable?.message).not.toContain("Contact.tsx");
       // The generic base guidance is left untouched (names no specific file → no bypass).
       expect(unparsable?.message).toContain("ONE broken file");
@@ -224,7 +221,7 @@ describe("boringstackCommandStage", () => {
       expect(unparsable?.message).toContain(
         "apps/ui/src/features/company/Company.tsx"
       );
-      expect(unparsable?.message).toContain("A real syntax error was found in");
+      expect(unparsable?.message).toContain("A real syntax error is in");
       // The unrelated API file was NOT scanned, so it is neither named nor treated as the blocker.
       expect(unparsable?.message).not.toContain("other.service.ts");
     } finally {
@@ -258,9 +255,7 @@ describe("boringstackCommandStage", () => {
       );
 
       expect(unparsable).toBeDefined();
-      expect(unparsable?.message).not.toContain(
-        "A real syntax error was found in"
-      );
+      expect(unparsable?.message).not.toContain("A real syntax error is in");
       expect(unparsable?.message).toContain("ONE broken file");
     } finally {
       await rm(dir, { recursive: true, force: true });
@@ -289,10 +284,95 @@ describe("boringstackCommandStage", () => {
         (e) => e.rule === "eslint-program-unparsable"
       );
 
-      expect(unparsable?.message).not.toContain(
-        "A real syntax error was found in"
-      );
+      expect(unparsable?.message).not.toContain("A real syntax error is in");
       expect(unparsable?.message).toContain("ONE broken file");
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  test("TWO broken feature-owned files → names one, WITHOUT a false 'only file / cascade clears' claim", async () => {
+    // Round-6 finding: with 2+ broken files, claiming the named one is THE file that clears the
+    // cascade mis-steers. The message must name one owned file and admit there may be more.
+    const dir = await mkdtemp(join(tmpdir(), "tsforge-cmd-parse-multi-"));
+
+    try {
+      await mkdir(join(dir, "apps/ui/src/features/company"), {
+        recursive: true,
+      });
+      await writeFile(
+        join(dir, "apps/ui/src/features/company/Company.tsx"),
+        "export const A = () => <div<;\n"
+      );
+      await writeFile(
+        join(dir, "apps/ui/src/features/company/Company.form.tsx"),
+        "export const B = () => <span<;\n"
+      );
+
+      const stage = boringstackCommandStage(
+        dir,
+        execWith(1, cascadeFor(dir)),
+        COMPANY_SCOPE
+      );
+      const result = await stage.run(dir);
+
+      const unparsable = result.errors.find(
+        (e) => e.rule === "eslint-program-unparsable"
+      );
+
+      // The APPENDED pointer names an owned broken file AND admits there may be more than one —
+      // so it never claims (as the earlier rounds did) that this single file clears the cascade.
+      expect(unparsable?.message).toContain("A real syntax error is in");
+      expect(unparsable?.message).toContain("there may be more than one");
+      // Names one of the two broken company files (whichever the scan hits first).
+      const names =
+        unparsable?.message.includes("Company.tsx") === true ||
+        unparsable?.message.includes("Company.form.tsx") === true;
+
+      expect(names).toBe(true);
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  test("an out-of-scope broken file does NOT suppress a later in-scope broken file (scope filter applied DURING scan)", async () => {
+    // Round-6 finding: scope must be checked during the scan, not on a single first hit — else a
+    // broken out-of-scope file encountered first makes enrichment a no-op despite a broken owned file.
+    const dir = await mkdtemp(join(tmpdir(), "tsforge-cmd-parse-order-"));
+
+    try {
+      await mkdir(join(dir, "apps/ui/src/features/contact"), {
+        recursive: true,
+      });
+      await mkdir(join(dir, "apps/ui/src/features/company"), {
+        recursive: true,
+      });
+      // Out of company scope (encountered in whatever Bun.Glob order):
+      await writeFile(
+        join(dir, "apps/ui/src/features/contact/Contact.tsx"),
+        "export const A = () => <div<;\n"
+      );
+      // In company scope — MUST be the one named regardless of walk order:
+      await writeFile(
+        join(dir, "apps/ui/src/features/company/Company.tsx"),
+        "export const B = () => <span<;\n"
+      );
+
+      const stage = boringstackCommandStage(
+        dir,
+        execWith(1, cascadeFor(dir)),
+        COMPANY_SCOPE
+      );
+      const result = await stage.run(dir);
+
+      const unparsable = result.errors.find(
+        (e) => e.rule === "eslint-program-unparsable"
+      );
+
+      expect(unparsable?.message).toContain(
+        "apps/ui/src/features/company/Company.tsx"
+      );
+      expect(unparsable?.message).not.toContain("Contact.tsx");
     } finally {
       await rm(dir, { recursive: true, force: true });
     }
@@ -527,7 +607,11 @@ describe("locateParseError", () => {
         "export const B = () => <div className='x' hi</div>;\n"
       );
 
-      const located = await locateParseError(dir, ["apps/api", "apps/ui"]);
+      const located = await locateParseError(
+        dir,
+        ["apps/api", "apps/ui"],
+        () => true
+      );
 
       expect(located).not.toBeNull();
       expect(located?.file).toBe("apps/ui/src/features/company/Broken.tsx");
@@ -547,7 +631,9 @@ describe("locateParseError", () => {
         "export const G = () => <span>ok</span>;\n"
       );
 
-      expect(await locateParseError(dir, ["apps/api", "apps/ui"])).toBeNull();
+      expect(
+        await locateParseError(dir, ["apps/api", "apps/ui"], () => true)
+      ).toBeNull();
     } finally {
       await rm(dir, { recursive: true, force: true });
     }
@@ -574,7 +660,9 @@ describe("locateParseError", () => {
         "export function first<T,>(xs: readonly T[]): T | undefined {\n  return xs[0];\n}\n"
       );
 
-      expect(await locateParseError(dir, ["apps/api", "apps/ui"])).toBeNull();
+      expect(
+        await locateParseError(dir, ["apps/api", "apps/ui"], () => true)
+      ).toBeNull();
     } finally {
       await rm(dir, { recursive: true, force: true });
     }
@@ -592,7 +680,11 @@ describe("locateParseError", () => {
         "export const bad: = 1;\n"
       );
 
-      const located = await locateParseError(dir, ["apps/api", "apps/ui"]);
+      const located = await locateParseError(
+        dir,
+        ["apps/api", "apps/ui"],
+        () => true
+      );
 
       expect(located?.file).toBe(
         "apps/api/tests/api/company/company.route.test.ts"
@@ -610,118 +702,127 @@ describe("composeBoringstackGate scope wiring", () => {
       toolCalls: [],
     }),
   };
-  const cascade = (dir: string): string =>
+  // composeBoringstackGate derives the rewritable globs from feature.id ("note") via
+  // featureOwnedGlobs — there is NO scopeGlobs param to forget, so the wiring is exercised here.
+  const noteCascade = (dir: string): string =>
     [
       "::tsforge-app apps/ui::",
-      join(dir, "apps/ui/src/features/company/Company.tsx"),
+      join(dir, "apps/ui/src/features/note/Note.tsx"),
       "  1:29 error Parsing error: parserOptions.project has been set for @typescript-eslint/parser",
       "",
       "✖ 1 problem (1 error, 0 warnings)",
     ].join("\n");
 
-  const runComposed = async (
-    dir: string,
-    scopeGlobs: readonly string[]
-  ): Promise<string> => {
+  const runComposed = async (dir: string, output: string): Promise<string> => {
     const gate = composeBoringstackGate({
       cwd: dir,
-      exec: execWith(1, cascade(dir)),
+      exec: execWith(1, output),
       evaluator: passthroughJudge,
       baseline: new Set<string>(),
       feature,
-      scopeGlobs,
     });
     const result = await gate.run(dir);
-    const unparsable = result.errors.find(
-      (e) => e.rule === "eslint-program-unparsable"
-    );
 
-    return unparsable?.message ?? "";
+    return (
+      result.errors.find((e) => e.rule === "eslint-program-unparsable")
+        ?.message ?? ""
+    );
   };
 
-  test("scopeGlobs flow through composeBoringstackGate → the located file is treated as editable when in scope", async () => {
-    // The panel's wiring finding: forwarding scopeGlobs from composeBoringstackGate into the command
-    // stage must be exercised — otherwise the stage-level tests stay green even if compose stops
-    // forwarding. A REAL scopeFor("company") glob set proves the production path.
+  test("wiring: composeBoringstackGate derives the feature's OWN dirs → names an in-scope broken file", async () => {
+    // The recurring wiring finding: the rewritable scope must reach the command stage. composeBoringstackGate
+    // derives featureOwnedGlobs(feature.id) internally (feature = "note"), so this exercises the real path
+    // with NO scopeGlobs to pass — a broken file in the note feature dir is named.
     const dir = await mkdtemp(join(tmpdir(), "tsforge-compose-in-"));
 
     try {
-      await mkdir(join(dir, "apps/ui/src/features/company"), {
-        recursive: true,
-      });
+      await mkdir(join(dir, "apps/ui/src/features/note"), { recursive: true });
       await writeFile(
-        join(dir, "apps/ui/src/features/company/Company.tsx"),
+        join(dir, "apps/ui/src/features/note/Note.tsx"),
         "export const B = () => <div className='x' hi</div>;\n"
       );
 
-      const message = await runComposed(dir, scopeFor("company"));
+      const message = await runComposed(dir, noteCascade(dir));
 
-      expect(message).toContain("apps/ui/src/features/company/Company.tsx");
-      expect(message).toContain("A real syntax error was found in");
+      expect(message).toContain("apps/ui/src/features/note/Note.tsx");
+      expect(message).toContain("A real syntax error is in");
     } finally {
       await rm(dir, { recursive: true, force: true });
     }
   });
 
-  test("scopeGlobs flow through composeBoringstackGate → an out-of-scope located file gets NO append", async () => {
+  test("wiring: a broken file OUTSIDE the feature's own dirs gets NO append", async () => {
     const dir = await mkdtemp(join(tmpdir(), "tsforge-compose-out-"));
 
     try {
-      // A broken file in ANOTHER feature's dir — not covered by scopeFor("company").
-      await mkdir(join(dir, "apps/ui/src/features/contact"), {
-        recursive: true,
-      });
+      // A broken file in ANOTHER feature's dir — not covered by featureOwnedGlobs("note").
+      await mkdir(join(dir, "apps/ui/src/features/other"), { recursive: true });
       await writeFile(
-        join(dir, "apps/ui/src/features/contact/Contact.tsx"),
+        join(dir, "apps/ui/src/features/other/Other.tsx"),
         "export const B = () => <div className='x' hi</div>;\n"
       );
 
-      const message = await runComposed(dir, scopeFor("company"));
+      const message = await runComposed(dir, noteCascade(dir));
 
-      // Out of scope → no pointer appended; the file is never named.
-      expect(message).not.toContain("A real syntax error was found in");
-      expect(message).not.toContain("Contact.tsx");
+      expect(message).not.toContain("A real syntax error is in");
+      expect(message).not.toContain("Other.tsx");
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  test("wiring: a SHARED add-only file (app.schema.ts) is NEVER named for rewrite even when broken", async () => {
+    // scope-bypass finding: scopeFor grants edit access to shared add-only files, but the locator
+    // must use featureOwnedGlobs (feature dirs only), so a broken shared file is not named.
+    const dir = await mkdtemp(join(tmpdir(), "tsforge-compose-shared-"));
+
+    try {
+      await mkdir(join(dir, "apps/api/src/clients/postgres/schema"), {
+        recursive: true,
+      });
+      await writeFile(
+        join(dir, "apps/api/src/clients/postgres/schema/app.schema.ts"),
+        "export const bad: = 1;\n"
+      );
+
+      // Cascade attributed to apps/api; only the shared schema file is broken.
+      const output = [
+        "::tsforge-app apps/api::",
+        join(dir, "apps/api/src/clients/postgres/schema/app.schema.ts"),
+        "  1:14 error Parsing error: parserOptions.project has been set for @typescript-eslint/parser",
+        "✖ 1 problem (1 error, 0 warnings)",
+      ].join("\n");
+
+      const message = await runComposed(dir, output);
+
+      expect(message).not.toContain("A real syntax error is in");
+      expect(message).not.toContain("app.schema.ts");
+      expect(message).toContain("ONE broken file");
     } finally {
       await rm(dir, { recursive: true, force: true });
     }
   });
 
   test("a cascade with NO ::tsforge-app section → NO append (unattributed, we don't guess)", async () => {
-    // The round-4 finding: no both-apps fallback. If the cascade can't be attributed to an app,
-    // enrichUnparsable is a silent no-op even when a broken in-scope file exists on disk.
+    // No both-apps fallback: an unattributed cascade is a silent no-op even with a broken file on disk.
     const dir = await mkdtemp(join(tmpdir(), "tsforge-compose-nosection-"));
 
     try {
-      await mkdir(join(dir, "apps/ui/src/features/company"), {
-        recursive: true,
-      });
+      await mkdir(join(dir, "apps/ui/src/features/note"), { recursive: true });
       await writeFile(
-        join(dir, "apps/ui/src/features/company/Company.tsx"),
+        join(dir, "apps/ui/src/features/note/Note.tsx"),
         "export const B = () => <div className='x' hi</div>;\n"
       );
 
-      // Cascade text WITHOUT the ::tsforge-app marker → appsWithParseCascade returns [].
-      const gate = composeBoringstackGate({
-        cwd: dir,
-        exec: execWith(
-          1,
-          [
-            join(dir, "apps/ui/src/features/company/Company.tsx"),
-            "  1:29 error Parsing error: parserOptions.project has been set for @typescript-eslint/parser",
-            "✖ 1 problem (1 error, 0 warnings)",
-          ].join("\n")
-        ),
-        evaluator: passthroughJudge,
-        baseline: new Set<string>(),
-        feature,
-        scopeGlobs: scopeFor("company"),
-      });
-      const result = await gate.run(dir);
-      const message =
-        result.errors.find((e) => e.rule === "eslint-program-unparsable")
-          ?.message ?? "";
+      const output = [
+        join(dir, "apps/ui/src/features/note/Note.tsx"),
+        "  1:29 error Parsing error: parserOptions.project has been set for @typescript-eslint/parser",
+        "✖ 1 problem (1 error, 0 warnings)",
+      ].join("\n");
 
-      expect(message).not.toContain("A real syntax error was found in");
+      const message = await runComposed(dir, output);
+
+      expect(message).not.toContain("A real syntax error is in");
       expect(message).toContain("ONE broken file");
     } finally {
       await rm(dir, { recursive: true, force: true });
@@ -742,5 +843,29 @@ describe("scopeFor", () => {
     );
     // Another feature's file is NOT in scope.
     expect(inScope("apps/ui/src/features/contact/Contact.tsx")).toBe(false);
+  });
+});
+
+describe("featureOwnedGlobs", () => {
+  test("covers the feature's own dirs but EXCLUDES the shared add-only files (no wholesale-rewrite target)", () => {
+    const globs = featureOwnedGlobs("company");
+    const owned = (file: string): boolean =>
+      globs.some((g) => new Bun.Glob(g).match(file));
+
+    // Feature-exclusive dirs — safe to name for a full rewrite.
+    expect(owned("apps/ui/src/features/company/Company.tsx")).toBe(true);
+    expect(owned("apps/api/src/api/company/company.service.ts")).toBe(true);
+    expect(owned("apps/api/tests/api/company/company.route.test.ts")).toBe(
+      true
+    );
+    // Shared ADD-ONLY files scopeFor grants edit access to must NOT be owned (never rewrite them).
+    expect(owned("apps/api/src/clients/postgres/schema/app.schema.ts")).toBe(
+      false
+    );
+    expect(owned("apps/ui/src/lib/i18n/locales/en.json")).toBe(false);
+    expect(owned("apps/ui/src/components/core/AppSidebar/AppSidebar.tsx")).toBe(
+      false
+    );
+    expect(owned("apps/ui/src/app/router/routes.tsx")).toBe(false);
   });
 });

--- a/packages/core/tests/boringstack-gate-stages.test.ts
+++ b/packages/core/tests/boringstack-gate-stages.test.ts
@@ -71,6 +71,94 @@ describe("boringstackCommandStage", () => {
     expect(error?.phase).toBe(2);
   });
 
+  test("unparsable cascade → enriches the error with the located broken file (integration path)", async () => {
+    // The panel's core finding: the enrichment branch (unparsable signature → locateParseError →
+    // append the real broken file to the message) must be exercised end-to-end against a REAL
+    // filesystem — not just locateParseError in isolation. Here the fake gate emits a genuine
+    // `parserOptions.project` cascade (which extractFailures collapses to eslint-program-unparsable)
+    // while a real temp tree holds one malformed file among healthy siblings.
+    const dir = await mkdtemp(join(tmpdir(), "tsforge-cmd-parse-"));
+
+    try {
+      await mkdir(join(dir, "apps/ui/src/features/company"), {
+        recursive: true,
+      });
+      // Healthy sibling — must NOT be named.
+      await writeFile(
+        join(dir, "apps/ui/src/features/company/Good.tsx"),
+        "export const G = () => <div className='x'>hi</div>;\n"
+      );
+      // The ONE malformed file the cascade hides ('>' expected).
+      await writeFile(
+        join(dir, "apps/ui/src/features/company/Company.tsx"),
+        "export const B = () => <div className='x' hi</div>;\n"
+      );
+
+      const cascade = [
+        join(dir, "apps/ui/src/features/company/Company.tsx"),
+        "  1:29 error Parsing error: parserOptions.project has been set for @typescript-eslint/parser",
+        "",
+        "✖ 1 problem (1 error, 0 warnings)",
+      ].join("\n");
+
+      const stage = boringstackCommandStage(dir, execWith(1, cascade));
+      const result = await stage.run(dir);
+
+      const unparsable = result.errors.find(
+        (e) => e.rule === "eslint-program-unparsable"
+      );
+
+      expect(unparsable).toBeDefined();
+      // The enrichment fired: the message now NAMES the real broken file the cascade hid,
+      expect(unparsable?.message).toContain("The parse failure is in");
+      expect(unparsable?.message).toContain(
+        "apps/ui/src/features/company/Company.tsx"
+      );
+      // carries the located line/col detail,
+      expect(unparsable?.message).toContain("line 1:");
+      // and does NOT falsely finger the healthy sibling (same-parser: no false positives).
+      expect(unparsable?.message).not.toContain("Good.tsx");
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  test("unparsable cascade with NO locatable broken file → message left unenriched (no false pointer)", async () => {
+    // Guard the honesty case: if locateParseError finds nothing (e.g. the broken file was already
+    // fixed on disk but the stale gate output still shows the cascade), the enrichment must NOT
+    // fabricate a file pointer.
+    const dir = await mkdtemp(join(tmpdir(), "tsforge-cmd-parse-clean-"));
+
+    try {
+      await mkdir(join(dir, "apps/ui/src/features/company"), {
+        recursive: true,
+      });
+      await writeFile(
+        join(dir, "apps/ui/src/features/company/Company.tsx"),
+        "export const G = () => <div className='x'>hi</div>;\n"
+      );
+
+      const cascade = [
+        join(dir, "apps/ui/src/features/company/Company.tsx"),
+        "  1:29 error Parsing error: parserOptions.project has been set for @typescript-eslint/parser",
+        "",
+        "✖ 1 problem (1 error, 0 warnings)",
+      ].join("\n");
+
+      const stage = boringstackCommandStage(dir, execWith(1, cascade));
+      const result = await stage.run(dir);
+
+      const unparsable = result.errors.find(
+        (e) => e.rule === "eslint-program-unparsable"
+      );
+
+      expect(unparsable).toBeDefined();
+      expect(unparsable?.message).not.toContain("The parse failure is in");
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
   test("unknown failure format preserves the final failing app, not the healthy output head", async () => {
     const out = `::tsforge-app apps/api::
 healthy API output that used to consume the first 500 characters

--- a/packages/core/tests/boringstack-gate-stages.test.ts
+++ b/packages/core/tests/boringstack-gate-stages.test.ts
@@ -132,15 +132,14 @@ describe("boringstackCommandStage", () => {
       );
 
       expect(unparsable).toBeDefined();
-      // The enrichment fired and NAMES the real broken file the cascade hid,
-      expect(unparsable?.message).toContain("The parse failure is in");
+      // The enrichment appended a hint that NAMES the real broken file the cascade hid,
+      expect(unparsable?.message).toContain("A real syntax error was found in");
       expect(unparsable?.message).toContain(
         "apps/ui/src/features/company/Company.tsx"
       );
-      // with the located line/col detail,
+      // with the located line/col detail and the fix framing,
       expect(unparsable?.message).toContain("line 1:");
-      // in-scope → an actionable fix instruction,
-      expect(unparsable?.message).toContain("Fix the syntax error there");
+      expect(unparsable?.message).toContain("ONE file to rewrite");
       // and it did NOT falsely finger ANY valid-TS sibling (the whole point of the parser fix).
       expect(unparsable?.message).not.toContain("Enum.ts");
       expect(unparsable?.message).not.toContain("Types.ts");
@@ -150,9 +149,10 @@ describe("boringstackCommandStage", () => {
     }
   });
 
-  test("located file OUTSIDE the feature scope → flagged as blocked, NOT a rewrite instruction (no scope bypass)", async () => {
-    // Scope-bypass finding: the guidance must never direct the model to edit a file it does not
-    // own. A broken file in ANOTHER feature's dir (same failing app) gets a 'blocked' note, not 'fix it'.
+  test("located file OUTSIDE the feature scope → NO pointer appended (base guidance untouched, no scope bypass)", async () => {
+    // Scope-bypass finding: the guidance must never name/direct a file the model does not own. A
+    // broken file in ANOTHER feature's dir (same failing app) yields NO appended pointer — the
+    // generic base message (which names no specific file) stands.
     const dir = await mkdtemp(join(tmpdir(), "tsforge-cmd-parse-oos-"));
 
     try {
@@ -176,17 +176,13 @@ describe("boringstackCommandStage", () => {
       );
 
       expect(unparsable).toBeDefined();
-      expect(unparsable?.message).toContain(
-        "apps/ui/src/features/contact/Contact.tsx"
+      // No append: the out-of-scope file is never named nor directed for a rewrite.
+      expect(unparsable?.message).not.toContain(
+        "A real syntax error was found in"
       );
-      // Out of scope → blocked note, never a 'fix it / rewrite' directive.
-      expect(unparsable?.message).toContain("OUTSIDE your editable scope");
-      expect(unparsable?.message).toContain("Report this as blocked");
-      expect(unparsable?.message).not.toContain("Fix the syntax error there");
-      // The message is REPLACED, so the base "REWRITE IT IN FULL" directive must be GONE — else
-      // the model gets "rewrite this file" AND "do not edit it" (the contradiction the panel flagged).
-      expect(unparsable?.message).not.toContain("REWRITE IT IN FULL");
-      expect(unparsable?.message).not.toContain("rewrite that file in full");
+      expect(unparsable?.message).not.toContain("Contact.tsx");
+      // The generic base guidance is left untouched (names no specific file → no bypass).
+      expect(unparsable?.message).toContain("ONE broken file");
     } finally {
       await rm(dir, { recursive: true, force: true });
     }
@@ -228,19 +224,17 @@ describe("boringstackCommandStage", () => {
       expect(unparsable?.message).toContain(
         "apps/ui/src/features/company/Company.tsx"
       );
-      expect(unparsable?.message).toContain("Fix the syntax error there");
+      expect(unparsable?.message).toContain("A real syntax error was found in");
       // The unrelated API file was NOT scanned, so it is neither named nor treated as the blocker.
       expect(unparsable?.message).not.toContain("other.service.ts");
-      expect(unparsable?.message).not.toContain("OUTSIDE your editable scope");
     } finally {
       await rm(dir, { recursive: true, force: true });
     }
   });
 
-  test("unparsable cascade with NO locatable broken file → FAIL-CLOSED message (no in-scope rewrite target asserted)", async () => {
-    // Honesty + fail-closed: if locateParseError finds nothing (a config/`include` failure, or the
-    // broken file was already fixed on disk), the message must NOT claim a specific file NOR direct
-    // an unconfirmed in-scope rewrite — it points the model at its own recent edits, else blocked.
+  test("unparsable cascade with NO locatable broken file → NO append (base guidance untouched)", async () => {
+    // Honesty: if locateParseError finds nothing (a config/`include` failure, or the broken file was
+    // already fixed on disk), the enrichment must NOT fabricate a file pointer — the base stands.
     const dir = await mkdtemp(join(tmpdir(), "tsforge-cmd-parse-clean-"));
 
     try {
@@ -264,17 +258,18 @@ describe("boringstackCommandStage", () => {
       );
 
       expect(unparsable).toBeDefined();
-      expect(unparsable?.message).not.toContain("The parse failure is in");
-      expect(unparsable?.message).toContain("could not be pinpointed");
-      // FAIL-CLOSED: no unconfirmed rewrite directive.
-      expect(unparsable?.message).not.toContain("Fix the syntax error there");
+      expect(unparsable?.message).not.toContain(
+        "A real syntax error was found in"
+      );
+      expect(unparsable?.message).toContain("ONE broken file");
     } finally {
       await rm(dir, { recursive: true, force: true });
     }
   });
 
-  test("empty scopeGlobs (default) is FAIL-CLOSED → a located file is treated as blocked, never rewritable", async () => {
-    // Round-3 minor: an unknown/empty scope must not fail OPEN (command a rewrite of any file).
+  test("empty scopeGlobs (default) → NO append (can't confirm ownership, so never names a file)", async () => {
+    // An unknown/empty scope must not fail OPEN. With no ownership info we append nothing (a safe
+    // no-op), so no file is ever named or directed.
     const dir = await mkdtemp(join(tmpdir(), "tsforge-cmd-parse-noscope-"));
 
     try {
@@ -294,8 +289,10 @@ describe("boringstackCommandStage", () => {
         (e) => e.rule === "eslint-program-unparsable"
       );
 
-      expect(unparsable?.message).toContain("OUTSIDE your editable scope");
-      expect(unparsable?.message).not.toContain("Fix the syntax error there");
+      expect(unparsable?.message).not.toContain(
+        "A real syntax error was found in"
+      );
+      expect(unparsable?.message).toContain("ONE broken file");
     } finally {
       await rm(dir, { recursive: true, force: true });
     }
@@ -660,14 +657,13 @@ describe("composeBoringstackGate scope wiring", () => {
       const message = await runComposed(dir, scopeFor("company"));
 
       expect(message).toContain("apps/ui/src/features/company/Company.tsx");
-      expect(message).toContain("Fix the syntax error there");
-      expect(message).not.toContain("OUTSIDE your editable scope");
+      expect(message).toContain("A real syntax error was found in");
     } finally {
       await rm(dir, { recursive: true, force: true });
     }
   });
 
-  test("scopeGlobs flow through composeBoringstackGate → an out-of-scope located file is flagged blocked", async () => {
+  test("scopeGlobs flow through composeBoringstackGate → an out-of-scope located file gets NO append", async () => {
     const dir = await mkdtemp(join(tmpdir(), "tsforge-compose-out-"));
 
     try {
@@ -682,9 +678,51 @@ describe("composeBoringstackGate scope wiring", () => {
 
       const message = await runComposed(dir, scopeFor("company"));
 
-      expect(message).toContain("apps/ui/src/features/contact/Contact.tsx");
-      expect(message).toContain("OUTSIDE your editable scope");
-      expect(message).not.toContain("Fix the syntax error there");
+      // Out of scope → no pointer appended; the file is never named.
+      expect(message).not.toContain("A real syntax error was found in");
+      expect(message).not.toContain("Contact.tsx");
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  test("a cascade with NO ::tsforge-app section → NO append (unattributed, we don't guess)", async () => {
+    // The round-4 finding: no both-apps fallback. If the cascade can't be attributed to an app,
+    // enrichUnparsable is a silent no-op even when a broken in-scope file exists on disk.
+    const dir = await mkdtemp(join(tmpdir(), "tsforge-compose-nosection-"));
+
+    try {
+      await mkdir(join(dir, "apps/ui/src/features/company"), {
+        recursive: true,
+      });
+      await writeFile(
+        join(dir, "apps/ui/src/features/company/Company.tsx"),
+        "export const B = () => <div className='x' hi</div>;\n"
+      );
+
+      // Cascade text WITHOUT the ::tsforge-app marker → appsWithParseCascade returns [].
+      const gate = composeBoringstackGate({
+        cwd: dir,
+        exec: execWith(
+          1,
+          [
+            join(dir, "apps/ui/src/features/company/Company.tsx"),
+            "  1:29 error Parsing error: parserOptions.project has been set for @typescript-eslint/parser",
+            "✖ 1 problem (1 error, 0 warnings)",
+          ].join("\n")
+        ),
+        evaluator: passthroughJudge,
+        baseline: new Set<string>(),
+        feature,
+        scopeGlobs: scopeFor("company"),
+      });
+      const result = await gate.run(dir);
+      const message =
+        result.errors.find((e) => e.rule === "eslint-program-unparsable")
+          ?.message ?? "";
+
+      expect(message).not.toContain("A real syntax error was found in");
+      expect(message).toContain("ONE broken file");
     } finally {
       await rm(dir, { recursive: true, force: true });
     }

--- a/packages/core/tests/boringstack-gate-stages.test.ts
+++ b/packages/core/tests/boringstack-gate-stages.test.ts
@@ -71,37 +71,55 @@ describe("boringstackCommandStage", () => {
     expect(error?.phase).toBe(2);
   });
 
-  test("unparsable cascade → enriches the error with the located broken file (integration path)", async () => {
-    // The panel's core finding: the enrichment branch (unparsable signature → locateParseError →
-    // append the real broken file to the message) must be exercised end-to-end against a REAL
-    // filesystem — not just locateParseError in isolation. Here the fake gate emits a genuine
-    // `parserOptions.project` cascade (which extractFailures collapses to eslint-program-unparsable)
-    // while a real temp tree holds one malformed file among healthy siblings.
+  const cascadeFor = (dir: string): string =>
+    [
+      join(dir, "apps/ui/src/features/company/Company.tsx"),
+      "  1:29 error Parsing error: parserOptions.project has been set for @typescript-eslint/parser",
+      "",
+      "✖ 1 problem (1 error, 0 warnings)",
+    ].join("\n");
+
+  const COMPANY_SCOPE = [
+    "apps/ui/src/features/company/**",
+    "apps/api/src/api/company/**",
+  ];
+
+  test("unparsable cascade → enriches with the located broken file, IGNORING valid-TS siblings (integration path)", async () => {
+    // The panel's core findings: (1) the enrichment branch must be exercised end-to-end against a
+    // REAL filesystem — not just locateParseError in isolation; (2) the parser replacement must be
+    // proven on the exact valid-TypeScript constructs that a wrong parser (Bun.Transpiler /
+    // transpileModule) mis-flags. Here healthy siblings use `const enum`, `import type`, and a
+    // `<T,>` generic — all valid TS that typescript-eslint parses — and MUST NOT be named.
     const dir = await mkdtemp(join(tmpdir(), "tsforge-cmd-parse-"));
 
     try {
       await mkdir(join(dir, "apps/ui/src/features/company"), {
         recursive: true,
       });
-      // Healthy sibling — must NOT be named.
+      // Valid-TS constructs a non-parser tool would wrongly reject — must NOT be fingered.
       await writeFile(
-        join(dir, "apps/ui/src/features/company/Good.tsx"),
-        "export const G = () => <div className='x'>hi</div>;\n"
+        join(dir, "apps/ui/src/features/company/Enum.ts"),
+        "export const enum Status { Open, Closed }\n"
       );
-      // The ONE malformed file the cascade hides ('>' expected).
+      await writeFile(
+        join(dir, "apps/ui/src/features/company/Types.ts"),
+        "import type { ReactNode } from 'react';\nexport const render = (n: ReactNode): ReactNode => n;\n"
+      );
+      await writeFile(
+        join(dir, "apps/ui/src/features/company/Generic.ts"),
+        "export function identity<T,>(x: T): T {\n  return x;\n}\n"
+      );
+      // The ONE genuinely malformed file the cascade hides ('>' expected).
       await writeFile(
         join(dir, "apps/ui/src/features/company/Company.tsx"),
         "export const B = () => <div className='x' hi</div>;\n"
       );
 
-      const cascade = [
-        join(dir, "apps/ui/src/features/company/Company.tsx"),
-        "  1:29 error Parsing error: parserOptions.project has been set for @typescript-eslint/parser",
-        "",
-        "✖ 1 problem (1 error, 0 warnings)",
-      ].join("\n");
-
-      const stage = boringstackCommandStage(dir, execWith(1, cascade));
+      const stage = boringstackCommandStage(
+        dir,
+        execWith(1, cascadeFor(dir)),
+        COMPANY_SCOPE
+      );
       const result = await stage.run(dir);
 
       const unparsable = result.errors.find(
@@ -109,24 +127,63 @@ describe("boringstackCommandStage", () => {
       );
 
       expect(unparsable).toBeDefined();
-      // The enrichment fired: the message now NAMES the real broken file the cascade hid,
+      // The enrichment fired and NAMES the real broken file the cascade hid,
       expect(unparsable?.message).toContain("The parse failure is in");
       expect(unparsable?.message).toContain(
         "apps/ui/src/features/company/Company.tsx"
       );
-      // carries the located line/col detail,
+      // with the located line/col detail,
       expect(unparsable?.message).toContain("line 1:");
-      // and does NOT falsely finger the healthy sibling (same-parser: no false positives).
-      expect(unparsable?.message).not.toContain("Good.tsx");
+      // in-scope → an actionable fix instruction,
+      expect(unparsable?.message).toContain("Fix the syntax error there");
+      // and it did NOT falsely finger ANY valid-TS sibling (the whole point of the parser fix).
+      expect(unparsable?.message).not.toContain("Enum.ts");
+      expect(unparsable?.message).not.toContain("Types.ts");
+      expect(unparsable?.message).not.toContain("Generic.ts");
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  test("located file OUTSIDE the feature scope → flagged as blocked, NOT a rewrite instruction (no scope bypass)", async () => {
+    // Scope-bypass finding: the guidance must never direct the model to edit a file it does not
+    // own. A broken shared/scaffold file gets a 'blocked' note, not 'fix it'.
+    const dir = await mkdtemp(join(tmpdir(), "tsforge-cmd-parse-oos-"));
+
+    try {
+      await mkdir(join(dir, "apps/api/src/db"), { recursive: true });
+      // The broken file lives in a SHARED location the company scope does not cover.
+      await writeFile(
+        join(dir, "apps/api/src/db/schema.ts"),
+        "export const table = ;\n"
+      );
+
+      const stage = boringstackCommandStage(
+        dir,
+        execWith(1, cascadeFor(dir)),
+        COMPANY_SCOPE
+      );
+      const result = await stage.run(dir);
+
+      const unparsable = result.errors.find(
+        (e) => e.rule === "eslint-program-unparsable"
+      );
+
+      expect(unparsable).toBeDefined();
+      expect(unparsable?.message).toContain("apps/api/src/db/schema.ts");
+      // Out of scope → blocked note, never a 'fix it / rewrite' directive.
+      expect(unparsable?.message).toContain("OUTSIDE your editable scope");
+      expect(unparsable?.message).toContain("Report this as blocked");
+      expect(unparsable?.message).not.toContain("Fix the syntax error there");
     } finally {
       await rm(dir, { recursive: true, force: true });
     }
   });
 
   test("unparsable cascade with NO locatable broken file → message left unenriched (no false pointer)", async () => {
-    // Guard the honesty case: if locateParseError finds nothing (e.g. the broken file was already
-    // fixed on disk but the stale gate output still shows the cascade), the enrichment must NOT
-    // fabricate a file pointer.
+    // Honesty case: if locateParseError finds nothing (a config/`include` failure, not a syntax
+    // cascade, or the broken file was already fixed on disk), the enrichment must NOT fabricate a
+    // file pointer.
     const dir = await mkdtemp(join(tmpdir(), "tsforge-cmd-parse-clean-"));
 
     try {
@@ -138,14 +195,11 @@ describe("boringstackCommandStage", () => {
         "export const G = () => <div className='x'>hi</div>;\n"
       );
 
-      const cascade = [
-        join(dir, "apps/ui/src/features/company/Company.tsx"),
-        "  1:29 error Parsing error: parserOptions.project has been set for @typescript-eslint/parser",
-        "",
-        "✖ 1 problem (1 error, 0 warnings)",
-      ].join("\n");
-
-      const stage = boringstackCommandStage(dir, execWith(1, cascade));
+      const stage = boringstackCommandStage(
+        dir,
+        execWith(1, cascadeFor(dir)),
+        COMPANY_SCOPE
+      );
       const result = await stage.run(dir);
 
       const unparsable = result.errors.find(
@@ -406,6 +460,33 @@ describe("locateParseError", () => {
       await writeFile(
         join(dir, "apps/ui/src/Ok.tsx"),
         "export const G = () => <span>ok</span>;\n"
+      );
+
+      expect(await locateParseError(dir)).toBeNull();
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  test("does NOT false-positive on valid TypeScript a non-parser tool mis-flags (const enum / import type / generic)", async () => {
+    // The exact regression the panel demanded: `ts.transpileModule` (and Bun.Transpiler) report
+    // some of these valid constructs as errors; the parser (getSyntacticDiagnostics) must not.
+    const dir = await mkdtemp(join(tmpdir(), "tsforge-parse-validts-"));
+
+    try {
+      await mkdir(join(dir, "apps/api/src"), { recursive: true });
+      await mkdir(join(dir, "apps/ui/src"), { recursive: true });
+      await writeFile(
+        join(dir, "apps/api/src/Enum.ts"),
+        "export const enum Level { Low, High }\n"
+      );
+      await writeFile(
+        join(dir, "apps/api/src/Reexport.ts"),
+        "export { type Foo } from './foo';\n"
+      );
+      await writeFile(
+        join(dir, "apps/ui/src/Generic.ts"),
+        "export function first<T,>(xs: readonly T[]): T | undefined {\n  return xs[0];\n}\n"
       );
 
       expect(await locateParseError(dir)).toBeNull();

--- a/packages/core/tests/boringstack-gate-stages.test.ts
+++ b/packages/core/tests/boringstack-gate-stages.test.ts
@@ -179,7 +179,7 @@ describe("boringstackCommandStage", () => {
       expect(unparsable?.message).not.toContain("A real syntax error is in");
       expect(unparsable?.message).not.toContain("Contact.tsx");
       // The generic base guidance is left untouched (names no specific file → no bypass).
-      expect(unparsable?.message).toContain("ONE broken file");
+      expect(unparsable?.message).toContain("could not build its program");
     } finally {
       await rm(dir, { recursive: true, force: true });
     }
@@ -256,7 +256,7 @@ describe("boringstackCommandStage", () => {
 
       expect(unparsable).toBeDefined();
       expect(unparsable?.message).not.toContain("A real syntax error is in");
-      expect(unparsable?.message).toContain("ONE broken file");
+      expect(unparsable?.message).toContain("could not build its program");
     } finally {
       await rm(dir, { recursive: true, force: true });
     }
@@ -285,7 +285,7 @@ describe("boringstackCommandStage", () => {
       );
 
       expect(unparsable?.message).not.toContain("A real syntax error is in");
-      expect(unparsable?.message).toContain("ONE broken file");
+      expect(unparsable?.message).toContain("could not build its program");
     } finally {
       await rm(dir, { recursive: true, force: true });
     }
@@ -324,6 +324,10 @@ describe("boringstackCommandStage", () => {
       // so it never claims (as the earlier rounds did) that this single file clears the cascade.
       expect(unparsable?.message).toContain("A real syntax error is in");
       expect(unparsable?.message).toContain("there may be more than one");
+      // The COMBINED message (base + append) carries NO false single-file certainty — the base was
+      // rewritten so this contradiction can't hide there (the round-7 finding).
+      expect(unparsable?.message).not.toContain("ONE broken file");
+      expect(unparsable?.message).not.toContain("clears at once");
       // Names one of the two broken company files (whichever the scan hits first).
       const names =
         unparsable?.message.includes("Company.tsx") === true ||
@@ -411,16 +415,23 @@ describe("signatureToError", () => {
     expect(err.message).toContain("Do NOT edit");
   });
 
-  test("the eslint-program-unparsable signature maps to a file-less rewrite-the-broken-file error", () => {
+  test("the eslint-program-unparsable signature maps to a file-less, honest (no false single-file certainty) error", () => {
     const err = signatureToError("eslint-program-unparsable");
 
-    // File-less (model-visible "own" error), phase 2, and steers toward a FULL
-    // rewrite of the one broken file — not chasing the per-file cascade.
+    // File-less (model-visible "own" error), phase 2. The base message steers toward finding the
+    // genuine syntax error(s) in OWNED files — WITHOUT the old false certainty ("ONE broken file",
+    // "the whole cascade clears at once") that contradicted the multi-file enrichment, and WITHOUT
+    // a blanket "REWRITE IT IN FULL" that could direct a wholesale rewrite of a shared file.
     expect(err.rule).toBe("eslint-program-unparsable");
     expect(err.file).toBeUndefined();
     expect(err.phase).toBe(2);
-    expect(err.message).toContain("ONE broken file");
-    expect(err.message).toContain("REWRITE IT IN FULL");
+    expect(err.message).toContain("could not build its program");
+    expect(err.message).toContain("files YOU OWN");
+    expect(err.message).toContain("Do NOT wholesale-rewrite shared files");
+    // No false single-file certainty, no blanket full-rewrite directive.
+    expect(err.message).not.toContain("ONE broken file");
+    expect(err.message).not.toContain("REWRITE IT IN FULL");
+    expect(err.message).not.toContain("clears at once");
   });
 
   test("a discrete PARSE error is steered to a full rewrite (not a surgical patch)", () => {
@@ -797,7 +808,11 @@ describe("composeBoringstackGate scope wiring", () => {
 
       expect(message).not.toContain("A real syntax error is in");
       expect(message).not.toContain("app.schema.ts");
-      expect(message).toContain("ONE broken file");
+      expect(message).toContain("could not build its program");
+      // The base must NOT direct a blanket full rewrite (which could clobber the shared file); it
+      // explicitly warns against wholesale-rewriting shared files.
+      expect(message).not.toContain("REWRITE IT IN FULL");
+      expect(message).toContain("Do NOT wholesale-rewrite shared files");
     } finally {
       await rm(dir, { recursive: true, force: true });
     }
@@ -823,7 +838,7 @@ describe("composeBoringstackGate scope wiring", () => {
       const message = await runComposed(dir, output);
 
       expect(message).not.toContain("A real syntax error is in");
-      expect(message).toContain("ONE broken file");
+      expect(message).toContain("could not build its program");
     } finally {
       await rm(dir, { recursive: true, force: true });
     }

--- a/packages/core/tests/boringstack-gate-stages.test.ts
+++ b/packages/core/tests/boringstack-gate-stages.test.ts
@@ -73,9 +73,12 @@ describe("boringstackCommandStage", () => {
     expect(error?.phase).toBe(2);
   });
 
-  const cascadeFor = (dir: string): string =>
+  // A realistic cascade: the composed gate echoes `::tsforge-app <app>::` before each app's
+  // stages, and the parserOptions.project error lands inside that app's section.
+  const cascadeFor = (dir: string, app = "apps/ui"): string =>
     [
-      join(dir, "apps/ui/src/features/company/Company.tsx"),
+      `::tsforge-app ${app}::`,
+      join(dir, `${app}/src/features/company/Company.tsx`),
       "  1:29 error Parsing error: parserOptions.project has been set for @typescript-eslint/parser",
       "",
       "✖ 1 problem (1 error, 0 warnings)",
@@ -149,15 +152,16 @@ describe("boringstackCommandStage", () => {
 
   test("located file OUTSIDE the feature scope → flagged as blocked, NOT a rewrite instruction (no scope bypass)", async () => {
     // Scope-bypass finding: the guidance must never direct the model to edit a file it does not
-    // own. A broken shared/scaffold file gets a 'blocked' note, not 'fix it'.
+    // own. A broken file in ANOTHER feature's dir (same failing app) gets a 'blocked' note, not 'fix it'.
     const dir = await mkdtemp(join(tmpdir(), "tsforge-cmd-parse-oos-"));
 
     try {
-      await mkdir(join(dir, "apps/api/src/db"), { recursive: true });
-      // The broken file lives in a SHARED location the company scope does not cover.
+      await mkdir(join(dir, "apps/ui/src/features/contact"), {
+        recursive: true,
+      });
       await writeFile(
-        join(dir, "apps/api/src/db/schema.ts"),
-        "export const table = ;\n"
+        join(dir, "apps/ui/src/features/contact/Contact.tsx"),
+        "export const B = () => <div className='x' hi</div>;\n"
       );
 
       const stage = boringstackCommandStage(
@@ -172,7 +176,9 @@ describe("boringstackCommandStage", () => {
       );
 
       expect(unparsable).toBeDefined();
-      expect(unparsable?.message).toContain("apps/api/src/db/schema.ts");
+      expect(unparsable?.message).toContain(
+        "apps/ui/src/features/contact/Contact.tsx"
+      );
       // Out of scope → blocked note, never a 'fix it / rewrite' directive.
       expect(unparsable?.message).toContain("OUTSIDE your editable scope");
       expect(unparsable?.message).toContain("Report this as blocked");
@@ -186,10 +192,55 @@ describe("boringstackCommandStage", () => {
     }
   });
 
-  test("unparsable cascade with NO locatable broken file → message left unenriched (no false pointer)", async () => {
-    // Honesty case: if locateParseError finds nothing (a config/`include` failure, not a syntax
-    // cascade, or the broken file was already fixed on disk), the enrichment must NOT fabricate a
-    // file pointer.
+  test("correlation: a UI cascade is NOT mis-attributed to an unrelated broken API file", async () => {
+    // The panel's deep finding: the locator must scan the app whose section actually shows the
+    // cascade. Here the cascade is in apps/ui, an in-scope UI file is broken, AND an unrelated
+    // out-of-scope API file is ALSO broken. The API file must be ignored (different app), so the
+    // in-scope UI file is named and the feature is NOT wrongly marked blocked.
+    const dir = await mkdtemp(join(tmpdir(), "tsforge-cmd-parse-corr-"));
+
+    try {
+      await mkdir(join(dir, "apps/ui/src/features/company"), {
+        recursive: true,
+      });
+      await mkdir(join(dir, "apps/api/src/api/other"), { recursive: true });
+      await writeFile(
+        join(dir, "apps/ui/src/features/company/Company.tsx"),
+        "export const B = () => <div className='x' hi</div>;\n"
+      );
+      // Unrelated broken API file — must be ignored because the cascade is in apps/ui.
+      await writeFile(
+        join(dir, "apps/api/src/api/other/other.service.ts"),
+        "export const bad: = 1;\n"
+      );
+
+      const stage = boringstackCommandStage(
+        dir,
+        execWith(1, cascadeFor(dir, "apps/ui")),
+        COMPANY_SCOPE
+      );
+      const result = await stage.run(dir);
+
+      const unparsable = result.errors.find(
+        (e) => e.rule === "eslint-program-unparsable"
+      );
+
+      expect(unparsable?.message).toContain(
+        "apps/ui/src/features/company/Company.tsx"
+      );
+      expect(unparsable?.message).toContain("Fix the syntax error there");
+      // The unrelated API file was NOT scanned, so it is neither named nor treated as the blocker.
+      expect(unparsable?.message).not.toContain("other.service.ts");
+      expect(unparsable?.message).not.toContain("OUTSIDE your editable scope");
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  test("unparsable cascade with NO locatable broken file → FAIL-CLOSED message (no in-scope rewrite target asserted)", async () => {
+    // Honesty + fail-closed: if locateParseError finds nothing (a config/`include` failure, or the
+    // broken file was already fixed on disk), the message must NOT claim a specific file NOR direct
+    // an unconfirmed in-scope rewrite — it points the model at its own recent edits, else blocked.
     const dir = await mkdtemp(join(tmpdir(), "tsforge-cmd-parse-clean-"));
 
     try {
@@ -214,6 +265,37 @@ describe("boringstackCommandStage", () => {
 
       expect(unparsable).toBeDefined();
       expect(unparsable?.message).not.toContain("The parse failure is in");
+      expect(unparsable?.message).toContain("could not be pinpointed");
+      // FAIL-CLOSED: no unconfirmed rewrite directive.
+      expect(unparsable?.message).not.toContain("Fix the syntax error there");
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  test("empty scopeGlobs (default) is FAIL-CLOSED → a located file is treated as blocked, never rewritable", async () => {
+    // Round-3 minor: an unknown/empty scope must not fail OPEN (command a rewrite of any file).
+    const dir = await mkdtemp(join(tmpdir(), "tsforge-cmd-parse-noscope-"));
+
+    try {
+      await mkdir(join(dir, "apps/ui/src/features/company"), {
+        recursive: true,
+      });
+      await writeFile(
+        join(dir, "apps/ui/src/features/company/Company.tsx"),
+        "export const B = () => <div className='x' hi</div>;\n"
+      );
+
+      // No scopeGlobs passed → default [].
+      const stage = boringstackCommandStage(dir, execWith(1, cascadeFor(dir)));
+      const result = await stage.run(dir);
+
+      const unparsable = result.errors.find(
+        (e) => e.rule === "eslint-program-unparsable"
+      );
+
+      expect(unparsable?.message).toContain("OUTSIDE your editable scope");
+      expect(unparsable?.message).not.toContain("Fix the syntax error there");
     } finally {
       await rm(dir, { recursive: true, force: true });
     }
@@ -448,7 +530,7 @@ describe("locateParseError", () => {
         "export const B = () => <div className='x' hi</div>;\n"
       );
 
-      const located = await locateParseError(dir);
+      const located = await locateParseError(dir, ["apps/api", "apps/ui"]);
 
       expect(located).not.toBeNull();
       expect(located?.file).toBe("apps/ui/src/features/company/Broken.tsx");
@@ -468,7 +550,7 @@ describe("locateParseError", () => {
         "export const G = () => <span>ok</span>;\n"
       );
 
-      expect(await locateParseError(dir)).toBeNull();
+      expect(await locateParseError(dir, ["apps/api", "apps/ui"])).toBeNull();
     } finally {
       await rm(dir, { recursive: true, force: true });
     }
@@ -495,7 +577,7 @@ describe("locateParseError", () => {
         "export function first<T,>(xs: readonly T[]): T | undefined {\n  return xs[0];\n}\n"
       );
 
-      expect(await locateParseError(dir)).toBeNull();
+      expect(await locateParseError(dir, ["apps/api", "apps/ui"])).toBeNull();
     } finally {
       await rm(dir, { recursive: true, force: true });
     }
@@ -513,7 +595,7 @@ describe("locateParseError", () => {
         "export const bad: = 1;\n"
       );
 
-      const located = await locateParseError(dir);
+      const located = await locateParseError(dir, ["apps/api", "apps/ui"]);
 
       expect(located?.file).toBe(
         "apps/api/tests/api/company/company.route.test.ts"
@@ -533,6 +615,7 @@ describe("composeBoringstackGate scope wiring", () => {
   };
   const cascade = (dir: string): string =>
     [
+      "::tsforge-app apps/ui::",
       join(dir, "apps/ui/src/features/company/Company.tsx"),
       "  1:29 error Parsing error: parserOptions.project has been set for @typescript-eslint/parser",
       "",


### PR DESCRIPTION
## What
When the type-aware ESLint program can't build, a single syntax error fans a `parserOptions.project` parse error across every file, so the gate is file-less and the model thrashes near-green hunting for the culprit. This appends a **high-confidence, append-only** pointer to the one broken file — when, and only when, we can be sure.

## How (converged over an 8-round panel review)
- **Syntax-only parser**: `Program.getSyntacticDiagnostics` (syntax-only *by contract*) — valid TS (`const enum`, `import type`, `<T,>`) is never mis-flagged. NOT `ts.transpileModule`/`Bun.Transpiler` (which mis-flag valid TS).
- **App-correlated**: scan only the app whose `::tsforge-app` section shows the cascade — no both-apps fallback, no cross-app misattribution.
- **Feature-owned only**: `featureOwnedGlobs(feature.id)` (the feature's own dirs) — never the shared add-only files (schema/locale/sidebar/routes), so it can't direct a wholesale rewrite that clobbers siblings. Derived inside `composeBoringstackGate` (no wiring to regress).
- **Scan-for-owned**: the scope predicate is applied *during* the scan, so an out-of-scope broken file never suppresses a later owned one.
- **Append-only, no false certainty**: silent no-op unless attributed-app + genuine-syntax-error + feature-owned all hold. The base message was rewritten honest — no "ONE broken file"/"cascade clears at once", no blanket "REWRITE IT IN FULL" — so base+append never contradict and neither directs a shared-file rewrite. Keeps the `.ts`-with-JSX→`.tsx` hint.

## Tests
32 gate-stages tests (append in-scope; silent no-op for out-of-scope / not-located / empty-scope / no-section / shared-file; correlation; two-broken hedged; out-of-scope-before-in-scope; valid-TS siblings ignored; real-feature-id compose wiring; `featureOwnedGlobs` excludes shared files). Full core suite 3048 pass, 0 fail.

## Accepted residuals (panel PASS, ag1, non-blocking)
- A `parserOptions.project` message *can* be a TSConfig-inclusion problem rather than a syntax error; when no owned file has a genuine syntax error we stay silent (append nothing), so we never mislabel — the base wording says "one or more" and does not assert a specific file.
- If the model's own edit to a *shared* add-only file (e.g. app.schema.ts) is what's malformed, the locator names nothing (shared files are excluded); the base still tells the model to fix syntax errors and not wholesale-rewrite shared files. Reconstructing ESLint's exact project graph to close this is impractical (shown across the review).

🤖 Generated with [Claude Code](https://claude.com/claude-code)