### PR TITLE
fix(WS-B): exempt logic-files-require-test-sibling from near-green rollback (deterministic near-green trap)

### DIFF
--- a/packages/core/src/loop/near-green-checkpoint.ts
+++ b/packages/core/src/loop/near-green-checkpoint.ts
@@ -53,18 +53,25 @@ export interface INearGreenCheckpoint {
 
 /** Gate errors that in THIS stack clear ONLY by ADDING code — wiring the i18n keys the feature
  *  declared (`i18n-locale-keys-used`; the i18n-destructive-delete guard forbids the removal
- *  shortcut, so the model MUST add the UI that references them), or making the feature reachable
- *  (`reachability`; add the route/mount). A near-green state whose remaining errors are all of
- *  this class is a HOLLOW state (e.g. a list-only page with unused create/edit/delete
- *  translations): reaching green REQUIRES the model to add the form + buttons + toasts, which
- *  transiently spikes the error count. WS-B's count-only spray detection can't tell that
- *  legitimate completion edit from a bad convention spray, so checkpointing this state and
- *  reverting to it traps the model in the hollow app. NOTE: `judge` is deliberately EXCLUDED —
- *  the quality judge can reject defects in EXISTING code (fixable in place), not only
- *  hollowness, so it is not a reliable add-only signal. */
+ *  shortcut, so the model MUST add the UI that references them), making the feature reachable
+ *  (`reachability`; add the route/mount), or writing the required colocated test for a logic
+ *  module (`logic-files-require-test-sibling`; every `*.{hooks,queries,mutations,store,schemas,
+ *  service,utils}.ts` module the model adds demands a `.test.ts(x)` sibling — cleared ONLY by
+ *  ADDING that test file). A near-green state whose remaining errors are all of this class is a
+ *  HOLLOW/INCOMPLETE state (a list-only page with unused create/edit/delete translations, or fresh
+ *  logic modules still awaiting their tests): reaching green REQUIRES the model to ADD the form +
+ *  buttons + toasts + test siblings, which transiently spikes the error count. WS-B's count-only
+ *  spray detection can't tell that legitimate completion work from a bad convention spray, so
+ *  checkpointing this state and reverting to it TRAPS the model — it deletes the logic modules the
+ *  model just added, so it can never accumulate the N tests it needs (live: build34/36 ground
+ *  near-green reverting exactly this). NOTE: `judge` is deliberately EXCLUDED — the quality judge
+ *  can reject defects in EXISTING code (fixable in place), not only hollowness, so it is not a
+ *  reliable add-only signal. `logic-files-require-test-sibling` IS reliable: it has no fix-in-place
+ *  form — the only non-destructive resolution is to add the test. */
 const COMPLETION_CLASS_RULES: ReadonlySet<string> = new Set([
   "reachability",
   "i18n-locale-keys-used",
+  "logic-files-require-test-sibling",
 ]);
 
 /** Whether a gate error clears only by adding code (see COMPLETION_CLASS_RULES). Matches the

--- a/packages/core/tests/near-green-checkpoint.test.ts
+++ b/packages/core/tests/near-green-checkpoint.test.ts
@@ -82,10 +82,23 @@ test("build34/36 spike (1 dead-locale-key + N missing-test siblings) is ALL comp
   ];
 
   expect(allCompletionClass(spike)).toBe(true);
-  // Entering/staying in the completion phase across the spike (WS-B rollback stood down).
+  // ENTER the completion phase across the spike (WS-B rollback stood down so the added logic
+  // modules + their pending tests are not reverted).
   expect(nextCompletionPhase(false, spike)).toBe(true);
-  // But a genuine code regression mixed in (a broken test) re-arms WS-B — not all add-only.
-  expect(allCompletionClass([...spike, err("no-unsafe-argument")])).toBe(false);
+
+  // Mechanism note (mirrors the i18n/reachability STAY-through-mixed semantics that already exist):
+  // while ANY completion-class error still remains, the phase STAYS true even if a genuine fixable
+  // regression (a broken test) is mixed in — a per-cycle re-arm would flip the rollback + undo
+  // banner mid-add and re-trap the model. So the phase does NOT re-arm here…
+  const mixed = [...spike, err("no-unsafe-argument")];
+
+  expect(allCompletionClass(mixed)).toBe(false);
+  expect(nextCompletionPhase(true, mixed)).toBe(true);
+  // …and it correctly EXITS (re-arms WS-B) only once the completion work is DONE — no test-sibling
+  // (or other add-only) error remains, leaving just the fixable regression to protect against.
+  expect(nextCompletionPhase(true, [err("no-unsafe-argument")])).toBe(false);
+  // Standing WS-B down does NOT relax the GATE: the final validate still runs every rule, so a
+  // broken test can never reach green — the model must fix it (guided by the gate + the ladder).
 });
 
 // WS-B: the pure checkpoint/rollback decision, unit-locked with the Phase 0a thresholds

--- a/packages/core/tests/near-green-checkpoint.test.ts
+++ b/packages/core/tests/near-green-checkpoint.test.ts
@@ -20,10 +20,13 @@ import type { IFileSnapshot } from "../src/loop/file-snapshot";
 // reachability, judge) must NOT be checkpointed, or WS-B reverts the demanded completion edit.
 const err = (rule: string): IErrorItem => ({ key: rule, rule, message: rule });
 
-test("isCompletionClass: only reliable add-code rules (reachability/i18n-locale-keys-used), bare or prefixed", () => {
+test("isCompletionClass: reliable add-code rules (reachability/i18n-locale-keys-used/test-sibling), bare or prefixed", () => {
   expect(isCompletionClass(err("reachability"))).toBe(true);
   expect(isCompletionClass(err("i18n-locale-keys-used"))).toBe(true);
   expect(isCompletionClass(err("plugin/i18n-locale-keys-used"))).toBe(true);
+  // #61/#65: a missing colocated test clears ONLY by ADDING the test file — reliably add-only, so
+  // WS-B must not revert the logic modules the model just added (build34/36 ground on this).
+  expect(isCompletionClass(err("logic-files-require-test-sibling"))).toBe(true);
   // `judge` is EXCLUDED — it can reject defects in existing code, not only hollowness, so it
   // isn't a reliable add-only signal (would falsely disable WS-B on a fixable judge rejection).
   expect(isCompletionClass(err("judge"))).toBe(false);
@@ -63,6 +66,26 @@ test("allCompletionClass: true only when EVERY error is completion-class; empty 
     allCompletionClass([err("i18n-locale-keys-used"), err("no-console")])
   ).toBe(false);
   expect(allCompletionClass([])).toBe(false);
+});
+
+test("build34/36 spike (1 dead-locale-key + N missing-test siblings) is ALL completion-class → WS-B stands down", () => {
+  // The exact live spike that trapped build34/36: fixing near-green, the model added logic modules
+  // (each needs a test) + declared an i18n key not yet wired. All add-only → the count jump is
+  // legitimate completion work, not a spray, so allCompletionClass is true (WS-B must NOT revert).
+  const spike = [
+    err("i18n-locale-keys-used"),
+    err("logic-files-require-test-sibling"),
+    err("logic-files-require-test-sibling"),
+    err("logic-files-require-test-sibling"),
+    err("logic-files-require-test-sibling"),
+    err("logic-files-require-test-sibling"),
+  ];
+
+  expect(allCompletionClass(spike)).toBe(true);
+  // Entering/staying in the completion phase across the spike (WS-B rollback stood down).
+  expect(nextCompletionPhase(false, spike)).toBe(true);
+  // But a genuine code regression mixed in (a broken test) re-arms WS-B — not all add-only.
+  expect(allCompletionClass([...spike, err("no-unsafe-argument")])).toBe(false);
 });
 
 // WS-B: the pure checkpoint/rollback decision, unit-locked with the Phase 0a thresholds


### PR DESCRIPTION
## The trap (live: build34/36 ground ~30–47min near-green)
At ~1 error the model correctly **adds logic modules** (`*.hooks.ts` / `*.store.ts` / `*.schemas.ts` / …). The boringstack meta-lint requires a colocated test for each, so "Missing colocated test" (`logic-files-require-test-sibling`) errors appear and **spike the count** past the WS-B `checkpoint + M` threshold. WS-B then **rolls back** to the lower-error checkpoint — *deleting the logic modules the model just added*. So it can never accumulate the N test siblings it needs → it oscillates and parks. The symptom looks "stochastic" (build32/34 crossed, build35/36 didn't) but this rollback is a *deterministic* driver of it (tasks #61/#65 under #77).

## Fix
`logic-files-require-test-sibling` clears **only by ADDING** the test file — the same add-only class as the already-exempt `i18n-locale-keys-used` and `reachability`, and (unlike the deliberately-excluded `judge`) it has **no fix-in-place form**, so it's a reliable add-only signal. Added it to `COMPLETION_CLASS_RULES`. When every remaining near-green error is add-only, WS-B stands down and lets the model finish the completion work; a genuine code regression mixed in (e.g. a broken test) makes `allCompletionClass` false so a fresh state won't newly enter the phase, and the phase EXITs (re-arms WS-B) once the add-only work is done.

## Not a gate relaxation
WS-B is a *mid-loop rollback heuristic*, not the gate. The final `validate` still runs every rule, so a broken test can never reach green — standing WS-B down only stops it reverting legitimate progress; the model must still satisfy every rule (guided by the gate + escalation ladder).

## Tests
Panel-clean (PASS). Cover: `isCompletionClass(test-sibling)=true`; the exact build34/36 spike (1 i18n + 5 missing-test) ENTERs the completion phase; STAY-through-mixed when a fixable regression is added; EXIT (re-arm) when only the fixable error remains. Full core suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)