### PR TITLE
feat(gate): runtime route-presence via the live OpenAPI spec (P1)

### DIFF
--- a/packages/core/src/loop/boringstack/gate-stages.ts
+++ b/packages/core/src/loop/boringstack/gate-stages.ts
@@ -9,6 +9,13 @@ import type { IFeature } from "../greenfield/greenfield.types";
 import type { Exec, IExecResult } from "./exec";
 import { dbPushForce } from "./db-push";
 import { checkEntitySchema, schemaMismatchError } from "./db-oracle";
+import { resolveOpenApiUrl } from "./openapi-preflight";
+import {
+  fetchServedPaths,
+  checkRoutesServed,
+  type SpecFetcher,
+} from "./openapi-routes";
+import { readHostPorts, hostPortOr } from "../../scaffold";
 import { toCamelCase } from "./case";
 import { runBoringstackGate } from "./gate";
 import { extractFailures, ESLINT_PROGRAM_UNPARSABLE } from "./extract-failures";
@@ -553,18 +560,48 @@ export function boringstackCommandStage(
  * usable. This stage runs the static reachability check (route wired, API mounted,
  * i18n keys present); a failure becomes one gate error the loop can escalate on.
  */
-export function reachabilityStage(cwd: string, featureId: string): IStage {
+export function reachabilityStage(
+  cwd: string,
+  featureId: string,
+  fetcher?: SpecFetcher
+): IStage {
   return {
     async run(): Promise<IValidateResult> {
       const reach = await verifyFeatureReachable(cwd, featureId);
+      const problems = [...reach.problems];
 
-      if (reach.ok) {
+      // RUNTIME route-presence (P1): the static check above proves the resource NAME
+      // appears in routes.ts — a proxy #202 false-greened. Confirm the running API
+      // ACTUALLY serves the feature's CRUD routes by querying its public OpenAPI spec
+      // (/swagger/json, no auth — the same spec generate:api consumes). A route in source
+      // but absent from the live spec means the resource isn't mounted → 404 at runtime.
+      // INCONCLUSIVE (spec unreachable) is non-blocking (build-start pre-flight fail-closes
+      // a genuinely down API; a transient blip must not red a feature).
+      const apiPort = hostPortOr(readHostPorts(cwd), "API_HOST_PORT");
+      const served = await fetchServedPaths(
+        resolveOpenApiUrl(process.env.OPENAPI_URL, apiPort),
+        fetcher
+      );
+
+      if (served !== null) {
+        const routes = checkRoutesServed(served, toCamelCase(featureId));
+
+        if (!routes.ok) {
+          problems.push(
+            `API routes NOT served by the running API — present in routes.ts source but ` +
+              `ABSENT from the live /swagger/json: ${routes.missing.join(", ")}. The resource ` +
+              `isn't actually mounted, so its create/list/edit/delete would 404 at runtime. ` +
+              `Register + mount the resource so these paths appear in the served spec.`
+          );
+        }
+      }
+
+      if (problems.length === 0) {
         return { passed: true, errors: [], output: "reachable" };
       }
 
       const message =
-        `"${featureId}" is not reachable/usable:\n- ` +
-        reach.problems.join("\n- ");
+        `"${featureId}" is not reachable/usable:\n- ` + problems.join("\n- ");
 
       return {
         passed: false,

--- a/packages/core/src/loop/boringstack/openapi-routes.ts
+++ b/packages/core/src/loop/boringstack/openapi-routes.ts
@@ -1,0 +1,76 @@
+import { isOpenApiSpec } from "./openapi-preflight";
+import { isRecord } from "../../lib/guards";
+
+/**
+ * Runtime route-presence (P1): assert the feature's CRUD routes are ACTUALLY served by
+ * the running API, not merely present as a substring in the route-table source.
+ *
+ * The static reachability check reads `routes.ts` and looks for the resource name — a
+ * proxy that #202 proved false-greens (a route that merely LOOKS mounted). This queries
+ * the running server's OpenAPI spec (`/swagger/json`, public, no auth — the same spec
+ * `generate:api` already consumes every cycle) and asserts the feature's paths exist in
+ * it: if the resource isn't genuinely mounted, its create/list/edit/delete would 404 at
+ * runtime. Observable end-state, not the source's story.
+ *
+ * INCONCLUSIVE (spec unreachable / not a spec) is non-blocking: a transient mid-loop blip
+ * must not red a feature, and the build-start pre-flight already fail-closes a genuinely
+ * down API.
+ */
+
+/** The two CRUD paths a BoringStack resource MUST serve — verified against the live spec:
+ *  the collection root (list + create, TRAILING SLASH) and the by-id path (get/update/
+ *  delete, literal `{id}`). */
+export function expectedRoutePaths(entityKey: string): string[] {
+  return [`/api/v1/${entityKey}/`, `/api/v1/${entityKey}/{id}`];
+}
+
+export interface IRoutesServed {
+  readonly ok: boolean;
+  readonly missing: readonly string[];
+}
+
+/** Pure: are the feature's required CRUD paths present in the served spec's path set? */
+export function checkRoutesServed(
+  servedPaths: readonly string[],
+  entityKey: string
+): IRoutesServed {
+  const served = new Set(servedPaths);
+  const missing = expectedRoutePaths(entityKey).filter((p) => !served.has(p));
+
+  return { ok: missing.length === 0, missing };
+}
+
+/** Fetches a URL and returns the parsed JSON body (injectable for tests). */
+export type SpecFetcher = (url: string) => Promise<unknown>;
+
+async function defaultFetcher(url: string): Promise<unknown> {
+  const res = await fetch(url, { signal: AbortSignal.timeout(10_000) });
+
+  if (!res.ok) {
+    throw new Error(`status ${String(res.status)}`);
+  }
+
+  return res.json();
+}
+
+/**
+ * Fetch the running API's OpenAPI spec and return its path keys, or null when the read is
+ * INCONCLUSIVE (unreachable, non-2xx, or not a valid spec) — the caller MUST treat null as
+ * non-blocking.
+ */
+export async function fetchServedPaths(
+  url: string,
+  fetcher: SpecFetcher = defaultFetcher
+): Promise<string[] | null> {
+  try {
+    const body = await fetcher(url);
+
+    if (!isOpenApiSpec(body) || !isRecord(body) || !isRecord(body.paths)) {
+      return null;
+    }
+
+    return Object.keys(body.paths);
+  } catch {
+    return null; // unreachable / parse error → inconclusive, never blocks
+  }
+}

--- a/packages/core/tests/boringstack-gate-stages.test.ts
+++ b/packages/core/tests/boringstack-gate-stages.test.ts
@@ -15,6 +15,7 @@ import { scopeFor, featureOwnedGlobs } from "../src/loop/boringstack/build";
 import { testIdsFor } from "../src/loop/acceptance/acceptance-spec";
 import type { IEntityAcceptance } from "../src/loop/acceptance/acceptance.types";
 import type { Exec } from "../src/loop/boringstack/exec";
+import type { SpecFetcher } from "../src/loop/boringstack/openapi-routes";
 import type { IFeature } from "../src/loop/greenfield/greenfield.types";
 import type { IProvider } from "../src/inference";
 
@@ -860,11 +861,45 @@ describe("signatureToError", () => {
 });
 
 describe("reachabilityStage", () => {
+  // An unreachable-spec fetcher → the runtime route probe is INCONCLUSIVE (non-blocking),
+  // so these tests exercise ONLY the static reachability behavior, deterministically.
+  const specDown: SpecFetcher = async () => {
+    throw new Error("no server");
+  };
+
   test("when feature directory doesn't exist → skips gracefully (no reachability errors)", async () => {
-    const stage = reachabilityStage("/nonexistent", "note");
+    const stage = reachabilityStage("/nonexistent", "note", specDown);
     const r = await stage.run("/nonexistent");
 
     // Without the router/API files present, the check can't prove it's unreachable, so it passes
+    expect(r.passed).toBe(true);
+  });
+
+  test("runtime route-presence: routes ABSENT from the live spec → NOT reachable (kills the #202 source-only false-green)", async () => {
+    // Static files absent (so the static check is silent), but the running API's spec does
+    // NOT serve the feature's routes → the resource isn't mounted → fail.
+    const servesOtherOnly: SpecFetcher = async () => ({
+      openapi: "3.0.0",
+      info: { title: "x", version: "1" },
+      paths: { "/api/v1/other/": {}, "/api/v1/other/{id}": {} },
+    });
+    const stage = reachabilityStage("/nonexistent", "note", servesOtherOnly);
+    const r = await stage.run("/nonexistent");
+
+    expect(r.passed).toBe(false);
+    expect(r.errors[0]?.rule).toBe("reachability");
+    expect(r.errors[0]?.message).toContain("/api/v1/note/");
+  });
+
+  test("runtime route-presence: routes PRESENT in the live spec → reachable", async () => {
+    const servesNote: SpecFetcher = async () => ({
+      openapi: "3.0.0",
+      info: { title: "x", version: "1" },
+      paths: { "/api/v1/note/": {}, "/api/v1/note/{id}": {} },
+    });
+    const stage = reachabilityStage("/nonexistent", "note", servesNote);
+    const r = await stage.run("/nonexistent");
+
     expect(r.passed).toBe(true);
   });
 });

--- a/packages/core/tests/openapi-routes.test.ts
+++ b/packages/core/tests/openapi-routes.test.ts
@@ -1,0 +1,64 @@
+import { test, expect } from "bun:test";
+import {
+  expectedRoutePaths,
+  checkRoutesServed,
+  fetchServedPaths,
+  type SpecFetcher,
+} from "../src/loop/boringstack/openapi-routes";
+
+test("expectedRoutePaths: collection root (trailing slash) + by-id", () => {
+  expect(expectedRoutePaths("bookmark")).toEqual([
+    "/api/v1/bookmark/",
+    "/api/v1/bookmark/{id}",
+  ]);
+});
+
+test("checkRoutesServed: both paths present → ok", () => {
+  const r = checkRoutesServed(
+    ["/api/v1/bookmark/", "/api/v1/bookmark/{id}", "/api/v1/other/"],
+    "bookmark"
+  );
+
+  expect(r.ok).toBe(true);
+  expect(r.missing).toEqual([]);
+});
+
+test("checkRoutesServed: by-id path missing → NOT ok, names it", () => {
+  const r = checkRoutesServed(["/api/v1/bookmark/"], "bookmark");
+
+  expect(r.ok).toBe(false);
+  expect(r.missing).toEqual(["/api/v1/bookmark/{id}"]);
+});
+
+test("checkRoutesServed: a source-registered route that isn't served at all → both missing", () => {
+  const r = checkRoutesServed(["/api/v1/other/", "/health"], "bookmark");
+
+  expect(r.ok).toBe(false);
+  expect(r.missing).toEqual(["/api/v1/bookmark/", "/api/v1/bookmark/{id}"]);
+});
+
+test("fetchServedPaths: valid spec → its path keys", async () => {
+  const fetcher: SpecFetcher = async () => ({
+    openapi: "3.0.0",
+    info: { title: "x", version: "1" },
+    paths: { "/api/v1/bookmark/": {}, "/api/v1/bookmark/{id}": {} },
+  });
+
+  const paths = await fetchServedPaths("http://x/swagger/json", fetcher);
+
+  expect(paths).toEqual(["/api/v1/bookmark/", "/api/v1/bookmark/{id}"]);
+});
+
+test("fetchServedPaths: unreachable / throwing fetch → null (inconclusive, non-blocking)", async () => {
+  const fetcher: SpecFetcher = async () => {
+    throw new Error("ECONNREFUSED");
+  };
+
+  expect(await fetchServedPaths("http://x/swagger/json", fetcher)).toBeNull();
+});
+
+test("fetchServedPaths: 2xx body that is NOT an OpenAPI spec → null (never trust garbage)", async () => {
+  const fetcher: SpecFetcher = async () => ({ hello: "world" });
+
+  expect(await fetchServedPaths("http://x/swagger/json", fetcher)).toBeNull();
+});


### PR DESCRIPTION
**Observable-gates plan, P1** (3rd in the false-green-hardening series after #205/#206).

The reachability stage's API-registration check was **source-substring** — 'does the resource name appear in `routes.ts`' — a proxy #202 proved false-greens (a route that merely *looks* mounted). New `openapi-routes.ts` queries the **running** API's public OpenAPI spec (`/swagger/json` — no auth; the same spec `generate:api` consumes every cycle) and asserts the feature's CRUD paths (`/api/v1/<entity>/` + `/{id}`) are **actually served**. A route present in source but absent from the live spec = the resource isn't mounted → 404 at runtime. Observable end-state, not source.

- Augments (doesn't replace) the static check in `reachabilityStage`.
- **Inconclusive is non-blocking** (spec unreachable/not-a-spec/non-2xx) — the build-start pre-flight already fail-closes a down API; a transient blip must not red a feature. Only a *reachable* spec that omits the routes reds.
- Injectable `SpecFetcher` → deterministic unit tests, no server; default fetch aborts after 10s. Path convention verified against the live spec.
- **Scope note:** the authenticated create→row-appears sentinel round-trip stays with the browser-based acceptance (P2) — replicating Elysia's refresh-token auth in a bare `fetch` is fragile and would risk gate flakiness (the panel's explicit caution). This P1 is the no-auth runtime observable.

**Proven:** 7 `openapi-routes` unit tests + 2 `reachabilityStage` wiring tests (routes absent → not reachable; present → reachable) + **live integration vs valbuild27's running API** (mounted `bookmark` passes; never-built `widget` reds, 62 real paths). Full suite 3158/0; typecheck + lint clean. Additive/gate-preserving.