### PR TITLE
fix(acceptance): parent-FK field must be a native <select> (Playwright selectOption) — relational-slice park

### DIFF
--- a/packages/core/src/loop/boringstack/acceptance/testid-contract.ts
+++ b/packages/core/src/loop/boringstack/acceptance/testid-contract.ts
@@ -77,8 +77,18 @@ Every UI element that end-to-end tests will interact with MUST have a \`data-tes
 - **Create button**: \`data-testid="${ids.create}"\` — the button to open the create form
 - **Form container**: \`data-testid="${ids.form}"\` — the form element for create/edit
 - **Submit button**: \`data-testid="${ids.submit}"\` — the submit button inside the form
-- **Form fields**: Each input field needs \`data-testid\` for each of your entity's fields:
-${entity.fields.map((f) => `  - \`data-testid="${ids.field(f.name)}"\` for the "${f.name}" field`).join("\n")}
+- **Form fields**: Each NON-relationship field needs an \`<input>\` (or type-appropriate control) carrying \`data-testid\`:
+${entity.fields
+  .filter((f) => !entity.parents.some((p) => p.fkField === f.name))
+  .map(
+    (f) =>
+      `  - \`data-testid="${ids.field(f.name)}"\` for the "${f.name}" field`
+  )
+  .join("\n")}${
+    entity.parents.length > 0
+      ? `\n  (Parent foreign-key fields — ${entity.parents.map((p) => `"${p.fkField}"`).join(", ")} — are NOT plain inputs; render them as \`<select>\` per **Relationship selectors** below.)`
+      : ""
+  }
 - **Table row**: \`data-testid="${ids.row}"\` — each row in the list (use this as a prefix, e.g. in a \`data-testid\` attribute on the row container)
 - **Row cells**: Each cell in a row needs \`data-testid\` for each of your entity's shows (${entity.shows.join(", ")}):
 ${entity.shows.map((s) => `  - \`data-testid="${ids.rowCell(s)}"\` for the "${s}" column`).join("\n")}
