### PR TITLE
fix(gate): run prettier LAST in autofix so format:check converges (build44 opaqueGateError)

### DIFF
--- a/packages/core/src/loop/boringstack/build.ts
+++ b/packages/core/src/loop/boringstack/build.ts
@@ -53,8 +53,16 @@ export async function autofixApps(cwd: string, exec: Exec): Promise<void> {
     // acceptance — a gate-parity hole (4/4 panel). `lint:fix` re-populates a fresh cache
     // for this cycle right after, so the later `check` → `lint` read stays fast AND sound.
     await exec(["rm", "-f", ".eslintcache"], { cwd: appCwd });
-    await exec(["bun", "run", "format"], { cwd: appCwd });
+    // ORDER MATTERS: `lint:fix` (eslint --fix) BEFORE `format` (prettier --write) — prettier must
+    // be the LAST formatter. If prettier runs first and eslint --fix then re-formats (import order,
+    // etc.), the gate's later `format:check` (prettier --check) fails on what eslint --fix changed,
+    // and since prettier --write already ran there's nothing left to converge it — the build burns
+    // cycles on a format error autofix can't clear (live: build44 Contact hit `format:check` on
+    // ContactPage.types.ts every cycle → opaqueGateError). Running prettier LAST gives it the final
+    // say, so `format:check` is always clean. (Prettier changing a file after lint:fix invalidates
+    // only that file's eslint-cache entry, which the gate then re-lints — still sound.)
     await exec(["bun", "run", "lint:fix"], { cwd: appCwd });
+    await exec(["bun", "run", "format"], { cwd: appCwd });
   }
 }
 

--- a/packages/core/src/loop/boringstack/build.ts
+++ b/packages/core/src/loop/boringstack/build.ts
@@ -35,11 +35,13 @@ import { readHostPorts, hostPortOr } from "../../scaffold";
 import { FLAG_ON, ENV_FLAG } from "../../config/config.constants";
 
 /** Apply BoringStack's DETERMINISTIC auto-fixes over both apps before the gate:
- *  `format` (prettier, canonical formatting) then `lint:fix` (eslint --fix for the
- *  auto-fixable lint rules prettier can't touch — padding-line, import order, etc.).
- *  Neither changes logic, so neither should ever cost the model a gate attempt — a
- *  dev gets both on save. Best-effort: a missing script or non-zero exit is ignored;
- *  the gate stays the source of truth. */
+ *  `lint:fix` (eslint --fix for the auto-fixable lint rules — padding-line, import order, etc.)
+ *  then `format` (prettier, canonical formatting) — in THAT order, prettier LAST. Neither changes
+ *  logic, so neither should ever cost the model a gate attempt — a dev gets both on save. The
+ *  order is load-bearing: prettier must run after eslint --fix so the gate's `format:check`
+ *  always converges (if prettier ran first, eslint --fix could re-format after it and format:check
+ *  would then fail with nothing left to fix it — see the ORDER MATTERS note in the body).
+ *  Best-effort: a missing script or non-zero exit is ignored; the gate stays the source of truth. */
 export async function autofixApps(cwd: string, exec: Exec): Promise<void> {
   for (const app of ["apps/api", "apps/ui"]) {
     const appCwd = join(cwd, app);

--- a/packages/core/tests/boringstack-build.test.ts
+++ b/packages/core/tests/boringstack-build.test.ts
@@ -668,23 +668,26 @@ describe("runBoringstackBuild", () => {
       expect(full).toBeGreaterThan(0);
 
       // …and the SIX exec calls immediately before it are the full autofixApps
-      // contract — clear eslint cache + format + lint:fix for BOTH apps — proving
+      // contract — clear eslint cache + lint:fix + format for BOTH apps — proving
       // acceptance is preceded by the same deterministic auto-fixes the per-cycle gate
       // applies. The `rm -f .eslintcache` FIRST is the type-aware-lint soundness fix:
       // eslint --cache can return a stale-clean result for a file whose content is
       // unchanged but whose cross-file types changed, so the cache is cleared each cycle.
-      // Dropping the cache clear, `format`, or the api half must fail this.
+      // ORDER: `lint:fix` (eslint --fix) BEFORE `format` (prettier --write) — prettier LAST so the
+      // gate's `format:check` always converges (else eslint --fix re-formats after prettier and
+      // format:check fails on it with nothing left to fix it — build44 Contact opaqueGateError).
+      // Dropping the cache clear, `format`, the ordering, or the api half must fail this.
       const before = execCalls
         .slice(full - 6, full)
         .map((c) => `${c.argv.join(" ")} @ ${c.cwd.replace(dir, "")}`);
 
       expect(before).toEqual([
         "rm -f .eslintcache @ /apps/api",
-        "bun run format @ /apps/api",
         "bun run lint:fix @ /apps/api",
+        "bun run format @ /apps/api",
         "rm -f .eslintcache @ /apps/ui",
-        "bun run format @ /apps/ui",
         "bun run lint:fix @ /apps/ui",
+        "bun run format @ /apps/ui",
       ]);
     } finally {
       await rm(dir, { recursive: true, force: true });


### PR DESCRIPTION
## Wall (build44 Contact)
Contact burned near-green ladder cycles on an **opaqueGateError** ("Gate exited nonzero in apps/ui and its output format was not recognized"). Root-caused from the log to a prettier `format:check` failure:
```
$ prettier --check .
[warn] src/features/contact/components/ContactPage/ContactPage.types.ts
[warn] Code style issues found in the above file. Run Prettier with --write to fix.
error: script "format:check" exited with code 1
```

## Root cause (by elimination)
`autofixApps` runs `prettier --write .` **every cycle**, so `format:check` should never fail. The only mutation after prettier was the very next autofix step — `lint:fix` (`eslint --cache --fix .`) — re-formatting after prettier. Since `prettier --write` already ran, nothing converges it, so `format:check` fails every cycle and the model can't clear it. Worse, `extract-failures` doesn't parse prettier's output, so it surfaces as an unactionable opaqueGateError (wasted ladder budget → contributes to the near-green park).

## Fix
Reorder `autofixApps` to run **`lint:fix` before `format`** — prettier is the final formatter, so `format:check` always converges. The `rm -f .eslintcache` stays first; cache soundness is preserved (a file prettier changes after lint:fix has its cache entry invalidated and is re-linted by the gate). JSDoc + the autofix-order contract test updated with the rationale.

## Tests
`boringstack-build.test.ts` pins the new order (`clear-cache → lint:fix → format`, both apps). Full core suite green. Panel PASS (the one ag1 note — a stale JSDoc — is fixed in this branch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)