### PR TITLE
fix(deps): bump brace-expansion 5.0.7 → 5.0.8 (GHSA-mh99-v99m-4gvg)

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -99,7 +99,7 @@
   },
   "overrides": {
     "@typescript-eslint/utils": "8.65.0",
-    "brace-expansion": "5.0.7",
+    "brace-expansion": "5.0.8",
     "dompurify": "^3.4.12",
     "esbuild": "^0.28.1",
     "js-yaml": "4.3.0",
@@ -934,7 +934,7 @@
 
     "boolbase": ["boolbase@1.0.0", "", {}, "sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww=="],
 
-    "brace-expansion": ["brace-expansion@5.0.7", "", { "dependencies": { "balanced-match": "^4.0.2" } }, "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA=="],
+    "brace-expansion": ["brace-expansion@5.0.8", "", { "dependencies": { "balanced-match": "^4.0.2" } }, "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg=="],
 
     "browserslist": ["browserslist@4.28.6", "", { "dependencies": { "baseline-browser-mapping": "^2.10.42", "caniuse-lite": "^1.0.30001803", "electron-to-chromium": "^1.5.389", "node-releases": "^2.0.51", "update-browserslist-db": "^1.2.3" }, "bin": { "browserslist": "cli.js" } }, "sha512-FQBYNK15VMslhLHpA7+n+n1GOlF1kId2xcCg7/j95f24AOF6VDYMNH4mFxF7KuaTdv627faazpOAjFzMrfJOUw=="],
 

--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
   },
   "overrides": {
     "@typescript-eslint/utils": "8.65.0",
-    "brace-expansion": "5.0.7",
+    "brace-expansion": "5.0.8",
     "dompurify": "^3.4.12",
     "esbuild": "^0.28.1",
     "js-yaml": "4.3.0",


### PR DESCRIPTION
The `brace-expansion` override pinned 5.0.7, which the newly-published High advisory **GHSA-mh99-v99m-4gvg** (ReDoS) flags; patched in 5.0.8.

This was the single unfiltered `osv-scanner` finding failing the required **dep vuln scan** check on every open PR and on `main`. Bumping the override removes the vuln outright rather than allowlisting it.

Verified locally: `osv-scanner --config=osv-scanner.toml --lockfile=bun.lock` exits 0; brace-expansion no longer reported (only the accepted dev-only valibot advisory stays filtered).