@@ -87,7 +97,7 @@ ${entity.shows.map((s) => `  - \`data-testid="${ids.rowCell(s)}"\` for the "${s}
 - **Delete confirm button**: \`data-testid="${ids.confirmDelete}"\` — put this on the BUTTON that actually performs the deletion (the one whose click fires the delete mutation), NOT on the dialog container/overlay. End-to-end acceptance CLICKS this testid to confirm the delete; if it sits on a wrapper \`<div>\` the click hits the backdrop, the delete never fires, and the row stays (delete acceptance fails).
 ${
   entity.parents.length > 0
-    ? `- **Relationship selectors**: \`data-testid\` for each parent entity select:\n${entity.parents.map((p) => `  - \`data-testid="${ids.field(p.fkField)}"\` for selecting a ${p.key}`).join("\n")}`
+    ? `- **Relationship selectors (parent foreign keys)**: each parent FK field MUST be a native \`<select>\` element — NOT an \`<input>\`, and not a custom combobox/autocomplete. Populate it with one \`<option>\` per existing parent record, where the option's \`value\` is the parent's \`id\`; fetch the parent list with its list query / api-client and map the rows to options. End-to-end acceptance picks a parent with Playwright \`selectOption\`, which ONLY works on a real \`<select>\` — an \`<input>\` (or non-native control) fails the create step and the feature parks at acceptance.\n${entity.parents.map((p) => `  - \`<select data-testid="${ids.field(p.fkField)}">\` — the "${p.fkField}" field: a list of ${p.key} records (each \`<option value={${p.key}.id}>\`)`).join("\n")}`
     : ""
 }
 

--- a/packages/core/src/loop/boringstack/acceptance/testid-contract.ts
+++ b/packages/core/src/loop/boringstack/acceptance/testid-contract.ts
@@ -71,20 +71,22 @@ export function buildTestIdGuide(entity: IEntityAcceptance): string {
     (f) => !entity.parents.some((p) => p.fkField === f.name)
   )?.name;
   const firstParentFk = entity.parents[0]?.fkField;
-  const rowCellField =
-    entity.shows[0] ?? plainFieldName ?? entity.fields[0]?.name ?? "name";
-  const rowExampleLine = `- In the table row: \`<td data-testid="${ids.rowCell(rowCellField)}">{record.${rowCellField}}</td>\``;
-  const patternExample =
+  // Row-cell example ONLY when a real `shows` column exists — rowCell testids are generated for
+  // entity.shows only, so never invent a field name or reference a non-contract testid here.
+  const firstShow = entity.shows[0];
+  const rowExampleLine =
+    firstShow === undefined
+      ? ""
+      : `\n- In the table row: \`<td data-testid="${ids.rowCell(firstShow)}">{record.${firstShow}}</td>\``;
+  const formExample =
     plainFieldName !== undefined
       ? `**Pattern example** (for a NON-relationship field named "${plainFieldName}" in a "${entity.key}" feature):
-- In the create/edit form: \`<input data-testid="${ids.field(plainFieldName)}" />\` (a parent FK field is a \`<select>\` instead — see Relationship selectors)
-${rowExampleLine}`
+- In the create/edit form: \`<input data-testid="${ids.field(plainFieldName)}" />\` (a parent FK field is a \`<select>\` instead — see Relationship selectors)`
       : firstParentFk !== undefined
         ? `**Pattern example** (every field of "${entity.key}" is a parent foreign key — render each as a native \`<select>\`, NEVER an \`<input>\`):
-- In the create/edit form: \`<select data-testid="${ids.field(firstParentFk)}"> … </select>\`
-${rowExampleLine}`
-        : `**Pattern example**: give each form field a \`data-testid\` on its \`<input>\` control.
-${rowExampleLine}`;
+- In the create/edit form: \`<select data-testid="${ids.field(firstParentFk)}"> … </select>\``
+        : `**Pattern example**: give each form field a \`data-testid\` on its \`<input>\` control.`;
+  const patternExample = `${formExample}${rowExampleLine}`;
 
   return `## Test IDs for "${entity.key}" — Required Test Hooks
 

--- a/packages/core/src/loop/boringstack/acceptance/testid-contract.ts
+++ b/packages/core/src/loop/boringstack/acceptance/testid-contract.ts
@@ -64,6 +64,13 @@ export function requiredTestIds(entity: IEntityAcceptance): string[] {
 export function buildTestIdGuide(entity: IEntityAcceptance): string {
   const ids = testIdsFor(entity.key);
   const required = requiredTestIds(entity);
+  // The <input> Pattern example must use a NON-relationship field — a parent FK renders as a
+  // <select> (see Relationship selectors), so showing one as an <input> would contradict the fix.
+  const exampleField =
+    entity.fields.find((f) => !entity.parents.some((p) => p.fkField === f.name))
+      ?.name ??
+    entity.fields[0]?.name ??
+    "title";
 
   return `## Test IDs for "${entity.key}" — Required Test Hooks
 
@@ -101,15 +108,15 @@ ${
     : ""
 }
 
