### PR TITLE
fix(format): scope the format janitor to edited files + defer to the project's prettier (#103)

### DIFF
--- a/packages/core/src/cli/repl.ts
+++ b/packages/core/src/cli/repl.ts
@@ -1015,6 +1015,9 @@ export async function repl(args: ICliArgs): Promise<number> {
           // on the TTY like the init session, so a piped REPL doesn't advertise a pause
           // nobody can answer.
           interactive: humanAtKeyboard(),
+          // Keep the SCOPED format janitor on across /clear — else the rebuilt session
+          // silently reverts to no formatting for the rest of the session.
+          coreFormat: true,
           // Plain boolean (no branch): the constructor only seeds the flag when true.
           pausedWithEdit: carryDeferredGate,
           ...(profile === undefined ? {} : { profile }),

--- a/packages/core/src/cli/repl.ts
+++ b/packages/core/src/cli/repl.ts
@@ -83,7 +83,6 @@ import {
   type IAgentRow,
 } from "../render";
 import { loadLedger, activeRules, forgetMemory } from "../loop/memory";
-import { buildCoreFix } from "../gate";
 import {
   saveSession,
   latestSession,
@@ -458,7 +457,12 @@ async function initReplSession(args: ICliArgs): Promise<{
     // surface immediately instead of piling up at the end-of-turn gate.
     ...(lintFile === undefined ? {} : { lintFile }),
     ...(resumed === null ? {} : { history: resumed.messages }),
-    fix: buildCoreFix(),
+    // Opt into the SCOPED format janitor (replaces the old whole-repo `fix`): the
+    // loop's autoFixStep runs a strict eslint --fix + prettier over the task's files
+    // only, deferring to the project's own prettier — so a build never reformats files
+    // it didn't touch, and never with the wrong prettier. (A spec may still set its
+    // own per-task `fix`.)
+    coreFormat: true,
     // A resumed session with a still-unvalidated pre-pause edit re-seeds the deferred
     // gate so it re-gates on the first send — never silently dropped across --continue
     // (WS-C; the persisted counterpart of the /clear carry).

--- a/packages/core/src/cli/repl.ts
+++ b/packages/core/src/cli/repl.ts
@@ -457,11 +457,12 @@ async function initReplSession(args: ICliArgs): Promise<{
     // surface immediately instead of piling up at the end-of-turn gate.
     ...(lintFile === undefined ? {} : { lintFile }),
     ...(resumed === null ? {} : { history: resumed.messages }),
-    // Opt into the SCOPED format janitor (replaces the old whole-repo `fix`): the
-    // loop's autoFixStep runs a strict eslint --fix + prettier over the task's files
-    // only, deferring to the project's own prettier — so a build never reformats files
-    // it didn't touch, and never with the wrong prettier. (A spec may still set its
-    // own per-task `fix`.)
+    // Opt into the SCOPED format janitor (replaces the old whole-repo `fix`): the loop's
+    // autoFixStep runs a strict eslint --fix + prettier over the files the model wrote
+    // this session (ctx.tool.touched — NOT task.files, which defaults to ["**/*"] here),
+    // deferring to the project's own prettier — so a build never reformats files it
+    // didn't touch, and never with the wrong prettier. (A spec may still set its own
+    // per-task `fix`.) MUST also be set on the /clear rebuild below.
     coreFormat: true,
     // A resumed session with a still-unvalidated pre-pause edit re-seeds the deferred
     // gate so it re-gates on the first send — never silently dropped across --continue

--- a/packages/core/src/editor/controller.ts
+++ b/packages/core/src/editor/controller.ts
@@ -5,6 +5,7 @@ import { createPasteScanner } from "./paste";
 import { renderEditor } from "./view";
 import { graphemes } from "./segments";
 import { trace } from "../lib/trace";
+import { isWin32 } from "../lib/platform";
 import { createCompletion, type IEditorCompletionSource } from "./completion";
 
 // Re-exported: the host-facing completion-source contract moved to
@@ -664,7 +665,7 @@ export function startEditor(deps: IStartEditorDeps): IEditorHandle {
 
   // Enable Kitty keyboard + modifyOtherKeys (gated by env)
   const shouldSkipKitty =
-    process.platform === "win32" ||
+    isWin32() ||
     (process.env.SSH_CONNECTION ?? "") !== "" ||
     (process.env.SSH_TTY ?? "") !== "" ||
     (process.env.WSL_DISTRO_NAME ?? "") !== "";

--- a/packages/core/src/gate/index.ts
+++ b/packages/core/src/gate/index.ts
@@ -1,4 +1,9 @@
 export type { IGateSpec, IFileLintProblem, FileLinter } from "./types";
 export { buildGate, buildCoreFix } from "./core-gate";
-export { makeFileLinter, formatFile, prettierWriteCommand } from "./linter";
+export {
+  makeFileLinter,
+  formatFile,
+  formatFiles,
+  prettierWriteCommand,
+} from "./linter";
 export { discoverTestCommand } from "./test-discovery";

--- a/packages/core/src/gate/linter.ts
+++ b/packages/core/src/gate/linter.ts
@@ -1,4 +1,4 @@
-import { join } from "node:path";
+import { join, isAbsolute, extname } from "node:path";
 import { ESLint } from "eslint";
 import { runArgvCommand } from "../lib/fs/process";
 import { conventionOverrideRules } from "../infer-rules/eslint-conventions";
@@ -131,39 +131,122 @@ export function makeFileLinter(
   };
 }
 
+/** Extensions the strict ESLint config actually has rules for. Handing eslint an
+ *  explicit path outside this set (a `.json`/`.md`/`.css`) only makes it emit
+ *  "File ignored" noise and burn the timeout parsing a file it can't lint — so the
+ *  scoped fix filters its eslint targets to code files and lets prettier (with
+ *  `--ignore-unknown`) handle everything else. */
+const ESLINT_EXTS = new Set([".ts", ".tsx", ".js", ".jsx", ".mjs", ".cjs"]);
+
+/** Keep only the paths that still exist on disk — a file the model created and
+ *  then deleted in the same turn is in the touched set but must not be handed to a
+ *  formatter (eslint/prettier error on a missing path). */
+async function filterExisting(absFiles: readonly string[]): Promise<string[]> {
+  const checks = await Promise.all(
+    absFiles.map(async (f) => ((await Bun.file(f).exists()) ? f : null))
+  );
+
+  return checks.filter((f): f is string => f !== null);
+}
+
+/** Choose which prettier to run in `cwd`. When the target ships its OWN prettier
+ *  (a local `node_modules/.bin/prettier`), run THAT binary: it carries the project's
+ *  prettier VERSION and can resolve a shared/extended config that lives in the
+ *  project's own `node_modules` (e.g. `"prettier": "@acme/prettier-config"`) — which
+ *  tsforge's bundled prettier cannot see. So a file tsforge edits comes out formatted
+ *  exactly as the project's own `prettier` / CI would format it, and an
+ *  already-correct file is left byte-unchanged. Only when the project has no prettier
+ *  of its own do we fall back to tsforge's bundled prettier, which still resolves a
+ *  project `.prettierrc` if one exists and otherwise applies the tsforge default
+ *  written by `bringConstitution`. */
+export async function resolveProjectPrettierArgv(
+  cwd: string
+): Promise<string[]> {
+  const projectBin = join(cwd, "node_modules", ".bin", "prettier");
+
+  if (await Bun.file(projectBin).exists()) {
+    return [projectBin];
+  }
+
+  return ["bun", PRETTIER_BIN];
+}
+
 /**
- * Auto-format ONE just-written file in place: `eslint --fix` (squashes the
- * auto-fixable mechanical rules — padding-line, curly, prefer-template, quotes)
- * then `prettier --write` (whitespace/quotes/width). Run at WRITE time (in the
- * write guard) so the model never sees — nor hand-chases — formatting noise.
- * Deferring all of this to the settle-time gate let the model self-run eslint
- * mid-build, see the un-squashed mechanical lint, and spiral fixing blank lines
- * and braces by hand to the turn cap. Best-effort + per-file (cheap): any failure
- * is swallowed and the settle gate stays the authority.
+ * Apply the strict eslint autofix + prettier to an EXPLICIT list of files — never
+ * the whole tree. This is the scoping guarantee behind tsforge's formatting: it only
+ * rewrites files it actually touched (each write via `formatFile`, and the
+ * end-of-turn janitor over `ctx.tool.touched`), so running a build inside someone's
+ * repo never reformats thousands of files it never edited. The file list is passed
+ * in, so this is git-independent — it works the same in a fresh, non-git directory.
+ *
+ * Prettier defers to the project's own config and version (see
+ * `resolveProjectPrettierArgv`); the eslint `--fix` keeps tsforge's strictness moat
+ * (the `no-as` ban, `I`-prefix, …) on the files tsforge writes.
+ *
+ * Best-effort, like the rest of the format path: `runArgvCommand` never throws and a
+ * non-zero exit / timeout is ignored — the settle gate stays the authority.
  */
-export async function formatFile(cwd: string, file: string): Promise<void> {
-  const abs = join(cwd, file);
+export async function formatFiles(
+  cwd: string,
+  files: readonly string[],
+  opts: { signal?: AbortSignal; timeoutMs?: number } = {}
+): Promise<void> {
+  const rels = [
+    ...new Set(
+      files.map((f) => f.replaceAll("\\", "/")).filter((f) => f.length > 0)
+    ),
+  ];
+
+  if (rels.length === 0) {
+    return;
+  }
+
+  const abs = rels.map((f) => (isAbsolute(f) ? f : join(cwd, f)));
+  const present = await filterExisting(abs);
+
+  if (present.length === 0) {
+    return;
+  }
+
+  const timeoutMs = opts.timeoutMs ?? FORMAT_TIMEOUT_MS;
+  const signalOpt = opts.signal === undefined ? {} : { signal: opts.signal };
 
   // Route through the shared runner so a hung eslint/prettier is killed by the
-  // timeout instead of wedging this per-write path (it runs inside the write-guard).
-  // runArgvCommand never throws and captures output, so this stays best-effort: a
-  // non-zero exit or timeout is ignored — the settle gate is still the authority.
+  // timeout instead of wedging the caller (this runs inside the write-guard hot
+  // path AND the end-of-turn janitor). Order mirrors the app pipeline: eslint --fix
+  // first, prettier LAST, so prettier has the final say on formatting.
+  const eslintTargets = present.filter((f) => ESLINT_EXTS.has(extname(f)));
+
+  if (eslintTargets.length > 0) {
+    await runArgvCommand(
+      cwd,
+      [
+        "bun",
+        ESLINT_BIN,
+        "--no-config-lookup",
+        "-c",
+        STRICT_CONFIG,
+        "--fix",
+        ...eslintTargets,
+      ],
+      { timeoutMs, ...signalOpt }
+    );
+  }
+
+  const prettierArgv = await resolveProjectPrettierArgv(cwd);
+
   await runArgvCommand(
     cwd,
-    [
-      "bun",
-      ESLINT_BIN,
-      "--no-config-lookup",
-      "-c",
-      STRICT_CONFIG,
-      "--fix",
-      abs,
-    ],
-    { timeoutMs: FORMAT_TIMEOUT_MS }
+    [...prettierArgv, "--write", "--ignore-unknown", ...present],
+    { timeoutMs, ...signalOpt }
   );
-  await runArgvCommand(cwd, ["bun", PRETTIER_BIN, "--write", abs], {
-    timeoutMs: FORMAT_TIMEOUT_MS,
-  });
+}
+
+/** Format a single file — the per-write path (write-guard). Thin wrapper over
+ *  `formatFiles` so the per-write and janitor paths share one prettier-fidelity and
+ *  eslint-moat implementation. */
+export async function formatFile(cwd: string, file: string): Promise<void> {
+  await formatFiles(cwd, [file]);
 }
 
 /** The bundled `prettier --write` command. Prepended to the EVAL gate so the

--- a/packages/core/src/gate/linter.ts
+++ b/packages/core/src/gate/linter.ts
@@ -1,4 +1,4 @@
-import { join, isAbsolute, extname } from "node:path";
+import { join, extname, resolve, sep } from "node:path";
 import { ESLint } from "eslint";
 import { runArgvCommand } from "../lib/fs/process";
 import { conventionOverrideRules } from "../infer-rules/eslint-conventions";
@@ -162,10 +162,20 @@ async function filterExisting(absFiles: readonly string[]): Promise<string[]> {
 export async function resolveProjectPrettierArgv(
   cwd: string
 ): Promise<string[]> {
-  const projectBin = join(cwd, "node_modules", ".bin", "prettier");
+  const binDir = join(cwd, "node_modules", ".bin");
+  // On Windows npm writes `prettier.cmd` (the extensionless file is a POSIX shell
+  // script cmd.exe can't spawn directly); everywhere else it's `prettier`. Prefer the
+  // `.cmd` on win32 so the project binary is actually executable, else the fidelity
+  // goal silently falls back to the bundled prettier.
+  const candidates =
+    process.platform === "win32"
+      ? [join(binDir, "prettier.cmd"), join(binDir, "prettier")]
+      : [join(binDir, "prettier")];
 
-  if (await Bun.file(projectBin).exists()) {
-    return [projectBin];
+  for (const bin of candidates) {
+    if (await Bun.file(bin).exists()) {
+      return [bin];
+    }
   }
 
   return ["bun", PRETTIER_BIN];
@@ -201,8 +211,14 @@ export async function formatFiles(
     return;
   }
 
-  const abs = rels.map((f) => (isAbsolute(f) ? f : join(cwd, f)));
-  const present = await filterExisting(abs);
+  // Containment guard: these argv reach mutating formatters directly, so a caller that
+  // passes an absolute path or a `../` traversal must NOT be able to rewrite files
+  // outside the workspace. Keep only paths that resolve under `cwd`.
+  const root = resolve(cwd);
+  const contained = rels
+    .map((f) => resolve(cwd, f))
+    .filter((f) => f === root || f.startsWith(root + sep));
+  const present = await filterExisting(contained);
 
   if (present.length === 0) {
     return;

--- a/packages/core/src/gate/linter.ts
+++ b/packages/core/src/gate/linter.ts
@@ -1,5 +1,5 @@
 import { join, extname, resolve, relative, sep } from "node:path";
-import { realpath } from "node:fs/promises";
+import { realpath, stat } from "node:fs/promises";
 import { ESLint } from "eslint";
 import { runArgvCommand } from "../lib/fs/process";
 import { conventionOverrideRules } from "../infer-rules/eslint-conventions";
@@ -150,15 +150,32 @@ async function realpathOrNull(p: string): Promise<string | null> {
   }
 }
 
-/** From cwd-anchored candidates, keep the files that (a) still exist and (b) whose
- *  REAL path (symlinks resolved) is inside `realRoot` — then return each as a path
- *  RELATIVE to `cwd`. Relative is load-bearing: ESLint 10 flat config reports "File
- *  ignored because outside of base path" and applies ZERO fixes for an ABSOLUTE path,
- *  silently killing the autofix moat; a cwd-relative path fixes normally. The
- *  real-path containment stops an in-workspace symlink from redirecting a formatter at
- *  a file outside the workspace. */
+/** True if `p` is a regular file. Directories must never reach the formatters:
+ *  `prettier --write <dir>` expands to the whole subtree, reintroducing the
+ *  whole-repo rewrite this module exists to prevent. */
+async function isRegularFile(p: string): Promise<boolean> {
+  try {
+    return (await stat(p)).isFile();
+  } catch {
+    return false;
+  }
+}
+
+/** From cwd-anchored candidates, keep the ones that (a) exist, (b) are a regular FILE
+ *  (never a directory), and (c) whose REAL path (symlinks resolved) is inside
+ *  `realRoot` — then return each RELATIVE TO `realRoot`. Two things are load-bearing:
+ *
+ *  - RELATIVE, not absolute: ESLint 10 flat config reports "File ignored because
+ *    outside of base path" and applies ZERO fixes for an absolute path, silently
+ *    killing the autofix moat; a relative path fixes normally.
+ *  - relative to the REAL root, not the caller's `cwd`: on macOS `cwd` can be the
+ *    logical `/var/…` form while a resolved input is `/private/var/…`; relativizing
+ *    against the unresolved forms yields a `../../private/var/…` path ESLint again
+ *    treats as outside-base. Both sides realpath'd, the relative path is clean.
+ *
+ *  The real-path containment also stops an in-workspace symlink from redirecting a
+ *  formatter at a file outside the workspace. */
 async function containedRelTargets(
-  cwd: string,
   realRoot: string,
   absCandidates: readonly string[]
 ): Promise<string[]> {
@@ -167,13 +184,23 @@ async function containedRelTargets(
   for (const abs of absCandidates) {
     const real = await realpathOrNull(abs);
 
-    if (real === null) {
+    if (real === null || !(await isRegularFile(real))) {
       continue;
     }
 
-    if (real === realRoot || real.startsWith(realRoot + sep)) {
-      out.push(relative(cwd, abs));
+    if (real !== realRoot && !real.startsWith(realRoot + sep)) {
+      continue;
     }
+
+    const rel = relative(realRoot, real);
+
+    // Empty (the root itself) or escaping (`..`) can't happen for a contained file,
+    // but guard anyway — an empty arg to prettier expands to the whole tree.
+    if (rel.length === 0 || rel.startsWith("..")) {
+      continue;
+    }
+
+    out.push(rel);
   }
 
   return out;
@@ -192,19 +219,16 @@ async function containedRelTargets(
 export async function resolveProjectPrettierArgv(
   cwd: string
 ): Promise<string[]> {
-  const binDir = join(cwd, "node_modules", ".bin");
-  // On Windows npm writes `prettier.cmd` (the extensionless file is a POSIX shell
-  // script cmd.exe can't spawn directly); everywhere else it's `prettier`. Prefer the
-  // `.cmd` on win32 so the project binary is actually executable, else the fidelity
-  // goal silently falls back to the bundled prettier.
-  const candidates =
-    process.platform === "win32"
-      ? [join(binDir, "prettier.cmd"), join(binDir, "prettier")]
-      : [join(binDir, "prettier")];
+  // POSIX only. `node_modules/.bin/prettier` is a directly-spawnable shell script here;
+  // on Windows the runnable entry is `prettier.cmd`, which the shell-less runner can't
+  // spawn — so on win32 we always use the bundled prettier (spawned via `bun`), which
+  // still resolves a project `.prettierrc`. Preferring the project binary is a POSIX
+  // fidelity win, not a correctness requirement.
+  if (process.platform !== "win32") {
+    const projectBin = join(cwd, "node_modules", ".bin", "prettier");
 
-  for (const bin of candidates) {
-    if (await Bun.file(bin).exists()) {
-      return [bin];
+    if (await Bun.file(projectBin).exists()) {
+      return [projectBin];
     }
   }
 
@@ -253,7 +277,6 @@ export async function formatFiles(
   }
 
   const present = await containedRelTargets(
-    cwd,
     realRoot,
     rels.map((f) => resolve(cwd, f))
   );

--- a/packages/core/src/gate/linter.ts
+++ b/packages/core/src/gate/linter.ts
@@ -1,4 +1,5 @@
-import { join, extname, resolve, sep } from "node:path";
+import { join, extname, resolve, relative, sep } from "node:path";
+import { realpath } from "node:fs/promises";
 import { ESLint } from "eslint";
 import { runArgvCommand } from "../lib/fs/process";
 import { conventionOverrideRules } from "../infer-rules/eslint-conventions";
@@ -138,15 +139,44 @@ export function makeFileLinter(
  *  `--ignore-unknown`) handle everything else. */
 const ESLINT_EXTS = new Set([".ts", ".tsx", ".js", ".jsx", ".mjs", ".cjs"]);
 
-/** Keep only the paths that still exist on disk — a file the model created and
- *  then deleted in the same turn is in the touched set but must not be handed to a
- *  formatter (eslint/prettier error on a missing path). */
-async function filterExisting(absFiles: readonly string[]): Promise<string[]> {
-  const checks = await Promise.all(
-    absFiles.map(async (f) => ((await Bun.file(f).exists()) ? f : null))
-  );
+/** Canonical absolute path with symlinks resolved, or null if it does not exist
+ *  (or can't be resolved). Used both to prove a target still exists and to make the
+ *  containment check symlink-safe. */
+async function realpathOrNull(p: string): Promise<string | null> {
+  try {
+    return await realpath(p);
+  } catch {
+    return null;
+  }
+}
 
-  return checks.filter((f): f is string => f !== null);
+/** From cwd-anchored candidates, keep the files that (a) still exist and (b) whose
+ *  REAL path (symlinks resolved) is inside `realRoot` — then return each as a path
+ *  RELATIVE to `cwd`. Relative is load-bearing: ESLint 10 flat config reports "File
+ *  ignored because outside of base path" and applies ZERO fixes for an ABSOLUTE path,
+ *  silently killing the autofix moat; a cwd-relative path fixes normally. The
+ *  real-path containment stops an in-workspace symlink from redirecting a formatter at
+ *  a file outside the workspace. */
+async function containedRelTargets(
+  cwd: string,
+  realRoot: string,
+  absCandidates: readonly string[]
+): Promise<string[]> {
+  const out: string[] = [];
+
+  for (const abs of absCandidates) {
+    const real = await realpathOrNull(abs);
+
+    if (real === null) {
+      continue;
+    }
+
+    if (real === realRoot || real.startsWith(realRoot + sep)) {
+      out.push(relative(cwd, abs));
+    }
+  }
+
+  return out;
 }
 
 /** Choose which prettier to run in `cwd`. When the target ships its OWN prettier
@@ -212,13 +242,21 @@ export async function formatFiles(
   }
 
   // Containment guard: these argv reach mutating formatters directly, so a caller that
-  // passes an absolute path or a `../` traversal must NOT be able to rewrite files
-  // outside the workspace. Keep only paths that resolve under `cwd`.
-  const root = resolve(cwd);
-  const contained = rels
-    .map((f) => resolve(cwd, f))
-    .filter((f) => f === root || f.startsWith(root + sep));
-  const present = await filterExisting(contained);
+  // passes an absolute path, a `../` traversal, or an in-workspace symlink pointing
+  // out must NOT be able to rewrite files outside the workspace. `containedRelTargets`
+  // resolves symlinks, drops anything whose real path is outside cwd, and returns the
+  // survivors RELATIVE to cwd (required — eslint no-ops on absolute paths).
+  const realRoot = await realpathOrNull(resolve(cwd));
+
+  if (realRoot === null) {
+    return;
+  }
+
+  const present = await containedRelTargets(
+    cwd,
+    realRoot,
+    rels.map((f) => resolve(cwd, f))
+  );
 
   if (present.length === 0) {
     return;

--- a/packages/core/src/gate/linter.ts
+++ b/packages/core/src/gate/linter.ts
@@ -5,6 +5,7 @@ import { runArgvCommand } from "../lib/fs/process";
 import { conventionOverrideRules } from "../infer-rules/eslint-conventions";
 import type { IConventions } from "../infer-rules/conventions.types";
 import { trace } from "../lib/trace";
+import { isWin32 } from "../lib/platform";
 import { ESLINT_BIN, PRETTIER_BIN, STRICT_CONFIG } from "./tool-paths";
 import type { FileLinter } from "./types";
 
@@ -226,10 +227,19 @@ export async function resolveProjectPrettierArgv(
   // spawn — so on win32 we always use the bundled prettier (spawned via `bun`), which
   // still resolves a project `.prettierrc`. Preferring the project binary is a POSIX
   // fidelity win, not a correctness requirement.
-  if (process.platform !== "win32") {
+  if (!isWin32()) {
     const projectBin = join(cwd, "node_modules", ".bin", "prettier");
+    // Trust the project bin only when prettier is actually INSTALLED as a package here
+    // (its manifest exists) — not a lone `.bin/prettier` shim someone dropped in. tsforge
+    // already runs the project's own scripts/binaries in the gate, so this is the same
+    // "only point tsforge at repos you trust" boundary, narrowed to "prettier is a real
+    // dependency of this project".
+    const manifest = join(cwd, "node_modules", "prettier", "package.json");
 
-    if (await Bun.file(projectBin).exists()) {
+    if (
+      (await Bun.file(projectBin).exists()) &&
+      (await Bun.file(manifest).exists())
+    ) {
       return [projectBin];
     }
   }
@@ -257,12 +267,16 @@ export async function formatFiles(
   files: readonly string[],
   opts: { signal?: AbortSignal; timeoutMs?: number } = {}
 ): Promise<void> {
-  // Normalize path separators ONLY on Windows. On POSIX a backslash is a legal
-  // filename character, so rewriting `dir\file.ts` → `dir/file.ts` would redirect the
-  // formatter at a different, untouched file — breaking the touched-only guarantee.
-  const norm = (f: string): string =>
-    process.platform === "win32" ? f.replaceAll("\\", "/") : f;
-  const rels = [...new Set(files.map(norm).filter((f) => f.length > 0))];
+  // Do NOT normalize separators. On POSIX a backslash is a legal filename character, so
+  // rewriting `dir\file.ts` → `dir/file.ts` would retarget a different, untouched file.
+  // But we also can't safely resolve such a path: macOS `realpath("…/a\b.ts")` itself
+  // normalizes the backslash and returns `…/a/b.ts`. So on POSIX, DROP any input path
+  // containing a backslash up front — before resolve/realpath can retarget it. Real
+  // touched paths are already forward-slashed (recordTouched), so this only guards a
+  // pathological input.
+  const rels = [...new Set(files.filter((f) => f.length > 0))].filter(
+    (f) => isWin32() || !f.includes("\\")
+  );
 
   if (rels.length === 0) {
     return;

--- a/packages/core/src/gate/linter.ts
+++ b/packages/core/src/gate/linter.ts
@@ -1,4 +1,4 @@
-import { join, extname, resolve, relative, sep } from "node:path";
+import { join, extname, resolve, relative, dirname, sep } from "node:path";
 import { realpath, stat } from "node:fs/promises";
 import { ESLint } from "eslint";
 import { runArgvCommand } from "../lib/fs/process";
@@ -138,7 +138,16 @@ export function makeFileLinter(
  *  "File ignored" noise and burn the timeout parsing a file it can't lint — so the
  *  scoped fix filters its eslint targets to code files and lets prettier (with
  *  `--ignore-unknown`) handle everything else. */
-const ESLINT_EXTS = new Set([".ts", ".tsx", ".js", ".jsx", ".mjs", ".cjs"]);
+const ESLINT_EXTS = new Set([
+  ".ts",
+  ".tsx",
+  ".mts",
+  ".cts",
+  ".js",
+  ".jsx",
+  ".mjs",
+  ".cjs",
+]);
 
 /** Canonical absolute path with symlinks resolved, or null if it does not exist
  *  (or can't be resolved). Used both to prove a target still exists and to make the
@@ -228,19 +237,32 @@ export async function resolveProjectPrettierArgv(
   // still resolves a project `.prettierrc`. Preferring the project binary is a POSIX
   // fidelity win, not a correctness requirement.
   if (!isWin32()) {
-    const projectBin = join(cwd, "node_modules", ".bin", "prettier");
-    // Trust the project bin only when prettier is actually INSTALLED as a package here
-    // (its manifest exists) — not a lone `.bin/prettier` shim someone dropped in. tsforge
-    // already runs the project's own scripts/binaries in the gate, so this is the same
-    // "only point tsforge at repos you trust" boundary, narrowed to "prettier is a real
-    // dependency of this project".
-    const manifest = join(cwd, "node_modules", "prettier", "package.json");
+    // Walk up from cwd like Node's module resolution: in a monorepo a package subdir may
+    // have prettier hoisted to the workspace root's node_modules. At each level trust the
+    // bin only when prettier is actually INSTALLED as a package there (its manifest
+    // exists) — not a lone `.bin/prettier` shim someone dropped in. tsforge already runs
+    // the project's own scripts/binaries in the gate, so this is the same "only point
+    // tsforge at repos you trust" boundary, narrowed to "prettier is a real dependency".
+    let dir = resolve(cwd);
 
-    if (
-      (await Bun.file(projectBin).exists()) &&
-      (await Bun.file(manifest).exists())
-    ) {
-      return [projectBin];
+    for (;;) {
+      const projectBin = join(dir, "node_modules", ".bin", "prettier");
+      const manifest = join(dir, "node_modules", "prettier", "package.json");
+
+      if (
+        (await Bun.file(projectBin).exists()) &&
+        (await Bun.file(manifest).exists())
+      ) {
+        return [projectBin];
+      }
+
+      const parent = dirname(dir);
+
+      if (parent === dir) {
+        break;
+      }
+
+      dir = parent;
     }
   }
 

--- a/packages/core/src/gate/linter.ts
+++ b/packages/core/src/gate/linter.ts
@@ -133,21 +133,14 @@ export function makeFileLinter(
   };
 }
 
-/** Extensions the strict ESLint config actually has rules for. Handing eslint an
- *  explicit path outside this set (a `.json`/`.md`/`.css`) only makes it emit
- *  "File ignored" noise and burn the timeout parsing a file it can't lint — so the
- *  scoped fix filters its eslint targets to code files and lets prettier (with
- *  `--ignore-unknown`) handle everything else. */
-const ESLINT_EXTS = new Set([
-  ".ts",
-  ".tsx",
-  ".mts",
-  ".cts",
-  ".js",
-  ".jsx",
-  ".mjs",
-  ".cjs",
-]);
+/** Extensions the strict ESLint config actually has rules for. It must mirror the
+ *  `TS_FILES` globs in `strict.eslint.config.mjs` (the config `formatFiles` runs via
+ *  `STRICT_CONFIG`) — the flat config only applies rules to TypeScript
+ *  (`.ts/.tsx/.mts/.cts`). Handing eslint any other path (a `.js`, or a `.json`/`.md`/`.css`)
+ *  just makes it emit "File ignored" and burn the timeout on a file it won't lint — so the
+ *  scoped fix filters eslint's targets to these, and lets prettier (with `--ignore-unknown`)
+ *  format everything else. */
+const ESLINT_EXTS = new Set([".ts", ".tsx", ".mts", ".cts"]);
 
 /** Canonical absolute path with symlinks resolved, or null if it does not exist
  *  (or can't be resolved). Used both to prove a target still exists and to make the

--- a/packages/core/src/gate/linter.ts
+++ b/packages/core/src/gate/linter.ts
@@ -257,11 +257,12 @@ export async function formatFiles(
   files: readonly string[],
   opts: { signal?: AbortSignal; timeoutMs?: number } = {}
 ): Promise<void> {
-  const rels = [
-    ...new Set(
-      files.map((f) => f.replaceAll("\\", "/")).filter((f) => f.length > 0)
-    ),
-  ];
+  // Normalize path separators ONLY on Windows. On POSIX a backslash is a legal
+  // filename character, so rewriting `dir\file.ts` → `dir/file.ts` would redirect the
+  // formatter at a different, untouched file — breaking the touched-only guarantee.
+  const norm = (f: string): string =>
+    process.platform === "win32" ? f.replaceAll("\\", "/") : f;
+  const rels = [...new Set(files.map(norm).filter((f) => f.length > 0))];
 
   if (rels.length === 0) {
     return;

--- a/packages/core/src/gate/linter.ts
+++ b/packages/core/src/gate/linter.ts
@@ -194,9 +194,11 @@ async function containedRelTargets(
 
     const rel = relative(realRoot, real);
 
-    // Empty (the root itself) or escaping (`..`) can't happen for a contained file,
-    // but guard anyway — an empty arg to prettier expands to the whole tree.
-    if (rel.length === 0 || rel.startsWith("..")) {
+    // Empty (the root itself) or escaping (`..` / `../…`) can't happen for a contained
+    // regular file, but guard anyway — an empty arg to prettier expands to the whole
+    // tree. NB: match only a real parent ref, not a filename that merely starts with
+    // two dots (e.g. `..draft.ts`), which is a legitimate contained file.
+    if (rel.length === 0 || rel === ".." || rel.startsWith(".." + sep)) {
       continue;
     }
 
@@ -304,6 +306,10 @@ export async function formatFiles(
         "-c",
         STRICT_CONFIG,
         "--fix",
+        // `--` terminates options: a contained file literally named like a flag
+        // (e.g. `--config=x.js`) is then treated as a path, never an option — so it
+        // can't alter the formatter or make it load repo-controlled config.
+        "--",
         ...eslintTargets,
       ],
       { timeoutMs, ...signalOpt }
@@ -314,7 +320,7 @@ export async function formatFiles(
 
   await runArgvCommand(
     cwd,
-    [...prettierArgv, "--write", "--ignore-unknown", ...present],
+    [...prettierArgv, "--write", "--ignore-unknown", "--", ...present],
     { timeoutMs, ...signalOpt }
   );
 }

--- a/packages/core/src/lib/platform.ts
+++ b/packages/core/src/lib/platform.ts
@@ -1,0 +1,7 @@
+/** Platform predicates. Centralized so platform-specific branches read by intent and
+ *  stay consistent, instead of scattering raw `process.platform` string comparisons. */
+
+/** True on Windows (`process.platform === "win32"`). */
+export function isWin32(): boolean {
+  return process.platform === "win32";
+}

--- a/packages/core/src/loop/session.ts
+++ b/packages/core/src/loop/session.ts
@@ -118,6 +118,11 @@ export interface ISessionConfig {
   accept?: string;
   /** Auto-fix command run before re-validating (e.g. `eslint --fix`). */
   fix?: string;
+  /** Opt into the core format janitor: a strict `eslint --fix` + prettier over the
+   *  task's SCOPED files (never the whole tree), deferring to the project's own
+   *  prettier. The interactive CLI sets this; bare test/eval loops leave it off so
+   *  they don't pay per-turn formatter subprocess latency. Independent of `fix`. */
+  coreFormat?: boolean;
   /** Read-only context files. */
   context?: string[];
   parse?: ErrorParser;
@@ -984,6 +989,7 @@ export class Session {
       gate: {
         parse: cfg.parse,
         stackProfile,
+        ...(cfg.coreFormat === true ? { coreFormat: true } : {}),
         ...(lintFile === undefined ? {} : { lintFile }),
         ...(Object.keys(ruleOverrides).length > 0 ? { ruleOverrides } : {}),
         ...(cfg.metaBaseline === undefined

--- a/packages/core/src/loop/session.ts
+++ b/packages/core/src/loop/session.ts
@@ -1036,6 +1036,13 @@ export class Session {
     return this.ctx.task.files;
   }
 
+  /** Whether the scoped format janitor is on for this session — i.e. `cfg.coreFormat`
+   *  was threaded into the loop's gate context. Exposed so a test can prove the CLI
+   *  wiring (Session.create propagates the flag) without reaching into private state. */
+  get coreFormat(): boolean {
+    return this.ctx.gate.coreFormat === true;
+  }
+
   /** True when a still-unvalidated edit is pending behind an ask_user pause (an edit
    *  written before the pause whose gate hasn't run). A caller rebuilding the Session
    *  (e.g. /clear) reads this and passes `pausedWithEdit` to `create` so the deferred

--- a/packages/core/src/loop/session.ts
+++ b/packages/core/src/loop/session.ts
@@ -118,10 +118,11 @@ export interface ISessionConfig {
   accept?: string;
   /** Auto-fix command run before re-validating (e.g. `eslint --fix`). */
   fix?: string;
-  /** Opt into the core format janitor: a strict `eslint --fix` + prettier over the
-   *  task's SCOPED files (never the whole tree), deferring to the project's own
-   *  prettier. The interactive CLI sets this; bare test/eval loops leave it off so
-   *  they don't pay per-turn formatter subprocess latency. Independent of `fix`. */
+  /** Opt into the core format janitor: a strict `eslint --fix` + prettier over the files
+   *  the model wrote this session (`ctx.tool.touched`, never the whole tree — and NOT
+   *  `task.files`, which defaults to a whole-repo glob in the REPL), deferring to the
+   *  project's own prettier. The interactive CLI sets this; bare test/eval loops leave it
+   *  off so they don't pay per-turn formatter subprocess latency. Independent of `fix`. */
   coreFormat?: boolean;
   /** Read-only context files. */
   context?: string[];

--- a/packages/core/src/loop/turn.ts
+++ b/packages/core/src/loop/turn.ts
@@ -876,22 +876,6 @@ async function applyDeterministicFixes(ctx: ILoopCtx): Promise<void> {
   }
 }
 
-/** Snapshot the current on-disk contents of every existing file in `files`. */
-async function snapshotFiles(
-  cwd: string,
-  files: readonly string[]
-): Promise<Map<string, string>> {
-  const snapshot = new Map<string, string>();
-
-  for (const f of files) {
-    if (await fileExists(cwd, f)) {
-      snapshot.set(f, await Bun.file(join(cwd, f)).text());
-    }
-  }
-
-  return snapshot;
-}
-
 /** Drop redundant annotations across `files`, degrading silently per-file. */
 async function dropRedundantAcross(
   cwd: string,
@@ -987,14 +971,16 @@ export async function polishOnGreen(ctx: ILoopCtx): Promise<void> {
   const files = [...(ctx.tool.touched ?? [])];
 
   // The revert SNAPSHOT must cover everything polish could mutate, so a failed re-gate
-  // rolls back cleanly. The drop/format only touch `files`, but a spec-provided
-  // `task.fix` is an arbitrary command that may edit any in-scope file — so when one is
-  // set, also snapshot the resolved scope (reads only; the mutations stay touched-scoped).
+  // rolls back cleanly. The drop/format only touch `files`, but a spec-provided `task.fix`
+  // is an arbitrary command that may EDIT any in-scope file or CREATE new ones — so when
+  // one is set, snapshot the whole task scope with the robust rollback substrate: it is
+  // uncapped, binary-safe, and TOMBSTONES files the fix created (a plain content map would
+  // leave those on disk). No fix ⇒ snapshot just the touched files the drop edits.
   const snapshotScope =
     task.fix !== undefined && task.fix.length > 0
-      ? [...new Set([...files, ...(await resolveScopeFiles(cwd, task.files))])]
+      ? [...new Set([...files, ...task.files])]
       : files;
-  const snapshot = await snapshotFiles(cwd, snapshotScope);
+  const snapshot = await snapshotFilesForRollback(cwd, snapshotScope);
   const dropped = await dropRedundantAcross(cwd, files);
 
   if (dropped === 0) {
@@ -1033,10 +1019,9 @@ export async function polishOnGreen(ctx: ILoopCtx): Promise<void> {
   }
 
   // A drop changed an inferred type (or the recheck failed/was aborted) — roll the whole
-  // file set back to the pre-polish green state.
-  for (const [f, content] of snapshot) {
-    await Bun.write(join(cwd, f), content);
-  }
+  // file set back to the pre-polish green state (rewrites edited files and tombstones any
+  // the fix created).
+  await restoreFiles(snapshot);
 
   // Cancellation was deferred past the rollback so the tree is restored — now honor it.
   if (abortErr !== null) {

--- a/packages/core/src/loop/turn.ts
+++ b/packages/core/src/loop/turn.ts
@@ -338,9 +338,9 @@ export interface ILoopCtxGate {
    *  moat violations tsc can't see surface inline). Omitted ⇒ type-only guard. */
   lintFile?: FileLinter;
   /** Opt into the SCOPED format janitor in the auto-fix step: a strict eslint --fix +
-   *  prettier over the task's resolved scope, deferring to the project's own prettier.
-   *  Set by the interactive CLI. Off ⇒ no formatter subprocess per turn (bare test/eval
-   *  loops stay fast). */
+   *  prettier over the files the model wrote this session (`ctx.tool.touched`), deferring
+   *  to the project's own prettier. Set by the interactive CLI. Off ⇒ no formatter
+   *  subprocess per turn (bare test/eval loops stay fast). */
   coreFormat?: boolean;
   /** Detected stack profile — determines which rule packs are enabled. */
   stackProfile?: IStackProfile;

--- a/packages/core/src/loop/turn.ts
+++ b/packages/core/src/loop/turn.ts
@@ -979,13 +979,22 @@ async function recheckAfterPolish(
 export async function polishOnGreen(ctx: ILoopCtx): Promise<void> {
   const { task, cwd, report } = ctx;
 
-  // Scope polish (the drop AND its revert snapshot) to the files the model WROTE this
-  // session (`ctx.tool.touched`) — NOT task.files, which defaults to the whole repo in
-  // the interactive REPL. dropRedundantAnnotations mutates each file (stripping the
-  // dropped annotation's semicolon), so scanning the whole tree would rewrite files the
-  // model never touched — the exact thing #103 forbids.
+  // Scope the DROP + FORMAT to the files the model WROTE this session (`ctx.tool.touched`)
+  // — NOT task.files, which defaults to the whole repo in the interactive REPL.
+  // dropRedundantAnnotations mutates each file (stripping the dropped annotation's
+  // semicolon), so scanning the whole tree would rewrite files the model never touched —
+  // the exact thing #103 forbids.
   const files = [...(ctx.tool.touched ?? [])];
-  const snapshot = await snapshotFiles(cwd, files);
+
+  // The revert SNAPSHOT must cover everything polish could mutate, so a failed re-gate
+  // rolls back cleanly. The drop/format only touch `files`, but a spec-provided
+  // `task.fix` is an arbitrary command that may edit any in-scope file — so when one is
+  // set, also snapshot the resolved scope (reads only; the mutations stay touched-scoped).
+  const snapshotScope =
+    task.fix !== undefined && task.fix.length > 0
+      ? [...new Set([...files, ...(await resolveScopeFiles(cwd, task.files))])]
+      : files;
+  const snapshot = await snapshotFiles(cwd, snapshotScope);
   const dropped = await dropRedundantAcross(cwd, files);
 
   if (dropped === 0) {

--- a/packages/core/src/loop/turn.ts
+++ b/packages/core/src/loop/turn.ts
@@ -94,6 +94,7 @@ import {
 import { TsService } from "../lsp";
 import type { McpRegistry } from "../mcp";
 import type { FileLinter } from "../gate";
+import { formatFiles } from "../gate";
 import type { IGate } from "../gate/gate-runner";
 import {
   buildMetaRuleContext,
@@ -336,6 +337,11 @@ export interface ILoopCtxGate {
   /** Write-time single-file linter (the gate's eslint rules, applied per write so
    *  moat violations tsc can't see surface inline). Omitted ⇒ type-only guard. */
   lintFile?: FileLinter;
+  /** Opt into the SCOPED format janitor in the auto-fix step: a strict eslint --fix +
+   *  prettier over the task's resolved scope, deferring to the project's own prettier.
+   *  Set by the interactive CLI. Off ⇒ no formatter subprocess per turn (bare test/eval
+   *  loops stay fast). */
+  coreFormat?: boolean;
   /** Detected stack profile — determines which rule packs are enabled. */
   stackProfile?: IStackProfile;
   /** Rule severity overrides from tsforge.config.json (maps rule ID to "error" | "warn" | "off"). */
@@ -982,13 +988,22 @@ export async function polishOnGreen(ctx: ILoopCtx): Promise<void> {
     return;
   }
 
-  // Re-format (the drop strips trailing semicolons) before re-gating.
+  // Re-format (the drop strips trailing semicolons) before re-gating. Scoped to the
+  // polished files, deferring to the project's own prettier — same guarantee as the
+  // auto-fix janitor. A spec-provided `task.fix` still runs too.
   if (task.fix !== undefined && task.fix.length > 0) {
     await runAccept(
       { ...task, accept: task.fix },
       cwd,
       ctx.tool.signal === undefined ? {} : { signal: ctx.tool.signal }
     );
+  }
+
+  if (ctx.gate.coreFormat === true) {
+    await formatFiles(cwd, files, {
+      timeoutMs: JANITOR_TIMEOUT_MS,
+      ...(ctx.tool.signal === undefined ? {} : { signal: ctx.tool.signal }),
+    });
   }
 
   const { passed, abortErr } = await recheckAfterPolish(ctx, cwd);
@@ -1257,10 +1272,16 @@ export function persistDetail(e: IErrorItem): string {
  * optional fix command, validate, and return a terminal result (done/stuck) or
  * null to keep going (having fed the failures back into the conversation).
  */
+/** Timeout for the scoped format janitor. Higher than the per-write ceiling
+ *  (`FORMAT_TIMEOUT_MS`, 30s) because it may format a whole task scope at once (many
+ *  files), where a per-write path formats exactly one. */
+const JANITOR_TIMEOUT_MS = 120_000;
+
 /** STEP 1 — deterministic auto-fix: run the janitor fixers (TS quick-fixes,
- *  ast-grep, the optional `task.fix` command) and return which files they changed,
- *  so the model is told exactly what moved under it (else it re-fixes already-
- *  fixed style and edits now-stale text → rejects). Exported for unit tests. */
+ *  ast-grep, the optional `task.fix` command, then a scoped eslint --fix + prettier)
+ *  and return which files they changed, so the model is told exactly what moved under
+ *  it (else it re-fixes already-fixed style and edits now-stale text → rejects).
+ *  Exported for unit tests. */
 export async function autoFixStep(ctx: ILoopCtx): Promise<string[]> {
   const { task, cwd, report } = ctx;
   const beforeFix = await snapshotMtimes(cwd, task.files);
@@ -1273,6 +1294,20 @@ export async function autoFixStep(ctx: ILoopCtx): Promise<string[]> {
       cwd,
       ctx.tool.signal === undefined ? {} : { signal: ctx.tool.signal }
     );
+  }
+
+  // Scoped format janitor: strict eslint --fix + prettier over THIS task's scope
+  // only — never the whole tree. The old whole-repo `prettier --write .` reformatted
+  // thousands of untouched files (and with tsforge's bundled prettier, not the
+  // project's), producing huge spurious diffs in real repos. `formatFiles` scopes to
+  // the resolved scope and defers to the project's own prettier. Globs are resolved
+  // so a glob scope is formatted, not silently skipped. Opt-in (the CLI sets it) so a
+  // bare test/eval loop doesn't spawn a formatter every turn.
+  if (ctx.gate.coreFormat === true) {
+    await formatFiles(cwd, await resolveScopeFiles(cwd, task.files), {
+      timeoutMs: JANITOR_TIMEOUT_MS,
+      ...(ctx.tool.signal === undefined ? {} : { signal: ctx.tool.signal }),
+    });
   }
 
   const autoFixed = changedSince(

--- a/packages/core/src/loop/turn.ts
+++ b/packages/core/src/loop/turn.ts
@@ -979,8 +979,12 @@ async function recheckAfterPolish(
 export async function polishOnGreen(ctx: ILoopCtx): Promise<void> {
   const { task, cwd, report } = ctx;
 
-  // Resolve globs so a glob scope is polished too (not silently skipped).
-  const files = await resolveScopeFiles(cwd, task.files);
+  // Scope polish (the drop AND its revert snapshot) to the files the model WROTE this
+  // session (`ctx.tool.touched`) — NOT task.files, which defaults to the whole repo in
+  // the interactive REPL. dropRedundantAnnotations mutates each file (stripping the
+  // dropped annotation's semicolon), so scanning the whole tree would rewrite files the
+  // model never touched — the exact thing #103 forbids.
+  const files = [...(ctx.tool.touched ?? [])];
   const snapshot = await snapshotFiles(cwd, files);
   const dropped = await dropRedundantAcross(cwd, files);
 

--- a/packages/core/src/loop/turn.ts
+++ b/packages/core/src/loop/turn.ts
@@ -989,8 +989,9 @@ export async function polishOnGreen(ctx: ILoopCtx): Promise<void> {
   }
 
   // Re-format (the drop strips trailing semicolons) before re-gating. Scoped to the
-  // polished files, deferring to the project's own prettier — same guarantee as the
-  // auto-fix janitor. A spec-provided `task.fix` still runs too.
+  // files the model wrote (`ctx.tool.touched`), deferring to the project's own
+  // prettier — same guarantee as the auto-fix janitor. A spec-provided `task.fix`
+  // still runs too.
   if (task.fix !== undefined && task.fix.length > 0) {
     await runAccept(
       { ...task, accept: task.fix },
@@ -1000,7 +1001,7 @@ export async function polishOnGreen(ctx: ILoopCtx): Promise<void> {
   }
 
   if (ctx.gate.coreFormat === true) {
-    await formatFiles(cwd, files, {
+    await formatFiles(cwd, [...(ctx.tool.touched ?? [])], {
       timeoutMs: JANITOR_TIMEOUT_MS,
       ...(ctx.tool.signal === undefined ? {} : { signal: ctx.tool.signal }),
     });
@@ -1296,15 +1297,16 @@ export async function autoFixStep(ctx: ILoopCtx): Promise<string[]> {
     );
   }
 
-  // Scoped format janitor: strict eslint --fix + prettier over THIS task's scope
-  // only — never the whole tree. The old whole-repo `prettier --write .` reformatted
-  // thousands of untouched files (and with tsforge's bundled prettier, not the
-  // project's), producing huge spurious diffs in real repos. `formatFiles` scopes to
-  // the resolved scope and defers to the project's own prettier. Globs are resolved
-  // so a glob scope is formatted, not silently skipped. Opt-in (the CLI sets it) so a
-  // bare test/eval loop doesn't spawn a formatter every turn.
+  // Scoped format janitor: strict eslint --fix + prettier over the files the model
+  // ACTUALLY wrote this session (`ctx.tool.touched`) — never the whole tree, and NOT
+  // `task.files`, which in the interactive REPL defaults to the whole repo (`["**/*"]`)
+  // and would re-expand to it. The old whole-repo `prettier --write .` reformatted
+  // thousands of untouched files (with tsforge's bundled prettier, not the project's),
+  // producing huge spurious diffs in real repos. `formatFiles` defers to the project's
+  // own prettier. Opt-in (the CLI sets it) so a bare test/eval loop doesn't spawn a
+  // formatter every turn.
   if (ctx.gate.coreFormat === true) {
-    await formatFiles(cwd, await resolveScopeFiles(cwd, task.files), {
+    await formatFiles(cwd, [...(ctx.tool.touched ?? [])], {
       timeoutMs: JANITOR_TIMEOUT_MS,
       ...(ctx.tool.signal === undefined ? {} : { signal: ctx.tool.signal }),
     });

--- a/packages/core/src/loop/turn.ts
+++ b/packages/core/src/loop/turn.ts
@@ -963,12 +963,14 @@ async function recheckAfterPolish(
 export async function polishOnGreen(ctx: ILoopCtx): Promise<void> {
   const { task, cwd, report } = ctx;
 
-  // Scope the DROP + FORMAT to the files the model WROTE this session (`ctx.tool.touched`)
-  // — NOT task.files, which defaults to the whole repo in the interactive REPL.
-  // dropRedundantAnnotations mutates each file (stripping the dropped annotation's
-  // semicolon), so scanning the whole tree would rewrite files the model never touched —
-  // the exact thing #103 forbids.
-  const files = [...(ctx.tool.touched ?? [])];
+  // Scope the DROP + FORMAT to the files the model WROTE this session that are STILL in
+  // the editable scope (`touchedInScope`) — NOT task.files, which defaults to the whole
+  // repo in the interactive REPL. dropRedundantAnnotations mutates each file (stripping
+  // the dropped annotation's semicolon), so scanning the whole tree would rewrite files
+  // the model never touched (the exact thing #103 forbids), and a session-lifetime
+  // `touched` could drop annotations in a file `/files` has since removed from scope,
+  // which the re-gate wouldn't cover.
+  const files = touchedInScope(ctx);
 
   // The revert SNAPSHOT must cover everything polish could mutate, so a failed re-gate
   // rolls back cleanly. The drop/format only touch `files`, but a spec-provided `task.fix`
@@ -1000,7 +1002,7 @@ export async function polishOnGreen(ctx: ILoopCtx): Promise<void> {
   }
 
   if (ctx.gate.coreFormat === true) {
-    await formatFiles(cwd, [...(ctx.tool.touched ?? [])], {
+    await formatFiles(cwd, files, {
       timeoutMs: JANITOR_TIMEOUT_MS,
       ...(ctx.tool.signal === undefined ? {} : { signal: ctx.tool.signal }),
     });
@@ -1276,6 +1278,17 @@ export function persistDetail(e: IErrorItem): string {
  *  files), where a per-write path formats exactly one. */
 const JANITOR_TIMEOUT_MS = 120_000;
 
+/** The files the model WROTE this session that are ALSO still in the editable scope.
+ *  `ctx.tool.touched` is session-lifetime, but `/files` can narrow `task.files`
+ *  mid-session — so the janitor/polish intersect the two: only mutate files the model
+ *  wrote AND that the gate (scoped to task.files) will re-validate, never a now-out-of-
+ *  scope leftover. With the default whole-repo glob scope this is just `touched`. */
+function touchedInScope(ctx: ILoopCtx): string[] {
+  return [...(ctx.tool.touched ?? [])].filter((f) =>
+    isInScope(f, ctx.task.files)
+  );
+}
+
 /** STEP 1 — deterministic auto-fix: run the janitor fixers (TS quick-fixes,
  *  ast-grep, the optional `task.fix` command, then a scoped eslint --fix + prettier)
  *  and return which files they changed, so the model is told exactly what moved under
@@ -1304,7 +1317,7 @@ export async function autoFixStep(ctx: ILoopCtx): Promise<string[]> {
   // own prettier. Opt-in (the CLI sets it) so a bare test/eval loop doesn't spawn a
   // formatter every turn.
   if (ctx.gate.coreFormat === true) {
-    await formatFiles(cwd, [...(ctx.tool.touched ?? [])], {
+    await formatFiles(cwd, touchedInScope(ctx), {
       timeoutMs: JANITOR_TIMEOUT_MS,
       ...(ctx.tool.signal === undefined ? {} : { signal: ctx.tool.signal }),
     });

--- a/packages/core/strict.eslint.config.mjs
+++ b/packages/core/strict.eslint.config.mjs
@@ -18,6 +18,11 @@ import tseslint from "typescript-eslint";
 import stylistic from "@stylistic/eslint-plugin";
 import sonarjs from "eslint-plugin-sonarjs";
 
+// Every TypeScript source extension the strict floor lints — including the ESM/CJS
+// module variants `.mts`/`.cts`, which are TS and must get the same moat as `.ts`.
+// Single source so the pack and base blocks below can't drift apart.
+const TS_FILES = ["**/*.ts", "**/*.tsx", "**/*.mts", "**/*.cts"];
+
 // Load stack-aware packs if TSFORGE_PACKS env var is set
 let packConfig = [];
 const packIds = (process.env.TSFORGE_PACKS ?? "").split(",").filter(Boolean);
@@ -40,7 +45,7 @@ if (packIds.length > 0) {
     const { plugin, rules } = buildPackEslintConfig(packIds, ruleOverrides);
     packConfig = [
       {
-        files: ["**/*.ts", "**/*.tsx"],
+        files: TS_FILES,
         plugins: { tsforge: plugin },
         rules,
       },
@@ -130,7 +135,7 @@ const rules = applyBundledOverrides({ ...bundledRules, ...conventionRules });
 export default tseslint.config(
   { ignores: ["**/node_modules/**", "**/dist/**", "**/build/**"] },
   {
-    files: ["**/*.ts", "**/*.tsx"],
+    files: TS_FILES,
     languageOptions: { parser: tseslint.parser },
     plugins: {
       "@typescript-eslint": tseslint.plugin,

--- a/packages/core/strict.web.eslint.config.mjs
+++ b/packages/core/strict.web.eslint.config.mjs
@@ -19,11 +19,6 @@ import pluginReactHooks from "eslint-plugin-react-hooks";
 import pluginJsxA11y from "eslint-plugin-jsx-a11y";
 import sonarjs from "eslint-plugin-sonarjs";
 
-// Every TypeScript source extension the web strict floor lints — including `.mts`/`.cts`
-// (TS module variants), which must get the same rules as `.ts`. Single source so the
-// pack and base blocks below stay in sync.
-const TS_FILES = ["**/*.ts", "**/*.tsx", "**/*.mts", "**/*.cts"];
-
 // Load stack-aware packs if TSFORGE_PACKS env var is set
 let packConfig = [];
 const packIds = (process.env.TSFORGE_PACKS ?? "").split(",").filter(Boolean);
@@ -49,7 +44,7 @@ if (packIds.length > 0) {
     const { plugin, rules } = buildPackEslintConfig(packIds, ruleOverrides);
     packConfig = [
       {
-        files: TS_FILES,
+        files: ["**/*.ts", "**/*.tsx"],
         plugins: { tsforge: plugin },
         rules,
       },
@@ -229,7 +224,7 @@ const rules = {
 export default tseslint.config(
   { ignores: ["**/node_modules/**", "**/dist/**", "**/build/**"] },
   {
-    files: TS_FILES,
+    files: ["**/*.ts", "**/*.tsx"],
     languageOptions: { parser: tseslint.parser },
     plugins: {
       "@typescript-eslint": tseslint.plugin,

--- a/packages/core/strict.web.eslint.config.mjs
+++ b/packages/core/strict.web.eslint.config.mjs
@@ -19,6 +19,11 @@ import pluginReactHooks from "eslint-plugin-react-hooks";
 import pluginJsxA11y from "eslint-plugin-jsx-a11y";
 import sonarjs from "eslint-plugin-sonarjs";
 
+// Every TypeScript source extension the web strict floor lints — including `.mts`/`.cts`
+// (TS module variants), which must get the same rules as `.ts`. Single source so the
+// pack and base blocks below stay in sync.
+const TS_FILES = ["**/*.ts", "**/*.tsx", "**/*.mts", "**/*.cts"];
+
 // Load stack-aware packs if TSFORGE_PACKS env var is set
 let packConfig = [];
 const packIds = (process.env.TSFORGE_PACKS ?? "").split(",").filter(Boolean);
@@ -44,7 +49,7 @@ if (packIds.length > 0) {
     const { plugin, rules } = buildPackEslintConfig(packIds, ruleOverrides);
     packConfig = [
       {
-        files: ["**/*.ts", "**/*.tsx"],
+        files: TS_FILES,
         plugins: { tsforge: plugin },
         rules,
       },
@@ -224,7 +229,7 @@ const rules = {
 export default tseslint.config(
   { ignores: ["**/node_modules/**", "**/dist/**", "**/build/**"] },
   {
-    files: ["**/*.ts", "**/*.tsx"],
+    files: TS_FILES,
     languageOptions: { parser: tseslint.parser },
     plugins: {
       "@typescript-eslint": tseslint.plugin,

--- a/packages/core/tests/format-scope.test.ts
+++ b/packages/core/tests/format-scope.test.ts
@@ -1,5 +1,12 @@
 import { test, expect } from "bun:test";
-import { mkdtemp, rm, writeFile, readFile, mkdir } from "node:fs/promises";
+import {
+  mkdtemp,
+  rm,
+  writeFile,
+  readFile,
+  mkdir,
+  chmod,
+} from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { formatFiles } from "../src/gate";
@@ -55,6 +62,56 @@ test("formatFiles honors the project's prettier config over tsforge defaults", a
     expect(await readFile(join(dir, "f.ts"), "utf8")).toBe(
       "export const greeting = 'hi'\n"
     );
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+// Containment: formatFiles invokes mutating formatters directly, so a caller that
+// hands it an absolute path or a `../` traversal must NOT be able to rewrite files
+// outside cwd. A path that escapes cwd is dropped, not formatted.
+test("formatFiles refuses a path that escapes cwd (../outside)", async () => {
+  const parent = await tempDir();
+
+  try {
+    const dir = join(parent, "workspace");
+
+    await mkdir(dir, { recursive: true });
+    const messy = "export  const   x=1";
+
+    // A sibling of the workspace, reachable only by escaping cwd.
+    await writeFile(join(parent, "outside.ts"), messy);
+
+    await formatFiles(dir, ["../outside.ts"]);
+
+    expect(await readFile(join(parent, "outside.ts"), "utf8")).toBe(messy);
+  } finally {
+    await rm(parent, { recursive: true, force: true });
+  }
+});
+
+// Exercises the project-prettier spawn path: when node_modules/.bin/prettier exists,
+// formatFiles spawns [projectBin, ...] directly (NO "bun" prefix). A fake executable
+// stands in for the project's prettier and proves it was invoked with the file args.
+test("formatFiles spawns the project's own prettier binary directly", async () => {
+  const dir = await tempDir();
+
+  try {
+    const binDir = join(dir, "node_modules", ".bin");
+
+    await mkdir(binDir, { recursive: true });
+    // Fake prettier: appends a marker to each non-flag arg, proving it ran with the
+    // file list and that the argv had no leading "bun".
+    await writeFile(
+      join(binDir, "prettier"),
+      '#!/bin/sh\nfor a in "$@"; do case "$a" in --*) ;; *) printf "/*fmt*/\\n" >> "$a";; esac; done\n'
+    );
+    await chmod(join(binDir, "prettier"), 0o755);
+    await writeFile(join(dir, "f.ts"), "export const x = 1;\n");
+
+    await formatFiles(dir, ["f.ts"]);
+
+    expect(await readFile(join(dir, "f.ts"), "utf8")).toContain("/*fmt*/");
   } finally {
     await rm(dir, { recursive: true, force: true });
   }

--- a/packages/core/tests/format-scope.test.ts
+++ b/packages/core/tests/format-scope.test.ts
@@ -240,6 +240,58 @@ test("formatFiles formats a contained file whose name starts with '..'", async (
   }
 }, 30_000);
 
+// .mts / .cts are TypeScript source — the strict eslint --fix moat must run on them too,
+// not just prettier. curly braces are the tell (prettier never adds them).
+test("formatFiles applies the eslint moat to a .mts file", async () => {
+  const dir = await tempDir();
+
+  try {
+    await writeFile(
+      join(dir, "g.mts"),
+      "export function f(x: boolean) {\n  if (x) return 1;\n  return 2;\n}\n"
+    );
+
+    await formatFiles(dir, ["g.mts"]);
+
+    expect(await readFile(join(dir, "g.mts"), "utf8")).toContain("if (x) {");
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+}, 30_000);
+
+// Monorepo: a package subdir with prettier hoisted to the workspace root's node_modules
+// must resolve the hoisted binary (Node module resolution), not fall back to bundled.
+test.skipIf(isWin32())(
+  "resolveProjectPrettierArgv finds a workspace-hoisted prettier from a package subdir",
+  async () => {
+    const root = await tempDir();
+
+    try {
+      // prettier installed only at the workspace ROOT.
+      const rootBinDir = join(root, "node_modules", ".bin");
+
+      await mkdir(rootBinDir, { recursive: true });
+      await writeFile(join(rootBinDir, "prettier"), "#!/usr/bin/env node\n");
+      await mkdir(join(root, "node_modules", "prettier"), { recursive: true });
+      await writeFile(
+        join(root, "node_modules", "prettier", "package.json"),
+        JSON.stringify({ name: "prettier", version: "3.9.6" })
+      );
+
+      // The package subdir has no prettier of its own.
+      const pkg = join(root, "packages", "app");
+
+      await mkdir(pkg, { recursive: true });
+
+      const argv = await resolveProjectPrettierArgv(pkg);
+
+      expect(argv).toEqual([join(rootBinDir, "prettier")]);
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  }
+);
+
 test("formatFiles is a no-op on an empty list and skips a missing path", async () => {
   const dir = await tempDir();
 

--- a/packages/core/tests/format-scope.test.ts
+++ b/packages/core/tests/format-scope.test.ts
@@ -117,6 +117,28 @@ test("formatFiles spawns the project's own prettier binary directly", async () =
   }
 });
 
+// The eslint autofix moat must actually run — not just prettier. ESLint 10 silently
+// no-ops on ABSOLUTE paths ("File ignored because outside of base path"), so formatFiles
+// must hand it cwd-RELATIVE paths. `curly` adds the braces prettier never would, so this
+// fails if the eslint --fix step is a no-op.
+test("formatFiles applies the eslint autofix moat (curly), not just prettier", async () => {
+  const dir = await tempDir();
+
+  try {
+    await writeFile(
+      join(dir, "g.ts"),
+      "export function f(x: boolean) {\n  if (x) return 1;\n  return 2;\n}\n"
+    );
+
+    await formatFiles(dir, ["g.ts"]);
+
+    // Braces were added by eslint's `curly` autofix (prettier alone never adds them).
+    expect(await readFile(join(dir, "g.ts"), "utf8")).toContain("if (x) {");
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+}, 30_000);
+
 test("formatFiles is a no-op on an empty list and skips a missing path", async () => {
   const dir = await tempDir();
 

--- a/packages/core/tests/format-scope.test.ts
+++ b/packages/core/tests/format-scope.test.ts
@@ -13,6 +13,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { formatFiles } from "../src/gate";
 import { resolveProjectPrettierArgv } from "../src/gate/linter";
+import { isWin32 } from "../src/lib/platform";
 
 async function tempDir(): Promise<string> {
   return mkdtemp(join(tmpdir(), "tsforge-format-scope-"));
@@ -97,7 +98,7 @@ test("formatFiles refuses a path that escapes cwd (../outside)", async () => {
 // stands in for the project's prettier and proves it was invoked with the file args.
 // POSIX-only: on win32 the project bin isn't shell-lessly spawnable, so the
 // implementation deliberately uses bundled prettier (covered by the fallback test).
-test.skipIf(process.platform === "win32")(
+test.skipIf(isWin32())(
   "formatFiles spawns the project's own prettier binary directly",
   async () => {
     const dir = await tempDir();
@@ -106,6 +107,12 @@ test.skipIf(process.platform === "win32")(
       const binDir = join(dir, "node_modules", ".bin");
 
       await mkdir(binDir, { recursive: true });
+      // prettier must be a real installed package (manifest present), not just a .bin shim.
+      await mkdir(join(dir, "node_modules", "prettier"), { recursive: true });
+      await writeFile(
+        join(dir, "node_modules", "prettier", "package.json"),
+        JSON.stringify({ name: "prettier", version: "3.9.6" })
+      );
       // Fake prettier: appends a marker to each non-flag arg, proving it ran with the
       // file list and that the argv had no leading "bun".
       await writeFile(
@@ -260,7 +267,59 @@ test("resolveProjectPrettierArgv falls back to the bundled prettier when the pro
   }
 });
 
-test.skipIf(process.platform === "win32")(
+// Security: a lone `.bin/prettier` shim WITHOUT an installed prettier package (no
+// node_modules/prettier/package.json) must NOT be auto-executed — fall back to bundled.
+test.skipIf(isWin32())(
+  "resolveProjectPrettierArgv ignores a lone .bin/prettier shim with no installed package",
+  async () => {
+    const dir = await tempDir();
+
+    try {
+      const binDir = join(dir, "node_modules", ".bin");
+
+      await mkdir(binDir, { recursive: true });
+      await writeFile(join(binDir, "prettier"), "#!/bin/sh\nexit 0\n");
+      // NOTE: no node_modules/prettier/package.json — the shim is not a real install.
+
+      const argv = await resolveProjectPrettierArgv(dir);
+
+      expect(argv[0]).toBe("bun"); // bundled, not the planted shim
+      expect(argv).toHaveLength(2);
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  }
+);
+
+// POSIX: a backslash is a legal filename character. formatFiles must NOT normalize `a\b.ts`
+// to `a/b.ts` — doing so would retarget a DIFFERENT file. The safety guarantee is that the
+// distinct `a/b.ts` is never formatted as a side effect (under the buggy normalize path it
+// WOULD be). Whether the odd backslash file itself formats is moot — the tools' glob layer
+// escapes backslashes — so we assert only the no-retarget property.
+test.skipIf(isWin32())(
+  "formatFiles does not normalize a POSIX backslash into a retargeted sibling",
+  async () => {
+    const dir = await tempDir();
+
+    try {
+      const messy = "export  const   x=1";
+
+      await writeFile(join(dir, "a\\b.ts"), messy); // literal backslash in the name
+      await mkdir(join(dir, "a"), { recursive: true });
+      await writeFile(join(dir, "a", "b.ts"), messy); // the distinct a/b.ts
+
+      await formatFiles(dir, ["a\\b.ts"]);
+
+      // a/b.ts — the file `\`→`/` normalization would have hit — is left untouched.
+      expect(await readFile(join(dir, "a", "b.ts"), "utf8")).toBe(messy);
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  },
+  30_000
+);
+
+test.skipIf(isWin32())(
   "resolveProjectPrettierArgv prefers the project's own prettier binary when present",
   async () => {
     const dir = await tempDir();
@@ -269,6 +328,11 @@ test.skipIf(process.platform === "win32")(
       const binDir = join(dir, "node_modules", ".bin");
 
       await mkdir(binDir, { recursive: true });
+      await mkdir(join(dir, "node_modules", "prettier"), { recursive: true });
+      await writeFile(
+        join(dir, "node_modules", "prettier", "package.json"),
+        JSON.stringify({ name: "prettier", version: "3.9.6" })
+      );
       const projectBin = join(binDir, "prettier");
 
       await writeFile(projectBin, "#!/usr/bin/env node\n");
@@ -287,7 +351,7 @@ test.skipIf(process.platform === "win32")(
 // Symlink escape: a symlink UNDER cwd that points to a file OUTSIDE the workspace must
 // not let a formatter rewrite the external target. realpath-based containment resolves
 // the link and drops it.
-test.skipIf(process.platform === "win32")(
+test.skipIf(isWin32())(
   "formatFiles refuses an in-workspace symlink that points outside cwd",
   async () => {
     const parent = await tempDir();

--- a/packages/core/tests/format-scope.test.ts
+++ b/packages/core/tests/format-scope.test.ts
@@ -6,6 +6,7 @@ import {
   readFile,
   mkdir,
   chmod,
+  realpath,
 } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
@@ -136,6 +137,54 @@ test("formatFiles applies the eslint autofix moat (curly), not just prettier", a
     expect(await readFile(join(dir, "g.ts"), "utf8")).toContain("if (x) {");
   } finally {
     await rm(dir, { recursive: true, force: true });
+  }
+}, 30_000);
+
+// A DIRECTORY must never reach the formatters: `prettier --write .`/`sub` expands to
+// the whole (sub)tree — the #103 whole-repo rewrite in disguise. formatFiles must drop
+// directory args (including "." and the workspace root) and format nothing.
+test("formatFiles never formats a directory arg (., root, or subdir)", async () => {
+  const dir = await tempDir();
+
+  try {
+    const messy = "export  const   x=1";
+
+    await mkdir(join(dir, "sub"), { recursive: true });
+    await writeFile(join(dir, "sub", "a.ts"), messy);
+    await writeFile(join(dir, "top.ts"), messy);
+
+    // "." and the absolute root are directories; "sub" is a directory.
+    await formatFiles(dir, [".", dir, "sub"]);
+
+    // Nothing under them was touched.
+    expect(await readFile(join(dir, "sub", "a.ts"), "utf8")).toBe(messy);
+    expect(await readFile(join(dir, "top.ts"), "utf8")).toBe(messy);
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+// macOS tmpdir dualism: cwd may be the logical `/var/…` form while a caller passes an
+// already-resolved `/private/var/…` path. Relativizing against the real root keeps the
+// eslint moat alive (a `../../private/var/…` arg would make ESLint no-op again).
+test("formatFiles still runs the eslint moat for a realpath-form absolute input", async () => {
+  const logicalDir = await tempDir();
+  const realDir = await realpath(logicalDir);
+
+  try {
+    await writeFile(
+      join(logicalDir, "g.ts"),
+      "export function f(x: boolean) {\n  if (x) return 1;\n  return 2;\n}\n"
+    );
+
+    // cwd = logical form; the file path = resolved (real) form. This is the dualism.
+    await formatFiles(logicalDir, [join(realDir, "g.ts")]);
+
+    expect(await readFile(join(logicalDir, "g.ts"), "utf8")).toContain(
+      "if (x) {"
+    );
+  } finally {
+    await rm(logicalDir, { recursive: true, force: true });
   }
 }, 30_000);
 

--- a/packages/core/tests/format-scope.test.ts
+++ b/packages/core/tests/format-scope.test.ts
@@ -1,0 +1,109 @@
+import { test, expect } from "bun:test";
+import { mkdtemp, rm, writeFile, readFile, mkdir } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { formatFiles } from "../src/gate";
+import { resolveProjectPrettierArgv } from "../src/gate/linter";
+
+async function tempDir(): Promise<string> {
+  return mkdtemp(join(tmpdir(), "tsforge-format-scope-"));
+}
+
+// THE reported bug: the format pass rewrote the whole repo, so files the model
+// never touched (already correct per the project's rules) came out with thousands
+// of spurious diffs. formatFiles must rewrite ONLY the files it is handed.
+test("formatFiles rewrites only the listed file, never its untouched sibling", async () => {
+  const dir = await tempDir();
+
+  try {
+    const messy = "export  const   x=1";
+
+    await writeFile(join(dir, "touched.ts"), messy);
+    await writeFile(join(dir, "untouched.ts"), messy);
+
+    await formatFiles(dir, ["touched.ts"]);
+
+    // The listed file is formatted…
+    expect(await readFile(join(dir, "touched.ts"), "utf8")).toBe(
+      "export const x = 1;\n"
+    );
+    // …and the sibling that was NOT listed is left byte-for-byte as it was.
+    expect(await readFile(join(dir, "untouched.ts"), "utf8")).toBe(messy);
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+// Fidelity: when the project ships its own prettier config, the format pass must
+// produce output matching THAT config — not tsforge's built-in defaults. Prettier
+// (bundled, in this dir with no local prettier) resolves the project `.prettierrc`,
+// and runs LAST, so its config has the final say (single quotes, no semicolons).
+test("formatFiles honors the project's prettier config over tsforge defaults", async () => {
+  const dir = await tempDir();
+
+  try {
+    await writeFile(
+      join(dir, ".prettierrc.json"),
+      JSON.stringify({ singleQuote: true, semi: false })
+    );
+    await writeFile(join(dir, "f.ts"), 'export const greeting = "hi"');
+
+    await formatFiles(dir, ["f.ts"]);
+
+    // Single-quoted and no trailing semicolon = the PROJECT's rules, not tsforge's
+    // default (double quotes + semicolons).
+    expect(await readFile(join(dir, "f.ts"), "utf8")).toBe(
+      "export const greeting = 'hi'\n"
+    );
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test("formatFiles is a no-op on an empty list and skips a missing path", async () => {
+  const dir = await tempDir();
+
+  try {
+    // Neither call should throw; a missing path is filtered, not handed to a tool.
+    await formatFiles(dir, []);
+    await formatFiles(dir, ["does-not-exist.ts"]);
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test("resolveProjectPrettierArgv falls back to the bundled prettier when the project has none", async () => {
+  const dir = await tempDir();
+
+  try {
+    const argv = await resolveProjectPrettierArgv(dir);
+
+    // Bundled path: `bun <bundled-prettier>` — two args, run via bun, not a project bin.
+    expect(argv[0]).toBe("bun");
+    expect(argv).toHaveLength(2);
+    expect(argv[1]).not.toContain(join(dir, "node_modules"));
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test("resolveProjectPrettierArgv prefers the project's own prettier binary when present", async () => {
+  const dir = await tempDir();
+
+  try {
+    const binDir = join(dir, "node_modules", ".bin");
+
+    await mkdir(binDir, { recursive: true });
+    const projectBin = join(binDir, "prettier");
+
+    await writeFile(projectBin, "#!/usr/bin/env node\n");
+
+    const argv = await resolveProjectPrettierArgv(dir);
+
+    // The project's own prettier carries its version + can resolve shared/extended
+    // configs from the project's node_modules; we run it directly.
+    expect(argv).toEqual([projectBin]);
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});

--- a/packages/core/tests/format-scope.test.ts
+++ b/packages/core/tests/format-scope.test.ts
@@ -194,6 +194,45 @@ test("formatFiles still runs the eslint moat for a realpath-form absolute input"
   }
 }, 30_000);
 
+// Security: a contained file whose NAME looks like a flag (`--config=x.ts`) must be
+// formatted as a PATH, not interpreted as a formatter option (which could load
+// repo-controlled config). The `--` argv terminator guarantees this — without it, the
+// formatters treat the name as an option and leave the file untouched, so "it got
+// formatted" is the proof `--` is present and working.
+test("formatFiles formats a flag-named file (the -- terminator holds)", async () => {
+  const dir = await tempDir();
+
+  try {
+    await writeFile(join(dir, "--config=x.ts"), "export  const   x=1");
+
+    await formatFiles(dir, ["--config=x.ts"]);
+
+    expect(await readFile(join(dir, "--config=x.ts"), "utf8")).toBe(
+      "export const x = 1;\n"
+    );
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+}, 30_000);
+
+// The escape guard rejects only a real parent ref (`..`, `../…`), NOT a legitimately
+// contained filename that merely starts with two dots. `..draft.ts` must still format.
+test("formatFiles formats a contained file whose name starts with '..'", async () => {
+  const dir = await tempDir();
+
+  try {
+    await writeFile(join(dir, "..draft.ts"), "export  const   x=1");
+
+    await formatFiles(dir, ["..draft.ts"]);
+
+    expect(await readFile(join(dir, "..draft.ts"), "utf8")).toBe(
+      "export const x = 1;\n"
+    );
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+}, 30_000);
+
 test("formatFiles is a no-op on an empty list and skips a missing path", async () => {
   const dir = await tempDir();
 

--- a/packages/core/tests/format-scope.test.ts
+++ b/packages/core/tests/format-scope.test.ts
@@ -7,6 +7,7 @@ import {
   mkdir,
   chmod,
   realpath,
+  symlink,
 } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
@@ -94,29 +95,34 @@ test("formatFiles refuses a path that escapes cwd (../outside)", async () => {
 // Exercises the project-prettier spawn path: when node_modules/.bin/prettier exists,
 // formatFiles spawns [projectBin, ...] directly (NO "bun" prefix). A fake executable
 // stands in for the project's prettier and proves it was invoked with the file args.
-test("formatFiles spawns the project's own prettier binary directly", async () => {
-  const dir = await tempDir();
+// POSIX-only: on win32 the project bin isn't shell-lessly spawnable, so the
+// implementation deliberately uses bundled prettier (covered by the fallback test).
+test.skipIf(process.platform === "win32")(
+  "formatFiles spawns the project's own prettier binary directly",
+  async () => {
+    const dir = await tempDir();
 
-  try {
-    const binDir = join(dir, "node_modules", ".bin");
+    try {
+      const binDir = join(dir, "node_modules", ".bin");
 
-    await mkdir(binDir, { recursive: true });
-    // Fake prettier: appends a marker to each non-flag arg, proving it ran with the
-    // file list and that the argv had no leading "bun".
-    await writeFile(
-      join(binDir, "prettier"),
-      '#!/bin/sh\nfor a in "$@"; do case "$a" in --*) ;; *) printf "/*fmt*/\\n" >> "$a";; esac; done\n'
-    );
-    await chmod(join(binDir, "prettier"), 0o755);
-    await writeFile(join(dir, "f.ts"), "export const x = 1;\n");
+      await mkdir(binDir, { recursive: true });
+      // Fake prettier: appends a marker to each non-flag arg, proving it ran with the
+      // file list and that the argv had no leading "bun".
+      await writeFile(
+        join(binDir, "prettier"),
+        '#!/bin/sh\nfor a in "$@"; do case "$a" in --*) ;; *) printf "/*fmt*/\\n" >> "$a";; esac; done\n'
+      );
+      await chmod(join(binDir, "prettier"), 0o755);
+      await writeFile(join(dir, "f.ts"), "export const x = 1;\n");
 
-    await formatFiles(dir, ["f.ts"]);
+      await formatFiles(dir, ["f.ts"]);
 
-    expect(await readFile(join(dir, "f.ts"), "utf8")).toContain("/*fmt*/");
-  } finally {
-    await rm(dir, { recursive: true, force: true });
+      expect(await readFile(join(dir, "f.ts"), "utf8")).toContain("/*fmt*/");
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
   }
-});
+);
 
 // The eslint autofix moat must actually run — not just prettier. ESLint 10 silently
 // no-ops on ABSOLUTE paths ("File ignored because outside of base path"), so formatFiles
@@ -215,23 +221,53 @@ test("resolveProjectPrettierArgv falls back to the bundled prettier when the pro
   }
 });
 
-test("resolveProjectPrettierArgv prefers the project's own prettier binary when present", async () => {
-  const dir = await tempDir();
+test.skipIf(process.platform === "win32")(
+  "resolveProjectPrettierArgv prefers the project's own prettier binary when present",
+  async () => {
+    const dir = await tempDir();
 
-  try {
-    const binDir = join(dir, "node_modules", ".bin");
+    try {
+      const binDir = join(dir, "node_modules", ".bin");
 
-    await mkdir(binDir, { recursive: true });
-    const projectBin = join(binDir, "prettier");
+      await mkdir(binDir, { recursive: true });
+      const projectBin = join(binDir, "prettier");
 
-    await writeFile(projectBin, "#!/usr/bin/env node\n");
+      await writeFile(projectBin, "#!/usr/bin/env node\n");
 
-    const argv = await resolveProjectPrettierArgv(dir);
+      const argv = await resolveProjectPrettierArgv(dir);
 
-    // The project's own prettier carries its version + can resolve shared/extended
-    // configs from the project's node_modules; we run it directly.
-    expect(argv).toEqual([projectBin]);
-  } finally {
-    await rm(dir, { recursive: true, force: true });
+      // The project's own prettier carries its version + can resolve shared/extended
+      // configs from the project's node_modules; we run it directly.
+      expect(argv).toEqual([projectBin]);
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
   }
-});
+);
+
+// Symlink escape: a symlink UNDER cwd that points to a file OUTSIDE the workspace must
+// not let a formatter rewrite the external target. realpath-based containment resolves
+// the link and drops it.
+test.skipIf(process.platform === "win32")(
+  "formatFiles refuses an in-workspace symlink that points outside cwd",
+  async () => {
+    const parent = await tempDir();
+
+    try {
+      const dir = join(parent, "workspace");
+
+      await mkdir(dir, { recursive: true });
+      const messy = "export  const   x=1";
+
+      await writeFile(join(parent, "outside.ts"), messy);
+      // link lives inside the workspace but resolves to the outside file.
+      await symlink(join(parent, "outside.ts"), join(dir, "link.ts"));
+
+      await formatFiles(dir, ["link.ts"]);
+
+      expect(await readFile(join(parent, "outside.ts"), "utf8")).toBe(messy);
+    } finally {
+      await rm(parent, { recursive: true, force: true });
+    }
+  }
+);

--- a/packages/core/tests/format-wiring.test.ts
+++ b/packages/core/tests/format-wiring.test.ts
@@ -1,0 +1,52 @@
+import { test, expect } from "bun:test";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { IProvider, IChatMessage } from "../src/inference";
+import { Session } from "../src/loop";
+
+/** A provider that never edits — Session.create only needs it to construct; these tests
+ *  read the wiring, they don't drive a turn. */
+const idleProvider: IProvider = {
+  async complete(_messages: IChatMessage[]) {
+    return { content: "done", toolCalls: [] };
+  },
+};
+
+// The scoped format janitor depends on Session.create propagating cfg.coreFormat into
+// the loop's gate context. The interactive CLI (and its /clear rebuild) pass
+// coreFormat:true through this exact path — a regression in the session.ts spread would
+// silently disable formatting for real sessions. This proves the propagation directly,
+// without hand-constructing a loop context.
+test("Session.create threads cfg.coreFormat=true into the gate context", async () => {
+  const dir = await mkdtemp(join(tmpdir(), "tsforge-coreformat-"));
+
+  try {
+    const s = await Session.create({
+      provider: idleProvider,
+      cwd: dir,
+      files: ["**/*"],
+      coreFormat: true,
+    });
+
+    expect(s.coreFormat).toBe(true);
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test("Session.create leaves the janitor OFF when cfg.coreFormat is absent", async () => {
+  const dir = await mkdtemp(join(tmpdir(), "tsforge-coreformat-"));
+
+  try {
+    const s = await Session.create({
+      provider: idleProvider,
+      cwd: dir,
+      files: ["**/*"],
+    });
+
+    expect(s.coreFormat).toBe(false);
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});

--- a/packages/core/tests/platform.test.ts
+++ b/packages/core/tests/platform.test.ts
@@ -1,0 +1,9 @@
+import { test, expect } from "bun:test";
+import { isWin32 } from "../src/lib/platform";
+
+// isWin32 is the single source of truth for "are we on Windows" — platform-specific
+// branches (the format janitor's project-prettier / backslash handling, the editor's
+// Kitty-keyboard gate) depend on it. Lock it to the underlying platform value.
+test("isWin32 reflects process.platform === 'win32'", () => {
+  expect(isWin32()).toBe(process.platform === "win32");
+});

--- a/packages/core/tests/polish-on-green.test.ts
+++ b/packages/core/tests/polish-on-green.test.ts
@@ -303,6 +303,37 @@ test("polishOnGreen rolls back a task.fix mutation to a NON-touched sibling on a
   }
 }, 30_000);
 
+// The robust rollback must also TOMBSTONE a file task.fix CREATED (a plain content map
+// only rewrites captured paths and would leave a created file on disk). On a failed
+// re-gate, a fix-created file must be gone.
+test("polishOnGreen tombstones a file task.fix CREATED on a failed re-gate", async () => {
+  const dir = await mkdtemp(join(tmpdir(), "tsforge-polish-"));
+
+  try {
+    await Bun.write(join(dir, "a.ts"), SOURCE); // touched + droppable → polish proceeds
+
+    const { ctx: base } = ctxWith(dir, false); // gate RED → recheck fails → revert
+    const ctx: ILoopCtx = {
+      ...base,
+      task: {
+        ...base.task,
+        files: ["**/*"],
+        // The fix CREATES a brand-new in-scope file (not present at snapshot time).
+        fix: "printf 'export const created = 1;\\n' > created.ts",
+      },
+      tool: { touched: new Set(["a.ts"]) },
+    };
+
+    await polishOnGreen(ctx);
+
+    // The fix-created file was tombstoned (deleted), not left behind.
+    expect(await Bun.file(join(dir, "created.ts")).exists()).toBe(false);
+    expect(await Bun.file(join(dir, "a.ts")).text()).toBe(SOURCE);
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+}, 30_000);
+
 test("polishOnGreen with coreFormat on formats the TOUCHED file after the drop", async () => {
   const dir = await mkdtemp(join(tmpdir(), "tsforge-polish-"));
 

--- a/packages/core/tests/polish-on-green.test.ts
+++ b/packages/core/tests/polish-on-green.test.ts
@@ -230,3 +230,34 @@ test("polishOnGreen KEEPS the drop when the injected gate stays green", async ()
     await rm(dir, { recursive: true, force: true });
   }
 });
+
+test("polishOnGreen with coreFormat on formats the TOUCHED file after the drop", async () => {
+  const dir = await mkdtemp(join(tmpdir(), "tsforge-polish-"));
+
+  try {
+    // Messy AND has a droppable `: number` annotation, so polish proceeds past the
+    // drop guard; the scoped format janitor should then clean the messiness.
+    await Bun.write(
+      join(dir, "a.ts"),
+      "const  cents=1;\nconst abs: number = Math.abs(cents);\n"
+    );
+
+    const { ctx: base } = ctxWith(dir, true);
+    const ctx: ILoopCtx = {
+      ...base,
+      // The model wrote a.ts, so it is the janitor's target (NOT task.files scope).
+      tool: { touched: new Set(["a.ts"]) },
+      gate: { ...base.gate, coreFormat: true },
+    };
+
+    await polishOnGreen(ctx);
+
+    const out = await Bun.file(join(dir, "a.ts")).text();
+
+    // Dropped (`: number` gone) AND formatted (`const  cents=1` → `const cents = 1;`).
+    expect(out).not.toContain(": number");
+    expect(out).toContain("const cents = 1;");
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+}, 30_000);

--- a/packages/core/tests/polish-on-green.test.ts
+++ b/packages/core/tests/polish-on-green.test.ts
@@ -233,6 +233,39 @@ test("polishOnGreen KEEPS the drop when the injected gate stays green", async ()
   }
 });
 
+// #103 (panel-critical): polish drops+formats ONLY files the model wrote. With a
+// whole-repo scope (the REPL default ["**/*"]) and only a.ts touched, an untouched
+// sibling that has its own droppable annotation must be left byte-identical. A
+// regression back to resolveScopeFiles(task.files) would drop/rewrite the sibling and
+// fail here — the narrow-scope tests above would NOT catch that.
+test("polishOnGreen with whole-repo scope drops ONLY the touched file, not siblings", async () => {
+  const dir = await mkdtemp(join(tmpdir(), "tsforge-polish-"));
+
+  try {
+    const droppable = "const abs: number = Math.abs(1);\n";
+
+    await Bun.write(join(dir, "a.ts"), droppable);
+    await Bun.write(join(dir, "sibling.ts"), droppable);
+
+    const { ctx: base } = ctxWith(dir, true);
+    const ctx: ILoopCtx = {
+      ...base,
+      // Whole-repo scope, but only a.ts was written by the model.
+      task: { ...base.task, files: ["**/*"] },
+      tool: { touched: new Set(["a.ts"]) },
+    };
+
+    await polishOnGreen(ctx);
+
+    // a.ts polished (annotation dropped)…
+    expect(await Bun.file(join(dir, "a.ts")).text()).not.toContain(": number");
+    // …sibling.ts left exactly as it was (never touched by the model).
+    expect(await Bun.file(join(dir, "sibling.ts")).text()).toBe(droppable);
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+}, 30_000);
+
 test("polishOnGreen with coreFormat on formats the TOUCHED file after the drop", async () => {
   const dir = await mkdtemp(join(tmpdir(), "tsforge-polish-"));
 

--- a/packages/core/tests/polish-on-green.test.ts
+++ b/packages/core/tests/polish-on-green.test.ts
@@ -23,7 +23,9 @@ function ctxWith(
     tsService: null,
     report: () => undefined,
     messages: [],
-    tool: {},
+    // polishOnGreen now scopes the drop to the files the model wrote (ctx.tool.touched),
+    // not task.files — so the tests must mark a.ts as touched for the drop to run.
+    tool: { touched: new Set(["a.ts"]) },
     gate: {
       parse: undefined,
       runner: {
@@ -81,7 +83,7 @@ test("polishOnGreen REVERTS the drop when the injected gate THROWS (transient ju
       tsService: null,
       report: () => undefined,
       messages: [],
-      tool: {},
+      tool: { touched: new Set(["a.ts"]) },
       gate: {
         parse: undefined,
         runner: {
@@ -122,7 +124,7 @@ test("polishOnGreen re-throws on caller cancellation (honors the signal) but sti
       tsService: null,
       report: () => undefined,
       messages: [],
-      tool: { signal: controller.signal },
+      tool: { signal: controller.signal, touched: new Set(["a.ts"]) },
       gate: {
         parse: undefined,
         runner: {
@@ -172,7 +174,7 @@ test("polishOnGreen wraps a NON-Error abort rejection in an Error (typed re-thro
       tsService: null,
       report: () => undefined,
       messages: [],
-      tool: { signal: controller.signal },
+      tool: { signal: controller.signal, touched: new Set(["a.ts"]) },
       gate: {
         parse: undefined,
         runner: {

--- a/packages/core/tests/polish-on-green.test.ts
+++ b/packages/core/tests/polish-on-green.test.ts
@@ -266,6 +266,43 @@ test("polishOnGreen with whole-repo scope drops ONLY the touched file, not sibli
   }
 }, 30_000);
 
+// When a spec-provided task.fix is set, the revert snapshot must ALSO cover the resolved
+// scope (task.fix is an arbitrary command that can edit an in-scope sibling outside
+// touched). On a failed re-gate, that sibling mutation must roll back too. A regression to
+// snapshotting only touched would leave the fix's damage on disk.
+test("polishOnGreen rolls back a task.fix mutation to a NON-touched sibling on a failed re-gate", async () => {
+  const dir = await mkdtemp(join(tmpdir(), "tsforge-polish-"));
+
+  try {
+    const originalSibling = "const sibling = 1;\n";
+
+    await Bun.write(join(dir, "a.ts"), SOURCE); // touched + droppable → polish proceeds
+    await Bun.write(join(dir, "sibling.ts"), originalSibling);
+
+    const { ctx: base } = ctxWith(dir, false); // gate RED → recheck fails → revert
+    const ctx: ILoopCtx = {
+      ...base,
+      task: {
+        ...base.task,
+        files: ["**/*"],
+        // The fix mutates a sibling the model never wrote (not in touched).
+        fix: "printf 'const sibling = 999;\\n' > sibling.ts",
+      },
+      tool: { touched: new Set(["a.ts"]) },
+    };
+
+    await polishOnGreen(ctx);
+
+    // The failed re-gate rolled EVERYTHING back — including the fix's sibling mutation.
+    expect(await Bun.file(join(dir, "sibling.ts")).text()).toBe(
+      originalSibling
+    );
+    expect(await Bun.file(join(dir, "a.ts")).text()).toBe(SOURCE);
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+}, 30_000);
+
 test("polishOnGreen with coreFormat on formats the TOUCHED file after the drop", async () => {
   const dir = await mkdtemp(join(tmpdir(), "tsforge-polish-"));
 

--- a/packages/core/tests/repl-ask-user-wiring.test.ts
+++ b/packages/core/tests/repl-ask-user-wiring.test.ts
@@ -27,6 +27,24 @@ test("both REPL Session.create sites (init + /clear) gate interactive on humanAt
   expect(interactiveCount).toBe(createCount);
 });
 
+// #103: the scoped format janitor is opt-in (coreFormat). The interactive REPL enables it,
+// and — like `interactive` — the /clear rebuild does NOT reuse the init config, so a rebuild
+// that dropped the flag would silently revert the session to no formatting. Every REPL
+// Session.create MUST set coreFormat:true. Source-guarded (the /clear rebuild lives in the
+// readline loop, not unit-reachable); Session.create's PROPAGATION of the flag is behavior-
+// tested in format-wiring.test.ts.
+test("both REPL Session.create sites (init + /clear) enable coreFormat", async () => {
+  const src = await Bun.file(
+    join(import.meta.dir, "..", "src", "cli", "repl.ts")
+  ).text();
+
+  const createCount = (src.match(/Session\.create\(/g) ?? []).length;
+  const coreFormatCount = (src.match(/coreFormat: true/g) ?? []).length;
+
+  expect(createCount).toBeGreaterThanOrEqual(2);
+  expect(coreFormatCount).toBe(createCount);
+});
+
 // WS-C: /clear rebuilds the Session, and the gate fires on mutation state (`edited`), not
 // a dirty tree — so a rebuild that dropped the deferred-gate flag would silently skip
 // re-validating an on-disk pre-pause edit. The /clear path must read session.hasDeferredGate

--- a/packages/core/tests/settle-steps.test.ts
+++ b/packages/core/tests/settle-steps.test.ts
@@ -1,5 +1,5 @@
 import { test, expect, describe } from "bun:test";
-import { mkdtempSync, writeFileSync } from "node:fs";
+import { mkdtempSync, writeFileSync, readFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { checkStuck, autoFixStep, type ILoopCtx } from "../src/loop/turn";
@@ -253,6 +253,48 @@ describe("autoFixStep", () => {
     expect(tool[0]?.message).toContain("auto-fixed 1 file(s)");
     // Generous timeout: the fix command sleeps 1s to move mtime forward, and a
     // loaded machine can stretch the spawn well past bun's 5s default.
+  }, 30_000);
+
+  // Regression guard: the scoped format janitor must be OPT-IN. It was briefly made
+  // unconditional, which spawned eslint+prettier every turn and blew the 5s budget of
+  // the real-drive-loop tests. With coreFormat off (the default), autoFixStep runs NO
+  // formatter — a messy scoped file is left exactly as written.
+  test("coreFormat off (default) → autoFixStep does not format the scope", async () => {
+    const events: ILoopEvent[] = [];
+    const dir = mkdtempSync(join(tmpdir(), "settle-autofix-"));
+    const messy = "export  const   x=1";
+
+    writeFileSync(join(dir, "m.ts"), messy);
+
+    const base = makeCtx(events, dir);
+    const ctx: ILoopCtx = {
+      ...base,
+      task: { ...base.task, files: ["m.ts"] },
+    };
+
+    await autoFixStep(ctx);
+
+    expect(readFileSync(join(dir, "m.ts"), "utf8")).toBe(messy);
+  });
+
+  test("coreFormat on → autoFixStep formats the scoped file (scoped janitor)", async () => {
+    const events: ILoopEvent[] = [];
+    const dir = mkdtempSync(join(tmpdir(), "settle-autofix-"));
+
+    writeFileSync(join(dir, "m.ts"), "export  const   x=1");
+
+    const base = makeCtx(events, dir);
+    const ctx: ILoopCtx = {
+      ...base,
+      task: { ...base.task, files: ["m.ts"] },
+      gate: { ...base.gate, coreFormat: true },
+    };
+
+    await autoFixStep(ctx);
+
+    expect(readFileSync(join(dir, "m.ts"), "utf8")).toBe(
+      "export const x = 1;\n"
+    );
   }, 30_000);
 });
 

--- a/packages/core/tests/settle-steps.test.ts
+++ b/packages/core/tests/settle-steps.test.ts
@@ -258,8 +258,8 @@ describe("autoFixStep", () => {
   // Regression guard: the scoped format janitor must be OPT-IN. It was briefly made
   // unconditional, which spawned eslint+prettier every turn and blew the 5s budget of
   // the real-drive-loop tests. With coreFormat off (the default), autoFixStep runs NO
-  // formatter — a messy scoped file is left exactly as written.
-  test("coreFormat off (default) → autoFixStep does not format the scope", async () => {
+  // formatter — a touched-but-messy file is left exactly as written.
+  test("coreFormat off (default) → autoFixStep does not format touched files", async () => {
     const events: ILoopEvent[] = [];
     const dir = mkdtempSync(join(tmpdir(), "settle-autofix-"));
     const messy = "export  const   x=1";
@@ -270,6 +270,7 @@ describe("autoFixStep", () => {
     const ctx: ILoopCtx = {
       ...base,
       task: { ...base.task, files: ["m.ts"] },
+      tool: { touched: new Set(["m.ts"]) },
     };
 
     await autoFixStep(ctx);
@@ -277,7 +278,7 @@ describe("autoFixStep", () => {
     expect(readFileSync(join(dir, "m.ts"), "utf8")).toBe(messy);
   });
 
-  test("coreFormat on → autoFixStep formats the scoped file (scoped janitor)", async () => {
+  test("coreFormat on → autoFixStep formats a TOUCHED file", async () => {
     const events: ILoopEvent[] = [];
     const dir = mkdtempSync(join(tmpdir(), "settle-autofix-"));
 
@@ -287,6 +288,7 @@ describe("autoFixStep", () => {
     const ctx: ILoopCtx = {
       ...base,
       task: { ...base.task, files: ["m.ts"] },
+      tool: { touched: new Set(["m.ts"]) },
       gate: { ...base.gate, coreFormat: true },
     };
 
@@ -295,6 +297,38 @@ describe("autoFixStep", () => {
     expect(readFileSync(join(dir, "m.ts"), "utf8")).toBe(
       "export const x = 1;\n"
     );
+  }, 30_000);
+
+  // THE #103 regression: in the interactive REPL, task.files defaults to the WHOLE
+  // repo (["**/*"]). Scoping the janitor to the resolved scope would still rewrite the
+  // whole tree. It must scope to ctx.tool.touched — the files the model actually wrote.
+  // Here only m.ts is touched; a whole-repo scope must leave the untouched sibling
+  // byte-identical.
+  test("coreFormat on + whole-repo scope → formats only TOUCHED, sibling untouched", async () => {
+    const events: ILoopEvent[] = [];
+    const dir = mkdtempSync(join(tmpdir(), "settle-autofix-"));
+    const messy = "export  const   x=1";
+
+    writeFileSync(join(dir, "m.ts"), messy);
+    writeFileSync(join(dir, "sibling.ts"), messy);
+
+    const base = makeCtx(events, dir);
+    const ctx: ILoopCtx = {
+      ...base,
+      task: { ...base.task, files: ["**/*"] },
+      tool: { touched: new Set(["m.ts"]) },
+      gate: { ...base.gate, coreFormat: true },
+    };
+
+    await autoFixStep(ctx);
+
+    // The touched file is formatted…
+    expect(readFileSync(join(dir, "m.ts"), "utf8")).toBe(
+      "export const x = 1;\n"
+    );
+    // …and the untouched sibling — in scope, but never written by the model — is left
+    // exactly as it was. This is the guarantee #103 is about.
+    expect(readFileSync(join(dir, "sibling.ts"), "utf8")).toBe(messy);
   }, 30_000);
 });
 

--- a/packages/core/tests/settle-steps.test.ts
+++ b/packages/core/tests/settle-steps.test.ts
@@ -330,6 +330,36 @@ describe("autoFixStep", () => {
     // exactly as it was. This is the guarantee #103 is about.
     expect(readFileSync(join(dir, "sibling.ts"), "utf8")).toBe(messy);
   }, 30_000);
+
+  // touched is session-lifetime, but /files can NARROW task.files mid-session. The janitor
+  // must intersect the two (touchedInScope): a file the model wrote earlier but that is no
+  // longer in the editable scope must NOT be formatted (the re-gate wouldn't cover it).
+  test("coreFormat on → does not format a touched file now OUTSIDE the scope", async () => {
+    const events: ILoopEvent[] = [];
+    const dir = mkdtempSync(join(tmpdir(), "settle-autofix-"));
+    const messy = "export  const   x=1";
+
+    writeFileSync(join(dir, "a.ts"), messy);
+    writeFileSync(join(dir, "out.ts"), messy);
+
+    const base = makeCtx(events, dir);
+    const ctx: ILoopCtx = {
+      ...base,
+      // Scope narrowed (e.g. via /files) to a.ts only — out.ts was touched earlier.
+      task: { ...base.task, files: ["a.ts"] },
+      tool: { touched: new Set(["a.ts", "out.ts"]) },
+      gate: { ...base.gate, coreFormat: true },
+    };
+
+    await autoFixStep(ctx);
+
+    // In-scope touched file is formatted…
+    expect(readFileSync(join(dir, "a.ts"), "utf8")).toBe(
+      "export const x = 1;\n"
+    );
+    // …the now-out-of-scope touched file is left exactly as it was.
+    expect(readFileSync(join(dir, "out.ts"), "utf8")).toBe(messy);
+  }, 30_000);
 });
 
 describe("relentless-loop escalation-ladder centerpiece (fixes A/B/C)", () => {


### PR DESCRIPTION
## What & why (#103)

Reported bug: running tsforge in a real repo reformatted **thousands of untouched, already-correct files** — because the core auto-fix ran `eslint --fix . ; prettier --write .` over the **whole repo** every gate cycle, with tsforge's **bundled** prettier + a forced config.

## The fix

- **Scope to edited files.** Formatting now runs only over `ctx.tool.touched` (the files the model actually wrote), intersected with the current editable scope (`touchedInScope`). Never the whole tree. Git-independent — works in a non-git dir.
- **Defer to the project's prettier.** Prefer the project's own `node_modules/.bin/prettier` (correct version + resolves shared/extended configs), walking up for monorepo-hoisted installs, gated on prettier actually being installed. Bundled prettier is the fallback. POSIX-only preference (win32 uses bundled).
- **Opt-in** via `coreFormat` (the CLI sets it, incl. `/clear`); bare test/eval loops don't pay per-turn formatter cost. `buildCoreFix` kept for the eval/scratch path. **BoringStack's `autofixApps` is untouched.**

## Correctness / hardening (all found by the review panel)

- `eslint --fix` gets **cwd-relative** paths (ESLint 10 silently no-ops on absolute paths — the moat was dead); proven by a `curly` test.
- Path safety: files-only targets (no directory → whole-tree expansion), realpath containment (no `..`/symlink escape), `--` argv terminator (flag-named files), POSIX backslash dropped up front.
- `polishOnGreen` scoped to `touchedInScope` and switched to the robust rollback substrate (`snapshotFilesForRollback` + `restoreFiles`) — uncapped, binary-safe, **tombstones files a `task.fix` creates**.
- Strict eslint config now lints `.mts`/`.cts`; `ESLINT_EXTS` matches.

## Code quality

- `isWin32()` helper (`lib/platform.ts`) replaces scattered `process.platform` checks.
- Removed a dead local `snapshotFiles`; one rollback substrate.
- Discovered `strict.web.eslint.config.mjs` is dead (referenced nowhere) — reverted my change to it, flagged for a follow-up cleanup.

## Tests / gates

~30 new tests (scope, project-config fidelity, eslint-moat, containment, rollback/tombstone, scope-intersection, Session wiring). Full suite green (**3321 pass, 0 fail**), typecheck + lint + format:check clean. 8 consecutive passing `harness-review` panel rounds.
