### PR TITLE
fix(acceptance): type-correct valid samples & negatives (date fields → real dates; type beats name)

### DIFF
--- a/packages/core/src/loop/acceptance/acceptance-spec.ts
+++ b/packages/core/src/loop/acceptance/acceptance-spec.ts
@@ -50,6 +50,19 @@ function validValue(
     return String(seed + 1);
   }
 
+  if (
+    field.type === "date" ||
+    field.type === "datetime" ||
+    field.type === "timestamp"
+  ) {
+    // A real calendar date. Date-typed fields land in a DB date/timestamp column, so the generic
+    // `${name}-${seed}` sample would pass string-level validation (Zod z.string / TypeBox t.String)
+    // yet throw at the insert ("invalid input syntax for type timestamp") → the create 500s and the
+    // form never closes → false e2e park. Date-only ("YYYY-MM-DD") so it stays a substring of
+    // whatever timestamp representation the row cell renders back for the shows assertion.
+    return "2024-06-15";
+  }
+
   if (/url|website/i.test(field.name)) {
     return `https://example${seed}.com`;
   }

--- a/packages/core/src/loop/acceptance/acceptance-spec.ts
+++ b/packages/core/src/loop/acceptance/acceptance-spec.ts
@@ -40,9 +40,10 @@ function validValue(
   field: { name: string; type: string },
   seed: number
 ): string {
-  const isEmail = field.type === "email" || /email/i.test(field.name);
-
-  if (isEmail) {
+  // Explicit TYPE wins over name heuristics. A date-typed field must get a real date even when its
+  // name matches the email heuristic (e.g. `emailVerifiedAt`, `lastEmailSentAt`) — otherwise it gets
+  // an email string that 500s the timestamp-column insert, the exact false-park this branch fixes.
+  if (field.type === "email") {
     return `user${seed}@example.com`;
   }
 
@@ -61,6 +62,11 @@ function validValue(
     // form never closes → false e2e park. Date-only ("YYYY-MM-DD") so it stays a substring of
     // whatever timestamp representation the row cell renders back for the shows assertion.
     return "2024-06-15";
+  }
+
+  // Name-based heuristics for otherwise-untyped (string) fields.
+  if (/email/i.test(field.name)) {
+    return `user${seed}@example.com`;
   }
 
   if (/url|website/i.test(field.name)) {

--- a/packages/core/src/loop/acceptance/acceptance-spec.ts
+++ b/packages/core/src/loop/acceptance/acceptance-spec.ts
@@ -35,15 +35,34 @@ export function testIdsFor(key: string): ITestIds {
   };
 }
 
+function isDateType(type: string): boolean {
+  return type === "date" || type === "datetime" || type === "timestamp";
+}
+
+// Whether a field should be treated as an email. Explicit TYPE wins over the name heuristic: a
+// `date`/`number`-typed field named like an email (e.g. `emailVerifiedAt`) is NOT an email — else
+// both the positive sample and the invalid-email negative feed a non-string value into a
+// date/number column and 500 the insert (a false park). Shared by validValue AND negativesFor so
+// the two can never disagree about whether a field is an email.
+function isEmailField(field: { name: string; type: string }): boolean {
+  if (field.type === "email") {
+    return true;
+  }
+
+  if (field.type === "number" || isDateType(field.type)) {
+    return false;
+  }
+
+  return /email/i.test(field.name);
+}
+
 // Deterministic valid sample per field, seeded off (entityIndex, fieldName) — no Date/random.
 function validValue(
   field: { name: string; type: string },
   seed: number
 ): string {
-  // Explicit TYPE wins over name heuristics. A date-typed field must get a real date even when its
-  // name matches the email heuristic (e.g. `emailVerifiedAt`, `lastEmailSentAt`) — otherwise it gets
-  // an email string that 500s the timestamp-column insert, the exact false-park this branch fixes.
-  if (field.type === "email") {
+  // Explicit TYPE wins over name heuristics (see isEmailField).
+  if (isEmailField(field)) {
     return `user${seed}@example.com`;
   }
 
@@ -51,22 +70,13 @@ function validValue(
     return String(seed + 1);
   }
 
-  if (
-    field.type === "date" ||
-    field.type === "datetime" ||
-    field.type === "timestamp"
-  ) {
+  if (isDateType(field.type)) {
     // A real calendar date. Date-typed fields land in a DB date/timestamp column, so the generic
     // `${name}-${seed}` sample would pass string-level validation (Zod z.string / TypeBox t.String)
     // yet throw at the insert ("invalid input syntax for type timestamp") → the create 500s and the
     // form never closes → false e2e park. Date-only ("YYYY-MM-DD") so it stays a substring of
     // whatever timestamp representation the row cell renders back for the shows assertion.
     return "2024-06-15";
-  }
-
-  // Name-based heuristics for otherwise-untyped (string) fields.
-  if (/email/i.test(field.name)) {
-    return `user${seed}@example.com`;
   }
 
   if (/url|website/i.test(field.name)) {
@@ -96,7 +106,10 @@ function negativesFor(
       out.push({ field: f.name, value: "", why: `${f.name} is required` });
     }
 
-    if (!isForeignKey && (f.type === "email" || /email/i.test(f.name))) {
+    // Use the SAME email determination as validValue (type wins over name), so a date/number
+    // field named like an email (emailVerifiedAt) never gets a "not-an-email" negative — that
+    // value would reach a timestamp/number column and 500 (not the expected 400/422) → false park.
+    if (!isForeignKey && isEmailField(f)) {
       out.push({
         field: f.name,
         value: "not-an-email",

--- a/packages/core/tests/acceptance-spec.test.ts
+++ b/packages/core/tests/acceptance-spec.test.ts
@@ -540,3 +540,52 @@ test("fieldIsMentioned matches on WORD BOUNDARIES, not raw substring", () => {
   // And it isn't tripped by an unrelated word either.
   expect(fieldIsMentioned(acceptField("name"), "the total amount")).toBe(false);
 });
+
+test("planToAcceptanceSpec: date-typed fields get a REAL calendar date sample (not a `${name}-${seed}` string a timestamp column rejects)", () => {
+  // Regression: a `date`/`datetime`/`timestamp` field used to fall through to the generic
+  // "${name}-${seed}" sample (e.g. "dueDate-2"). That passes z.string()/t.String() but the app
+  // inserts it into a timestamptz column, where Postgres throws "invalid input syntax for type
+  // timestamp" → the create 500s and the form never closes → false e2e park.
+  const datePlan: IProductPlan = {
+    product: "Tracker",
+    slices: [
+      {
+        entity: {
+          id: "Task",
+          desc: "t",
+          fields: [
+            { name: "title", type: "string" },
+            { name: "dueDate", type: "date" },
+            { name: "startsAt", type: "datetime" },
+          ],
+          relationships: [],
+          rules: ["title is required"],
+        },
+        ui: {
+          screens: ["list", "form"],
+          action: "add",
+          shows: ["title", "dueDate"],
+          nav: "Tasks",
+        },
+        verification: {
+          mustRemainTrue: ["x"],
+          mustNotHappen: ["a task can be saved without a title"],
+          acceptanceCheck: "create a task",
+        },
+      },
+    ],
+  };
+
+  const task = planToAcceptanceSpec(datePlan).entities[0];
+
+  for (const name of ["dueDate", "startsAt"]) {
+    const field = task?.fields.find((f) => f.name === name);
+
+    expect(field, `expected field ${name}`).toBeDefined();
+    // NOT the generic garbage sample.
+    expect(field?.valid).not.toContain(`${name}-`);
+    // A real, parseable YYYY-MM-DD date (what a timestamp column accepts).
+    expect(field?.valid).toMatch(/^\d{4}-\d{2}-\d{2}$/);
+    expect(Number.isNaN(new Date(field?.valid ?? "").getTime())).toBe(false);
+  }
+});

--- a/packages/core/tests/acceptance-spec.test.ts
+++ b/packages/core/tests/acceptance-spec.test.ts
@@ -546,6 +546,29 @@ test("planToAcceptanceSpec: date-typed fields get a REAL calendar date sample (n
   // "${name}-${seed}" sample (e.g. "dueDate-2"). That passes z.string()/t.String() but the app
   // inserts it into a timestamptz column, where Postgres throws "invalid input syntax for type
   // timestamp" → the create 500s and the form never closes → false e2e park.
+  // A strict calendar-date check: rejects impossible dates that `new Date()` would silently
+  // normalize (e.g. "2024-02-31" rolls to 2024-03-02, which a naive !isNaN check would accept).
+  const isRealCalendarDate = (s: string): boolean => {
+    const m = /^(\d{4})-(\d{2})-(\d{2})$/.exec(s);
+
+    if (!m) {
+      return false;
+    }
+
+    const [year, month, day] = [Number(m[1]), Number(m[2]), Number(m[3])];
+    const dt = new Date(Date.UTC(year, month - 1, day));
+
+    return (
+      dt.getUTCFullYear() === year &&
+      dt.getUTCMonth() === month - 1 &&
+      dt.getUTCDate() === day
+    );
+  };
+
+  // Sanity-check the checker itself: it must reject a normalized-impossible date.
+  expect(isRealCalendarDate("2024-02-31")).toBe(false);
+  expect(isRealCalendarDate("2024-06-15")).toBe(true);
+
   const datePlan: IProductPlan = {
     product: "Tracker",
     slices: [
@@ -557,6 +580,7 @@ test("planToAcceptanceSpec: date-typed fields get a REAL calendar date sample (n
             { name: "title", type: "string" },
             { name: "dueDate", type: "date" },
             { name: "startsAt", type: "datetime" },
+            { name: "loggedAt", type: "timestamp" },
           ],
           relationships: [],
           rules: ["title is required"],
@@ -578,14 +602,14 @@ test("planToAcceptanceSpec: date-typed fields get a REAL calendar date sample (n
 
   const task = planToAcceptanceSpec(datePlan).entities[0];
 
-  for (const name of ["dueDate", "startsAt"]) {
+  // Cover every date-ish type the production branch handles: date, datetime, timestamp.
+  for (const name of ["dueDate", "startsAt", "loggedAt"]) {
     const field = task?.fields.find((f) => f.name === name);
 
     expect(field, `expected field ${name}`).toBeDefined();
     // NOT the generic garbage sample.
     expect(field?.valid).not.toContain(`${name}-`);
-    // A real, parseable YYYY-MM-DD date (what a timestamp column accepts).
-    expect(field?.valid).toMatch(/^\d{4}-\d{2}-\d{2}$/);
-    expect(Number.isNaN(new Date(field?.valid ?? "").getTime())).toBe(false);
+    // A real, valid calendar date (what a timestamp column accepts) — not a normalized impossible one.
+    expect(isRealCalendarDate(field?.valid ?? "")).toBe(true);
   }
 });

--- a/packages/core/tests/acceptance-spec.test.ts
+++ b/packages/core/tests/acceptance-spec.test.ts
@@ -586,6 +586,9 @@ test("planToAcceptanceSpec: date-typed fields get a REAL calendar date sample (n
             { name: "emailVerifiedAt", type: "timestamp", optional: true },
             // A genuine email field — positive control: it SHOULD get the not-an-email negative.
             { name: "contactEmail", type: "email", optional: true },
+            // Number type whose name matches the email heuristic — type must win here too: a
+            // numeric sample + the negative-number negative, never an email value/negative.
+            { name: "emailCount", type: "number", optional: true },
           ],
           relationships: [],
           rules: ["title is required"],
@@ -630,4 +633,17 @@ test("planToAcceptanceSpec: date-typed fields get a REAL calendar date sample (n
 
   expect(emailNegs("emailVerifiedAt")).toBe(false);
   expect(emailNegs("contactEmail")).toBe(true);
+
+  // A NUMBER field named like an email must also resolve by type, not name: numeric valid sample
+  // (no "@"), and the negative-number negative — never a not-an-email negative.
+  const emailCount = task?.fields.find((f) => f.name === "emailCount");
+
+  expect(emailCount?.valid).not.toContain("@");
+  expect(emailCount?.valid).toMatch(/^\d+$/);
+  expect(emailNegs("emailCount")).toBe(false);
+  expect(
+    (task?.negatives ?? []).some(
+      (n) => n.field === "emailCount" && n.value === "-1"
+    )
+  ).toBe(true);
 });

--- a/packages/core/tests/acceptance-spec.test.ts
+++ b/packages/core/tests/acceptance-spec.test.ts
@@ -581,6 +581,8 @@ test("planToAcceptanceSpec: date-typed fields get a REAL calendar date sample (n
             { name: "dueDate", type: "date" },
             { name: "startsAt", type: "datetime" },
             { name: "loggedAt", type: "timestamp" },
+            // Name matches the email heuristic but the TYPE is a date — type must win.
+            { name: "emailVerifiedAt", type: "timestamp" },
           ],
           relationships: [],
           rules: ["title is required"],
@@ -602,13 +604,15 @@ test("planToAcceptanceSpec: date-typed fields get a REAL calendar date sample (n
 
   const task = planToAcceptanceSpec(datePlan).entities[0];
 
-  // Cover every date-ish type the production branch handles: date, datetime, timestamp.
-  for (const name of ["dueDate", "startsAt", "loggedAt"]) {
+  // Cover every date-ish type the production branch handles, incl. a date field whose name
+  // matches the email heuristic (emailVerifiedAt) — TYPE must take precedence over name.
+  for (const name of ["dueDate", "startsAt", "loggedAt", "emailVerifiedAt"]) {
     const field = task?.fields.find((f) => f.name === name);
 
     expect(field, `expected field ${name}`).toBeDefined();
-    // NOT the generic garbage sample.
+    // NOT the generic garbage sample, and NOT an email (the name-precedence trap).
     expect(field?.valid).not.toContain(`${name}-`);
+    expect(field?.valid).not.toContain("@");
     // A real, valid calendar date (what a timestamp column accepts) — not a normalized impossible one.
     expect(isRealCalendarDate(field?.valid ?? "")).toBe(true);
   }

--- a/packages/core/tests/acceptance-spec.test.ts
+++ b/packages/core/tests/acceptance-spec.test.ts
@@ -581,8 +581,11 @@ test("planToAcceptanceSpec: date-typed fields get a REAL calendar date sample (n
             { name: "dueDate", type: "date" },
             { name: "startsAt", type: "datetime" },
             { name: "loggedAt", type: "timestamp" },
-            // Name matches the email heuristic but the TYPE is a date — type must win.
-            { name: "emailVerifiedAt", type: "timestamp" },
+            // Name matches the email heuristic but the TYPE is a date — type must win, in BOTH
+            // the positive sample (validValue) and the negatives (no "not-an-email").
+            { name: "emailVerifiedAt", type: "timestamp", optional: true },
+            // A genuine email field — positive control: it SHOULD get the not-an-email negative.
+            { name: "contactEmail", type: "email", optional: true },
           ],
           relationships: [],
           rules: ["title is required"],
@@ -616,4 +619,15 @@ test("planToAcceptanceSpec: date-typed fields get a REAL calendar date sample (n
     // A real, valid calendar date (what a timestamp column accepts) — not a normalized impossible one.
     expect(isRealCalendarDate(field?.valid ?? "")).toBe(true);
   }
+
+  // Negatives must apply the SAME type-precedence: a date-typed field named like an email gets
+  // NO "not-an-email" negative (that value would 500 a timestamp insert, not 400/422 → false park),
+  // while a genuinely email-typed field DOES.
+  const emailNegs = (fieldName: string): boolean =>
+    (task?.negatives ?? []).some(
+      (n) => n.field === fieldName && n.value === "not-an-email"
+    );
+
+  expect(emailNegs("emailVerifiedAt")).toBe(false);
+  expect(emailNegs("contactEmail")).toBe(true);
 });


### PR DESCRIPTION
## The wall
Live deep-chain build (Organization→Project→Task) parked the **Task** slice: fast gate green, but the e2e acceptance timed out with `task-form` never hiding. The build's own note guessed 'transient socket hang up' — but the boundary state (form stays visible) said the **create was failing**.

## Root cause
`validValue` (acceptance-spec.ts) had **no case for date types**, so a `dueDate` field got the generic `"dueDate-2"` sample. That passes UI Zod (`z.string`) and API TypeBox (`t.String`), but the service inserts it into a `timestamptz` column → Postgres throws → 500 → create fails → form never closes → 10s `waitFor(hidden)` times out → false park.

Confirmed at the live DB:
```
'dueDate-3'::timestamptz  → ERROR: invalid input syntax for type timestamp
'2024-06-15'::timestamptz → 2024-06-15 00:00:00+00   (accepted)
```

## Fix
- `validValue` returns `"2024-06-15"` for `date`/`datetime`/`timestamp` types (date-only → substring-safe for the row-cell `toContainText` shows assertion).
- **Explicit field TYPE now beats name heuristics**, applied **symmetrically** to `validValue` and `negativesFor` via a shared `isEmailField` helper: a date- or number-typed field named like an email (`emailVerifiedAt`, `emailCount`) is not treated as an email — otherwise the positive sample / `not-an-email` negative feeds a non-date/number value into a date/number column and 500s (same false-park class).

## Tests
Date/datetime/timestamp valid samples with a strict UTC round-trip that rejects normalized-impossible dates (e.g. `2024-02-31`); the `emailVerifiedAt` precedence in **both** the valid sample and the negatives array; a genuine-email positive control; and a number-named-email (`emailCount`) case.

## Validation
- **4-model panel: PASS** (round 5; earlier rounds tightened test coverage + the negativesFor symmetry, all real findings).
- Live projtracker rebuild for full 3/3 green: **in progress** (will comment).

Full suite: typecheck / lint / format clean, 3193 green.

## Follow-ups (filed, not blocking)
- #86 empty optional date/number `''` also 500s a timestamptz/number insert (generated form should coerce `'' → undefined`).
- #87 e2e acceptance resilience: retry transient socket-hang-up / vitest worker timeouts under load instead of parking.