### PR TITLE
fix(reachability): whole-identifier API-route match (kill substring false-green)

### DIFF
--- a/packages/core/src/loop/boringstack/reachability.ts
+++ b/packages/core/src/loop/boringstack/reachability.ts
@@ -87,10 +87,12 @@ export function checkFeatureReachable(
  * `fieldIsMentioned`) reject a match glued to an adjacent identifier char on either
  * side, while still matching every real mount idiom (`count: countRoutes`,
  * `.use(countRoutes)`, `[countRoutes]`), whose delimiter before the name is not an
- * identifier char.
+ * identifier char. `$` is added to the class because it is a JS IdentifierPart that
+ * `\p{ID_Continue}` omits — so `$countRoutes` is a distinct identifier, not a match.
+ * (`_`, ZWJ, and ZWNJ are already in `\p{ID_Continue}`, verified at runtime.)
  */
 function registersRoutes(apiRoutes: string, camel: string): boolean {
-  const boundary = "\\p{ID_Continue}";
+  const boundary = "[\\p{ID_Continue}$]";
   const ident = `${camel}Routes`.replace(/[.*+?^${}()|[\]\\]/gu, "\\$&");
 
   return new RegExp(`(?<!${boundary})${ident}(?!${boundary})`, "u").test(

--- a/packages/core/src/loop/boringstack/reachability.ts
+++ b/packages/core/src/loop/boringstack/reachability.ts
@@ -56,10 +56,7 @@ export function checkFeatureReachable(
   }
 
   // 2. API registration: the resource must be mounted in the API route table.
-  if (
-    inputs.apiRoutes !== null &&
-    !inputs.apiRoutes.includes(`${camel}Routes`)
-  ) {
+  if (inputs.apiRoutes !== null && !registersRoutes(inputs.apiRoutes, camel)) {
     problems.push(
       `API route missing: ${camel}Routes is not registered in ` +
         `config/routes/routes.ts — the endpoints would be unreachable.`
@@ -78,6 +75,27 @@ export function checkFeatureReachable(
   }
 
   return { ok: problems.length === 0, problems };
+}
+
+/**
+ * True when `apiRoutes` mounts `<camel>Routes` as a WHOLE identifier, not merely as a
+ * substring of a longer name. A bare `.includes("countRoutes")` matches an unrelated
+ * slice's `accountRoutes` (`account` ⊃ `count`), so a `count` feature whose own
+ * `countRoutes` is genuinely absent would be reported reachable — a false green in the
+ * one check meant to catch unregistered (hollow) features. The `\p{ID_Continue}`
+ * lookarounds (the canonical Unicode "identifier continue" set — same idiom as
+ * `fieldIsMentioned`) reject a match glued to an adjacent identifier char on either
+ * side, while still matching every real mount idiom (`count: countRoutes`,
+ * `.use(countRoutes)`, `[countRoutes]`), whose delimiter before the name is not an
+ * identifier char.
+ */
+function registersRoutes(apiRoutes: string, camel: string): boolean {
+  const boundary = "\\p{ID_Continue}";
+  const ident = `${camel}Routes`.replace(/[.*+?^${}()|[\]\\]/gu, "\\$&");
+
+  return new RegExp(`(?<!${boundary})${ident}(?!${boundary})`, "u").test(
+    apiRoutes
+  );
 }
 
 /** True when a locale JSON string has non-empty `features.<lower>.title` + `.empty`. */

--- a/packages/core/tests/boringstack-reachability.test.ts
+++ b/packages/core/tests/boringstack-reachability.test.ts
@@ -65,6 +65,24 @@ describe("checkFeatureReachable", () => {
     expect(r.problems.join("\n")).toMatch(/API route missing/u);
   });
 
+  test("a `$`-prefixed sibling identifier is NOT accepted (JS `$` is an identifier char)", () => {
+    // `$` is a valid JS IdentifierPart that `\p{ID_Continue}` omits, so `$countRoutes`
+    // is a DISTINCT identifier — it must not satisfy `count`'s reachability.
+    const r = checkFeatureReachable("Count", {
+      uiRoutes:
+        'const CountPage = lazy(() => import("@/features/count/components/CountPage/CountPage"));',
+      apiRoutes: "export const routes = {\n  meta: $countRoutes,\n};",
+      localeJsons: [
+        JSON.stringify({
+          features: { count: { title: "Counts", empty: "None." } },
+        }),
+      ],
+    });
+
+    expect(r.ok).toBe(false);
+    expect(r.problems.join("\n")).toMatch(/API route missing/u);
+  });
+
   test("a whole-identifier API match is accepted even next to a superstring sibling", () => {
     // Both `count` and `account` are registered: `count` must be seen as reachable
     // (its own whole-word `countRoutes` is present), not masked by `accountRoutes`.

--- a/packages/core/tests/boringstack-reachability.test.ts
+++ b/packages/core/tests/boringstack-reachability.test.ts
@@ -46,6 +46,43 @@ describe("checkFeatureReachable", () => {
     expect(r.problems.join("\n")).toMatch(/API route missing/u);
   });
 
+  test("a substring-only API match is NOT accepted (no false green off a sibling slice)", () => {
+    // `count`'s own `countRoutes` is absent, but a prior slice registered
+    // `accountRoutes` — which CONTAINS "countRoutes". A bare `.includes` would wrongly
+    // pass `count` as reachable; the whole-identifier check must still flag it.
+    const r = checkFeatureReachable("Count", {
+      uiRoutes:
+        'const CountPage = lazy(() => import("@/features/count/components/CountPage/CountPage"));',
+      apiRoutes: "export const routes = {\n  account: accountRoutes,\n};",
+      localeJsons: [
+        JSON.stringify({
+          features: { count: { title: "Counts", empty: "None." } },
+        }),
+      ],
+    });
+
+    expect(r.ok).toBe(false);
+    expect(r.problems.join("\n")).toMatch(/API route missing/u);
+  });
+
+  test("a whole-identifier API match is accepted even next to a superstring sibling", () => {
+    // Both `count` and `account` are registered: `count` must be seen as reachable
+    // (its own whole-word `countRoutes` is present), not masked by `accountRoutes`.
+    const r = checkFeatureReachable("Count", {
+      uiRoutes:
+        'const CountPage = lazy(() => import("@/features/count/components/CountPage/CountPage"));',
+      apiRoutes:
+        "export const routes = {\n  account: accountRoutes,\n  count: countRoutes,\n};",
+      localeJsons: [
+        JSON.stringify({
+          features: { count: { title: "Counts", empty: "None." } },
+        }),
+      ],
+    });
+
+    expect(r.ok).toBe(true);
+  });
+
   test("flags missing i18n keys (page would show raw keys)", () => {
     const r = checkFeatureReachable("Bookmark", {
       ...wiredInputs(),


### PR DESCRIPTION
## Problem
`checkFeatureReachable` (the static anti-hollow-feature check, #50 class) verified API registration with a bare substring:
```ts
!inputs.apiRoutes.includes(`${camel}Routes`)
```
So a feature named `count` matched an **unrelated** slice's `accountRoutes` (`account` ⊃ `count`) and was reported **reachable even when its own `countRoutes` mount was genuinely absent** — a false green in the very check meant to catch unregistered features. Same defect class as #201 (`fieldIsMentioned`), but higher-severity: it lets a truly-unreachable feature pass rather than fabricating a spurious test. (The UI check on the same function is safe — its `/` path delimiters block the suffix collision.)

## Fix
Match `${camel}Routes` as a **whole identifier** via boundary lookarounds over the JS IdentifierPart set — `[\p{ID_Continue}$]` — the same idiom as `fieldIsMentioned`. Every real mount idiom still matches (`count: countRoutes`, `.use(countRoutes)`, `[countRoutes]`); a substring (`accountRoutes`) or `$`-glued (`$countRoutes`) sibling does not. `$` is added because `\p{ID_Continue}` omits it; `_`/ZWJ/ZWNJ are already in `\p{ID_Continue}` (verified at runtime).

## Tests
Three regression tests: substring sibling (`accountRoutes` present, `count` absent → flagged), `$`-prefixed sibling (`$countRoutes` → flagged), and superstring co-registration (`account`+`count` both mounted → `count` reachable). 12/12 pass, lint + typecheck clean.

## Review
Local 4-model harness-review panel: **PASS (4/4)**. Two advisory findings (agreement 1) both claimed `\p{ID_Continue}` excludes ZWJ/ZWNJ — empirically false (`bun -e` confirms ZWJ ∈ ID_Continue and the regex rejects `other\u200DcountRoutes`); the one real gap (`$`) was incorporated.