### PR TITLE
fix(gate): fast UI gate runs the AppSidebar test — nav-count gate-parity (final-acceptance park)

### DIFF
--- a/packages/core/src/loop/boringstack/gate.ts
+++ b/packages/core/src/loop/boringstack/gate.ts
@@ -56,9 +56,18 @@ const eslintJson = (app: string): string =>
 // run src/features`: the app's own `test` script is vitest (WATCH by default — it would
 // hang a gate), and passing `run` switches it to a single non-watch run via the LOCAL
 // vitest (no `bunx` network/install risk), scoped to the feature tests.
+//
+// ALSO run the AppSidebar test dir. A feature MUST add its NavLink to the shared
+// `src/components/core/AppSidebar` (reachability), and that component's co-located test asserts the
+// EXACT nav-link count — so every nav-adding feature breaks it until the model bumps the count. It
+// lives OUTSIDE `src/features`, so without this it only failed at the FINAL acceptance gate, AFTER
+// the feature was already "verified" — build39 shipped a feature the fast gate called green, then
+// final acceptance failed on `AppSidebar.test` (expected 6, got 7) with no in-loop feedback (the
+// guide asks the model to bump the count, but nothing GATES it, so compliance was stochastic). One
+// tiny extra test file (~negligible) closes the parity gap so the count mismatch is an in-loop error.
 const FAST_GATE =
   `echo '::tsforge-app apps/api::' && (cd apps/api && ${eslintJson("apps/api")} && bun run check && bun run test) && ` +
-  `echo '::tsforge-app apps/ui::' && (cd apps/ui && bun run generate:api && ${eslintJson("apps/ui")} && bun run check && bun run test -- run src/features)`;
+  `echo '::tsforge-app apps/ui::' && (cd apps/ui && bun run generate:api && ${eslintJson("apps/ui")} && bun run check && bun run test -- run src/features src/components/core/AppSidebar)`;
 
 /**
  * FULL acceptance gate — run ONCE, when every feature has passed the fast gate. The

--- a/packages/core/tests/boringstack-gate.test.ts
+++ b/packages/core/tests/boringstack-gate.test.ts
@@ -53,7 +53,7 @@ describe("runBoringstackGate", () => {
     // the feature tests — the stage ends with `&& bun run test -- run src/features)`.
     expect(cmd).toContain("cd apps/ui && bun run generate:api &&");
     expect(cmd).toContain(
-      "&& bun run check && bun run test -- run src/features)"
+      "&& bun run check && bun run test -- run src/features src/components/core/AppSidebar)"
     );
     // The slow acceptance-only work must NOT be in the per-cycle gate.
     expect(cmd).not.toContain("bun run validate");
@@ -74,6 +74,12 @@ describe("runBoringstackGate", () => {
     expect(cmd).toContain("bun run test -- run src/features");
     expect(cmd.indexOf("bun run test -- run src/features")).toBeGreaterThan(
       cmd.indexOf("cd apps/ui")
+    );
+    // …AND the AppSidebar test dir (gate-parity: every nav-adding feature breaks its exact-count
+    // assertion, but it lives outside src/features so it only failed at FINAL acceptance — build39
+    // shipped a fast-gate-green feature that then failed the sidebar count. It must be an in-loop error.
+    expect(cmd).toContain(
+      "bun run test -- run src/features src/components/core/AppSidebar"
     );
   });
 


### PR DESCRIPTION
## The gap (build39)
Company passed the fast per-feature gate (**verified 1/1**) but **failed final acceptance** on `AppSidebar.test.tsx` — *"expected length 6, got 7"*. Every feature must add its NavLink to the shared `src/components/core/AppSidebar` (reachability), and that component's co-located test asserts the **exact** nav-link count. The fast UI gate ran `bun run test -- run src/features`, which **excludes** `src/components/core/AppSidebar`, so the count mismatch was invisible during the loop and only surfaced at the final full `validate` — *after* the feature was frozen "verified".

The guide already asks the model to bump the count, but nothing **gated** it, so compliance was stochastic (build37 bumped it → final GREEN; build39 didn't → stuck). Because it hits every nav-adding feature, it fails final acceptance on essentially every build unless the model happens to comply.

## Fix
The fast UI test run now includes the AppSidebar dir:
`bun run test -- run src/features src/components/core/AppSidebar`
so the count mismatch is an **in-loop gate error** the model must fix before the feature verifies — one tiny extra test file, negligible added time. This is the same gate-parity principle already applied to the feature test suite (a fast-gate-green feature must not fail a test only the final gate ran).

## Tests
`boringstack-gate.test.ts` asserts the new fast-gate scope and documents why. Full core suite green. Panel PASS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)