### PR TITLE
feat(loop): truthful park reason instead of always "ladder exhausted"

### DIFF
--- a/packages/core/src/loop/boringstack/build.ts
+++ b/packages/core/src/loop/boringstack/build.ts
@@ -477,7 +477,10 @@ export function e2eParkReason(
   reRun: IAcceptanceOutcome
 ): string {
   const failingDetail = (o: IAcceptanceOutcome): string | undefined =>
-    o.detail ?? o.results.find((r) => !r.ok)?.detail;
+    // Prefer the top-level detail, then the FIRST failing result that actually carries a
+    // (non-empty) detail — not merely the first failing result, whose detail may be blank
+    // while a later failing step holds the real diagnostic.
+    o.detail ?? o.results.find((r) => !r.ok && r.detail.length > 0)?.detail;
 
   if (!reRun.ok) {
     const detail =

--- a/packages/core/src/loop/boringstack/build.ts
+++ b/packages/core/src/loop/boringstack/build.ts
@@ -476,16 +476,22 @@ export function e2eParkReason(
   outcome: IAcceptanceOutcome,
   reRun: IAcceptanceOutcome
 ): string {
+  const nonEmpty = (s: string | undefined): string | undefined =>
+    s !== undefined && s.length > 0 ? s : undefined;
   const failingDetail = (o: IAcceptanceOutcome): string | undefined =>
-    // Prefer the top-level detail, then the FIRST failing result that actually carries a
-    // (non-empty) detail — not merely the first failing result, whose detail may be blank
-    // while a later failing step holds the real diagnostic.
-    o.detail ?? o.results.find((r) => !r.ok && r.detail.length > 0)?.detail;
+    // Prefer the top-level detail (but treat a BLANK top-level detail as absent — `"" ?? x`
+    // keeps "", which would suppress a real step detail), then the first failing result that
+    // actually carries a non-empty detail — not merely the first failing result, whose detail
+    // may be blank while a later failing step holds the real diagnostic.
+    nonEmpty(o.detail) ??
+    o.results.find((r) => !r.ok && r.detail.length > 0)?.detail;
 
   if (!reRun.ok) {
+    // Prefer the CURRENT (post-steer) diagnostic; only if the re-run surfaced none fall back
+    // to the pre-steer outcome — including ITS step details, not just its top-level detail.
     const detail =
       failingDetail(reRun) ??
-      outcome.detail ??
+      failingDetail(outcome) ??
       "browser acceptance assertions failed";
 
     return steerComplete

--- a/packages/core/src/loop/boringstack/build.ts
+++ b/packages/core/src/loop/boringstack/build.ts
@@ -343,8 +343,11 @@ function revisitGuidance(seed?: { triedLevers: EscalationRung[] }): string {
 /**
  * Run acceptance verification for a feature after the fast gate passes.
  * Returns the done status and optional handoff; handles runner missing, infra errors, and assertion failures.
+ * On any `done:false` it also returns a `reason` naming WHY the feature can't be marked done, so the
+ * outer loop's park message is truthful (fast-gate ladder exhaustion vs e2e-acceptance failure vs
+ * misconfiguration) instead of always claiming "ladder exhausted". Exported for unit testing.
  */
-async function verifyAcceptance(
+export async function verifyAcceptance(
   sent: { status: string; handoff?: IHandoff },
   host: IBoringstackHost,
   cwd: string,
@@ -352,73 +355,113 @@ async function verifyAcceptance(
   acceptanceRunner: IAcceptanceRunner | undefined,
   e2eAcceptanceDisabled: boolean,
   fullSpec?: IAcceptanceSpec
-): Promise<{ done: boolean; handoff?: IHandoff; infra?: string }> {
+): Promise<{
+  done: boolean;
+  handoff?: IHandoff;
+  infra?: string;
+  reason?: string;
+}> {
   // If acceptance is not enabled, return based on fast gate
   if (!(!e2eAcceptanceDisabled && sent.status === "done")) {
+    const done = sent.status === "done";
+
     return {
-      done: sent.status === "done",
+      done,
       ...(sent.handoff !== undefined ? { handoff: sent.handoff } : {}),
+      ...(done
+        ? {}
+        : { reason: "fast gate not green after the escalation ladder" }),
     };
   }
 
   // FAIL-CLOSED: if acceptance is enabled and entity exists but runner is missing,
   // this is a misconfiguration — reject the feature until the runner is injected
   if (entity && !acceptanceRunner) {
-    return { done: false };
+    return {
+      done: false,
+      reason:
+        "e2e acceptance enabled but no runner configured (harness misconfiguration)",
+    };
   }
 
   // Run acceptance only if we have an entity and runner
   if (entity && acceptanceRunner) {
-    const hostPorts = readHostPorts(cwd);
-    const apiPort = hostPortOr(hostPorts, "API_HOST_PORT");
-    const uiPort = hostPortOr(hostPorts, "UI_HOST_PORT");
-    const ctx: IAcceptanceRunCtx = {
-      cwd,
-      apiBase: `http://localhost:${apiPort}`,
-      uiBase: `http://localhost:${uiPort}`,
-    };
-
-    const outcome = await acceptanceRunner.run(entity, ctx, fullSpec);
-
-    // Infrastructure error: route to needs-infra path; per-slice acceptance is best-effort.
-    // The feature's fast-gate pass is valid, but acceptance verification cannot complete
-    // due to infrastructure. Return infra error to thread it through the outer loop.
-    if (outcome.infraError !== undefined) {
-      return { done: false, infra: outcome.infraError };
-    }
-
-    // Test assertion failed: emit steer, re-verify, and close over post-steer state
-    if (!outcome.ok) {
-      const steer = acceptanceSteer(entity, outcome);
-
-      const steerSend = await host.send(steer);
-
-      // FIX 2: after sending the steer (which runs the full model loop),
-      // re-run acceptance once to see if the fix worked
-      const reRun = await acceptanceRunner.run(entity, ctx, fullSpec);
-
-      // If the re-run is an infra error, route it through the needs-infra channel
-      if (reRun.infraError !== undefined) {
-        return { done: false, infra: reRun.infraError };
-      }
-
-      // Return done:true ONLY when both the steer completed AND the re-run passed.
-      // If the steer did not complete (stuck), return done:false even if re-run passed.
-      return {
-        done: steerSend.status === "done" && reRun.ok,
-        ...(steerSend.handoff !== undefined
-          ? { handoff: steerSend.handoff }
-          : {}),
-      };
-    }
-
-    // All checks passed
-    return { done: true };
+    return runE2eAcceptance(host, cwd, entity, acceptanceRunner, fullSpec);
   }
 
   return {
     done: true,
     ...(sent.handoff !== undefined ? { handoff: sent.handoff } : {}),
+  };
+}
+
+/**
+ * Drive the per-slice browser acceptance for a feature whose fast gate is already green:
+ * run it, on failure emit the steer + re-run once, and report done + a truthful `reason`.
+ * Split out of verifyAcceptance to keep each function's cognitive complexity in bounds.
+ */
+async function runE2eAcceptance(
+  host: IBoringstackHost,
+  cwd: string,
+  entity: IEntityAcceptance,
+  acceptanceRunner: IAcceptanceRunner,
+  fullSpec?: IAcceptanceSpec
+): Promise<{
+  done: boolean;
+  handoff?: IHandoff;
+  infra?: string;
+  reason?: string;
+}> {
+  const hostPorts = readHostPorts(cwd);
+  const apiPort = hostPortOr(hostPorts, "API_HOST_PORT");
+  const uiPort = hostPortOr(hostPorts, "UI_HOST_PORT");
+  const ctx: IAcceptanceRunCtx = {
+    cwd,
+    apiBase: `http://localhost:${apiPort}`,
+    uiBase: `http://localhost:${uiPort}`,
+  };
+
+  const outcome = await acceptanceRunner.run(entity, ctx, fullSpec);
+
+  // Infrastructure error: route to needs-infra path; per-slice acceptance is best-effort.
+  // The feature's fast-gate pass is valid, but acceptance verification cannot complete
+  // due to infrastructure. Return infra error to thread it through the outer loop.
+  if (outcome.infraError !== undefined) {
+    return { done: false, infra: outcome.infraError };
+  }
+
+  // All checks passed on the first run.
+  if (outcome.ok) {
+    return { done: true };
+  }
+
+  // Test assertion failed: emit steer, re-verify, and close over post-steer state.
+  const steerSend = await host.send(acceptanceSteer(entity, outcome));
+
+  // Re-run acceptance once to see if the fix worked.
+  const reRun = await acceptanceRunner.run(entity, ctx, fullSpec);
+
+  // If the re-run is an infra error, route it through the needs-infra channel.
+  if (reRun.infraError !== undefined) {
+    return { done: false, infra: reRun.infraError };
+  }
+
+  // done:true ONLY when both the steer completed AND the re-run passed.
+  const done = steerSend.status === "done" && reRun.ok;
+  // A truthful reason: the fast gate WAS green here — the block is e2e acceptance, not the
+  // lint/type ladder. Distinguish "the steer stalled" from "steer ran but browser assertions
+  // still fail", carrying the failing-step detail when we have it.
+  const detail =
+    reRun.detail ?? outcome.detail ?? "browser acceptance assertions failed";
+  const reason =
+    steerSend.status !== "done"
+      ? `fast gate green but e2e acceptance failed; the fix steer did not complete: ${detail}`
+      : `fast gate green but e2e acceptance still failing after the fix steer: ${detail}`;
+
+  return {
+    done,
+    ...(steerSend.handoff !== undefined ? { handoff: steerSend.handoff } : {}),
+    ...(done ? {} : { reason }),
   };
 }
 
@@ -474,7 +517,12 @@ export function boringstackDeps(opts: {
       feature: IFeature,
       state: IGreenfieldState,
       seed?: { triedLevers: EscalationRung[] }
-    ): Promise<{ done: boolean; handoff?: IHandoff; infra?: string }> {
+    ): Promise<{
+      done: boolean;
+      handoff?: IHandoff;
+      infra?: string;
+      reason?: string;
+    }> {
       // Pre-step: generate the full vertical slice + sync the STUB schema. The
       // model then fills the domain INSIDE the loop, checked by the live gate.
       await generate(cwd, feature.id, exec);

--- a/packages/core/src/loop/boringstack/build.ts
+++ b/packages/core/src/loop/boringstack/build.ts
@@ -29,6 +29,7 @@ import type {
   IAcceptanceRunner,
   IAcceptanceRunCtx,
   IAcceptanceSpec,
+  IAcceptanceOutcome,
 } from "../acceptance/acceptance.types";
 import { acceptanceSteer } from "../acceptance/acceptance-steer";
 import { readHostPorts, hostPortOr } from "../../scaffold";
@@ -448,21 +449,50 @@ async function runE2eAcceptance(
 
   // done:true ONLY when both the steer completed AND the re-run passed.
   const done = steerSend.status === "done" && reRun.ok;
-  // A truthful reason: the fast gate WAS green here — the block is e2e acceptance, not the
-  // lint/type ladder. Distinguish "the steer stalled" from "steer ran but browser assertions
-  // still fail", carrying the failing-step detail when we have it.
-  const detail =
-    reRun.detail ?? outcome.detail ?? "browser acceptance assertions failed";
-  const reason =
-    steerSend.status !== "done"
-      ? `fast gate green but e2e acceptance failed; the fix steer did not complete: ${detail}`
-      : `fast gate green but e2e acceptance still failing after the fix steer: ${detail}`;
 
   return {
     done,
     ...(steerSend.handoff !== undefined ? { handoff: steerSend.handoff } : {}),
-    ...(done ? {} : { reason }),
+    ...(done
+      ? {}
+      : {
+          reason: e2eParkReason(steerSend.status === "done", outcome, reRun),
+        }),
   };
+}
+
+/**
+ * Compose the truthful park reason for a feature whose fast gate was GREEN but e2e
+ * acceptance did not confirm. Pure + unit-tested. The three done:false shapes:
+ *  - re-run still failing (steer complete)   → still failing after the steer
+ *  - re-run still failing (steer incomplete) → still failing AND the steer stalled
+ *  - re-run PASSED but steer incomplete      → the app verified; only the steer stalled
+ *    (crucially NOT a stale "assertions failed" — that was the pre-steer state).
+ * Prefers the CURRENT (post-steer) failing detail; falls back to the pre-steer detail only
+ * when the re-run itself surfaced none.
+ */
+export function e2eParkReason(
+  steerComplete: boolean,
+  outcome: IAcceptanceOutcome,
+  reRun: IAcceptanceOutcome
+): string {
+  const failingDetail = (o: IAcceptanceOutcome): string | undefined =>
+    o.detail ?? o.results.find((r) => !r.ok)?.detail;
+
+  if (!reRun.ok) {
+    const detail =
+      failingDetail(reRun) ??
+      outcome.detail ??
+      "browser acceptance assertions failed";
+
+    return steerComplete
+      ? `fast gate green but e2e acceptance still failing after the fix steer: ${detail}`
+      : `fast gate green but e2e acceptance still failing AND the fix steer did not complete: ${detail}`;
+  }
+
+  // The re-run PASSED — the app verified. Parked only because the steer itself stalled;
+  // report exactly that, never a stale assertion failure.
+  return "fast gate green and e2e acceptance passed on re-run, but the fix steer did not complete cleanly";
 }
 
 /**

--- a/packages/core/src/loop/greenfield/greenfield.types.ts
+++ b/packages/core/src/loop/greenfield/greenfield.types.ts
@@ -60,16 +60,24 @@ export interface IGreenfieldResult {
 export interface IGreenfieldDeps {
   /** Implement one feature with the internal escalation ladder. Returns {done: true}
    *  when the feature passes all gates and is ready to ship; {done: false, handoff}
-   *  when the ladder is exhausted and the feature is parked for later; {done: false, infra}
+   *  when it can't be marked done and is parked for later; {done: false, infra}
    *  when infrastructure is unavailable (browser/API down) and verification cannot proceed.
    *  The handoff carries the try-lever history for a revisit pass to seed a different tack.
+   *  `reason` (present on any {done:false} that isn't infra) names WHY it can't be marked
+   *  done — fast-gate ladder exhaustion vs e2e-acceptance failure vs misconfiguration — so
+   *  the outer loop's park message is truthful rather than always "ladder exhausted".
    *  Optionally accepts seeded tried-lever state (from a prior handoff.resume) to
    *  skip levers already tried in a revisit. */
   implement(
     feature: IFeature,
     state: IGreenfieldState,
     seed?: { triedLevers: EscalationRung[] }
-  ): Promise<{ done: boolean; handoff?: IHandoff; infra?: string }>;
+  ): Promise<{
+    done: boolean;
+    handoff?: IHandoff;
+    infra?: string;
+    reason?: string;
+  }>;
 }
 
 export interface IGreenfieldOptions {

--- a/packages/core/src/loop/greenfield/run.ts
+++ b/packages/core/src/loop/greenfield/run.ts
@@ -215,15 +215,19 @@ async function attemptFeature(
       return undefined;
     }
 
-    // Not done → the shared ladder (R1–R4 + R5) already ran inside the loop and
-    // exhausted. Park on its structured handoff for the revisit pass.
+    // Not done → park on the structured handoff for the revisit pass. The reason
+    // names the ACTUAL block (fast-gate ladder exhaustion vs e2e-acceptance failure vs
+    // misconfiguration) so the log doesn't always claim "ladder exhausted" when the fast
+    // gate was green and it was e2e acceptance that failed.
     feature.parked = true;
 
     if (result.handoff !== undefined) {
       feature.handoff = result.handoff;
     }
 
-    say(`feature '${feature.id}': ladder exhausted, parked — revisit later`);
+    const why = result.reason ?? "escalation ladder exhausted";
+
+    say(`feature '${feature.id}': parked (${why}) — revisit later`);
 
     return undefined;
   } finally {

--- a/packages/core/src/loop/greenfield/run.ts
+++ b/packages/core/src/loop/greenfield/run.ts
@@ -225,7 +225,11 @@ async function attemptFeature(
       feature.handoff = result.handoff;
     }
 
-    const why = result.reason ?? "escalation ladder exhausted";
+    // Every non-infra done:false from the boringstack impl carries a reason (fast-gate
+    // exhaustion / e2e failure / misconfig). The fallback is deliberately NEUTRAL, never a
+    // fabricated "ladder exhausted": if a future impl returns done:false without a reason,
+    // an honest "no reason reported" surfaces the gap instead of a plausible-but-wrong cause.
+    const why = result.reason ?? "no reason reported";
 
     say(`feature '${feature.id}': parked (${why}) — revisit later`);
 

--- a/packages/core/tests/boringstack-build.test.ts
+++ b/packages/core/tests/boringstack-build.test.ts
@@ -11,9 +11,15 @@ import {
   runBoringstackBuild,
   scopeFor,
   readResourceCode,
+  verifyAcceptance,
   APP_SCHEMA_FILE,
   LOCALE_GLOB,
 } from "../src/loop/boringstack/build";
+import type {
+  IAcceptanceRunner,
+  IAcceptanceOutcome,
+  IEntityAcceptance,
+} from "../src/loop/acceptance/acceptance.types";
 import type { IProvider } from "../src/inference";
 import type { IGate } from "../src/gate/gate-runner";
 import { writePlan } from "../src/loop/planning/plan-store";
@@ -994,5 +1000,125 @@ describe("readResourceCode — budget + ordering (root-cause coverage)", () => {
     } finally {
       await rm(dir, { recursive: true, force: true });
     }
+  });
+});
+
+describe("verifyAcceptance — truthful park reason on done:false", () => {
+  function acceptanceEntity(): IEntityAcceptance {
+    return {
+      id: "Company",
+      key: "name",
+      nav: "Companies",
+      fields: [
+        {
+          name: "name",
+          type: "string",
+          optional: false,
+          valid: "Acme",
+          invalid: [""],
+        },
+      ],
+      shows: ["name"],
+      screens: ["list", "form"],
+      parents: [],
+      negatives: [],
+      acceptanceCheck: "create a company and see it in the list",
+    };
+  }
+
+  function stubRunner(outcomes: IAcceptanceOutcome[]): IAcceptanceRunner {
+    let i = 0;
+
+    return {
+      run: async () => {
+        const idx = Math.min(i, outcomes.length - 1);
+
+        i += 1;
+
+        const out = outcomes[idx];
+
+        if (out === undefined) {
+          throw new Error("stubRunner: no outcome configured");
+        }
+
+        return out;
+      },
+      runChain: async () => ({ ok: true, results: [] }),
+    };
+  }
+
+  test("fast-gate failure (no e2e) reports the fast-gate reason, not e2e", async () => {
+    const result = await verifyAcceptance(
+      { status: "stuck" },
+      createHost(),
+      "/tmp/does-not-exist",
+      undefined,
+      undefined,
+      true,
+      undefined
+    );
+
+    expect(result.done).toBe(false);
+    expect(result.reason).toContain("fast gate not green");
+  });
+
+  test("acceptance enabled but runner missing reports a misconfiguration reason", async () => {
+    const result = await verifyAcceptance(
+      { status: "done" },
+      createHost(),
+      "/tmp/does-not-exist",
+      acceptanceEntity(),
+      undefined,
+      false,
+      undefined
+    );
+
+    expect(result.done).toBe(false);
+    expect(result.reason).toContain("misconfiguration");
+  });
+
+  test("fast-gate-green-but-e2e-failed reports the e2e reason with detail (NOT 'ladder exhausted')", async () => {
+    // The build52 case: the fast gate passed, but the browser acceptance still fails after
+    // the steer. The reason must say so — the old code parked this as "ladder exhausted".
+    const failing: IAcceptanceOutcome = {
+      ok: false,
+      results: [
+        { entity: "Company", step: "list", ok: false, detail: "row not found" },
+      ],
+      detail: "the created company did not appear in the list",
+    };
+    // host.send returns done → the steer completed; the re-run still fails.
+    const result = await verifyAcceptance(
+      { status: "done" },
+      createHost(),
+      "/tmp/does-not-exist",
+      acceptanceEntity(),
+      stubRunner([failing, failing]),
+      false,
+      undefined
+    );
+
+    expect(result.done).toBe(false);
+    expect(result.reason).toContain("e2e acceptance");
+    expect(result.reason).toContain(
+      "the created company did not appear in the list"
+    );
+    expect(result.reason).not.toContain("ladder exhausted");
+  });
+
+  test("all checks passing reports done with no reason", async () => {
+    const passing: IAcceptanceOutcome = { ok: true, results: [] };
+    const result = await verifyAcceptance(
+      { status: "done" },
+      createHost(),
+      "/tmp/does-not-exist",
+      acceptanceEntity(),
+      stubRunner([passing]),
+      false,
+      undefined
+    );
+
+    expect(result.done).toBe(true);
+    expect(result.reason).toBeUndefined();
   });
 });

--- a/packages/core/tests/boringstack-build.test.ts
+++ b/packages/core/tests/boringstack-build.test.ts
@@ -1106,6 +1106,35 @@ describe("verifyAcceptance — truthful park reason on done:false", () => {
     expect(result.reason).not.toContain("ladder exhausted");
   });
 
+  test("e2e failed AND the fix steer did not complete reports the steer-incomplete reason", async () => {
+    // The other done:false e2e branch: the browser assertions failed and the steer itself
+    // stalled (host.send returns a non-"done" status). The reason must name the steer stall.
+    const failing: IAcceptanceOutcome = {
+      ok: false,
+      results: [
+        { entity: "Company", step: "create", ok: false, detail: "no submit" },
+      ],
+      detail: "the create form never submitted",
+    };
+    const stuckHost = {
+      ...createHost(),
+      send: async () => ({ status: "stuck", turns: 1 }),
+    };
+    const result = await verifyAcceptance(
+      { status: "done" },
+      stuckHost,
+      "/tmp/does-not-exist",
+      acceptanceEntity(),
+      stubRunner([failing, failing]),
+      false,
+      undefined
+    );
+
+    expect(result.done).toBe(false);
+    expect(result.reason).toContain("the fix steer did not complete");
+    expect(result.reason).toContain("the create form never submitted");
+  });
+
   test("all checks passing reports done with no reason", async () => {
     const passing: IAcceptanceOutcome = { ok: true, results: [] };
     const result = await verifyAcceptance(

--- a/packages/core/tests/boringstack-build.test.ts
+++ b/packages/core/tests/boringstack-build.test.ts
@@ -12,6 +12,7 @@ import {
   scopeFor,
   readResourceCode,
   verifyAcceptance,
+  e2eParkReason,
   APP_SCHEMA_FILE,
   LOCALE_GLOB,
 } from "../src/loop/boringstack/build";
@@ -1135,6 +1136,40 @@ describe("verifyAcceptance — truthful park reason on done:false", () => {
     expect(result.reason).toContain("the create form never submitted");
   });
 
+  test("steer incomplete but re-run PASSED parks WITHOUT blaming e2e assertions", async () => {
+    // The subtle case: browser acceptance failed, the steer ran, the re-run PASSED, but the
+    // steer itself did not complete cleanly → done:false. The reason must NOT report a stale
+    // "assertions failing" (the app verified); it must name the steer stall.
+    const failing: IAcceptanceOutcome = {
+      ok: false,
+      results: [
+        { entity: "Company", step: "list", ok: false, detail: "empty" },
+      ],
+      detail: "list was empty before the fix",
+    };
+    const passing: IAcceptanceOutcome = { ok: true, results: [] };
+    const stuckHost = {
+      ...createHost(),
+      send: async () => ({ status: "stuck", turns: 1 }),
+    };
+    const result = await verifyAcceptance(
+      { status: "done" },
+      stuckHost,
+      "/tmp/does-not-exist",
+      acceptanceEntity(),
+      stubRunner([failing, passing]),
+      false,
+      undefined
+    );
+
+    expect(result.done).toBe(false);
+    expect(result.reason).toContain("passed on re-run");
+    expect(result.reason).toContain("the fix steer did not complete");
+    // Must NOT surface the obsolete pre-steer failure detail.
+    expect(result.reason).not.toContain("list was empty before the fix");
+    expect(result.reason).not.toContain("still failing");
+  });
+
   test("all checks passing reports done with no reason", async () => {
     const passing: IAcceptanceOutcome = { ok: true, results: [] };
     const result = await verifyAcceptance(
@@ -1149,5 +1184,53 @@ describe("verifyAcceptance — truthful park reason on done:false", () => {
 
     expect(result.done).toBe(true);
     expect(result.reason).toBeUndefined();
+  });
+});
+
+describe("e2eParkReason — the pure reason composer", () => {
+  const fail = (detail?: string): IAcceptanceOutcome => ({
+    ok: false,
+    results: [],
+    ...(detail !== undefined ? { detail } : {}),
+  });
+  const pass: IAcceptanceOutcome = { ok: true, results: [] };
+
+  test("re-run still failing after a completed steer → 'after the fix steer'", () => {
+    const reason = e2eParkReason(true, fail("orig"), fail("still red"));
+
+    expect(reason).toContain("still failing after the fix steer");
+    expect(reason).toContain("still red");
+  });
+
+  test("re-run still failing AND steer incomplete → names both", () => {
+    const reason = e2eParkReason(false, fail("orig"), fail("still red"));
+
+    expect(reason).toContain(
+      "still failing AND the fix steer did not complete"
+    );
+    expect(reason).toContain("still red");
+  });
+
+  test("re-run PASSED but steer incomplete → steer-stall reason, NO stale detail", () => {
+    const reason = e2eParkReason(false, fail("orig failure"), pass);
+
+    expect(reason).toContain("passed on re-run");
+    expect(reason).toContain("the fix steer did not complete");
+    expect(reason).not.toContain("orig failure");
+  });
+
+  test("uses a re-run failing-step detail when the top-level detail is absent", () => {
+    const reRun: IAcceptanceOutcome = {
+      ok: false,
+      results: [
+        { entity: "Company", step: "list", ok: true, detail: "ok" },
+        { entity: "Company", step: "create", ok: false, detail: "STEP_DETAIL" },
+      ],
+    };
+    const reason = e2eParkReason(true, fail("pre-steer"), reRun);
+
+    // Prefers the CURRENT re-run's failing-step detail over the obsolete pre-steer one.
+    expect(reason).toContain("STEP_DETAIL");
+    expect(reason).not.toContain("pre-steer");
   });
 });

--- a/packages/core/tests/boringstack-build.test.ts
+++ b/packages/core/tests/boringstack-build.test.ts
@@ -1219,18 +1219,61 @@ describe("e2eParkReason — the pure reason composer", () => {
     expect(reason).not.toContain("orig failure");
   });
 
-  test("uses a re-run failing-step detail when the top-level detail is absent", () => {
+  test("skips a failing step whose detail is BLANK for a later failing step that has one", () => {
+    // Distinguishing: the FIRST failing step has an empty detail; the real diagnostic is on a
+    // LATER failing step. `find(r => !r.ok)` (the old predicate) would pick the blank one and
+    // fall through to the pre-steer detail; the non-empty filter picks the real later one.
     const reRun: IAcceptanceOutcome = {
       ok: false,
       results: [
-        { entity: "Company", step: "list", ok: true, detail: "ok" },
-        { entity: "Company", step: "create", ok: false, detail: "STEP_DETAIL" },
+        { entity: "Company", step: "list", ok: false, detail: "" },
+        {
+          entity: "Company",
+          step: "create",
+          ok: false,
+          detail: "LATER_STEP_DETAIL",
+        },
+      ],
+    };
+    const reason = e2eParkReason(true, fail("pre-steer detail"), reRun);
+
+    expect(reason).toContain("LATER_STEP_DETAIL");
+    expect(reason).not.toContain("pre-steer detail");
+  });
+
+  test("treats a BLANK top-level re-run detail as absent and uses a failing-step detail", () => {
+    // `"" ?? x` keeps "", so a blank top-level detail must be normalized to absent, else it
+    // suppresses the real step diagnostic and emits an empty reason.
+    const reRun: IAcceptanceOutcome = {
+      ok: false,
+      detail: "",
+      results: [
+        { entity: "Company", step: "create", ok: false, detail: "STEP_REAL" },
       ],
     };
     const reason = e2eParkReason(true, fail("pre-steer"), reRun);
 
-    // Prefers the CURRENT re-run's failing-step detail over the obsolete pre-steer one.
-    expect(reason).toContain("STEP_DETAIL");
-    expect(reason).not.toContain("pre-steer");
+    expect(reason).toContain("STEP_REAL");
+  });
+
+  test("falls back to the pre-steer outcome's failing-STEP detail, not only its top-level", () => {
+    // The re-run surfaced no usable detail at all; the pre-steer outcome's detail lives only
+    // on a failing step, so `outcome.detail` alone would drop it in favor of the generic text.
+    const reRun: IAcceptanceOutcome = { ok: false, results: [] };
+    const outcome: IAcceptanceOutcome = {
+      ok: false,
+      results: [
+        {
+          entity: "Company",
+          step: "create",
+          ok: false,
+          detail: "PRE_STEP_DETAIL",
+        },
+      ],
+    };
+    const reason = e2eParkReason(true, outcome, reRun);
+
+    expect(reason).toContain("PRE_STEP_DETAIL");
+    expect(reason).not.toContain("browser acceptance assertions failed");
   });
 });

--- a/packages/core/tests/greenfield.test.ts
+++ b/packages/core/tests/greenfield.test.ts
@@ -333,6 +333,39 @@ describe("runGreenfield: outer loop", () => {
     expect(s.features[0]?.parked).toBe(true); // still parked after revisit
   });
 
+  test("the park message carries implement's reason, not a hardcoded 'ladder exhausted'", async () => {
+    // Guards the ONLY place reason becomes user-facing (run.ts `parked (${why})`). A
+    // regression that dropped result.reason would silently reintroduce the build52 mislabel
+    // (fast gate green, e2e failed, but logged as ladder exhaustion) — the verifyAcceptance
+    // unit tests would still pass, so this end-to-end assertion is the real guard.
+    const s = state("a");
+    const messages: string[] = [];
+    const deps: IGreenfieldDeps = {
+      implement: async () => ({
+        done: false,
+        reason:
+          "fast gate green but e2e acceptance still failing after the fix steer: row not found",
+      }),
+    };
+
+    await runGreenfield(dir, s, deps, {
+      onEvent: (ev) => {
+        if (typeof ev.message === "string") {
+          messages.push(ev.message);
+        }
+      },
+    });
+
+    const parkMsgs = messages.filter((m) => m.includes("parked"));
+
+    expect(parkMsgs.length).toBeGreaterThan(0);
+    expect(
+      parkMsgs.some((m) => m.includes("e2e acceptance still failing"))
+    ).toBe(true);
+    // The reason was supplied, so the hardcoded-fallback phrase must NOT appear.
+    expect(parkMsgs.every((m) => !m.includes("ladder exhausted"))).toBe(true);
+  });
+
   test("parked + handoff round-trip through saveState + loadState", async () => {
     const s = state("a");
 

--- a/packages/core/tests/greenfield.test.ts
+++ b/packages/core/tests/greenfield.test.ts
@@ -366,6 +366,31 @@ describe("runGreenfield: outer loop", () => {
     expect(parkMsgs.every((m) => !m.includes("ladder exhausted"))).toBe(true);
   });
 
+  test("a done:false with NO reason parks as 'no reason reported', never a fabricated cause", async () => {
+    // Guards the neutral fallback: if a future impl returns done:false without a reason, the
+    // log must surface the gap honestly, NOT re-introduce a plausible-but-wrong "ladder
+    // exhausted" that this whole change exists to eliminate.
+    const s = state("a");
+    const messages: string[] = [];
+    const deps: IGreenfieldDeps = {
+      implement: async () => ({ done: false }),
+    };
+
+    await runGreenfield(dir, s, deps, {
+      onEvent: (ev) => {
+        if (typeof ev.message === "string") {
+          messages.push(ev.message);
+        }
+      },
+    });
+
+    const parkMsgs = messages.filter((m) => m.includes("parked"));
+
+    expect(parkMsgs.length).toBeGreaterThan(0);
+    expect(parkMsgs.some((m) => m.includes("no reason reported"))).toBe(true);
+    expect(parkMsgs.every((m) => !m.includes("ladder exhausted"))).toBe(true);
+  });
+
   test("parked + handoff round-trip through saveState + loadState", async () => {
     const s = state("a");
 


### PR DESCRIPTION
**Stacked on #188** (shares `build.ts` + the boringstack-build test file). Merge order: #189 → #188 → this.

The greenfield outer loop printed `ladder exhausted, parked` for **every** `done:false`, but a feature can miss `done` for distinct reasons:
- the fast-gate escalation ladder genuinely exhausted, **or**
- the fast gate was GREEN and the per-slice **browser (e2e) acceptance** failed, **or**
- the acceptance runner was misconfigured.

Live (build52), features whose fast gate passed but whose e2e seed/assert failed were mislabeled "ladder exhausted" — reading as "the model couldn't fix its code" when the code was fine and the app just wasn't verifiably usable through the UI.

`verifyAcceptance` now returns a `reason` on every `done:false`, threaded through `implement` → `IGreenfieldDeps` → `run.ts`, and the park line prints it: `feature 'X': parked (<reason>) — revisit later`.

Refactor: extracted `runE2eAcceptance` to keep both functions under cc≤20. Tests cover each `done:false` reason (incl. the fast-green-but-e2e-failed case asserting it is NOT "ladder exhausted") + the done:true no-reason case. Full `bun run validate` green locally.