### PR TITLE
fix(gate): reject HOLLOW features — CRUD hooks must be wired, not just defined (#50)

### DIFF
--- a/osv-scanner.toml
+++ b/osv-scanner.toml
@@ -67,3 +67,14 @@ reason = "undici 7.24.8 (miniflare→wrangler dev dependency only); runtime undi
 id = "GHSA-vxpw-j846-p89q"
 ignoreUntil = 2026-09-12T00:00:00Z
 reason = "undici 7.24.8 (miniflare→wrangler dev dependency only); runtime undici (via jsdom) is 7.28.0/unaffected; not shipped in the published package. Re-evaluate when wrangler/miniflare bump undici."
+
+# valibot 1.4.1 reaches us ONLY transitively via eslint-plugin-better-tailwindcss
+# (dependencies.valibot ^1.3.1) — a build-time ESLint plugin dev dependency. It is
+# NOT in the published @agjs/tsforge package (files: bin, src, *.eslint.config.mjs),
+# so there is no runtime or published-artifact exposure. Advisory published
+# 2026-07-24 (Medium 6.9). Re-evaluate when eslint-plugin-better-tailwindcss bumps
+# its valibot range to >=1.4.2 (the patched version).
+[[IgnoredVulns]]
+id = "GHSA-5qjj-4xww-7phc"
+ignoreUntil = 2026-09-12T00:00:00Z
+reason = "valibot 1.4.1 (transitive via eslint-plugin-better-tailwindcss, a dev-only ESLint plugin); not shipped in the published package. Re-evaluate when the plugin bumps valibot to >=1.4.2."

--- a/packages/core/src/loop/boringstack/acceptance/testid-contract.ts
+++ b/packages/core/src/loop/boringstack/acceptance/testid-contract.ts
@@ -150,6 +150,54 @@ Without these test IDs, the feature cannot be validated end-to-end and will not 
  * @param sources - Map of {filePath → source code}
  * @param entity - The entity whose testids must be present
  */
+/**
+ * Detect a HOLLOW feature: the required test hooks are all present, but the CRUD
+ * hooks are never wired into the UI — a static shell that satisfies the testid
+ * contract while doing nothing (observed live: build49 Contact shipped every
+ * `data-testid` with hardcoded `-` rows, no `onSubmit`, and `useCreate/Update/Delete`
+ * defined but never called — a false-green the fast gate accepted).
+ *
+ * A hook is considered WIRED if its name (word-boundary matched, so `useContact`
+ * does not match `useContactPage`) appears in at least TWO non-test feature files:
+ * its own definition file PLUS at least one consumer (the page `.tsx` OR a view
+ * `<Component>.hooks.ts` that the page calls). A hook that appears in only ONE
+ * non-test file is just its own definition — dead, i.e. the feature can't perform
+ * that operation. This is pattern-agnostic: it passes both a direct call in the
+ * `.tsx` and the scaffold's handler-from-the-hook idiom (`view.onSubmit`).
+ *
+ * @param files - Map of {relPath → source} for the feature's .ts + .tsx sources
+ * @param entity - The entity whose CRUD hooks must be wired
+ */
+export function checkWiring(
+  files: Map<string, string>,
+  entity: IEntityAcceptance
+): string[] {
+  const errors: string[] = [];
+  const isTest = (p: string): boolean =>
+    /\.(test|spec|stories)\.[jt]sx?$/u.test(p);
+  const prod = Array.from(files.entries()).filter(([p]) => !isTest(p));
+
+  // The full-CRUD contract: the list query + the three mutation hooks the guide
+  // mandates (list/create/update/delete). PascalCase feature id → hook names.
+  const hooks = [
+    `use${entity.id}`,
+    `useCreate${entity.id}`,
+    `useUpdate${entity.id}`,
+    `useDelete${entity.id}`,
+  ];
+
+  for (const hook of hooks) {
+    const re = new RegExp(`\\b${hook}\\b`, "u");
+    const filesWithHook = prod.filter(([, src]) => re.test(src)).length;
+
+    if (filesWithHook < 2) {
+      errors.push(hook);
+    }
+  }
+
+  return errors;
+}
+
 export function checkTestIds(
   sources: Map<string, string>,
   entity: IEntityAcceptance

--- a/packages/core/src/loop/boringstack/acceptance/testid-contract.ts
+++ b/packages/core/src/loop/boringstack/acceptance/testid-contract.ts
@@ -150,20 +150,26 @@ Without these test IDs, the feature cannot be validated end-to-end and will not 
  * @param sources - Map of {filePath → source code}
  * @param entity - The entity whose testids must be present
  */
+/** Escape a string for safe use as a literal inside a RegExp. */
+function escapeRegExp(s: string): string {
+  return s.replace(/[.*+?^${}()|[\]\\]/gu, "\\$&");
+}
+
 /**
  * Detect a HOLLOW feature: the required test hooks are all present, but the CRUD
- * hooks are never wired into the UI — a static shell that satisfies the testid
+ * hooks are never CALLED from the UI — a static shell that satisfies the testid
  * contract while doing nothing (observed live: build49 Contact shipped every
  * `data-testid` with hardcoded `-` rows, no `onSubmit`, and `useCreate/Update/Delete`
  * defined but never called — a false-green the fast gate accepted).
  *
- * A hook is considered WIRED if its name (word-boundary matched, so `useContact`
- * does not match `useContactPage`) appears in at least TWO non-test feature files:
- * its own definition file PLUS at least one consumer (the page `.tsx` OR a view
- * `<Component>.hooks.ts` that the page calls). A hook that appears in only ONE
- * non-test file is just its own definition — dead, i.e. the feature can't perform
- * that operation. This is pattern-agnostic: it passes both a direct call in the
- * `.tsx` and the scaffold's handler-from-the-hook idiom (`view.onSubmit`).
+ * A hook is WIRED only when it is actually INVOKED — `useX(` — in a non-test file
+ * that is NOT its own definition file. Requiring the call paren defeats the trivial
+ * bypasses (a bare `import { useX }`, a re-export barrel `export { useX }`, a type
+ * reference, or a comment all mention the name WITHOUT the `(` and so do NOT count).
+ * Requiring a NON-definition file rules out the `export function useX(` definition
+ * site itself. Word-boundary matched, so `useContact(` never matches `useContactPage(`.
+ * Pattern-agnostic: passes both a direct call in the page `.tsx` and the scaffold's
+ * handler-from-the-hook idiom (the call living in a view `<Component>.hooks.ts`).
  *
  * @param files - Map of {relPath → source} for the feature's .ts + .tsx sources
  * @param entity - The entity whose CRUD hooks must be wired
@@ -187,10 +193,15 @@ export function checkWiring(
   ];
 
   for (const hook of hooks) {
-    const re = new RegExp(`\\b${hook}\\b`, "u");
-    const filesWithHook = prod.filter(([, src]) => re.test(src)).length;
+    const h = escapeRegExp(hook);
+    // Definition site: `function useX` / `const useX =` / `const useX:` (the file that OWNS the hook).
+    const defRe = new RegExp(`(?:function|const)\\s+${h}\\b`, "u");
+    // A genuine CALL: the hook name immediately followed by `(` (allowing whitespace).
+    const callRe = new RegExp(`\\b${h}\\s*\\(`, "u");
 
-    if (filesWithHook < 2) {
+    const wired = prod.some(([, src]) => !defRe.test(src) && callRe.test(src));
+
+    if (!wired) {
       errors.push(hook);
     }
   }

--- a/packages/core/src/loop/boringstack/gate-stages.ts
+++ b/packages/core/src/loop/boringstack/gate-stages.ts
@@ -605,8 +605,15 @@ export function testIdStage(cwd: string, entity: IEntityAcceptance): IStage {
         }
       }
 
-      // Check for required testids
-      const missing = checkTestIds(sources, entity);
+      // Check for required testids — ONLY over JSX-rendering files (.tsx/.jsx). A `data-testid`
+      // string in a non-render `.ts` must not satisfy the presence check while the `.tsx` stays a
+      // shell (the `.ts` files are collected only so checkWiring can see the view-hook call path).
+      const renderSources = new Map(
+        Array.from(sources.entries()).filter(
+          ([p]) => p.endsWith(".tsx") || p.endsWith(".jsx")
+        )
+      );
+      const missing = checkTestIds(renderSources, entity);
 
       if (missing.length > 0) {
         const message =
@@ -640,10 +647,11 @@ export function testIdStage(cwd: string, entity: IEntityAcceptance): IStage {
         `defined but NEVER wired into the UI (each appears only in its own definition file, not in ` +
         `the page component or its view hook). The testids exist but connect to nothing — no create/` +
         `edit/delete actually runs and the list shows no fetched data. WIRE each hook into the ` +
-        `feature: call \`use${entity.id}\` in the page (or its \`.hooks.ts\` view) and render the fetched ` +
-        `rows with \`.map\`; call \`useCreate/useUpdate/useDelete${entity.id}\` from the form submit and the ` +
-        `row edit/delete actions (the scaffold's \`view.onSubmit\` idiom). A feature whose hooks are ` +
-        `dead is INCOMPLETE and must not pass.`;
+        `feature: CALL \`use${entity.id}()\` in the page (or its \`.hooks.ts\` view) and render the fetched ` +
+        `rows with \`.map\`; CALL \`useCreate${entity.id}()\`, \`useUpdate${entity.id}()\`, and ` +
+        `\`useDelete${entity.id}()\` from the form submit and the row edit/delete actions (the scaffold's ` +
+        `\`view.onSubmit\` idiom). Importing a hook is NOT enough — it must be invoked. A feature whose ` +
+        `hooks are never called is INCOMPLETE and must not pass.`;
 
       return {
         passed: false,

--- a/packages/core/src/loop/boringstack/gate-stages.ts
+++ b/packages/core/src/loop/boringstack/gate-stages.ts
@@ -18,7 +18,7 @@ import {
   rescueFileFor,
 } from "./build";
 import type { IEntityAcceptance } from "../acceptance/acceptance.types";
-import { checkTestIds } from "./acceptance/testid-contract";
+import { checkTestIds, checkWiring } from "./acceptance/testid-contract";
 import { FLAG_ON, ENV_FLAG } from "../../config/config.constants";
 
 /** Turn one failure signature into an `IErrorItem`. Most signatures are their own
@@ -542,7 +542,8 @@ export function testIdStage(cwd: string, entity: IEntityAcceptance): IStage {
         const files = await readdir(featureDir, { recursive: true });
         const uiFiles = files.filter(
           (f): f is string =>
-            typeof f === "string" && (f.endsWith(".tsx") || f.endsWith(".jsx"))
+            typeof f === "string" &&
+            (f.endsWith(".tsx") || f.endsWith(".jsx") || f.endsWith(".ts"))
         );
 
         for (const file of uiFiles) {
@@ -607,24 +608,53 @@ export function testIdStage(cwd: string, entity: IEntityAcceptance): IStage {
       // Check for required testids
       const missing = checkTestIds(sources, entity);
 
-      if (missing.length === 0) {
-        return { passed: true, errors: [], output: "all testids present" };
+      if (missing.length > 0) {
+        const message =
+          `feature '${entity.id}' UI is missing required test hooks: ${missing.join(", ")}. ` +
+          `Add data-testid to the list, form, fields, and row controls so the app is testable.`;
+
+        return {
+          passed: false,
+          errors: [
+            { key: `testid:${entity.id}`, rule: "testid-presence", message },
+          ],
+          output: message,
+        };
       }
 
-      const message =
-        `feature '${entity.id}' UI is missing required test hooks: ${missing.join(", ")}. ` +
-        `Add data-testid to the list, form, fields, and row controls so the app is testable.`;
+      // Testids present — now reject a HOLLOW shell: the CRUD hooks must be WIRED
+      // into the UI, not just defined. (build49 shipped every testid with dead
+      // useCreate/Update/Delete and hardcoded rows — a false-green the fast gate took.)
+      const deadHooks = checkWiring(sources, entity);
+
+      if (deadHooks.length === 0) {
+        return {
+          passed: true,
+          errors: [],
+          output: "all testids present + wired",
+        };
+      }
+
+      const wiringMessage =
+        `feature '${entity.id}' is a HOLLOW shell: the CRUD hook(s) ${deadHooks.join(", ")} are ` +
+        `defined but NEVER wired into the UI (each appears only in its own definition file, not in ` +
+        `the page component or its view hook). The testids exist but connect to nothing — no create/` +
+        `edit/delete actually runs and the list shows no fetched data. WIRE each hook into the ` +
+        `feature: call \`use${entity.id}\` in the page (or its \`.hooks.ts\` view) and render the fetched ` +
+        `rows with \`.map\`; call \`useCreate/useUpdate/useDelete${entity.id}\` from the form submit and the ` +
+        `row edit/delete actions (the scaffold's \`view.onSubmit\` idiom). A feature whose hooks are ` +
+        `dead is INCOMPLETE and must not pass.`;
 
       return {
         passed: false,
         errors: [
           {
-            key: `testid:${entity.id}`,
-            rule: "testid-presence",
-            message,
+            key: `wiring:${entity.id}`,
+            rule: "feature-wiring",
+            message: wiringMessage,
           },
         ],
-        output: message,
+        output: wiringMessage,
       };
     },
   };

--- a/packages/core/tests/boringstack-gate-stages.test.ts
+++ b/packages/core/tests/boringstack-gate-stages.test.ts
@@ -9,8 +9,11 @@ import {
   judgeStage,
   signatureToError,
   locateParseError,
+  testIdStage,
 } from "../src/loop/boringstack/gate-stages";
 import { scopeFor, featureOwnedGlobs } from "../src/loop/boringstack/build";
+import { testIdsFor } from "../src/loop/acceptance/acceptance-spec";
+import type { IEntityAcceptance } from "../src/loop/acceptance/acceptance.types";
 import type { Exec } from "../src/loop/boringstack/exec";
 import type { IFeature } from "../src/loop/greenfield/greenfield.types";
 import type { IProvider } from "../src/inference";
@@ -882,5 +885,119 @@ describe("featureOwnedGlobs", () => {
       false
     );
     expect(owned("apps/ui/src/app/router/routes.tsx")).toBe(false);
+  });
+});
+
+describe("testIdStage — hollow-shell wiring gate (integration, real filesystem)", () => {
+  const entity: IEntityAcceptance = {
+    id: "Contact",
+    key: "contact",
+    nav: "Contacts",
+    fields: [
+      {
+        name: "name",
+        type: "string",
+        optional: false,
+        valid: "A",
+        invalid: [],
+      },
+    ],
+    shows: ["name"],
+    screens: ["list", "form"],
+    parents: [],
+    negatives: [],
+    acceptanceCheck: "create a contact",
+  };
+
+  // Every required testid (checkTestIds skips nav) rendered on a real element.
+  const ids = testIdsFor(entity.key);
+  const allTestIds = [
+    ids.list,
+    ids.empty,
+    ids.create,
+    ids.form,
+    ids.submit,
+    ids.row,
+    ids.rowEdit,
+    ids.rowDelete,
+    ids.confirmDelete,
+    ids.field("name"),
+    ids.rowCell("name"),
+  ];
+  const pageWithTestIds = `export const ContactPage = () => (<main>${allTestIds
+    .map((t) => `<div data-testid='${t}'></div>`)
+    .join("")}</main>);`;
+
+  const QUERIES = "export function useContact() { return []; }";
+  const MUTATIONS =
+    "export function useCreateContact() {} export function useUpdateContact() {} export function useDeleteContact() {}";
+
+  async function writeFeature(files: Record<string, string>): Promise<string> {
+    const dir = await mkdtemp(join(tmpdir(), "tsforge-wiring-"));
+    for (const [rel, src] of Object.entries(files)) {
+      const full = join(dir, "apps/ui/src/features/contact", rel);
+      await mkdir(join(full, ".."), { recursive: true });
+      await writeFile(full, src);
+    }
+    return dir;
+  }
+
+  test("all testids present but hooks NEVER called → HOLLOW → stage fails (feature-wiring)", async () => {
+    const dir = await writeFeature({
+      "Contact.queries.ts": QUERIES,
+      "Contact.mutations.ts": MUTATIONS,
+      "components/ContactPage/ContactPage.tsx": pageWithTestIds,
+    });
+
+    try {
+      const result = await testIdStage(dir, entity).run(dir);
+
+      expect(result.passed).toBe(false);
+      expect(result.errors[0]?.rule).toBe("feature-wiring");
+      expect(result.errors[0]?.message).toContain("HOLLOW");
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  test("testids present AND hooks called in the page → passes", async () => {
+    const wiredPage = `import { useContact } from "../../Contact.queries";
+      import { useCreateContact, useUpdateContact, useDeleteContact } from "../../Contact.mutations";
+      export const ContactPage = () => {
+        const rows = useContact();
+        const c = useCreateContact(); const u = useUpdateContact(); const d = useDeleteContact();
+        return (<main>${allTestIds.map((t) => `<div data-testid='${t}'>{rows.map(String)}</div>`).join("")}</main>);
+      };`;
+    const dir = await writeFeature({
+      "Contact.queries.ts": QUERIES,
+      "Contact.mutations.ts": MUTATIONS,
+      "components/ContactPage/ContactPage.tsx": wiredPage,
+    });
+
+    try {
+      const result = await testIdStage(dir, entity).run(dir);
+      expect(result.passed).toBe(true);
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  test("a data-testid in a NON-render .ts does NOT satisfy the testid presence check", async () => {
+    // Regression for the gate-relaxed finding: testids must be proven over .tsx, not any .ts.
+    const dir = await writeFeature({
+      "Contact.queries.ts": `${QUERIES}\n// data-testid='${ids.list}' data-testid='${ids.form}'`,
+      "Contact.mutations.ts": MUTATIONS,
+      // The .tsx renders NOTHING → testids missing there even though the .ts "contains" them.
+      "components/ContactPage/ContactPage.tsx":
+        "export const ContactPage = () => <main />;",
+    });
+
+    try {
+      const result = await testIdStage(dir, entity).run(dir);
+      expect(result.passed).toBe(false);
+      expect(result.errors[0]?.rule).toBe("testid-presence");
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
   });
 });

--- a/packages/core/tests/boringstack-gate-stages.test.ts
+++ b/packages/core/tests/boringstack-gate-stages.test.ts
@@ -934,11 +934,14 @@ describe("testIdStage — hollow-shell wiring gate (integration, real filesystem
 
   async function writeFeature(files: Record<string, string>): Promise<string> {
     const dir = await mkdtemp(join(tmpdir(), "tsforge-wiring-"));
+
     for (const [rel, src] of Object.entries(files)) {
       const full = join(dir, "apps/ui/src/features/contact", rel);
+
       await mkdir(join(full, ".."), { recursive: true });
       await writeFile(full, src);
     }
+
     return dir;
   }
 
@@ -976,6 +979,7 @@ describe("testIdStage — hollow-shell wiring gate (integration, real filesystem
 
     try {
       const result = await testIdStage(dir, entity).run(dir);
+
       expect(result.passed).toBe(true);
     } finally {
       await rm(dir, { recursive: true, force: true });
@@ -994,6 +998,7 @@ describe("testIdStage — hollow-shell wiring gate (integration, real filesystem
 
     try {
       const result = await testIdStage(dir, entity).run(dir);
+
       expect(result.passed).toBe(false);
       expect(result.errors[0]?.rule).toBe("testid-presence");
     } finally {

--- a/packages/core/tests/boringstack-testid-contract.test.ts
+++ b/packages/core/tests/boringstack-testid-contract.test.ts
@@ -597,3 +597,88 @@ describe("checkWiring — reject a hollow shell (build49 false-green)", () => {
     expect(checkWiring(files, contactEntity)).toContain("useContact");
   });
 });
+
+describe("checkWiring — the bypasses must NOT pass (a mention is not a call)", () => {
+  const ce: IEntityAcceptance = {
+    id: "Contact",
+    key: "contact",
+    nav: "Contacts",
+    fields: [
+      {
+        name: "name",
+        type: "string",
+        optional: false,
+        valid: "A",
+        invalid: [],
+      },
+    ],
+    shows: ["name"],
+    screens: ["list", "form"],
+    parents: [],
+    negatives: [],
+    acceptanceCheck: "create a contact",
+  };
+  const defs: [string, string][] = [
+    ["Contact.queries.ts", "export function useContact() { return []; }"],
+    [
+      "Contact.mutations.ts",
+      "export function useCreateContact() {} export function useUpdateContact() {} export function useDeleteContact() {}",
+    ],
+  ];
+
+  test("IMPORT-only (hooks imported but never invoked) is still HOLLOW", () => {
+    const files = new Map<string, string>([
+      ...defs,
+      [
+        "components/ContactPage/ContactPage.tsx",
+        `import { useContact } from "../../Contact.queries";
+         import { useCreateContact, useUpdateContact, useDeleteContact } from "../../Contact.mutations";
+         export const ContactPage = () => <main data-testid='contact-list'>-</main>;`,
+      ],
+    ]);
+    // Names appear in a 2nd file, but with NO call paren → must all be flagged dead.
+    const dead = checkWiring(files, ce);
+    expect(dead).toContain("useContact");
+    expect(dead).toContain("useCreateContact");
+    expect(dead).toContain("useUpdateContact");
+    expect(dead).toContain("useDeleteContact");
+  });
+
+  test("RE-EXPORT barrel (export { useX }) is not wiring", () => {
+    const files = new Map<string, string>([
+      ...defs,
+      [
+        "index.ts",
+        `export { useContact } from "./Contact.queries";
+         export { useCreateContact, useUpdateContact, useDeleteContact } from "./Contact.mutations";`,
+      ],
+    ]);
+    expect(checkWiring(files, ce).sort()).toEqual(
+      [
+        "useContact",
+        "useCreateContact",
+        "useDeleteContact",
+        "useUpdateContact",
+      ].sort()
+    );
+  });
+
+  test("a comment / type mention that names the hook is not wiring", () => {
+    const files = new Map<string, string>([
+      ...defs,
+      [
+        "components/ContactPage/ContactPage.tsx",
+        `// TODO: wire useCreateContact here later
+         type X = typeof useUpdateContact;
+         export const ContactPage = () => { const rows = useContact(); const d = useDeleteContact(); return <div>{rows.map(String)}</div>; };`,
+      ],
+    ]);
+    // useContact + useDeleteContact are CALLED → ok; useCreateContact (comment) + useUpdateContact
+    // (type ref) are only mentioned → dead.
+    const dead = checkWiring(files, ce);
+    expect(dead).toContain("useCreateContact");
+    expect(dead).toContain("useUpdateContact");
+    expect(dead).not.toContain("useContact");
+    expect(dead).not.toContain("useDeleteContact");
+  });
+});

--- a/packages/core/tests/boringstack-testid-contract.test.ts
+++ b/packages/core/tests/boringstack-testid-contract.test.ts
@@ -638,6 +638,7 @@ describe("checkWiring — the bypasses must NOT pass (a mention is not a call)",
     ]);
     // Names appear in a 2nd file, but with NO call paren → must all be flagged dead.
     const dead = checkWiring(files, ce);
+
     expect(dead).toContain("useContact");
     expect(dead).toContain("useCreateContact");
     expect(dead).toContain("useUpdateContact");
@@ -653,6 +654,7 @@ describe("checkWiring — the bypasses must NOT pass (a mention is not a call)",
          export { useCreateContact, useUpdateContact, useDeleteContact } from "./Contact.mutations";`,
       ],
     ]);
+
     expect(checkWiring(files, ce).sort()).toEqual(
       [
         "useContact",
@@ -676,6 +678,7 @@ describe("checkWiring — the bypasses must NOT pass (a mention is not a call)",
     // useContact + useDeleteContact are CALLED → ok; useCreateContact (comment) + useUpdateContact
     // (type ref) are only mentioned → dead.
     const dead = checkWiring(files, ce);
+
     expect(dead).toContain("useCreateContact");
     expect(dead).toContain("useUpdateContact");
     expect(dead).not.toContain("useContact");

--- a/packages/core/tests/boringstack-testid-contract.test.ts
+++ b/packages/core/tests/boringstack-testid-contract.test.ts
@@ -3,6 +3,7 @@ import type { IProductPlan } from "../src/loop/planning/plan-types";
 import {
   buildTestIdGuide,
   checkTestIds,
+  checkWiring,
   requiredTestIds,
 } from "../src/loop/boringstack/acceptance/testid-contract";
 import {
@@ -484,5 +485,115 @@ describe("checkTestIds", () => {
 
     // Should fail because we specifically look for data-testid= (not dataTestId)
     expect(result).toContain(ids.list);
+  });
+});
+
+describe("checkWiring — reject a hollow shell (build49 false-green)", () => {
+  const contactEntity: IEntityAcceptance = {
+    id: "Contact",
+    key: "contact",
+    nav: "Contacts",
+    fields: [
+      {
+        name: "name",
+        type: "string",
+        optional: false,
+        valid: "A",
+        invalid: [],
+      },
+    ],
+    shows: ["name"],
+    screens: ["list", "form"],
+    parents: [],
+    negatives: [],
+    acceptanceCheck: "create a contact",
+  };
+
+  // The exact build49 shape: hooks DEFINED in their own file + referenced ONLY by
+  // their test, never wired into the page. Must flag all four as dead.
+  test("flags a hollow feature whose CRUD hooks are defined but never wired", () => {
+    const files = new Map<string, string>([
+      ["Contact.queries.ts", "export function useContact() { return []; }"],
+      [
+        "Contact.mutations.ts",
+        "export function useCreateContact() {} export function useUpdateContact() {} export function useDeleteContact() {}",
+      ],
+      ["Contact.queries.test.tsx", "useContact();"],
+      [
+        "Contact.mutations.test.tsx",
+        "useCreateContact(); useUpdateContact(); useDeleteContact();",
+      ],
+      [
+        "components/ContactPage/ContactPage.tsx",
+        "export const ContactPage = () => (<main data-testid='contact-list'><tr data-testid='contact-row'><td>-</td></tr></main>);",
+      ],
+    ]);
+
+    const dead = checkWiring(files, contactEntity);
+
+    expect(dead).toContain("useContact");
+    expect(dead).toContain("useCreateContact");
+    expect(dead).toContain("useUpdateContact");
+    expect(dead).toContain("useDeleteContact");
+  });
+
+  test("passes when hooks are wired DIRECTLY in the page component", () => {
+    const files = new Map<string, string>([
+      ["Contact.queries.ts", "export function useContact() { return []; }"],
+      [
+        "Contact.mutations.ts",
+        "export function useCreateContact() {} export function useUpdateContact() {} export function useDeleteContact() {}",
+      ],
+      [
+        "components/ContactPage/ContactPage.tsx",
+        `import { useContact } from "../../Contact.queries";
+         import { useCreateContact, useUpdateContact, useDeleteContact } from "../../Contact.mutations";
+         export const ContactPage = () => {
+           const rows = useContact();
+           const create = useCreateContact(); const update = useUpdateContact(); const del = useDeleteContact();
+           return <div>{rows.map((r) => r.name)}</div>;
+         };`,
+      ],
+    ]);
+
+    expect(checkWiring(files, contactEntity)).toEqual([]);
+  });
+
+  test("passes when hooks are wired via the view hook (.hooks.ts), the scaffold idiom", () => {
+    const files = new Map<string, string>([
+      ["Contact.queries.ts", "export function useContact() { return []; }"],
+      [
+        "Contact.mutations.ts",
+        "export function useCreateContact() {} export function useUpdateContact() {} export function useDeleteContact() {}",
+      ],
+      [
+        "components/ContactPage/ContactPage.hooks.ts",
+        `import { useContact } from "../../Contact.queries";
+         import { useCreateContact, useUpdateContact, useDeleteContact } from "../../Contact.mutations";
+         export function useContactPage() {
+           const rows = useContact();
+           return { rows, onSubmit: useCreateContact(), onEdit: useUpdateContact(), onDelete: useDeleteContact() };
+         }`,
+      ],
+      [
+        "components/ContactPage/ContactPage.tsx",
+        "export const ContactPage = () => { const view = useContactPage(); return <div />; };",
+      ],
+    ]);
+
+    expect(checkWiring(files, contactEntity)).toEqual([]);
+  });
+
+  test("word-boundary: useContact is not satisfied by useContactPage alone", () => {
+    const files = new Map<string, string>([
+      ["Contact.queries.ts", "export function useContact() { return []; }"],
+      [
+        "components/ContactPage/ContactPage.tsx",
+        "export const ContactPage = () => { useContactPage(); return <div/>; };",
+      ],
+    ]);
+
+    // useContact appears only in its definition file (useContactPage does NOT count) → dead.
+    expect(checkWiring(files, contactEntity)).toContain("useContact");
   });
 });


### PR DESCRIPTION
**Closes the hollow-UI false-green** (#50) surfaced live by build49.

build49 shipped a Contact that passed the fast gate GREEN while being a **static shell**: every `data-testid` present, but `useContact`/`useCreateContact`/`useUpdateContact`/`useDeleteContact` were **defined and never called** — hardcoded `-` rows, no `onSubmit`, no row actions. The testid check only verified the testid *strings* exist, so it accepted it. (It also explains a false 'win' — a hollow shell makes no api-client calls and has no handlers, so `Readable`/`jsx-no-bind` errors trivially can't occur.)

**Fix:** `checkWiring()` — each required CRUD hook must appear in ≥2 non-test feature files (definition + ≥1 consumer). Dead hook (definition-only) → HOLLOW → gate fails with an actionable steer. Word-boundary matched (`useContact` ≠ `useContactPage`); pattern-agnostic (direct `.tsx` call OR the scaffold's `view.onSubmit`-from-`.hooks.ts` idiom). Wired into `testIdStage`.

**Validated on real artifacts:** flags build49's actual hollow Contact (all 4 dead); a properly-wired feature passes. Unit tests cover hollow + both wired patterns + word-boundary. Full core suite green (3078).