### PR TITLE
fix(cli): a value flag must not swallow the flag after it

### DIFF
--- a/packages/core/src/cli.ts
+++ b/packages/core/src/cli.ts
@@ -770,6 +770,19 @@ export async function main(): Promise<number> {
     return harnessDiagnoseMode(raw.slice(1));
   }
 
+  // BEFORE any dispatch, including --version/--help/recipes and the recipe overlay.
+  // A malformed invocation must not quietly do something else first: `tsforge
+  // recipes --dir --plan` would otherwise list recipes for the wrong directory and
+  // exit 0, and a recipe lookup would run its I/O before the error surfaced.
+  // (The subcommands above parse their own argv, so they are exempt.)
+  const valueErr = valueFlagError(raw);
+
+  if (valueErr !== null) {
+    process.stdout.write(`${valueErr}\n`);
+
+    return 1;
+  }
+
   const args = parseArgs(raw);
 
   // `--version`/`--help` print and exit — before this fix an unknown flag fell
@@ -805,16 +818,6 @@ export async function main(): Promise<number> {
 
   if (recipeAbort !== null) {
     return recipeAbort;
-  }
-
-  // A value flag handed no value — or handed the next flag — must fail loudly rather
-  // than run on the default, silently dropping what the user asked for.
-  const valueErr = valueFlagError(raw);
-
-  if (valueErr !== null) {
-    process.stdout.write(`${valueErr}\n`);
-
-    return 1;
   }
 
   // A typo'd `--profile` must fail loudly too: `--profile stict` parses fine but would

--- a/packages/core/src/cli.ts
+++ b/packages/core/src/cli.ts
@@ -24,6 +24,7 @@ import {
   cliUsage,
   resolveCliProfile,
   profileFlagError,
+  valueFlagError,
   type ICliArgs,
 } from "./cli/args";
 import { validate } from "./validate";
@@ -806,10 +807,19 @@ export async function main(): Promise<number> {
     return recipeAbort;
   }
 
-  // A typo'd OR value-less `--profile` must fail loudly, not silently run at the default
-  // (which would quietly drop the strictness the user asked for). Checked after the recipe
-  // overlay so it covers CLI and recipe-set profiles; `raw.includes` also catches a
-  // trailing `--profile` that parseArgs drops (leaving profile "").
+  // A value flag handed no value — or handed the next flag — must fail loudly rather
+  // than run on the default, silently dropping what the user asked for.
+  const valueErr = valueFlagError(raw);
+
+  if (valueErr !== null) {
+    process.stdout.write(`${valueErr}\n`);
+
+    return 1;
+  }
+
+  // A typo'd `--profile` must fail loudly too: `--profile stict` parses fine but would
+  // quietly run at the default strictness. Checked after the recipe overlay so it covers
+  // CLI and recipe-set profiles.
   const profileErr = profileFlagError(args.profile, raw.includes("--profile"));
 
   if (profileErr !== null) {

--- a/packages/core/src/cli/args.ts
+++ b/packages/core/src/cli/args.ts
@@ -150,6 +150,46 @@ const VALUE_FLAGS = new Set([
   "--notify",
 ]);
 
+/** True for any token the parser recognises as a flag, boolean or value-taking. */
+function isKnownFlag(token: string): boolean {
+  return Object.hasOwn(BOOL_FLAGS, token) || VALUE_FLAGS.has(token);
+}
+
+/**
+ * The first value-taking flag that was given no value — either nothing follows it
+ * or the next token is another flag. Null when every value flag has one.
+ *
+ * A value flag that quietly takes the default is the failure #105 hit with
+ * `--profile`: the user asks for something, the run proceeds without it, and
+ * nothing says so. That guard covered one flag; this covers all of them.
+ *
+ * A value may itself contain dashes (`--accept "bun test -- x.ts"`), so the check
+ * is "the next token is a flag the parser knows", never "it starts with -".
+ */
+export function valueFlagError(argv: readonly string[]): string | null {
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i];
+
+    if (arg === undefined || !VALUE_FLAGS.has(arg)) {
+      continue;
+    }
+
+    const value = argv[i + 1];
+
+    if (value === undefined) {
+      return `${arg} needs a value`;
+    }
+
+    if (isKnownFlag(value)) {
+      return `${arg} needs a value, but got the flag "${value}"`;
+    }
+
+    i += 1;
+  }
+
+  return null;
+}
+
 /** The `tsforge --help` usage text — kept next to the flag tables it documents
  *  so a new flag is added in one file. Pure so it's directly testable. */
 export function cliUsage(): string {
@@ -241,10 +281,19 @@ export function parseArgs(argv: readonly string[]): ICliArgs {
 
     if (boolKey !== undefined) {
       out[boolKey] = true;
-    } else if (VALUE_FLAGS.has(arg) && argv[i + 1] !== undefined) {
-      applyValueFlag(arg, argv[i + 1] ?? "", out);
-      i += 1;
-    } else if (!VALUE_FLAGS.has(arg)) {
+    } else if (VALUE_FLAGS.has(arg)) {
+      const value = argv[i + 1];
+
+      // Only consume the next token when it is a real value. Handing a value flag
+      // another flag (`--notify --continue`) must not eat it — that silently
+      // dropped the second flag and set the first to the flag's own name.
+      // `valueFlagError` aborts the run before this matters; the parse stays
+      // honest so the surviving flag still reads correctly.
+      if (value !== undefined && !isKnownFlag(value)) {
+        applyValueFlag(arg, value, out);
+        i += 1;
+      }
+    } else {
       positional.push(arg);
     }
   }

--- a/packages/core/tests/cli.test.ts
+++ b/packages/core/tests/cli.test.ts
@@ -1,9 +1,9 @@
-import { test, expect } from "bun:test";
+import { describe, test, expect } from "bun:test";
 import { mkdtemp, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { parseArgs, isOneShot, applyRecipe, runNotify } from "../src/cli";
-import { cliUsage } from "../src/cli/args";
+import { cliUsage, valueFlagError } from "../src/cli/args";
 import type { ITaskRecipe } from "../src/config/recipes";
 
 // Regression: runNotify used to spawn `sh -c cmd` with a bare `await proc.exited`
@@ -518,4 +518,66 @@ test("agents subcommand: list mode, ids+task mode, recipe fill", () => {
 
   applyRecipe(explicit, { id: "sweep", agents: ["verify"] });
   expect(explicit.agentIds).toBe("explore");
+});
+
+// A value-taking flag whose value is missing — or is another flag — used to be
+// swallowed silently: `--notify --continue` set notify to "--continue" and lost
+// the resume entirely. #105 added a loud guard for `--profile` alone; this is the
+// same guard for every value flag, at the parser rather than per flag.
+describe("a value flag never swallows the flag after it", () => {
+  const CASES: readonly [readonly string[], string][] = [
+    [["--notify", "--continue"], "--notify"],
+    [["--files", "--web"], "--files"],
+    [["--accept", "--no-gate"], "--accept"],
+    [["--dir", "--plan"], "--dir"],
+    [["--base", "--staged"], "--base"],
+    [["--recipe", "--scout"], "--recipe"],
+    [["--browser", "--log"], "--browser"],
+    [["--resume", "--greenfield"], "--resume"],
+    [["--policy-mode", "--plan"], "--policy-mode"],
+    [["--gate", "--web"], "--gate"],
+    [["--profile", "--help"], "--profile"],
+  ];
+
+  test("every value flag reports the flag it was handed instead of a value", () => {
+    for (const [argv, flag] of CASES) {
+      const err = valueFlagError(argv);
+
+      expect({ argv, named: err?.includes(flag) === true }).toEqual({
+        argv,
+        named: true,
+      });
+    }
+  });
+
+  test("the following flag still takes effect rather than being eaten", () => {
+    // Even though the run aborts on the error, the parse must not silently
+    // reinterpret the next flag as a value.
+    expect(parseArgs(["--notify", "--continue"]).continue).toBe(true);
+    expect(parseArgs(["--files", "--web"]).web).toBe(true);
+    expect(parseArgs(["--accept", "--no-gate"]).noGate).toBe(true);
+    expect(parseArgs(["--notify", "--continue"]).notify).toBe("");
+    expect(parseArgs(["--files", "--web"]).files).toEqual([]);
+  });
+
+  test("--dir does not path-join the flag that follows it", () => {
+    expect(parseArgs(["--dir", "--plan"]).dir).not.toContain("--plan");
+    expect(parseArgs(["--dir", "--plan"]).plan).toBe(true);
+  });
+
+  test("a trailing value flag with no value at all is reported", () => {
+    for (const flag of ["--notify", "--dir", "--accept", "--profile"]) {
+      expect(valueFlagError([flag])?.includes(flag)).toBe(true);
+    }
+  });
+
+  test("a legitimate value is accepted, including one containing dashes", () => {
+    expect(valueFlagError(["--accept", "bun test -- src/x.ts"])).toBeNull();
+    expect(parseArgs(["--accept", "bun test -- src/x.ts"]).accept).toBe(
+      "bun test -- src/x.ts"
+    );
+    expect(valueFlagError(["--dir", "./pkg", "--plan"])).toBeNull();
+    expect(valueFlagError([])).toBeNull();
+    expect(valueFlagError(["--plan", "--continue"])).toBeNull();
+  });
 });

--- a/packages/core/tests/cli.test.ts
+++ b/packages/core/tests/cli.test.ts
@@ -581,3 +581,58 @@ describe("a value flag never swallows the flag after it", () => {
     expect(valueFlagError(["--plan", "--continue"])).toBeNull();
   });
 });
