### PR TITLE
fix(loop): carry failing errors into a parked feature's revisit (was blind)

### DIFF
--- a/packages/core/src/loop/greenfield/run.ts
+++ b/packages/core/src/loop/greenfield/run.ts
@@ -225,6 +225,22 @@ async function attemptFeature(
       feature.handoff = result.handoff;
     }
 
+    // Carry the failing errors into the revisit. refinePrompt leads the next attempt with
+    // `feature.lastError` ("⚠️ PREVIOUS attempt FAILED — FIX THESE ERRORS FIRST"), but nothing
+    // ever set lastError on a park, so every revisit rebuilt BLIND and re-parked on the same
+    // errors. Prefer the handoff's structured error list (the specific failing rules/files);
+    // fall back to the reason summary when the park carried no handoff. saveState (in the
+    // `finally`) serializes it, so the revisit's implement reads it back.
+    const handoffErrors = result.handoff?.errors;
+    const errorText =
+      handoffErrors !== undefined && handoffErrors.length > 0
+        ? handoffErrors.join("\n")
+        : result.reason;
+
+    if (errorText !== undefined && errorText.length > 0) {
+      feature.lastError = errorText;
+    }
+
     // Every non-infra done:false from the boringstack impl carries a reason (fast-gate
     // exhaustion / e2e failure / misconfig). The fallback is deliberately NEUTRAL, never a
     // fabricated "ladder exhausted": if a future impl returns done:false without a reason,

--- a/packages/core/tests/greenfield.test.ts
+++ b/packages/core/tests/greenfield.test.ts
@@ -391,6 +391,90 @@ describe("runGreenfield: outer loop", () => {
     expect(parkMsgs.every((m) => !m.includes("ladder exhausted"))).toBe(true);
   });
 
+  test("a park persists its handoff errors as lastError (revisit isn't blind)", async () => {
+    // Regression guard: lastError was NEVER set on a park, so refinePrompt's "PREVIOUS attempt
+    // FAILED — FIX THESE ERRORS" block never fired on a revisit and the model rebuilt blind.
+    const s = state("a");
+    const deps: IGreenfieldDeps = {
+      implement: async () => ({
+        done: false,
+        handoff: {
+          block: "b",
+          rungHistory: [],
+          errors: [
+            "src/x.test.ts:1  require-await",
+            "src/y.ts:2  no-unused-vars",
+          ],
+          ask: "help",
+          resumable: true,
+          resume: { triedLevers: [] },
+        },
+      }),
+    };
+
+    await runGreenfield(dir, s, deps);
+
+    const onDisk = await loadState(dir);
+    const parked = onDisk?.features.find((f) => f.id === "a");
+
+    expect(parked?.lastError).toContain("require-await");
+    expect(parked?.lastError).toContain("no-unused-vars");
+  });
+
+  test("the revisit's implement RECEIVES the parked feature's lastError", async () => {
+    // The round-trip that matters: attempt 1 parks with errors → the revisit (attempt 2) sees
+    // them on `feature.lastError` so refinePrompt can lead with the specific failures.
+    const s = state("a");
+    const seenLastErrors: (string | undefined)[] = [];
+    let call = 0;
+    const deps: IGreenfieldDeps = {
+      implement: async (f) => {
+        seenLastErrors.push(f.lastError);
+        call += 1;
+
+        if (call === 1) {
+          return {
+            done: false,
+            handoff: {
+              block: "b",
+              rungHistory: [],
+              errors: ["ERR_LINE_MARKER"],
+              ask: "help",
+              resumable: true,
+              resume: { triedLevers: [] },
+            },
+          };
+        }
+
+        return { done: true };
+      },
+    };
+
+    await runGreenfield(dir, s, deps);
+
+    expect(seenLastErrors[0]).toBeUndefined();
+    expect(seenLastErrors[1]).toContain("ERR_LINE_MARKER");
+  });
+
+  test("a park with NO handoff falls back to the reason as lastError", async () => {
+    const s = state("a");
+    const deps: IGreenfieldDeps = {
+      implement: async () => ({
+        done: false,
+        reason: "fast gate not green after the escalation ladder",
+      }),
+    };
+
+    await runGreenfield(dir, s, deps);
+
+    const onDisk = await loadState(dir);
+    const parked = onDisk?.features.find((f) => f.id === "a");
+
+    expect(parked?.lastError).toBe(
+      "fast gate not green after the escalation ladder"
+    );
+  });
+
   test("parked + handoff round-trip through saveState + loadState", async () => {
     const s = state("a");
 


### PR DESCRIPTION
Re-opened (prior #194 auto-closed on a stale-status merge attempt). Grounded in build54: a parked feature's persisted record had **no `lastError`**, so the revisit's `refinePrompt` never led with the failing errors — every revisit rebuilt blind. On park, populate `feature.lastError` from the handoff's structured errors (else the #190 reason summary); `saveState` persists it, the revisit reads it back. Round-trip regression test included. (Panel PASS on the original #194.)