-**Pattern example** (for a field named "${entity.fields[0]?.name ?? "title"}" in a "${entity.key}" feature):
-- In the create/edit form: \`<input data-testid="${ids.field(entity.fields[0]?.name ?? "title")}" />\`
+**Pattern example** (for a NON-relationship field named "${exampleField}" in a "${entity.key}" feature):
+- In the create/edit form: \`<input data-testid="${ids.field(exampleField)}" />\` (a parent FK field is a \`<select>\` instead — see Relationship selectors)
 - In the table row: \`<td data-testid="${ids.rowCell(entity.shows[0] ?? entity.fields[0]?.name ?? "name")}">{record.${entity.shows[0] ?? entity.fields[0]?.name ?? "name"}}</td>\`
 
 **Where to add them:**
 - **Navigation (IMPORTANT — outside the feature directory):** add \`data-testid="${ids.nav}"\` to the "${entity.id}" link in the SHARED sidebar (\`apps/ui/src/components/core/AppSidebar/\`), NOT in the feature folder. A feature that isn't linked in the sidebar is unreachable and will fail end-to-end acceptance — every feature MUST be added to the sidebar navigation.
 - List page component: add \`data-testid="${ids.list}"\` to the list/table container, \`data-testid="${ids.empty}"\` to the empty state
 - Create button: add \`data-testid="${ids.create}"\` to the button that opens the form
-- Form component: add \`data-testid="${ids.form}"\` to the \`<form>\`, \`data-testid="${ids.submit}"\` to the submit button, and \`data-testid="${ids.field("...")}\` to each input
+- Form component: add \`data-testid="${ids.form}"\` to the \`<form>\`, \`data-testid="${ids.submit}"\` to the submit button, and \`data-testid="${ids.field("...")}\` to each field's control — an \`<input>\` for plain fields, a native \`<select>\` for a parent foreign-key field
 - Table rows: add \`data-testid="${ids.row}"\` to each row container, \`data-testid="${ids.rowCell("...")}\` to data cells, \`data-testid="${ids.rowEdit}"\` and \`data-testid="${ids.rowDelete}"\` to action buttons
 - Delete confirmation: add \`data-testid="${ids.confirmDelete}"\` to the CONFIRM BUTTON inside the delete dialog — the button whose \`onClick\` fires the delete mutation. NOT the dialog wrapper/overlay \`<div>\`: acceptance CLICKS this testid to confirm, and clicking a wrapper hits the backdrop, so the delete never runs and the row is never removed.
 

--- a/packages/core/src/loop/boringstack/acceptance/testid-contract.ts
+++ b/packages/core/src/loop/boringstack/acceptance/testid-contract.ts
@@ -65,12 +65,26 @@ export function buildTestIdGuide(entity: IEntityAcceptance): string {
   const ids = testIdsFor(entity.key);
   const required = requiredTestIds(entity);
   // The <input> Pattern example must use a NON-relationship field — a parent FK renders as a
-  // <select> (see Relationship selectors), so showing one as an <input> would contradict the fix.
-  const exampleField =
-    entity.fields.find((f) => !entity.parents.some((p) => p.fkField === f.name))
-      ?.name ??
-    entity.fields[0]?.name ??
-    "title";
+  // <select> (see Relationship selectors), so it must NEVER show an FK as an <input>. When the
+  // entity has no plain field (all fields are FKs), show the <select> form instead of an <input>.
+  const plainFieldName = entity.fields.find(
+    (f) => !entity.parents.some((p) => p.fkField === f.name)
+  )?.name;
+  const firstParentFk = entity.parents[0]?.fkField;
+  const rowCellField =
+    entity.shows[0] ?? plainFieldName ?? entity.fields[0]?.name ?? "name";
+  const rowExampleLine = `- In the table row: \`<td data-testid="${ids.rowCell(rowCellField)}">{record.${rowCellField}}</td>\``;
+  const patternExample =
+    plainFieldName !== undefined
+      ? `**Pattern example** (for a NON-relationship field named "${plainFieldName}" in a "${entity.key}" feature):
+- In the create/edit form: \`<input data-testid="${ids.field(plainFieldName)}" />\` (a parent FK field is a \`<select>\` instead — see Relationship selectors)
+${rowExampleLine}`
+      : firstParentFk !== undefined
+        ? `**Pattern example** (every field of "${entity.key}" is a parent foreign key — render each as a native \`<select>\`, NEVER an \`<input>\`):
+- In the create/edit form: \`<select data-testid="${ids.field(firstParentFk)}"> … </select>\`
+${rowExampleLine}`
+        : `**Pattern example**: give each form field a \`data-testid\` on its \`<input>\` control.
+${rowExampleLine}`;
 
   return `## Test IDs for "${entity.key}" — Required Test Hooks
 
@@ -108,9 +122,7 @@ ${
     : ""
 }
 
-**Pattern example** (for a NON-relationship field named "${exampleField}" in a "${entity.key}" feature):
-- In the create/edit form: \`<input data-testid="${ids.field(exampleField)}" />\` (a parent FK field is a \`<select>\` instead — see Relationship selectors)
-- In the table row: \`<td data-testid="${ids.rowCell(entity.shows[0] ?? entity.fields[0]?.name ?? "name")}">{record.${entity.shows[0] ?? entity.fields[0]?.name ?? "name"}}</td>\`
+${patternExample}
 
 **Where to add them:**
 - **Navigation (IMPORTANT — outside the feature directory):** add \`data-testid="${ids.nav}"\` to the "${entity.id}" link in the SHARED sidebar (\`apps/ui/src/components/core/AppSidebar/\`), NOT in the feature folder. A feature that isn't linked in the sidebar is unreachable and will fail end-to-end acceptance — every feature MUST be added to the sidebar navigation.

--- a/packages/core/tests/boringstack-testid-contract.test.ts
+++ b/packages/core/tests/boringstack-testid-contract.test.ts
@@ -168,11 +168,18 @@ describe("buildTestIdGuide", () => {
     // The FK field must not be double-listed as a plain input (which is what led the model to build
     // an <input>). It's flagged as NOT a plain input and deferred to the relationship selectors.
     const guide = buildTestIdGuide(contact);
+    const ids = testIdsFor(contact.key);
 
     expect(guide).toContain("are NOT plain inputs");
     // The non-FK fields ARE still listed as plain inputs.
     expect(guide).toContain('for the "name" field');
     expect(guide).toContain('for the "email" field');
+    // CRITICAL (regression the park was caused by): companyId must NOT appear as a plain-input
+    // form-field bullet. The plain-field bullets read `data-testid="…" for the "<field>" field`;
+    // assert that exact phrasing is absent for companyId (it lives in the <select> section instead).
+    expect(guide).not.toContain(
+      `\`data-testid="${ids.field("companyId")}"\` for the "companyId" field`
+    );
   });
 
   test("guide agreement: contains exactly the required testids", () => {

--- a/packages/core/tests/boringstack-testid-contract.test.ts
+++ b/packages/core/tests/boringstack-testid-contract.test.ts
@@ -152,6 +152,29 @@ describe("buildTestIdGuide", () => {
     }
   });
 
+  test("directs a parent FK field to a native <select> (Playwright selectOption), NOT an <input>", () => {
+    // build35 Contact parked: the model built companyId as an <input>, but acceptance uses Playwright
+    // selectOption which only works on a native <select>. The guide must mandate a <select>.
+    const guide = buildTestIdGuide(contact);
+    const ids = testIdsFor(contact.key);
+
+    expect(guide).toContain("native `<select>`");
+    expect(guide).toContain("selectOption");
+    // The FK field's testid appears attached to a <select>, not a plain input.
+    expect(guide).toContain(`<select data-testid="${ids.field("companyId")}">`);
+  });
+
+  test("does NOT list a parent FK field among the plain <input> form fields", () => {
+    // The FK field must not be double-listed as a plain input (which is what led the model to build
+    // an <input>). It's flagged as NOT a plain input and deferred to the relationship selectors.
+    const guide = buildTestIdGuide(contact);
+
+    expect(guide).toContain("are NOT plain inputs");
+    // The non-FK fields ARE still listed as plain inputs.
+    expect(guide).toContain('for the "name" field');
+    expect(guide).toContain('for the "email" field');
+  });
+
   test("guide agreement: contains exactly the required testids", () => {
     const guide = buildTestIdGuide(contact);
     const required = requiredTestIds(contact);

--- a/packages/core/tests/boringstack-testid-contract.test.ts
+++ b/packages/core/tests/boringstack-testid-contract.test.ts
@@ -9,6 +9,57 @@ import {
   planToAcceptanceSpec,
   testIdsFor,
 } from "../src/loop/acceptance/acceptance-spec";
+import type { IEntityAcceptance } from "../src/loop/acceptance/acceptance.types";
+
+/** Build a minimal entity where the FIRST field is a parent FK (the distinguishing case the
+ *  Contact fixture can't exercise — its first field "name" is already non-FK). */
+const fkFirstEntity: IEntityAcceptance = {
+  id: "Membership",
+  key: "membership",
+  nav: "Memberships",
+  fields: [
+    {
+      name: "userId",
+      type: "string",
+      optional: false,
+      valid: "u1",
+      invalid: [],
+    },
+    {
+      name: "role",
+      type: "string",
+      optional: false,
+      valid: "admin",
+      invalid: [],
+    },
+  ],
+  shows: ["role"],
+  screens: ["list", "form"],
+  parents: [{ entity: "User", key: "user", fkField: "userId" }],
+  negatives: [],
+  acceptanceCheck: "create a membership",
+};
+
+/** An entity whose ONLY field is a parent FK — the all-FK edge (join/link entity). */
+const allFkEntity: IEntityAcceptance = {
+  id: "Link",
+  key: "link",
+  nav: "Links",
+  fields: [
+    {
+      name: "userId",
+      type: "string",
+      optional: false,
+      valid: "u1",
+      invalid: [],
+    },
+  ],
+  shows: [],
+  screens: ["list", "form"],
+  parents: [{ entity: "User", key: "user", fkField: "userId" }],
+  negatives: [],
+  acceptanceCheck: "create a link",
+};
 
 // Create a test entity with fields, shows, and a parent relationship
 const testPlan: IProductPlan = {
@@ -180,6 +231,27 @@ describe("buildTestIdGuide", () => {
     expect(guide).not.toContain(
       `\`data-testid="${ids.field("companyId")}"\` for the "companyId" field`
     );
+  });
+
+  test("Pattern example names a NON-FK field even when the FIRST field IS a parent FK", () => {
+    // Distinguishing case the Contact fixture can't exercise (its fields[0]="name" is already non-FK).
+    // Here fields[0]="userId" IS the FK, so a regression to entity.fields[0] would show the FK as an
+    // <input> — contradicting the <select> mandate. The example must pick "role" (the non-FK field).
+    const guide = buildTestIdGuide(fkFirstEntity);
+    const ids = testIdsFor(fkFirstEntity.key);
+
+    expect(guide).toContain(`<input data-testid="${ids.field("role")}" />`);
+    // The FK is NEVER shown as an <input> in the example.
+    expect(guide).not.toContain(`<input data-testid="${ids.field("userId")}"`);
+  });
+
+  test("all-FK entity: Pattern example shows a <select>, NEVER an <input> of the FK", () => {
+    // Edge: an entity whose only field is a parent FK must not fall back to rendering it as an <input>.
+    const guide = buildTestIdGuide(allFkEntity);
+    const ids = testIdsFor(allFkEntity.key);
+
+    expect(guide).toContain(`<select data-testid="${ids.field("userId")}">`);
+    expect(guide).not.toContain(`<input data-testid="${ids.field("userId")}"`);
   });
 
   test("guide agreement: contains exactly the required testids", () => {

--- a/packages/core/tests/boringstack-testid-contract.test.ts
+++ b/packages/core/tests/boringstack-testid-contract.test.ts
@@ -252,6 +252,31 @@ describe("buildTestIdGuide", () => {
 
     expect(guide).toContain(`<select data-testid="${ids.field("userId")}">`);
     expect(guide).not.toContain(`<input data-testid="${ids.field("userId")}"`);
+    // shows=[] → NO row-cell example (rowCell testids exist only for shows; never invent one).
+    expect(guide).not.toContain("In the table row:");
+    expect(guide).not.toContain(ids.rowCell("userId"));
+  });
+
+  test("empty-fields entity: invents NO field name and emits NO row-cell example", () => {
+    // Edge (round-3 finding): with fields=[] and shows=[], the guide must not invent "name" nor
+    // reference record.name / a rowCell testid that isn't in the contract.
+    const emptyEntity: IEntityAcceptance = {
+      id: "Blank",
+      key: "blank",
+      nav: "Blanks",
+      fields: [],
+      shows: [],
+      screens: ["list", "form"],
+      parents: [],
+      negatives: [],
+      acceptanceCheck: "create a blank",
+    };
+    const guide = buildTestIdGuide(emptyEntity);
+
+    expect(guide).not.toContain("In the table row:");
+    expect(guide).not.toContain("record.name");
+    // Falls to the generic form-field note (no invented field, no <select>/<input> of a fake field).
+    expect(guide).toContain("give each form field a `data-testid`");
   });
 
   test("guide agreement: contains exactly the required testids", () => {


### PR DESCRIPTION
## What
build35 Contact reached the fast-gate GREEN, then **parked at acceptance**: the parent foreign-key field `contact-field-companyId` was built as an `<input>`, but the E2E create step uses Playwright `locator.selectOption`, which only works on a **native `<select>`**. The model even diagnosed it ("I need to change the companyId field from an Input to a Select") but the escalation ladder exhausted first. This is the relational-slice (`belongsTo`) wall for slice 2+.

## Root cause = the guide (the E2E generator already uses `selectOption` correctly)
`buildTestIdGuide`:
- **No longer lists parent-FK fields among the plain `<input>` form fields** — that double-listing is what led the model to build an `<input>`. Non-FK fields are still listed as inputs; FK fields are flagged "NOT plain inputs" and deferred to the relationship selectors.
- **Mandates a native `<select>`** for each parent FK, populated with one `<option>` per parent record (value = parent id, fetched via the parent's list query), and explains *why* (`selectOption` needs a real `<select>`, else the create step fails / the feature parks).
- **Pattern example** now derives a NON-relationship field (never renders an FK as `<input>`); the all-FK case shows a `<select>`; the empty-fields case invents no field and emits no row-cell example. "Where to add them" says each field's control is an `<input>` for plain fields, a native `<select>` for a parent FK.

## Tests (panel-clean over 4 rounds)
27 testid-contract tests, including distinguishing fixtures the Contact fixture can't exercise: `fkFirstEntity` (first field IS the FK → example must name the non-FK field, never the FK as `<input>`), `allFkEntity` (only field is FK → `<select>`, no invented rowCell), and an empty-fields fixture (no invented field, no row-cell example). Full core suite 3036 pass, 0 fail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)