+
+// The guard has to abort BEFORE any dispatch, so these spawn the real CLI rather
+// than calling the pure helper: a correct valueFlagError wired in too late still
+// lets `tsforge recipes --dir --plan` list recipes for the wrong directory and
+// exit 0. Only running the binary catches placement.
+describe("the real CLI aborts on a malformed value flag", () => {
+  const CLI = join(import.meta.dir, "..", "src", "cli.ts");
+
+  async function run(
+    argv: readonly string[]
+  ): Promise<{ code: number; out: string }> {
+    const proc = Bun.spawn(["bun", CLI, ...argv], {
+      stdout: "pipe",
+      stderr: "pipe",
+      stdin: "ignore",
+      env: { ...process.env, TSFORGE_NO_PERSIST: "1" },
+    });
+    const [stdout, stderr, code] = await Promise.all([
+      new Response(proc.stdout).text(),
+      new Response(proc.stderr).text(),
+      proc.exited,
+    ]);
+
+    return { code, out: stdout + stderr };
+  }
+
+  test("exits non-zero naming the flag", async () => {
+    const r = await run(["--dir", "--plan"]);
+
+    expect(r.code).toBe(1);
+    expect(r.out).toContain("--dir");
+  });
+
+  test("beats the --help early return", async () => {
+    const r = await run(["--profile", "--help"]);
+
+    expect(r.code).toBe(1);
+    expect(r.out).not.toContain("Usage");
+  });
+
+  test("beats the recipes subcommand", async () => {
+    // The bug this catches: recipes ran against the default cwd and exited 0.
+    const r = await run(["recipes", "--dir", "--plan"]);
+
+    expect(r.code).toBe(1);
+    expect(r.out).toContain("--dir");
+  });
+
+  test("a valid invocation still reaches its command", async () => {
+    const r = await run(["--help"]);
+
+    expect(r.code).toBe(0);
+    expect(r.out).toContain("tsforge");
+  });
+});


