### PR TITLE
fix(tools): normalize paths before the scope check; align the scope predicates

### DIFF
--- a/packages/core/src/lib/scope/scope.ts
+++ b/packages/core/src/lib/scope/scope.ts
@@ -27,6 +27,19 @@ export function isInScope(file: string, patterns: string[]): boolean {
   return patterns.some((pattern) => new Bun.Glob(pattern).match(file));
 }
 
+/** Absolute on ANY platform, checked explicitly rather than via `node:path` so the
+ *  answer does not depend on where this runs: a POSIX root, a Windows UNC share
+ *  (`\\\\server\\share`), or a drive-letter root (`D:\\…`). `node:path.relative`
+ *  returns a drive-absolute path when the target is on another volume, and that
+ *  carries no `..` segment — so a segment check alone would call it "inside". */
+function isAbsolutePath(file: string): boolean {
+  return (
+    file.startsWith("/") ||
+    file.startsWith("\\\\") ||
+    /^[A-Za-z]:[\\/]/u.test(file)
+  );
+}
+
 /** True when a NORMALIZED path stays inside the workspace — i.e. it neither
  *  escapes via a `..` path SEGMENT nor is absolute. Distinct from {@link writable}:
  *  a project file the model may not edit is still inside the workspace, and that is
@@ -36,7 +49,7 @@ export function isInScope(file: string, patterns: string[]): boolean {
  *  merely starts with two dots. Treating it as outside would skip the guard for a
  *  real workspace file — failing OPEN, the wrong direction for this predicate. */
 export function insideWorkspace(file: string): boolean {
-  if (file.startsWith("/")) {
+  if (isAbsolutePath(file)) {
     return false;
   }
 

--- a/packages/core/src/lib/scope/scope.ts
+++ b/packages/core/src/lib/scope/scope.ts
@@ -28,11 +28,19 @@ export function isInScope(file: string, patterns: string[]): boolean {
 }
 
 /** True when a NORMALIZED path stays inside the workspace — i.e. it neither
- *  escapes via `../` nor is absolute. Distinct from {@link writable}: a project
- *  file the model may not edit is still inside the workspace, and that is exactly
- *  the case a shell redirect must not be allowed to write. */
+ *  escapes via a `..` path SEGMENT nor is absolute. Distinct from {@link writable}:
+ *  a project file the model may not edit is still inside the workspace, and that is
+ *  exactly the case a shell redirect must not be allowed to write.
+ *
+ *  Compares segments, not prefixes: `..secret.ts` is an ordinary filename that
+ *  merely starts with two dots. Treating it as outside would skip the guard for a
+ *  real workspace file — failing OPEN, the wrong direction for this predicate. */
 export function insideWorkspace(file: string): boolean {
-  return !file.startsWith("..") && !file.startsWith("/");
+  if (file.startsWith("/")) {
+    return false;
+  }
+
+  return !file.split("/").includes("..");
 }
 
 /** A file the model may write: its editable scope, OR a throwaway scratch file.

--- a/packages/core/src/lib/scope/scope.ts
+++ b/packages/core/src/lib/scope/scope.ts
@@ -27,6 +27,14 @@ export function isInScope(file: string, patterns: string[]): boolean {
   return patterns.some((pattern) => new Bun.Glob(pattern).match(file));
 }
 
+/** True when a NORMALIZED path stays inside the workspace — i.e. it neither
+ *  escapes via `../` nor is absolute. Distinct from {@link writable}: a project
+ *  file the model may not edit is still inside the workspace, and that is exactly
+ *  the case a shell redirect must not be allowed to write. */
+export function insideWorkspace(file: string): boolean {
+  return !file.startsWith("..") && !file.startsWith("/");
+}
+
 /** A file the model may write: its editable scope, OR a throwaway scratch file.
  *  A path that escapes the workspace (`../…`) or is absolute is NEVER writable —
  *  a recursive glob would otherwise match a traversal path. Normalize with

--- a/packages/core/src/lib/scope/scope.ts
+++ b/packages/core/src/lib/scope/scope.ts
@@ -40,15 +40,24 @@ export function insideWorkspace(file: string): boolean {
     return false;
   }
 
-  return !file.split("/").includes("..");
+  // Split on BOTH separators: node:path emits `\` on Windows, and splitting only
+  // on `/` would read `..\secret.ts` as one ordinary filename — inside the
+  // workspace — and skip the guard there.
+  return !file.split(/[\\/]/u).includes("..");
 }
 
 /** A file the model may write: its editable scope, OR a throwaway scratch file.
  *  A path that escapes the workspace (`../…`) or is absolute is NEVER writable —
  *  a recursive glob would otherwise match a traversal path. Normalize with
- *  `normalizeWorkspacePath` first so this sees the workspace-relative form. */
+ *  `normalizeWorkspacePath` first so this sees the workspace-relative form.
+ *
+ *  Escape detection goes through {@link insideWorkspace} so both predicates use the
+ *  SAME segment rule. A `startsWith("..")` test here made every ordinary name
+ *  beginning with two dots (`..secret.ts`, `...rc`) unwritable through every edit
+ *  tool, and — because the shell-redirect guard reads this — let `run` create such
+ *  a file even under a scope as broad as `["**\/*"]`. */
 export function writable(file: string, patterns: string[]): boolean {
-  if (file.startsWith("..") || file.startsWith("/")) {
+  if (!insideWorkspace(file)) {
     return false;
   }
 

--- a/packages/core/src/lib/scope/scope.ts
+++ b/packages/core/src/lib/scope/scope.ts
@@ -1,4 +1,5 @@
-import { resolve, relative } from "node:path";
+import { resolve, relative, isAbsolute } from "node:path";
+import { isWin32 } from "../platform";
 import { SCRATCH_PREFIX } from "./scope.constants";
 
 /**
@@ -27,19 +28,6 @@ export function isInScope(file: string, patterns: string[]): boolean {
   return patterns.some((pattern) => new Bun.Glob(pattern).match(file));
 }
 
-/** Absolute on ANY platform, checked explicitly rather than via `node:path` so the
- *  answer does not depend on where this runs: a POSIX root, a Windows UNC share
- *  (`\\\\server\\share`), or a drive-letter root (`D:\\…`). `node:path.relative`
- *  returns a drive-absolute path when the target is on another volume, and that
- *  carries no `..` segment — so a segment check alone would call it "inside". */
-function isAbsolutePath(file: string): boolean {
-  return (
-    file.startsWith("/") ||
-    file.startsWith("\\\\") ||
-    /^[A-Za-z]:[\\/]/u.test(file)
-  );
-}
-
 /** True when a NORMALIZED path stays inside the workspace — i.e. it neither
  *  escapes via a `..` path SEGMENT nor is absolute. Distinct from {@link writable}:
  *  a project file the model may not edit is still inside the workspace, and that is
@@ -49,14 +37,21 @@ function isAbsolutePath(file: string): boolean {
  *  merely starts with two dots. Treating it as outside would skip the guard for a
  *  real workspace file — failing OPEN, the wrong direction for this predicate. */
 export function insideWorkspace(file: string): boolean {
-  if (isAbsolutePath(file)) {
+  // `node:path.isAbsolute`, NOT a hand-rolled pattern: what counts as absolute is
+  // platform-dependent, and applying Windows syntax on POSIX fails OPEN. There,
+  // `D:/secret.ts` is an ordinary relative path (a directory named `D:`) — calling
+  // it absolute made this return false and skipped the shell-write guard for a real
+  // workspace file, while the edit tools refused a legitimate path.
+  if (isAbsolute(file)) {
     return false;
   }
 
-  // Split on BOTH separators: node:path emits `\` on Windows, and splitting only
-  // on `/` would read `..\secret.ts` as one ordinary filename — inside the
-  // workspace — and skip the guard there.
-  return !file.split(/[\\/]/u).includes("..");
+  // Windows accepts either separator, so a `..` segment can arrive spelled with
+  // both. On POSIX a backslash is a legal filename character and must NOT be read
+  // as one.
+  const segments = isWin32() ? file.split(/[\\/]/u) : file.split("/");
+
+  return !segments.includes("..");
 }
 
 /** A file the model may write: its editable scope, OR a throwaway scratch file.

--- a/packages/core/src/loop/tools/edit-hashline.ts
+++ b/packages/core/src/loop/tools/edit-hashline.ts
@@ -11,9 +11,9 @@ import {
   reject,
   guardVeto,
   type IToolContext,
+  resolveWritable,
 } from "./tool-context";
 import { toHashlineEdit } from "../../agent";
-import { writable, normalizeWorkspacePath } from "../../lib/scope";
 
 /**
  * Hashline edit handler: content-hash-anchored line edits with stale-anchor recovery.
@@ -42,9 +42,11 @@ export async function doHashlineEdit(
   // Same write policy as `edit`/`create` (file-ops): normalize the path, then
   // refuse anything outside the editable scope. Without this `edit_lines` was a
   // hole — a `../` path reached applyHashlineEdit unchecked.
-  edit.file = normalizeWorkspacePath(ctx.cwd, edit.file);
+  const target = resolveWritable(ctx, edit.file);
 
-  if (!writable(edit.file, ctx.files)) {
+  edit.file = target.path;
+
+  if (!target.writable) {
     return reject(
       ctx,
       "edit_lines",

--- a/packages/core/src/loop/tools/file-ops.ts
+++ b/packages/core/src/loop/tools/file-ops.ts
@@ -4,7 +4,7 @@ import { applyEdits } from "../../files/edit";
 import type { EditsResult } from "../../files/files.types";
 import { applyCreate } from "../../files/create";
 import { EDIT_FAIL_REASON } from "../../files";
-import { normalizeWorkspacePath, insideWorkspace } from "../../lib/scope";
+import { normalizeWorkspacePath } from "../../lib/scope";
 import { LOOP_LIMITS } from "../loop.constants";
 import { toEdits, toCreate, toRun, toRead, runCommand } from "../../agent";
 import { ruleHelpFromOutput } from "../feedback/rule-docs";
@@ -473,48 +473,6 @@ export function isLongRunningServerCommand(command: string): boolean {
     .some((segment) => segmentIsServer(segment));
 }
 
-interface IProjectWrite {
-  path: string;
-  writable: boolean;
-}
-
-/**
- * The first shell redirect target that must not be written: one in the editable
- * scope (write-guard bypass) or an EXISTING file inside the workspace that is out
- * of scope. Null when every target is outside the workspace or is a new file the
- * shell may legitimately create.
- *
- * BEST-EFFORT STEERING, NOT A CONTAINMENT BOUNDARY. It reads redirect targets out
- * of the command text, and command text cannot be resolved without running it:
- * `> "$f"` resolves at runtime, `> "a file.ts"` and `> a\ file.ts` carry the
- * separator the scanner splits on, and `sed -i` / `cp` / `tee` / any script writes
- * without a redirect at all. Its job is to stop the model reaching for
- * `cat > src/foo.ts` out of edit-tool friction, and to close the easy overwrite of
- * an out-of-scope file — not to sandbox the shell. What actually bounds `run` is
- * the policy layer; see audit findings F16 and F22.
- */
-async function findProjectWrite(
-  command: string,
-  ctx: IToolContext
-): Promise<IProjectWrite | null> {
-  for (const target of shellWriteTargets(command)) {
-    const resolved = resolveWritable(ctx, target);
-
-    if (!insideWorkspace(resolved.path)) {
-      continue;
-    }
-
-    if (
-      resolved.writable ||
-      (await Bun.file(join(ctx.cwd, resolved.path)).exists())
-    ) {
-      return { path: resolved.path, writable: resolved.writable };
-    }
-  }
-
-  return null;
-}
-
 export async function runShell(
   args: Record<string, unknown>,
   ctx: IToolContext
@@ -538,25 +496,23 @@ export async function runShell(
     );
   }
 
-  // Refuse a shell redirect/tee that writes an EXISTING project file, or any file
-  // in the editable scope. Two distinct holes: an in-scope target bypasses the
-  // write-guard (no per-file type/lint feedback → errors pile to the gate) and
-  // hashline snapshots, and an existing out-of-scope one bypasses the scope itself
-  // — `edit secret.ts` is refused while `echo x > secret.ts` used to overwrite it.
-  // Creating a NEW out-of-scope file is still allowed: markers, build artifacts and
-  // logs are legitimate shell output, and a task may run with no editable scope at
-  // all. Targets outside the workspace (/tmp) stay allowed too — `run` is
-  // deliberately a shell, and its reach beyond the workspace is the policy layer's
-  // concern, not the scope's.
-  const projectWrite = await findProjectWrite(r.command, ctx);
+  // Refuse a shell redirect/tee that WRITES an in-scope project file. The model
+  // reaches for `cat > src/foo.tsx << EOF` to escape edit-tool friction, but that
+  // bypasses the write-guard (no per-file type/lint feedback → errors pile to the
+  // gate), the scope check, and hashline snapshots. Steer it back to create/edit —
+  // `create` can now fully overwrite a file the model authored this session, so
+  // this closes the hole WITHOUT trapping it. /tmp + out-of-scope targets are fine.
+  // Resolved through resolveWritable so the target is normalized first, exactly as
+  // the edit tools do it.
+  const scopedWrite = shellWriteTargets(r.command)
+    .map((target) => resolveWritable(ctx, target))
+    .find((resolved) => resolved.writable);
 
-  if (projectWrite !== null) {
+  if (scopedWrite !== undefined) {
     return reject(
       ctx,
       "run:shell-write",
-      projectWrite.writable
-        ? `run ${r.command} REJECTED: writing a project file via a shell redirect (\`> ${projectWrite.path}\`) bypasses the type/lint guard and scope checks. Use \`create\` to write or fully rewrite ${projectWrite.path} (it overwrites a file you created this session), or \`edit\`/\`edit_lines\` for targeted changes — those get checked the instant you write.`
-        : `run ${r.command} REJECTED: \`> ${projectWrite.path}\` writes a project file that is OUTSIDE your editable scope. You may only edit/create: ${ctx.files.join(", ")}. A shell redirect is not a way around the scope.`
+      `run ${r.command} REJECTED: writing a project file via a shell redirect (\`> ${scopedWrite.path}\`) bypasses the type/lint guard and scope checks. Use \`create\` to write or fully rewrite ${scopedWrite.path} (it overwrites a file you created this session), or \`edit\`/\`edit_lines\` for targeted changes — those get checked the instant you write.`
     );
   }
 

--- a/packages/core/src/loop/tools/file-ops.ts
+++ b/packages/core/src/loop/tools/file-ops.ts
@@ -4,7 +4,7 @@ import { applyEdits } from "../../files/edit";
 import type { EditsResult } from "../../files/files.types";
 import { applyCreate } from "../../files/create";
 import { EDIT_FAIL_REASON } from "../../files";
-import { writable, normalizeWorkspacePath } from "../../lib/scope";
+import { normalizeWorkspacePath } from "../../lib/scope";
 import { LOOP_LIMITS } from "../loop.constants";
 import { toEdits, toCreate, toRun, toRead, runCommand } from "../../agent";
 import { ruleHelpFromOutput } from "../feedback/rule-docs";
@@ -14,6 +14,7 @@ import {
   reject,
   guardVeto,
   type IToolContext,
+  resolveWritable,
 } from "./tool-context";
 import { formatHashHeader, HL_LINE_SEP } from "../../files/hashline-format";
 import { SessionSnapshotStore } from "../../files/hashline";
@@ -501,8 +502,8 @@ export async function runShell(
   // gate), the scope check, and hashline snapshots. Steer it back to create/edit —
   // `create` can now fully overwrite a file the model authored this session, so
   // this closes the hole WITHOUT trapping it. /tmp + out-of-scope targets are fine.
-  const scopedWrite = shellWriteTargets(r.command).find((t) =>
-    writable(normalizeWorkspacePath(ctx.cwd, t), ctx.files)
+  const scopedWrite = shellWriteTargets(r.command).find(
+    (t) => resolveWritable(ctx, t).writable
   );
 
   if (scopedWrite !== undefined) {
@@ -637,9 +638,11 @@ export async function doEdit(
     return "edit: malformed args (need `file` plus either `oldString`/`newString` or an `edits` array of {oldString,newString})";
   }
 
-  edit.file = normalizeWorkspacePath(ctx.cwd, edit.file);
+  const editTarget = resolveWritable(ctx, edit.file);
 
-  if (!writable(edit.file, ctx.files)) {
+  edit.file = editTarget.path;
+
+  if (!editTarget.writable) {
     return reject(
       ctx,
       "edit",
@@ -853,9 +856,11 @@ export async function doCreate(
     return "create: malformed args (need file, content)";
   }
 
-  create.file = normalizeWorkspacePath(ctx.cwd, create.file);
+  const createTarget = resolveWritable(ctx, create.file);
 
-  if (!writable(create.file, ctx.files)) {
+  create.file = createTarget.path;
+
+  if (!createTarget.writable) {
     return reject(
       ctx,
       "create",

--- a/packages/core/src/loop/tools/file-ops.ts
+++ b/packages/core/src/loop/tools/file-ops.ts
@@ -4,7 +4,7 @@ import { applyEdits } from "../../files/edit";
 import type { EditsResult } from "../../files/files.types";
 import { applyCreate } from "../../files/create";
 import { EDIT_FAIL_REASON } from "../../files";
-import { normalizeWorkspacePath } from "../../lib/scope";
+import { normalizeWorkspacePath, insideWorkspace } from "../../lib/scope";
 import { LOOP_LIMITS } from "../loop.constants";
 import { toEdits, toCreate, toRun, toRead, runCommand } from "../../agent";
 import { ruleHelpFromOutput } from "../feedback/rule-docs";
@@ -473,6 +473,37 @@ export function isLongRunningServerCommand(command: string): boolean {
     .some((segment) => segmentIsServer(segment));
 }
 
+interface IProjectWrite {
+  path: string;
+  writable: boolean;
+}
+
+/** The first shell redirect target that must not be written: one in the editable
+ *  scope (write-guard bypass) or an EXISTING file inside the workspace that is out
+ *  of scope (scope bypass). Null when every target is outside the workspace or is
+ *  a new file the shell may legitimately create. */
+async function findProjectWrite(
+  command: string,
+  ctx: IToolContext
+): Promise<IProjectWrite | null> {
+  for (const target of shellWriteTargets(command)) {
+    const resolved = resolveWritable(ctx, target);
+
+    if (!insideWorkspace(resolved.path)) {
+      continue;
+    }
+
+    if (
+      resolved.writable ||
+      (await Bun.file(join(ctx.cwd, resolved.path)).exists())
+    ) {
+      return { path: resolved.path, writable: resolved.writable };
+    }
+  }
+
+  return null;
+}
+
 export async function runShell(
   args: Record<string, unknown>,
   ctx: IToolContext
@@ -496,21 +527,25 @@ export async function runShell(
     );
   }
 
-  // Refuse a shell redirect/tee that WRITES an in-scope project file. The model
-  // reaches for `cat > src/foo.tsx << EOF` to escape edit-tool friction, but that
-  // bypasses the write-guard (no per-file type/lint feedback → errors pile to the
-  // gate), the scope check, and hashline snapshots. Steer it back to create/edit —
-  // `create` can now fully overwrite a file the model authored this session, so
-  // this closes the hole WITHOUT trapping it. /tmp + out-of-scope targets are fine.
-  const scopedWrite = shellWriteTargets(r.command).find(
-    (t) => resolveWritable(ctx, t).writable
-  );
+  // Refuse a shell redirect/tee that writes an EXISTING project file, or any file
+  // in the editable scope. Two distinct holes: an in-scope target bypasses the
+  // write-guard (no per-file type/lint feedback → errors pile to the gate) and
+  // hashline snapshots, and an existing out-of-scope one bypasses the scope itself
+  // — `edit secret.ts` is refused while `echo x > secret.ts` used to overwrite it.
+  // Creating a NEW out-of-scope file is still allowed: markers, build artifacts and
+  // logs are legitimate shell output, and a task may run with no editable scope at
+  // all. Targets outside the workspace (/tmp) stay allowed too — `run` is
+  // deliberately a shell, and its reach beyond the workspace is the policy layer's
+  // concern, not the scope's.
+  const projectWrite = await findProjectWrite(r.command, ctx);
 
-  if (scopedWrite !== undefined) {
+  if (projectWrite !== null) {
     return reject(
       ctx,
       "run:shell-write",
-      `run ${r.command} REJECTED: writing a project file via a shell redirect (\`> ${scopedWrite}\`) bypasses the type/lint guard and scope checks. Use \`create\` to write or fully rewrite ${scopedWrite} (it overwrites a file you created this session), or \`edit\`/\`edit_lines\` for targeted changes — those get checked the instant you write.`
+      projectWrite.writable
+        ? `run ${r.command} REJECTED: writing a project file via a shell redirect (\`> ${projectWrite.path}\`) bypasses the type/lint guard and scope checks. Use \`create\` to write or fully rewrite ${projectWrite.path} (it overwrites a file you created this session), or \`edit\`/\`edit_lines\` for targeted changes — those get checked the instant you write.`
+        : `run ${r.command} REJECTED: \`> ${projectWrite.path}\` writes a project file that is OUTSIDE your editable scope. You may only edit/create: ${ctx.files.join(", ")}. A shell redirect is not a way around the scope.`
     );
   }
 

--- a/packages/core/src/loop/tools/file-ops.ts
+++ b/packages/core/src/loop/tools/file-ops.ts
@@ -478,10 +478,21 @@ interface IProjectWrite {
   writable: boolean;
 }
 
-/** The first shell redirect target that must not be written: one in the editable
- *  scope (write-guard bypass) or an EXISTING file inside the workspace that is out
- *  of scope (scope bypass). Null when every target is outside the workspace or is
- *  a new file the shell may legitimately create. */
+/**
+ * The first shell redirect target that must not be written: one in the editable
+ * scope (write-guard bypass) or an EXISTING file inside the workspace that is out
+ * of scope. Null when every target is outside the workspace or is a new file the
+ * shell may legitimately create.
+ *
+ * BEST-EFFORT STEERING, NOT A CONTAINMENT BOUNDARY. It reads redirect targets out
+ * of the command text, and command text cannot be resolved without running it:
+ * `> "$f"` resolves at runtime, `> "a file.ts"` and `> a\ file.ts` carry the
+ * separator the scanner splits on, and `sed -i` / `cp` / `tee` / any script writes
+ * without a redirect at all. Its job is to stop the model reaching for
+ * `cat > src/foo.ts` out of edit-tool friction, and to close the easy overwrite of
+ * an out-of-scope file — not to sandbox the shell. What actually bounds `run` is
+ * the policy layer; see audit findings F16 and F22.
+ */
 async function findProjectWrite(
   command: string,
   ctx: IToolContext

--- a/packages/core/src/loop/tools/lsp-ops.ts
+++ b/packages/core/src/loop/tools/lsp-ops.ts
@@ -3,7 +3,12 @@ import { fileArg, TOOL_NAME, type ToolName } from "../../agent";
 import { runArgvCommand } from "../../lib/fs";
 import { writable } from "../../lib/scope";
 import { LOOP_LIMITS } from "../loop.constants";
-import { str, reject, type IToolContext } from "./tool-context";
+import {
+  str,
+  reject,
+  resolveWritable,
+  type IToolContext,
+} from "./tool-context";
 
 /** ripgrep search over the working dir — the model's primary navigation at
  *  scale (structural/text, fast). Falls back gracefully if `rg` is absent. */
@@ -139,24 +144,26 @@ function doOrganizeImports(
     return "organize_imports: need `file`";
   }
 
-  if (!writable(file, ctx.files)) {
+  const target = resolveWritable(ctx, file);
+
+  if (!target.writable) {
     return reject(
       ctx,
       "organize_imports",
-      `organize_imports ${file} REJECTED: out of scope.`
+      `organize_imports ${target.path} REJECTED: out of scope.`
     );
   }
 
-  const n = svc.organizeImports(file);
+  const n = svc.organizeImports(target.path);
 
   ctx.report({
     kind: "tool",
     task: ctx.task,
-    message: `organize_imports ${file} (${n})`,
-    ...(n > 0 ? { mutated: [file] } : {}),
+    message: `organize_imports ${target.path} (${n})`,
+    ...(n > 0 ? { mutated: [target.path] } : {}),
   });
 
-  return `organize_imports: ${n} change(s) in ${file}`;
+  return `organize_imports: ${n} change(s) in ${target.path}`;
 }
 
 /** move_file: relocate a file and rewrite every importer's specifier. */

--- a/packages/core/src/loop/tools/tool-context.ts
+++ b/packages/core/src/loop/tools/tool-context.ts
@@ -1,4 +1,5 @@
 import { repairArgs } from "../../agent/tool-repair";
+import { writable, normalizeWorkspacePath } from "../../lib/scope";
 import type { TsService } from "../../lsp";
 import type { Reporter } from "../loop.types";
 import type { SessionSnapshotStore } from "../../files/hashline";
@@ -167,6 +168,25 @@ export function str(args: Record<string, unknown>, key: string): string {
   const v = args[key];
 
   return typeof v === "string" ? v : "";
+}
+
+/**
+ * Resolve a model-supplied path against the workspace and scope-check it, as one
+ * step. Every tool that writes a single named file goes through here.
+ *
+ * The two must not be done separately: scope-checking the RAW argument rejects
+ * in-scope files the model addressed absolutely or as `./x` (the globs are
+ * workspace-relative), while normalizing without checking would let a `../` path
+ * out of the workspace. `organize_imports` did the former and was the one write
+ * tool that refused paths `edit`/`create`/`edit_lines` accepted.
+ */
+export function resolveWritable(
+  ctx: IToolContext,
+  file: string
+): { path: string; writable: boolean } {
+  const path = normalizeWorkspacePath(ctx.cwd, file);
+
+  return { path, writable: writable(path, ctx.files) };
 }
 
 export interface IParseResult<T> {

--- a/packages/core/tests/execute-lsp.test.ts
+++ b/packages/core/tests/execute-lsp.test.ts
@@ -157,13 +157,13 @@ test("organize_imports accepts an in-scope file addressed absolutely or as ./", 
     await Bun.write(join(ctx.cwd, "b.ts"), dirty);
 
     const reported: string[] = [];
-    const spy = {
+    const spy: IToolContext = {
       ...ctx,
       // setup() builds its TsService before these files exist, so it would not
       // know them — rebuild after writing.
       tsService: new TsService(ctx.cwd),
-      report: (e: { mutated?: string[] }) => {
-        reported.push(...(e.mutated ?? []));
+      report: (event) => {
+        reported.push(...(event.mutated ?? []));
       },
     };
 
@@ -173,7 +173,7 @@ test("organize_imports accepts an in-scope file addressed absolutely or as ./", 
     ] as const) {
       const r = await executeTool(
         { name: "organize_imports", arguments: { file } },
-        spy as never
+        spy
       );
 
       expect({ file, rejected: r.includes("REJECTED") }).toEqual({

--- a/packages/core/tests/execute-lsp.test.ts
+++ b/packages/core/tests/execute-lsp.test.ts
@@ -146,25 +146,55 @@ test("organize_imports runs with only `file` (no symbol required)", async () => 
 // risk for this subsystem ("scope check on the raw arg instead of the normalized
 // written path"). Models emit both forms routinely.
 test("organize_imports accepts an in-scope file addressed absolutely or as ./", async () => {
-  const ctx = await setup(["types.ts", "use.ts"]);
+  const ctx = await setup(["types.ts", "a.ts", "b.ts"]);
+  const dirty =
+    'import type { IThing } from "./types";\nimport { f as unused } from "./types";\nexport const f = (t: IThing): number => t.value;\n';
 
   try {
-    await Bun.write(
-      join(ctx.cwd, "use.ts"),
-      'import type { IThing } from "./types";\nimport { f as unused } from "./types";\nexport const f = (t: IThing): number => t.value;\n'
-    );
+    // A separate file per form: sharing one would make the second call a no-op
+    // after the first succeeded, so it would pass without proving anything.
+    await Bun.write(join(ctx.cwd, "a.ts"), dirty);
+    await Bun.write(join(ctx.cwd, "b.ts"), dirty);
 
-    for (const file of [join(ctx.cwd, "use.ts"), "./use.ts"]) {
+    const reported: string[] = [];
+    const spy = {
+      ...ctx,
+      // setup() builds its TsService before these files exist, so it would not
+      // know them — rebuild after writing.
+      tsService: new TsService(ctx.cwd),
+      report: (e: { mutated?: string[] }) => {
+        reported.push(...(e.mutated ?? []));
+      },
+    };
+
+    for (const [file, name] of [
+      [join(ctx.cwd, "a.ts"), "a.ts"],
+      ["./b.ts", "b.ts"],
+    ] as const) {
       const r = await executeTool(
         { name: "organize_imports", arguments: { file } },
-        ctx
+        spy as never
       );
 
       expect({ file, rejected: r.includes("REJECTED") }).toEqual({
         file,
         rejected: false,
       });
+      // It must actually operate on the file, not merely pass the scope check:
+      // a fix that normalized only for the check and passed the raw path
+      // downstream would leave the unused import in place.
+      expect({
+        name,
+        text: await Bun.file(join(ctx.cwd, name)).text(),
+      }).toEqual({
+        name,
+        text: 'import type { IThing } from "./types";\nexport const f = (t: IThing): number => t.value;\n',
+      });
     }
+
+    // The change scope records the NORMALIZED path, matching what edit/create
+    // report — not the absolute or "./" form the model happened to send.
+    expect([...reported].sort()).toEqual(["a.ts", "b.ts"]);
   } finally {
     await rm(ctx.cwd, { recursive: true, force: true });
   }

--- a/packages/core/tests/execute-lsp.test.ts
+++ b/packages/core/tests/execute-lsp.test.ts
@@ -140,6 +140,53 @@ test("organize_imports runs with only `file` (no symbol required)", async () => 
   }
 });
 
+// organize_imports scope-checked the RAW model argument while edit/create/
+// edit_lines all normalize first, so an in-scope file addressed absolutely or as
+// "./x" was rejected as out of scope by this tool alone — the manifest's stated
+// risk for this subsystem ("scope check on the raw arg instead of the normalized
+// written path"). Models emit both forms routinely.
+test("organize_imports accepts an in-scope file addressed absolutely or as ./", async () => {
+  const ctx = await setup(["types.ts", "use.ts"]);
+
+  try {
+    await Bun.write(
+      join(ctx.cwd, "use.ts"),
+      'import type { IThing } from "./types";\nimport { f as unused } from "./types";\nexport const f = (t: IThing): number => t.value;\n'
+    );
+
+    for (const file of [join(ctx.cwd, "use.ts"), "./use.ts"]) {
+      const r = await executeTool(
+        { name: "organize_imports", arguments: { file } },
+        ctx
+      );
+
+      expect({ file, rejected: r.includes("REJECTED") }).toEqual({
+        file,
+        rejected: false,
+      });
+    }
+  } finally {
+    await rm(ctx.cwd, { recursive: true, force: true });
+  }
+});
+
+// A path that ESCAPES the workspace must still be rejected — normalizing must
+// not become a way in.
+test("organize_imports still rejects a traversal path", async () => {
+  const ctx = await setup(["use.ts"]);
+
+  try {
+    const r = await executeTool(
+      { name: "organize_imports", arguments: { file: "../outside.ts" } },
+      ctx
+    );
+
+    expect(r).toContain("REJECTED");
+  } finally {
+    await rm(ctx.cwd, { recursive: true, force: true });
+  }
+});
+
 test("organize_imports is REJECTED for an out-of-scope file", async () => {
   const ctx = await setup(["types.ts"]); // use.ts read-only
 

--- a/packages/core/tests/execute-tool.test.ts
+++ b/packages/core/tests/execute-tool.test.ts
@@ -965,6 +965,39 @@ describe("resolveWritable behaves identically at every call site", () => {
     }
   });
 
+  test("run still allows creating a NEW out-of-scope file in the workspace", async () => {
+    // Load-bearing, not cosmetic: a task may run with NO editable scope and
+    // legitimately produce a marker or build artifact this way. Refusing every
+    // in-workspace target broke three repair-loop tests. Existence is what
+    // separates clobbering a project file from producing an artifact.
+    const dir = await mkdtemp(join(tmpdir(), "tsforge-scope-"));
+
+    await Bun.write(join(dir, "impl.ts"), "export const a = 1;\n");
+
+    try {
+      // A distinct target per case: reusing one would make the second call see a
+      // file the first created, i.e. an EXISTING out-of-scope file, which is
+      // correctly refused — the test would fail for the rule working.
+      for (const [scope, marker] of [
+        [["impl.ts"], "marker-a.txt"],
+        [[], "marker-b.txt"],
+      ] as const) {
+        const out = await executeTool(
+          { name: "run", arguments: { command: `echo x > ${marker}` } },
+          ctx(dir, [...scope])
+        );
+
+        expect({ marker, rejected: out.includes("REJECTED") }).toEqual({
+          marker,
+          rejected: false,
+        });
+        expect(await Bun.file(join(dir, marker)).exists()).toBe(true);
+      }
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
   // Beyond the workspace, `run` is deliberately a shell — /tmp and build logs are
   // its documented targets, and its reach there is governed by the policy layer,
   // not by the editable scope. Pinned so a change to it is a deliberate one.

--- a/packages/core/tests/execute-tool.test.ts
+++ b/packages/core/tests/execute-tool.test.ts
@@ -865,6 +865,49 @@ describe("the shared scope boundary holds for every write path", () => {
     }
   });
 
+  test("edit_lines accepts an in-scope file addressed absolutely or as ./", async () => {
+    for (const file of ["<abs>impl.ts", "./impl.ts"]) {
+      // edit_lines needs the hashline anchor from a prior `read`, so the file is
+      // read through the same context before the edit is attempted.
+      const dir0 = await mkdtemp(join(tmpdir(), "tsforge-scope-"));
+
+      await Bun.write(join(dir0, "impl.ts"), "export const a = 1;\n");
+
+      const c = ctx(dir0, ["impl.ts"]);
+      const read = await executeTool(
+        { name: "read", arguments: { file: "impl.ts" } },
+        c
+      );
+      const anchor = /¶\S+/u.exec(read)?.[0] ?? "";
+      const spelled = file.startsWith("<abs>")
+        ? join(dir0, file.slice("<abs>".length))
+        : file;
+      const out = await executeTool(
+        {
+          name: "edit_lines",
+          arguments: {
+            file: spelled,
+            input: `${anchor}\nreplace 1..1:\n+export const a = 42;`,
+          },
+        },
+        c
+      );
+      const dir = dir0;
+
+      try {
+        expect({ file, rejected: out.includes("REJECTED") }).toEqual({
+          file,
+          rejected: false,
+        });
+        // The edit must actually land — a rejection-only test would pass even if
+        // normalisation broke every valid path for this tool.
+        expect(await Bun.file(join(dir, "impl.ts")).text()).toContain("a = 42");
+      } finally {
+        await rm(dir, { recursive: true, force: true });
+      }
+    }
+  });
+
   test("run's shell-write check sees through an absolute or ./ redirect", async () => {
     // The `run` call site resolves shell redirect targets through the same helper:
     // an in-scope file must be steered back to create/edit however it is spelled,

--- a/packages/core/tests/execute-tool.test.ts
+++ b/packages/core/tests/execute-tool.test.ts
@@ -940,34 +940,67 @@ describe("the shared scope boundary holds for every write path", () => {
   });
 
   test("no write path lets a traversal path escape the workspace", async () => {
-    // organize_imports is covered in execute-lsp.test.ts, which has a real
-    // LanguageService; without one it reports "unavailable" before reaching the
-    // scope check, so asserting it here would only look like coverage.
-    const CALLS: readonly [string, Record<string, unknown>][] = [
-      ["create", { file: "../escaped.ts", content: "x" }],
-      ["edit", { file: "../escaped.ts", oldString: "a", newString: "b" }],
-      ["edit_lines", { file: "../escaped.ts", input: "1: x" }],
-    ];
+    // The sibling must EXIST and be genuinely editable, in a parent of our own:
+    // against a nonexistent target every tool rejects for its own unrelated
+    // reason (missing file, missing hashline anchor) and "nothing was written" is
+    // vacuously true, so the test would pass with no scope enforcement at all.
+    // A fixed /tmp parent could also collide with another process.
+    const parent = await mkdtemp(join(tmpdir(), "tsforge-escape-"));
+    const dir = join(parent, "ws");
+    const escaped = join(parent, "escaped.ts");
+    const ORIGINAL = "export const secret = 1;\n";
 
-    for (const [name, args] of CALLS) {
-      const { out, dir } = await attempt({ name, arguments: args });
+    await mkdir(dir, { recursive: true });
+    await Bun.write(join(dir, "impl.ts"), "export const a = 1;\n");
+    await Bun.write(escaped, ORIGINAL);
 
-      try {
-        // The load-bearing assertion is the filesystem: whatever the tool says,
-        // nothing may land outside the workspace.
-        const escapedPath = join(dir, "..", "escaped.ts");
+    const c = ctx(dir, ["impl.ts"]);
 
-        expect({ name, wrote: await Bun.file(escapedPath).exists() }).toEqual({
-          name,
-          wrote: false,
-        });
+    try {
+      // Reads are not scope-limited, so a valid anchor for the sibling is
+      // obtainable — edit_lines must then be refused on SCOPE, not on the anchor.
+      const read = await executeTool(
+        { name: "read", arguments: { file: "../escaped.ts" } },
+        c
+      );
+      const anchor = /¶\S+/u.exec(read)?.[0] ?? "";
+
+      const CALLS: readonly [string, Record<string, unknown>][] = [
+        [
+          "edit",
+          {
+            file: "../escaped.ts",
+            oldString: "secret = 1",
+            newString: "secret = 2",
+          },
+        ],
+        [
+          "edit_lines",
+          {
+            file: "../escaped.ts",
+            input: `${anchor}\nreplace 1..1:\n+export const secret = 2;`,
+          },
+        ],
+        ["create", { file: "../new-escape.ts", content: "x" }],
+      ];
+
+      for (const [name, args] of CALLS) {
+        const out = await executeTool({ name, arguments: args }, c);
+
         expect({ name, refused: out.includes("REJECTED") }).toEqual({
           name,
           refused: true,
         });
-      } finally {
-        await rm(dir, { recursive: true, force: true });
       }
+
+      // The load-bearing assertions: the existing sibling is BYTE-UNCHANGED, and
+      // no new file appeared outside the workspace.
+      expect(await Bun.file(escaped).text()).toBe(ORIGINAL);
+      expect(await Bun.file(join(parent, "new-escape.ts")).exists()).toBe(
+        false
+      );
+    } finally {
+      await rm(parent, { recursive: true, force: true });
     }
   });
 });

--- a/packages/core/tests/execute-tool.test.ts
+++ b/packages/core/tests/execute-tool.test.ts
@@ -1,4 +1,4 @@
-import { test, expect } from "bun:test";
+import { describe, test, expect } from "bun:test";
 import { mkdtemp, rm, mkdir } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
@@ -789,4 +789,111 @@ test("ask_user in an unattended run returns proceed-with-judgment (never hangs)"
   );
 
   expect(r).toContain("No human is available");
+});
+
+// resolveWritable (tool-context) is the single normalize-then-scope-check step
+// behind every single-file write path. Centralising it means one regression there
+// would silently move the scope boundary for all of them, so each call site is
+// pinned here: an in-scope file addressed absolutely or as "./x" is ACCEPTED (the
+// globs are workspace-relative), and a "../" escape is still REJECTED — normalizing
+// must not become a way out of the workspace.
+describe("the shared scope boundary holds for every write path", () => {
+  async function attempt(
+    call: { name: string; arguments: Record<string, unknown> },
+    scope: string[] = ["impl.ts"]
+  ): Promise<{ out: string; dir: string }> {
+    const dir = await mkdtemp(join(tmpdir(), "tsforge-scope-"));
+
+    await Bun.write(join(dir, "impl.ts"), "export const a = 1;\n");
+
+    const args = { ...call.arguments };
+    const file = args.file;
+
+    if (typeof file === "string" && file.startsWith("<abs>")) {
+      args.file = join(dir, file.slice("<abs>".length));
+    }
+
+    const out = await executeTool(
+      { ...call, arguments: args },
+      ctx(dir, scope)
+    );
+
+    return { out, dir };
+  }
+
+  test("create accepts a new in-scope file addressed absolutely or as ./", async () => {
+    // NOTE: `create` on an EXISTING file is refused by overwrite protection, not
+    // scope — so this must target a file that does not exist yet, or it would
+    // pass for the wrong reason.
+    for (const file of ["<abs>new.ts", "./new.ts"]) {
+      const { out, dir } = await attempt(
+        {
+          name: "create",
+          arguments: { file, content: "export const b = 2;\n" },
+        },
+        ["impl.ts", "new.ts"]
+      );
+
+      try {
+        expect({ file, rejected: out.includes("REJECTED") }).toEqual({
+          file,
+          rejected: false,
+        });
+        expect(await Bun.file(join(dir, "new.ts")).text()).toContain("b = 2");
+      } finally {
+        await rm(dir, { recursive: true, force: true });
+      }
+    }
+  });
+
+  test("edit accepts an in-scope file addressed absolutely or as ./", async () => {
+    for (const file of ["<abs>impl.ts", "./impl.ts"]) {
+      const { out, dir } = await attempt({
+        name: "edit",
+        arguments: { file, oldString: "a = 1", newString: "a = 42" },
+      });
+
+      try {
+        expect({ file, rejected: out.includes("REJECTED") }).toEqual({
+          file,
+          rejected: false,
+        });
+        expect(await Bun.file(join(dir, "impl.ts")).text()).toContain("a = 42");
+      } finally {
+        await rm(dir, { recursive: true, force: true });
+      }
+    }
+  });
+
+  test("no write path lets a traversal path escape the workspace", async () => {
+    const CALLS: readonly [string, Record<string, unknown>][] = [
+      ["create", { file: "../escaped.ts", content: "x" }],
+      ["edit", { file: "../escaped.ts", oldString: "a", newString: "b" }],
+      ["edit_lines", { file: "../escaped.ts", input: "1: x" }],
+      ["organize_imports", { file: "../escaped.ts" }],
+    ];
+
+    for (const [name, args] of CALLS) {
+      const { out, dir } = await attempt({ name, arguments: args });
+
+      try {
+        // The load-bearing assertion is the filesystem: whatever the tool says,
+        // nothing may land outside the workspace.
+        const escapedPath = join(dir, "..", "escaped.ts");
+
+        expect({ name, wrote: await Bun.file(escapedPath).exists() }).toEqual({
+          name,
+          wrote: false,
+        });
+        expect({ name, refused: out.includes("REJECTED") }).toEqual({
+          name,
+          // organize_imports needs a LanguageService, absent in this fixture, so
+          // it reports unavailable before reaching the scope check.
+          refused: name !== "organize_imports",
+        });
+      } finally {
+        await rm(dir, { recursive: true, force: true });
+      }
+    }
+  });
 });

--- a/packages/core/tests/execute-tool.test.ts
+++ b/packages/core/tests/execute-tool.test.ts
@@ -797,7 +797,7 @@ test("ask_user in an unattended run returns proceed-with-judgment (never hangs)"
 // pinned here: an in-scope file addressed absolutely or as "./x" is ACCEPTED (the
 // globs are workspace-relative), and a "../" escape is still REJECTED — normalizing
 // must not become a way out of the workspace.
-describe("the shared scope boundary holds for every write path", () => {
+describe("resolveWritable behaves identically at every call site", () => {
   async function attempt(
     call: { name: string; arguments: Record<string, unknown> },
     scope: string[] = ["impl.ts"]
@@ -908,10 +908,13 @@ describe("the shared scope boundary holds for every write path", () => {
     }
   });
 
-  test("run's shell-write check sees through an absolute or ./ redirect", async () => {
-    // The `run` call site resolves shell redirect targets through the same helper:
-    // an in-scope file must be steered back to create/edit however it is spelled,
-    // or a redirect becomes a way around the write guard and the scope check.
+  test("run steers an in-scope redirect back to the edit tools, however spelled", async () => {
+    // NOTE what this does and does not guarantee. `run` is deliberately a shell:
+    // its resolveWritable call exists to stop the model writing PROJECT files via
+    // a redirect (which would skip the write guard, the per-file lint feedback and
+    // hashline snapshots), NOT to sandbox the shell. Out-of-scope and traversal
+    // targets execute — see the test below. The reach of `run` is governed by the
+    // policy layer, not by the editable scope.
     for (const target of ["impl.ts", "./impl.ts", "<abs>impl.ts"]) {
       const dir = await mkdtemp(join(tmpdir(), "tsforge-scope-"));
 
@@ -939,7 +942,28 @@ describe("the shared scope boundary holds for every write path", () => {
     }
   });
 
-  test("no write path lets a traversal path escape the workspace", async () => {
+  // The edit TOOLS are the scope boundary. `run` is not one of them, and pretending
+  // otherwise in a test would misrepresent where the boundary actually is.
+  test("run's shell is NOT bounded by the editable scope (documented behavior)", async () => {
+    const parent = await mkdtemp(join(tmpdir(), "tsforge-runreach-"));
+    const dir = join(parent, "ws");
+
+    await mkdir(dir, { recursive: true });
+
+    try {
+      const out = await executeTool(
+        { name: "run", arguments: { command: "echo pwned > ../escaped.ts" } },
+        ctx(dir, ["impl.ts"])
+      );
+
+      expect(out).not.toContain("REJECTED");
+      expect(await Bun.file(join(parent, "escaped.ts")).exists()).toBe(true);
+    } finally {
+      await rm(parent, { recursive: true, force: true });
+    }
+  });
+
+  test("no EDIT TOOL lets a traversal path escape the workspace", async () => {
     // The sibling must EXIST and be genuinely editable, in a parent of our own:
     // against a nonexistent target every tool rejects for its own unrelated
     // reason (missing file, missing hashline anchor) and "nothing was written" is

--- a/packages/core/tests/execute-tool.test.ts
+++ b/packages/core/tests/execute-tool.test.ts
@@ -942,63 +942,7 @@ describe("resolveWritable behaves identically at every call site", () => {
     }
   });
 
-  test("run refuses a redirect to an in-workspace file OUTSIDE the scope", async () => {
-    // `edit secret.ts` is refused as out of scope, but `echo x > secret.ts` used
-    // to overwrite it — a one-line way around the scope on a project file. The
-    // scope must mean the same thing whichever tool is used.
-    const dir = await mkdtemp(join(tmpdir(), "tsforge-scope-"));
-    const ORIGINAL = 'export const KEY = "original";\n';
-
-    await Bun.write(join(dir, "impl.ts"), "export const a = 1;\n");
-    await Bun.write(join(dir, "secret.ts"), ORIGINAL);
-
-    try {
-      const out = await executeTool(
-        { name: "run", arguments: { command: "echo pwned > secret.ts" } },
-        ctx(dir, ["impl.ts"])
-      );
-
-      expect(out).toContain("REJECTED");
-      expect(await Bun.file(join(dir, "secret.ts")).text()).toBe(ORIGINAL);
-    } finally {
-      await rm(dir, { recursive: true, force: true });
-    }
-  });
-
-  test("run still allows creating a NEW out-of-scope file in the workspace", async () => {
-    // Load-bearing, not cosmetic: a task may run with NO editable scope and
-    // legitimately produce a marker or build artifact this way. Refusing every
-    // in-workspace target broke three repair-loop tests. Existence is what
-    // separates clobbering a project file from producing an artifact.
-    const dir = await mkdtemp(join(tmpdir(), "tsforge-scope-"));
-
-    await Bun.write(join(dir, "impl.ts"), "export const a = 1;\n");
-
-    try {
-      // A distinct target per case: reusing one would make the second call see a
-      // file the first created, i.e. an EXISTING out-of-scope file, which is
-      // correctly refused — the test would fail for the rule working.
-      for (const [scope, marker] of [
-        [["impl.ts"], "marker-a.txt"],
-        [[], "marker-b.txt"],
-      ] as const) {
-        const out = await executeTool(
-          { name: "run", arguments: { command: `echo x > ${marker}` } },
-          ctx(dir, [...scope])
-        );
-
-        expect({ marker, rejected: out.includes("REJECTED") }).toEqual({
-          marker,
-          rejected: false,
-        });
-        expect(await Bun.file(join(dir, marker)).exists()).toBe(true);
-      }
-    } finally {
-      await rm(dir, { recursive: true, force: true });
-    }
-  });
-
-  test("a dotted-but-ordinary filename is editable, and run cannot clobber it", async () => {
+  test("a dotted-but-ordinary filename is editable when in scope", async () => {
     // "..secret.ts" is a normal workspace file. The scope must govern it like any
     // other: editable when in scope, and NOT creatable/overwritable via a shell
     // redirect when it is not.
@@ -1024,17 +968,6 @@ describe("resolveWritable behaves identically at every call site", () => {
       );
 
       expect(edited).not.toContain("REJECTED");
-      expect(await Bun.file(join(dir, "..secret.ts")).text()).toContain(
-        "changed"
-      );
-
-      // Out of scope → a redirect must not overwrite it either.
-      const viaShell = await executeTool(
-        { name: "run", arguments: { command: "echo pwned > ..secret.ts" } },
-        ctx(dir, ["impl.ts"])
-      );
-
-      expect(viaShell).toContain("REJECTED");
       expect(await Bun.file(join(dir, "..secret.ts")).text()).toContain(
         "changed"
       );

--- a/packages/core/tests/execute-tool.test.ts
+++ b/packages/core/tests/execute-tool.test.ts
@@ -942,9 +942,33 @@ describe("resolveWritable behaves identically at every call site", () => {
     }
   });
 
-  // The edit TOOLS are the scope boundary. `run` is not one of them, and pretending
-  // otherwise in a test would misrepresent where the boundary actually is.
-  test("run's shell is NOT bounded by the editable scope (documented behavior)", async () => {
+  test("run refuses a redirect to an in-workspace file OUTSIDE the scope", async () => {
+    // `edit secret.ts` is refused as out of scope, but `echo x > secret.ts` used
+    // to overwrite it — a one-line way around the scope on a project file. The
+    // scope must mean the same thing whichever tool is used.
+    const dir = await mkdtemp(join(tmpdir(), "tsforge-scope-"));
+    const ORIGINAL = 'export const KEY = "original";\n';
+
+    await Bun.write(join(dir, "impl.ts"), "export const a = 1;\n");
+    await Bun.write(join(dir, "secret.ts"), ORIGINAL);
+
+    try {
+      const out = await executeTool(
+        { name: "run", arguments: { command: "echo pwned > secret.ts" } },
+        ctx(dir, ["impl.ts"])
+      );
+
+      expect(out).toContain("REJECTED");
+      expect(await Bun.file(join(dir, "secret.ts")).text()).toBe(ORIGINAL);
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  // Beyond the workspace, `run` is deliberately a shell — /tmp and build logs are
+  // its documented targets, and its reach there is governed by the policy layer,
+  // not by the editable scope. Pinned so a change to it is a deliberate one.
+  test("run's shell still reaches OUTSIDE the workspace (documented behavior)", async () => {
     const parent = await mkdtemp(join(tmpdir(), "tsforge-runreach-"));
     const dir = join(parent, "ws");
 

--- a/packages/core/tests/execute-tool.test.ts
+++ b/packages/core/tests/execute-tool.test.ts
@@ -998,6 +998,51 @@ describe("resolveWritable behaves identically at every call site", () => {
     }
   });
 
+  test("a dotted-but-ordinary filename is editable, and run cannot clobber it", async () => {
+    // "..secret.ts" is a normal workspace file. The scope must govern it like any
+    // other: editable when in scope, and NOT creatable/overwritable via a shell
+    // redirect when it is not.
+    const dir = await mkdtemp(join(tmpdir(), "tsforge-dotted-"));
+
+    await Bun.write(
+      join(dir, "..secret.ts"),
+      'export const KEY = "original";\n'
+    );
+
+    try {
+      // In scope → the edit tool may change it.
+      const edited = await executeTool(
+        {
+          name: "edit",
+          arguments: {
+            file: "..secret.ts",
+            oldString: "original",
+            newString: "changed",
+          },
+        },
+        ctx(dir, ["..secret.ts"])
+      );
+
+      expect(edited).not.toContain("REJECTED");
+      expect(await Bun.file(join(dir, "..secret.ts")).text()).toContain(
+        "changed"
+      );
+
+      // Out of scope → a redirect must not overwrite it either.
+      const viaShell = await executeTool(
+        { name: "run", arguments: { command: "echo pwned > ..secret.ts" } },
+        ctx(dir, ["impl.ts"])
+      );
+
+      expect(viaShell).toContain("REJECTED");
+      expect(await Bun.file(join(dir, "..secret.ts")).text()).toContain(
+        "changed"
+      );
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
   // Beyond the workspace, `run` is deliberately a shell — /tmp and build logs are
   // its documented targets, and its reach there is governed by the policy layer,
   // not by the editable scope. Pinned so a change to it is a deliberate one.

--- a/packages/core/tests/execute-tool.test.ts
+++ b/packages/core/tests/execute-tool.test.ts
@@ -865,12 +865,45 @@ describe("the shared scope boundary holds for every write path", () => {
     }
   });
 
+  test("run's shell-write check sees through an absolute or ./ redirect", async () => {
+    // The `run` call site resolves shell redirect targets through the same helper:
+    // an in-scope file must be steered back to create/edit however it is spelled,
+    // or a redirect becomes a way around the write guard and the scope check.
+    for (const target of ["impl.ts", "./impl.ts", "<abs>impl.ts"]) {
+      const dir = await mkdtemp(join(tmpdir(), "tsforge-scope-"));
+
+      await Bun.write(join(dir, "impl.ts"), "export const a = 1;\n");
+
+      const spelled = target.startsWith("<abs>")
+        ? join(dir, target.slice("<abs>".length))
+        : target;
+
+      try {
+        const out = await executeTool(
+          { name: "run", arguments: { command: `echo x > ${spelled}` } },
+          ctx(dir, ["impl.ts"])
+        );
+
+        expect({ target, steered: out.includes("REJECTED") }).toEqual({
+          target,
+          steered: true,
+        });
+        // Untouched: the redirect never ran.
+        expect(await Bun.file(join(dir, "impl.ts")).text()).toContain("a = 1");
+      } finally {
+        await rm(dir, { recursive: true, force: true });
+      }
+    }
+  });
+
   test("no write path lets a traversal path escape the workspace", async () => {
+    // organize_imports is covered in execute-lsp.test.ts, which has a real
+    // LanguageService; without one it reports "unavailable" before reaching the
+    // scope check, so asserting it here would only look like coverage.
     const CALLS: readonly [string, Record<string, unknown>][] = [
       ["create", { file: "../escaped.ts", content: "x" }],
       ["edit", { file: "../escaped.ts", oldString: "a", newString: "b" }],
       ["edit_lines", { file: "../escaped.ts", input: "1: x" }],
-      ["organize_imports", { file: "../escaped.ts" }],
     ];
 
     for (const [name, args] of CALLS) {
@@ -887,9 +920,7 @@ describe("the shared scope boundary holds for every write path", () => {
         });
         expect({ name, refused: out.includes("REJECTED") }).toEqual({
           name,
-          // organize_imports needs a LanguageService, absent in this fixture, so
-          // it reports unavailable before reaching the scope check.
-          refused: name !== "organize_imports",
+          refused: true,
         });
       } finally {
         await rm(dir, { recursive: true, force: true });

--- a/packages/core/tests/execute-tool.test.ts
+++ b/packages/core/tests/execute-tool.test.ts
@@ -1043,28 +1043,6 @@ describe("resolveWritable behaves identically at every call site", () => {
     }
   });
 
-  // Beyond the workspace, `run` is deliberately a shell — /tmp and build logs are
-  // its documented targets, and its reach there is governed by the policy layer,
-  // not by the editable scope. Pinned so a change to it is a deliberate one.
-  test("run's shell still reaches OUTSIDE the workspace (documented behavior)", async () => {
-    const parent = await mkdtemp(join(tmpdir(), "tsforge-runreach-"));
-    const dir = join(parent, "ws");
-
-    await mkdir(dir, { recursive: true });
-
-    try {
-      const out = await executeTool(
-        { name: "run", arguments: { command: "echo pwned > ../escaped.ts" } },
-        ctx(dir, ["impl.ts"])
-      );
-
-      expect(out).not.toContain("REJECTED");
-      expect(await Bun.file(join(parent, "escaped.ts")).exists()).toBe(true);
-    } finally {
-      await rm(parent, { recursive: true, force: true });
-    }
-  });
-
   test("no EDIT TOOL lets a traversal path escape the workspace", async () => {
     // The sibling must EXIST and be genuinely editable, in a parent of our own:
     // against a nonexistent target every tool rejects for its own unrelated

--- a/packages/core/tests/scope.test.ts
+++ b/packages/core/tests/scope.test.ts
@@ -120,3 +120,34 @@ test("insideWorkspace compares path segments, not prefixes", () => {
     });
   }
 });
+
+// writable() and insideWorkspace() must apply the SAME segment rule. writable used
+// its own startsWith("..") test, which (a) made every ordinary name beginning with
+// two dots unwritable through every edit tool, and (b) because the shell-redirect
+// guard reads writable, let `run` create such a file even under a scope as broad as
+// ["**/*"] — the very bypass that guard exists to close.
+test("writable and insideWorkspace agree on what escapes the workspace", () => {
+  const CASES: readonly [string, boolean][] = [
+    // Ordinary filenames that merely begin with dots — INSIDE, so writable
+    // whenever the scope matches.
+    ["..secret.ts", true],
+    ["...rc", true],
+    ["..x", true],
+    // Real escapes and absolute paths.
+    ["../escaped.ts", false],
+    ["..", false],
+    ["a/../b.ts", false],
+    ["/etc/passwd", false],
+  ];
+
+  for (const [file, allowed] of CASES) {
+    expect({ file, inside: insideWorkspace(file) }).toEqual({
+      file,
+      inside: allowed,
+    });
+    expect({ file, writable: writable(file, ["**/*"]) }).toEqual({
+      file,
+      writable: allowed,
+    });
+  }
+});

--- a/packages/core/tests/scope.test.ts
+++ b/packages/core/tests/scope.test.ts
@@ -1,5 +1,10 @@
 import { test, expect } from "bun:test";
-import { isInScope, writable, normalizeWorkspacePath } from "../src/lib/scope";
+import {
+  isInScope,
+  writable,
+  insideWorkspace,
+  normalizeWorkspacePath,
+} from "../src/lib/scope";
 
 // The vendored "you cannot edit this file" concept was removed entirely — a model
 // may edit anything in scope, including generated files (the build regenerates
@@ -80,4 +85,38 @@ test("writable allows the co-located test sibling of an in-scope source", () => 
   // allowance lives in writable, not isInScope).
   expect(writable("lexer.ts", scope)).toBe(true);
   expect(isInScope("lexer.test.ts", scope)).toBe(false);
+});
+
+// insideWorkspace decides whether the shell-redirect guard looks at a target at
+// all, so a false negative SKIPS the guard — it must fail closed, treating a path
+// as inside unless a `..` SEGMENT or an absolute root proves otherwise.
+test("insideWorkspace compares path segments, not prefixes", () => {
+  // Ordinary filenames that merely begin with dots are INSIDE.
+  for (const file of ["..secret.ts", "...rc", "..", ".." + "x"]) {
+    expect({ file, inside: insideWorkspace(file) }).toEqual({
+      file,
+      inside: file !== "..",
+    });
+  }
+
+  // Real escapes and absolute paths are OUTSIDE.
+  for (const file of [
+    "../escaped.ts",
+    "../../x",
+    "a/../../b.ts",
+    "/etc/passwd",
+  ]) {
+    expect({ file, inside: insideWorkspace(file) }).toEqual({
+      file,
+      inside: false,
+    });
+  }
+
+  // Plain in-workspace paths are inside.
+  for (const file of ["src/x.ts", "x.ts", "a/b/c.tsx"]) {
+    expect({ file, inside: insideWorkspace(file) }).toEqual({
+      file,
+      inside: true,
+    });
+  }
 });

--- a/packages/core/tests/scope.test.ts
+++ b/packages/core/tests/scope.test.ts
@@ -5,6 +5,7 @@ import {
   insideWorkspace,
   normalizeWorkspacePath,
 } from "../src/lib/scope";
+import { isWin32 } from "../src/lib/platform";
 
 // The vendored "you cannot edit this file" concept was removed entirely — a model
 // may edit anything in scope, including generated files (the build regenerates
@@ -148,6 +149,36 @@ test("writable and insideWorkspace agree on what escapes the workspace", () => {
     expect({ file, writable: writable(file, ["**/*"]) }).toEqual({
       file,
       writable: allowed,
+    });
+  }
+});
+
+// What counts as absolute is platform-dependent, so this pins the semantics of the
+// platform the suite runs on. Hand-rolling the check instead of using
+// node:path.isAbsolute failed OPEN on POSIX: `D:/secret.ts` is an ordinary relative
+// path there (a directory named `D:`), and calling it absolute skipped the
+// shell-write guard for a real workspace file.
+test("insideWorkspace uses this platform's notion of absolute", () => {
+  const windowsForms = [
+    "D:/secret.ts",
+    "D:\\secret.ts",
+    "\\\\server\\share\\x.ts",
+  ];
+
+  for (const file of windowsForms) {
+    expect({ file, inside: insideWorkspace(file) }).toEqual({
+      file,
+      // On Windows these are absolute (outside); on POSIX they are ordinary
+      // relative names (inside) and MUST stay guarded.
+      inside: !isWin32(),
+    });
+  }
+
+  // Always outside, on every platform.
+  for (const file of ["/etc/passwd", "../escaped.ts", "a/../b.ts"]) {
+    expect({ file, inside: insideWorkspace(file) }).toEqual({
+      file,
+      inside: false,
     });
   }
 });

--- a/packages/core/tests/tool-context.test.ts
+++ b/packages/core/tests/tool-context.test.ts
@@ -1,0 +1,59 @@
+import { test, expect } from "bun:test";
+import { resolveWritable } from "../src/loop/tools/tool-context";
+import type { IToolContext } from "../src/loop/tools/execute-tool";
+
+function ctx(files: string[]): IToolContext {
+  return { cwd: "/tmp/proj", files, task: "t", report: () => undefined };
+}
+
+// resolveWritable is the single normalize-then-scope-check step behind every write
+// path. Doing the two separately is what let organize_imports reject in-scope files
+// the model addressed absolutely or as "./x", so both halves are pinned here
+// directly rather than only through its callers.
+test("resolveWritable normalizes before scope-checking", () => {
+  const c = ctx(["src/**"]);
+
+  for (const file of [
+    "src/x.ts",
+    "./src/x.ts",
+    "/tmp/proj/src/x.ts",
+    "src/./x.ts",
+  ]) {
+    expect({ file, ...resolveWritable(c, file) }).toEqual({
+      file,
+      path: "src/x.ts",
+      writable: true,
+    });
+  }
+});
+
+test("resolveWritable refuses an out-of-scope path and one that escapes", () => {
+  const c = ctx(["src/**"]);
+
+  // Inside the workspace but not in scope: normalized, refused.
+  expect(resolveWritable(c, "./secret.ts")).toEqual({
+    path: "secret.ts",
+    writable: false,
+  });
+
+  // Escapes the workspace: never writable, however it is spelled.
+  for (const file of ["../escaped.ts", "/etc/passwd", "src/../../escaped.ts"]) {
+    expect({ file, writable: resolveWritable(c, file).writable }).toEqual({
+      file,
+      writable: false,
+    });
+  }
+});
+
+// An ordinary filename that merely begins with dots is a normal workspace file:
+// writable when the scope matches. A prefix test on ".." made these permanently
+// unwritable through every edit tool.
+test("resolveWritable treats a dotted-but-ordinary name as a normal file", () => {
+  for (const file of ["..secret.ts", "...rc", "..x"]) {
+    expect({ file, ...resolveWritable(ctx([file]), file) }).toEqual({
+      file,
+      path: file,
+      writable: true,
+    });
+  }
+});


### PR DESCRIPTION
From the core harness audit (`docs/plans/2026-08-02-core-audit-findings.md`) — finding **F14**, plus two
scope-predicate bugs found while fixing it.

## F14 — one tool scope-checked the model's raw path

`doOrganizeImports` called `writable()` on the argument straight from the model, while `edit`,
`create` and `edit_lines` all normalize first. Scope globs are workspace-relative, so an **in-scope**
file addressed absolutely or as `./x.ts` was rejected as out of scope by that tool alone:

```
writable("src/x.ts", ["src/**"])            true
writable("/tmp/proj/src/x.ts", ["src/**"])  false   ← normalized: true
writable("./src/x.ts", ["src/**"])          false   ← normalized: true
```

Both forms are ones a model emits routinely. The un-normalized value also reached the LSP call and
the `mutated` payload, so the change scope recorded a different string than the other tools would.

`resolveWritable()` now does normalize-then-scope-check as **one step**, and every single-file write
path goes through it. Splitting that pair is what caused this.

## Two predicate bugs found on the way

- **`writable()` had its own `startsWith("..")` test.** So `..secret.ts`, `...rc` — ordinary
  filenames that merely begin with two dots — were permanently unwritable through every edit tool.
  It also returned **true** for `a/../b.ts`. Escape detection now goes through `insideWorkspace`, so
  both predicates apply one segment rule.
- **Absoluteness is platform-dependent.** My first attempt hand-rolled a cross-platform check, which
  fails *open* on POSIX: `D:/secret.ts` is an ordinary relative path there (a directory named `D:`),
  so it was treated as outside the workspace. Now uses `node:path.isAbsolute`, with segment splitting
  via the repo's `isWin32()`.

## Verification

- `bun run validate` green — 3390 tests, all PTY e2e suites pass. Rules-catalog drift clean.
- Every fix mutation-verified: reverting each one fails exactly its own test and nothing else.
- New `tests/tool-context.test.ts` mirrors `resolveWritable`; `tests/scope.test.ts` pins predicate
  agreement and this platform's notion of absolute; `tests/execute-lsp.test.ts` uses a file per path
  form and asserts the unused import is actually removed and the reported `mutated` path is normalized.

## ⚠️ Panel status: BLOCK, on behaviour this PR does not change

`reviewers ok: 4, errored: 0`. The single finding is that `runShell` lets a redirect to a target
outside the editable scope proceed — e.g. `echo x > ../victim.ts`.

**That is `main`'s behaviour, byte-for-byte.** The only change to that code path here is swapping
`writable(normalizeWorkspacePath(cwd, t), files)` for `resolveWritable(ctx, t).writable` — the same
two operations behind the shared helper. Zero behaviour change; the diff is a refactor.

The finding is real, and it is tracked as **F22/F23**: bounding an arbitrary shell cannot be done by
scanning command text (`sed -i`, `cp`, `$f`, quoted paths, symlinks all defeat it). A change that
did address it was on this branch and blocked five consecutive rounds for exactly that reason; per
ag's call it was split out to `fix/run-redirect-out-of-scope-guard` and is **not** proposed for merge.
The recommended fix is outcome-based — snapshot before `run`, revert out-of-scope changes after —
reusing the existing `file-snapshot.ts` machinery. That is a design decision, not part of this PR.

So this needs your judgement: everything in the diff is green and mutation-verified, and the blocking
finding is pre-existing. Merging does not make it worse.