### PR DESCRIPTION
Third fix from the core harness audit (`docs/plans/2026-08-02-core-audit-findings.md`) — findings **F3** and **F5**.

## The bug

`parseArgs` consumed the next token whenever one existed, without checking whether it was itself a
flag. So every value-taking flag ate the flag that followed it:

| invocation | result |
|---|---|
| `--notify --continue` | `notify="--continue"`, **the resume is lost** |
| `--files --web` | `files=["--web"]`, `--web` lost |
| `--accept --no-gate` | `accept="--no-gate"`, `--no-gate` lost |
| `--dir --plan` | `dir="<cwd>/--plan"`, `--plan` lost |

Each silently did something other than what was asked — a `--continue` that never resumed, a
`--dir` pointing at a directory named `--plan`.

#105 hit exactly this with `--profile` and added `profileFlagError` for that one flag. The other ten
had no guard, so this moves the fix to the parser instead of adding an eleventh special case.

## The fix

`valueFlagError` reports the first value flag given no value, or handed another flag, and `main()`
aborts on it. `profileFlagError` stays for the thing only it can check — that a syntactically valid
value like `--profile stict` is a real profile id.

The test is **"is the next token a flag this parser knows"**, never "does it start with a dash", so
`--accept "bun test -- src/x.ts"` is still a legitimate value. `parseArgs` also stops consuming the
token, so the following flag keeps its effect rather than vanishing.

## What review caught

Round 1 blocked, on two findings that were both right:

- **Placement.** The guard was wired in after the `--version`/`--help`/`recipes` early returns and
  after `applyRecipeArg`, so it only covered invocations that fell through to a run.
  `tsforge recipes --dir --plan` listed recipes for the default cwd and exited 0; `--profile --help`
  printed usage; `--dir --recipe x` did recipe I/O first. It now runs at the top of `main()`, after
  the `scaffold`/`harness-review`/`harness-diagnose` branches (which parse their own argv) and
  before `parseArgs`.
- **Test depth.** The tests called only `valueFlagError` and `parseArgs` — which is precisely why a
  correct function wired in at the wrong point passed everything. Added tests that spawn the real
  CLI and assert exit code and message, including that the abort beats both `--help` and the
  `recipes` subcommand.

## Verification

- Real binary, measured exit codes:

  | argv | exit | first line |
  |---|---|---|
  | `recipes --dir --plan` | 1 | `--dir needs a value, but got the flag "--plan"` |
  | `--profile --help` | 1 | `--profile needs a value, but got the flag "--help"` |
  | `--dir --recipe x` | 1 | `--dir needs a value, but got the flag "--recipe"` |
  | `--help` | 0 | usage |

- Mutation: moving the guard back below dispatch fails exactly the two placement tests.
- `bun run validate` green — 3376 tests, 0 fail, all PTY e2e suites pass. Rules-catalog drift clean.
- 4-model `harness-review` panel: **PASS**, `reviewers ok: 4  errored: 0`, no findings.

Left unmerged for your signature.