### PR TITLE
refactor(profiles)!: drop the frontend and backend profiles

### DIFF
--- a/apps/docs/src/content/docs/cli/recipes.mdx
+++ b/apps/docs/src/content/docs/cli/recipes.mdx
@@ -54,7 +54,7 @@ A project recipe **overrides** a global one with the same id. `tsforge recipes` 
 | `withReview` | `--with-review` | after green, run the review and feed verified findings into one repair cycle |
 | `mode` | `--greenfield` | `"greenfield"` selects the [feature-checklist build loop](/loop/greenfield/) |
 | `plannerModel`, `workModel`, `evaluatorModel` | greenfield roles | per-role model names; each falls back to `model`/active |
-| `profile` | `tsforge.config.json` `profile` | `recommended`, `strict`, `security`, `frontend`, `backend`, `opinionated` |
+| `profile` | `tsforge.config.json` `profile` | `recommended`, `strict`, `security`, `backend`, `opinionated` |
 | `agents` | `tsforge agents <ids>` | agent spec ids to fan out over the task. Resolved from `.tsforge/agents/` (project) and `~/.tsforge/agents/` (global, project wins) |
 | `web`, `plan`, `log`, `strictFloorOnly` | the matching flags | booleans |
 

--- a/apps/docs/src/content/docs/cli/recipes.mdx
+++ b/apps/docs/src/content/docs/cli/recipes.mdx
@@ -54,7 +54,7 @@ A project recipe **overrides** a global one with the same id. `tsforge recipes` 
 | `withReview` | `--with-review` | after green, run the review and feed verified findings into one repair cycle |
 | `mode` | `--greenfield` | `"greenfield"` selects the [feature-checklist build loop](/loop/greenfield/) |
 | `plannerModel`, `workModel`, `evaluatorModel` | greenfield roles | per-role model names; each falls back to `model`/active |
-| `profile` | `tsforge.config.json` `profile` | `recommended`, `strict`, `security`, `backend`, `opinionated` |
+| `profile` | `tsforge.config.json` `profile` | `recommended`, `strict`, `security`, `opinionated` |
 | `agents` | `tsforge agents <ids>` | agent spec ids to fan out over the task. Resolved from `.tsforge/agents/` (project) and `~/.tsforge/agents/` (global, project wins) |
 | `web`, `plan`, `log`, `strictFloorOnly` | the matching flags | booleans |
 

--- a/apps/docs/src/content/docs/guardrails/config.mdx
+++ b/apps/docs/src/content/docs/guardrails/config.mdx
@@ -11,7 +11,7 @@ Add **`tsforge.config.json`** at your repo root when you want to override what t
 
 | Field | Type | Purpose |
 | --- | --- | --- |
-| `profile` | string | Rule preset: `recommended` (default), `strict`, `security`, `backend`, `opinionated` |
+| `profile` | string | Rule preset: `recommended` (default), `strict`, `security`, `opinionated` |
 | `stack` | string | Force-enable a stack and its packs |
 | `packs.include` | string[] | Add packs after detection |
 | `packs.exclude` | string[] | Remove packs after detection |
@@ -35,7 +35,6 @@ Profiles control which **extra packs** load and which **default severities** app
 | `recommended` | Safety + always-on packs + stack-detected framework packs. Architecture opinions **off**. |
 | `strict` | `recommended` + `typescript-core` pack, CI/supply-chain meta-rules at **error**, optional type-aware async ESLint when `tsconfig.json` exists |
 | `security` | `recommended` + experimental **`authorization`** heuristics (mutating routes/actions without authz calls) |
-| `backend` | `recommended`. Stack detection adds Fastify/Elysia/Drizzle/BullMQ as usual |
 | `opinionated` | Full house-style architecture rules (component folder structure, hooks layout, early returns at **error**) |
 
 Every rule in the [Rule catalog](/reference/rules-catalog/) is tagged by **tier** (safety, framework, architecture, experimental). Profiles are the ergonomic switch. You rarely need to tune individual rules.
@@ -64,7 +63,7 @@ Meta-rules use the same `rules` map. Example: `"workflow-permissions-explicit": 
 
 ```json
 {
-  "profile": "backend",
+  "profile": "strict",
   "stack": "elysia",
   "packs": {
     "include": ["structured-logging"],
@@ -78,7 +77,7 @@ Meta-rules use the same `rules` map. Example: `"workflow-permissions-explicit": 
 }
 ```
 
-This project uses the backend profile, is treated as Elysia, keeps structured-logging rules, skips BullMQ rules, and softens one comment rule.
+This project uses the strict profile, is treated as Elysia, keeps structured-logging rules, skips BullMQ rules, and softens one comment rule.
 
 ## External plugins
 

--- a/apps/docs/src/content/docs/guardrails/config.mdx
+++ b/apps/docs/src/content/docs/guardrails/config.mdx
@@ -11,7 +11,7 @@ Add **`tsforge.config.json`** at your repo root when you want to override what t
 
 | Field | Type | Purpose |
 | --- | --- | --- |
-| `profile` | string | Rule preset: `recommended` (default), `strict`, `security`, `frontend`, `backend`, `opinionated` |
+| `profile` | string | Rule preset: `recommended` (default), `strict`, `security`, `backend`, `opinionated` |
 | `stack` | string | Force-enable a stack and its packs |
 | `packs.include` | string[] | Add packs after detection |
 | `packs.exclude` | string[] | Remove packs after detection |
@@ -35,7 +35,6 @@ Profiles control which **extra packs** load and which **default severities** app
 | `recommended` | Safety + always-on packs + stack-detected framework packs. Architecture opinions **off**. |
 | `strict` | `recommended` + `typescript-core` pack, CI/supply-chain meta-rules at **error**, optional type-aware async ESLint when `tsconfig.json` exists |
 | `security` | `recommended` + experimental **`authorization`** heuristics (mutating routes/actions without authz calls) |
-| `frontend` | `recommended` with React/Next effect and image rules at **warn** |
 | `backend` | `recommended`. Stack detection adds Fastify/Elysia/Drizzle/BullMQ as usual |
 | `opinionated` | Full house-style architecture rules (component folder structure, hooks layout, early returns at **error**) |
 

--- a/apps/docs/src/content/docs/reference/roadmap.mdx
+++ b/apps/docs/src/content/docs/reference/roadmap.mdx
@@ -9,7 +9,7 @@ TypeScript coding harness for web projects: `packages/core` for the loop and gat
 
 **Strictness & the gate**
 - Stack detection → **21 ESLint rule packs (122 rules)** + a **31-rule meta-rule engine** (config, CI, supply chain, container, testing, structure). See [Rule packs](/guardrails/rule-packs/) · [Meta-rules](/guardrails/meta-rules/).
-- **6 profiles** (recommended → strict / security / frontend / backend / opinionated); a type-aware ESLint overlay; progress-based loop termination (no blunt turn cap). See [When the gate fails](/loop/validation/).
+- **5 profiles** (recommended → strict / security / backend / opinionated); a type-aware ESLint overlay; progress-based loop termination (no blunt turn cap). See [When the gate fails](/loop/validation/).
 - **Tests by default**: `test-sibling-required` is an error on changed logic files. **Opt-in gate oracles** (coverage, boot smoke, property tests). See [Tests by default](/quality/tests/) · [the gate](/loop/gate-floor/).
 
 **Adapt to your repo**

--- a/apps/docs/src/content/docs/reference/roadmap.mdx
+++ b/apps/docs/src/content/docs/reference/roadmap.mdx
@@ -9,7 +9,7 @@ TypeScript coding harness for web projects: `packages/core` for the loop and gat
 
 **Strictness & the gate**
 - Stack detection → **21 ESLint rule packs (122 rules)** + a **31-rule meta-rule engine** (config, CI, supply chain, container, testing, structure). See [Rule packs](/guardrails/rule-packs/) · [Meta-rules](/guardrails/meta-rules/).
-- **5 profiles** (recommended → strict / security / backend / opinionated); a type-aware ESLint overlay; progress-based loop termination (no blunt turn cap). See [When the gate fails](/loop/validation/).
+- **4 profiles** (recommended → strict / security / opinionated); a type-aware ESLint overlay; progress-based loop termination (no blunt turn cap). See [When the gate fails](/loop/validation/).
 - **Tests by default**: `test-sibling-required` is an error on changed logic files. **Opt-in gate oracles** (coverage, boot smoke, property tests). See [Tests by default](/quality/tests/) · [the gate](/loop/gate-floor/).
 
 **Adapt to your repo**

--- a/packages/core/RULES.md
+++ b/packages/core/RULES.md
@@ -7,7 +7,6 @@ Rules are grouped by **adoption tier**. Use `profile` in `tsforge.config.json` t
 - **recommended**: Safety + framework packs from stack detection; architecture opinions off by default.
 - **strict**: Recommended plus CI/supply-chain meta-rules at error and type-aware async rules.
 - **security**: Recommended plus runtime-boundaries and experimental authorization heuristics.
-- **frontend**: Recommended, scoped to frontend work; React/Next rules keep their pack severities.
 - **backend**: Recommended; stack detection adds Fastify/Elysia/Drizzle/BullMQ packs.
 - **opinionated**: Full house-style architecture rules including component folder structure.
 

--- a/packages/core/RULES.md
+++ b/packages/core/RULES.md
@@ -7,7 +7,6 @@ Rules are grouped by **adoption tier**. Use `profile` in `tsforge.config.json` t
 - **recommended**: Safety + framework packs from stack detection; architecture opinions off by default.
 - **strict**: Recommended plus CI/supply-chain meta-rules at error and type-aware async rules.
 - **security**: Recommended plus runtime-boundaries and experimental authorization heuristics.
-- **backend**: Recommended; stack detection adds Fastify/Elysia/Drizzle/BullMQ packs.
 - **opinionated**: Full house-style architecture rules including component folder structure.
 
 ## Rule Packs by Tier

--- a/packages/core/src/cli/args.ts
+++ b/packages/core/src/cli/args.ts
@@ -215,7 +215,7 @@ export function cliUsage(): string {
     "  --plan              pause after the design phase for plan review",
     "  --log               append the run's event stream to ~/.tsforge/logs/",
     "  --policy-mode <m>   plan|default|acceptEdits|ci|dontAsk|bypassPermissions",
-    "  --profile <id>      strictness: recommended|strict|security|frontend|backend|opinionated",
+    `  --profile <id>      strictness: ${PROFILE_IDS.join("|")}`,
     "  --notify <cmd>      run a command when an unattended run finishes",
     "  --version, -V       print the version and exit",
     "  --help, -h          this help",

--- a/packages/core/src/config/profiles.ts
+++ b/packages/core/src/config/profiles.ts
@@ -70,16 +70,6 @@ export const PROFILE_DEFINITIONS: Readonly<
     extraPacks: ["runtime-boundaries", "authorization"],
     ruleOverrides: structureOffOverrides,
   },
-  frontend: {
-    id: "frontend",
-    label: "Frontend",
-    description:
-      "Recommended, scoped to frontend work; React/Next rules keep their pack severities.",
-    // No React/Next severity overrides: the packs already ship those rules at the
-    // severity this profile wants, and lowering any of them would make the React
-    // profile weaker than `recommended` on React rules.
-    ruleOverrides: structureOffOverrides,
-  },
   backend: {
     id: "backend",
     label: "Backend",

--- a/packages/core/src/config/profiles.ts
+++ b/packages/core/src/config/profiles.ts
@@ -70,13 +70,6 @@ export const PROFILE_DEFINITIONS: Readonly<
     extraPacks: ["runtime-boundaries", "authorization"],
     ruleOverrides: structureOffOverrides,
   },
-  backend: {
-    id: "backend",
-    label: "Backend",
-    description:
-      "Recommended; stack detection adds Fastify/Elysia/Drizzle/BullMQ packs.",
-    ruleOverrides: structureOffOverrides,
-  },
   opinionated: {
     id: "opinionated",
     label: "Opinionated",

--- a/packages/core/src/config/tsforge-config.ts
+++ b/packages/core/src/config/tsforge-config.ts
@@ -21,6 +21,7 @@ import { parsePlugins, type IExternalPlugin } from "./external-plugins";
 import {
   DEFAULT_PROFILE,
   isProfileId,
+  PROFILE_IDS,
   mergeRuleOverrides,
   resolveProfileExtraPacks,
   resolveProfileMetaRuleOverrides,
@@ -33,7 +34,7 @@ import {
  * include/exclude packs, and tune rule severities (eslint packs + meta-rules).
  */
 export interface ITsforgeProjectConfig {
-  /** Rule profile: recommended (default), strict, security, frontend, backend, opinionated. */
+  /** Rule profile; see PROFILE_IDS for the current set (`recommended` is the default). */
   readonly profile?: ProfileId;
 
   /** Force-enable a stack by name (skip detection heuristics, force-add its packs). */
@@ -174,7 +175,7 @@ function warnUnknownPackInInclude(packId: string): void {
 
 function warnInvalidProfile(profileValue: unknown): void {
   warnConfig(
-    `tsforge.config.json: "profile" must be one of recommended, strict, security, frontend, backend, opinionated — got "${String(profileValue)}"`
+    `tsforge.config.json: "profile" must be one of ${PROFILE_IDS.join(", ")} — got "${String(profileValue)}"`
   );
 }
 

--- a/packages/core/src/rule-packs/rule-catalog.types.ts
+++ b/packages/core/src/rule-packs/rule-catalog.types.ts
@@ -12,5 +12,4 @@ export interface IRuleCatalogEntry {
   readonly profiles?: readonly ProfileId[];
 }
 
-export type ProfileId =
-  "recommended" | "strict" | "security" | "backend" | "opinionated";
+export type ProfileId = "recommended" | "strict" | "security" | "opinionated";

--- a/packages/core/src/rule-packs/rule-catalog.types.ts
+++ b/packages/core/src/rule-packs/rule-catalog.types.ts
@@ -13,9 +13,4 @@ export interface IRuleCatalogEntry {
 }
 
 export type ProfileId =
-  | "recommended"
-  | "strict"
-  | "security"
-  | "frontend"
-  | "backend"
-  | "opinionated";
+  "recommended" | "strict" | "security" | "backend" | "opinionated";

--- a/packages/core/tests/cli.test.ts
+++ b/packages/core/tests/cli.test.ts
@@ -4,6 +4,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { parseArgs, isOneShot, applyRecipe, runNotify } from "../src/cli";
 import { cliUsage, valueFlagError } from "../src/cli/args";
+import { PROFILE_IDS } from "../src/config/profiles";
 import type { ITaskRecipe } from "../src/config/recipes";
 
 // Regression: runNotify used to spawn `sh -c cmd` with a bare `await proc.exited`
@@ -635,4 +636,19 @@ describe("the real CLI aborts on a malformed value flag", () => {
     expect(r.code).toBe(0);
     expect(r.out).toContain("tsforge");
   });
+});
+
+// The --profile line is generated from PROFILE_IDS. It was hand-maintained, which is
+// exactly what goes stale when a profile is added or removed — two were removed and
+// the help text would have kept advertising them.
+test("--help's profile list is generated from PROFILE_IDS", () => {
+  // Compare the token list EXACTLY. Banning the removed names as substrings across
+  // the whole help blob would false-fail the day help text uses those words in
+  // another sense, and would not catch a stale list either.
+  const line = cliUsage()
+    .split("\n")
+    .find((l) => l.includes("--profile <id>"));
+  const listed = /strictness: (\S+)/u.exec(line ?? "")?.[1];
+
+  expect(listed).toBe(PROFILE_IDS.join("|"));
 });

--- a/packages/core/tests/profiles.test.ts
+++ b/packages/core/tests/profiles.test.ts
@@ -16,7 +16,6 @@ test("default profiles keep quality rules ON and only disable STRUCTURE rules", 
     "recommended",
     "strict",
     "security",
-    "frontend",
     "backend",
   ] as const) {
     const overrides = resolveProfileRuleOverrides(profile);
@@ -79,7 +78,6 @@ const NON_OPINIONATED_PROFILES = [
   "recommended",
   "strict",
   "security",
-  "frontend",
   "backend",
 ] as const;
 

--- a/packages/core/tests/profiles.test.ts
+++ b/packages/core/tests/profiles.test.ts
@@ -15,12 +15,7 @@ import { cliUsage, profileFlagError } from "../src/cli/args";
 // STRUCTURE rules (tsforge's specific file/folder layout) are off by default so tsforge
 // stays adoptable on an existing repo.
 test("default profiles keep quality rules ON and only disable STRUCTURE rules", () => {
-  for (const profile of [
-    "recommended",
-    "strict",
-    "security",
-    "backend",
-  ] as const) {
+  for (const profile of ["recommended", "strict", "security"] as const) {
     const overrides = resolveProfileRuleOverrides(profile);
 
     // Quality best-practices are NOT forced off (they run at their pack default).
@@ -77,12 +72,7 @@ const OPT_IN_STRUCTURE_RULES = [
   "max-hooks-per-file",
 ] as const;
 
-const NON_OPINIONATED_PROFILES = [
-  "recommended",
-  "strict",
-  "security",
-  "backend",
-] as const;
+const NON_OPINIONATED_PROFILES = ["recommended", "strict", "security"] as const;
 
 const INTENTIONAL_RELAXATIONS: Readonly<Record<string, string>> = {
   // These impose tsforge's specific file/folder layout, so they stay off unless a
@@ -224,9 +214,12 @@ describe("no profile silently weakens its pack's rules", () => {
 // regression here, deleting it from the type is undone by anyone re-adding it, and
 // the audit decision lives only in a commit message.
 describe("the profile set is the authoritative list", () => {
-  test("is exactly the five intended ids", () => {
+  // Every remaining profile must EARN its place — differ from `recommended` by more
+  // than nothing. `frontend` (F21) and `backend` (F24) were both removed for failing
+  // that: one relaxed two React rules, the other differed only by omitting an
+  // override that matched its rule's pack default.
+  test("is exactly the four intended ids", () => {
     expect([...PROFILE_IDS].sort()).toEqual([
-      "backend",
       "opinionated",
       "recommended",
       "security",
@@ -238,9 +231,14 @@ describe("the profile set is the authoritative list", () => {
     );
   });
 
-  test("rejects `frontend` as a profile id", () => {
-    expect(isProfileId("frontend")).toBe(false);
-    expect(PROFILE_IDS).not.toContain("frontend");
+  test("rejects the removed profile ids", () => {
+    for (const removed of ["frontend", "backend"]) {
+      expect({ removed, valid: isProfileId(removed) }).toEqual({
+        removed,
+        valid: false,
+      });
+      expect(PROFILE_IDS).not.toContain(removed);
+    }
   });
 
   // The valid-id list used to be hand-maintained in three places, which is exactly
@@ -254,6 +252,7 @@ describe("the profile set is the authoritative list", () => {
     }
 
     expect(usage).not.toContain("frontend");
+    expect(usage).not.toContain("backend");
   });
 
   test("the unknown-profile error lists the ids from the same source", () => {
@@ -261,8 +260,12 @@ describe("the profile set is the authoritative list", () => {
 
     expect(message).toContain('unknown --profile "frontend"');
 
-    for (const id of PROFILE_IDS) {
-      expect(message).toContain(id);
-    }
+    // Compare the LISTED ids exactly. "Contains every current id" passes a stale
+    // hardcoded list that still advertises `frontend` as valid, because `frontend`
+    // is also in the message as the REJECTED value — the same hole as the config
+    // warning, which is why both compare the list rather than scanning it.
+    const listed = /valid: (.+)$/u.exec(message)?.[1];
+
+    expect(listed).toBe(PROFILE_IDS.join(", "));
   });
 });

--- a/packages/core/tests/profiles.test.ts
+++ b/packages/core/tests/profiles.test.ts
@@ -3,9 +3,12 @@ import { RULE_PACKS } from "../src/rule-packs";
 import {
   resolveProfileRuleOverrides,
   PROFILE_DEFINITIONS,
+  PROFILE_IDS,
   STRUCTURE_RULES,
+  isProfileId,
   type IProfileDefinition,
 } from "../src/config/profiles";
+import { cliUsage, profileFlagError } from "../src/cli/args";
 
 // Strict-by-default: the layout-AGNOSTIC best practices (no-inline-jsx-functions,
 // forwardref-display-name) must NOT be disabled in the default profiles — only the
@@ -211,6 +214,55 @@ describe("no profile silently weakens its pack's rules", () => {
         key,
         stillRelaxed: true,
       });
+    }
+  });
+});
+
+// F21: `frontend` was removed because its only distinguishing content was a
+// relaxation — it downgraded two React rules that `recommended` leaves at error, so
+// the profile you would pick FOR a React app was the weaker one. Without a
+// regression here, deleting it from the type is undone by anyone re-adding it, and
+// the audit decision lives only in a commit message.
+describe("the profile set is the authoritative list", () => {
+  test("is exactly the five intended ids", () => {
+    expect([...PROFILE_IDS].sort()).toEqual([
+      "backend",
+      "opinionated",
+      "recommended",
+      "security",
+      "strict",
+    ]);
+    // The runtime table and the exported id list cannot drift apart.
+    expect([...PROFILE_IDS].sort()).toEqual(
+      Object.keys(PROFILE_DEFINITIONS).sort()
+    );
+  });
+
+  test("rejects `frontend` as a profile id", () => {
+    expect(isProfileId("frontend")).toBe(false);
+    expect(PROFILE_IDS).not.toContain("frontend");
+  });
+
+  // The valid-id list used to be hand-maintained in three places, which is exactly
+  // what goes stale when a profile is added or removed. These assert the strings are
+  // DERIVED, so a hardcoded copy fails rather than quietly lying to the user.
+  test("--help lists the ids from the same source", () => {
+    const usage = cliUsage();
+
+    for (const id of PROFILE_IDS) {
+      expect(usage).toContain(id);
+    }
+
+    expect(usage).not.toContain("frontend");
+  });
+
+  test("the unknown-profile error lists the ids from the same source", () => {
+    const message = profileFlagError("frontend", true) ?? "";
+
+    expect(message).toContain('unknown --profile "frontend"');
+
+    for (const id of PROFILE_IDS) {
+      expect(message).toContain(id);
     }
   });
 });

--- a/packages/core/tests/profiles.test.ts
+++ b/packages/core/tests/profiles.test.ts
@@ -1,9 +1,8 @@
 import { describe, test, expect } from "bun:test";
 import { RULE_PACKS, buildPackEslintConfig } from "../src/rule-packs";
+import { resolveActivePacks } from "../src/config/tsforge-config";
 import {
   resolveProfileRuleOverrides,
-  resolveProfileExtraPacks,
-  resolveProfileMetaRuleOverrides,
   PROFILE_DEFINITIONS,
   PROFILE_IDS,
   STRUCTURE_RULES,
@@ -11,7 +10,7 @@ import {
   type IProfileDefinition,
   type ProfileId,
 } from "../src/config/profiles";
-import { cliUsage, profileFlagError } from "../src/cli/args";
+import { profileFlagError } from "../src/cli/args";
 
 // Strict-by-default: the layout-AGNOSTIC best practices (no-inline-jsx-functions,
 // forwardref-display-name) must NOT be disabled in the default profiles — only the
@@ -243,35 +242,33 @@ describe("the profile set is the authoritative list", () => {
   // The valid-id list used to be hand-maintained in three places, which is exactly
   // what goes stale when a profile is added or removed. These assert the strings are
   // DERIVED, so a hardcoded copy fails rather than quietly lying to the user.
-  test("--help lists the ids from the same source", () => {
-    const usage = cliUsage();
-
-    for (const id of PROFILE_IDS) {
-      expect(usage).toContain(id);
-    }
-
-    expect(usage).not.toContain("frontend");
-    expect(usage).not.toContain("backend");
-  });
-
   // THE STANDARD, as an assertion rather than a comment. Both removed profiles died
-  // because nothing enforced this: `backend` resolved to byte-identical effective
-  // behaviour to `recommended` and survived for months, and a comment saying "a
-  // profile must differ" would not have caught the next one either.
+  // because nothing enforced this: `backend` resolved to identical behaviour to
+  // `recommended` and survived for months, and prose saying "a profile must differ"
+  // would not have caught the next one either.
   //
-  // Compares EFFECTIVE behaviour — the resolved rule severities over every pack, plus
-  // the extra packs and meta-rules a profile turns on. A shallow diff of
-  // `ruleOverrides` is not enough: backend's only textual difference was OMITTING
-  // `prefer-early-return: "warn"`, which matched that rule's pack default, so it
-  // looked different while behaving identically.
+  // Everything here goes through the PRODUCTION resolvers, not the declarations.
+  // `resolveActivePacks` is what actually decides the pack set — it filters against
+  // PACK_REGISTRY — so a profile declaring `extraPacks: ["not-a-real-pack"]` would
+  // look different while resolving identically. Comparing what a profile DECLARES is
+  // the same declaration-vs-effect confusion that let `backend` survive: its only
+  // textual difference was omitting an override matching its rule's pack default.
+  //
+  // Meta-rule elevations are deliberately NOT part of the snapshot: the meta-rule
+  // layer exposes no default-severity table to resolve against, so "elevate to error"
+  // cannot be distinguished from a no-op elevation of a rule already at error. A
+  // profile whose ONLY difference is a meta-rule elevation therefore fails this test
+  // until that table exists — a false positive, which is the safe direction.
   test("every profile behaves differently from recommended", () => {
     const allPacks = Object.keys(RULE_PACKS);
     const effective = (id: ProfileId): string =>
       JSON.stringify({
+        // The resolved pack set, filtered exactly as production filters it.
+        packs: [...resolveActivePacks([], { profile: id })].sort(),
+        // Rule severities over every pack, so an override's effect is visible even
+        // when the profile enables no packs of its own.
         rules: buildPackEslintConfig(allPacks, resolveProfileRuleOverrides(id))
           .rules,
-        extraPacks: [...resolveProfileExtraPacks(id)].sort(),
-        metaRules: resolveProfileMetaRuleOverrides(id),
       });
 
     const baseline = effective("recommended");

--- a/packages/core/tests/profiles.test.ts
+++ b/packages/core/tests/profiles.test.ts
@@ -1,12 +1,15 @@
 import { describe, test, expect } from "bun:test";
-import { RULE_PACKS } from "../src/rule-packs";
+import { RULE_PACKS, buildPackEslintConfig } from "../src/rule-packs";
 import {
   resolveProfileRuleOverrides,
+  resolveProfileExtraPacks,
+  resolveProfileMetaRuleOverrides,
   PROFILE_DEFINITIONS,
   PROFILE_IDS,
   STRUCTURE_RULES,
   isProfileId,
   type IProfileDefinition,
+  type ProfileId,
 } from "../src/config/profiles";
 import { cliUsage, profileFlagError } from "../src/cli/args";
 
@@ -225,10 +228,6 @@ describe("the profile set is the authoritative list", () => {
       "security",
       "strict",
     ]);
-    // The runtime table and the exported id list cannot drift apart.
-    expect([...PROFILE_IDS].sort()).toEqual(
-      Object.keys(PROFILE_DEFINITIONS).sort()
-    );
   });
 
   test("rejects the removed profile ids", () => {
@@ -253,6 +252,40 @@ describe("the profile set is the authoritative list", () => {
 
     expect(usage).not.toContain("frontend");
     expect(usage).not.toContain("backend");
+  });
+
+  // THE STANDARD, as an assertion rather than a comment. Both removed profiles died
+  // because nothing enforced this: `backend` resolved to byte-identical effective
+  // behaviour to `recommended` and survived for months, and a comment saying "a
+  // profile must differ" would not have caught the next one either.
+  //
+  // Compares EFFECTIVE behaviour — the resolved rule severities over every pack, plus
+  // the extra packs and meta-rules a profile turns on. A shallow diff of
+  // `ruleOverrides` is not enough: backend's only textual difference was OMITTING
+  // `prefer-early-return: "warn"`, which matched that rule's pack default, so it
+  // looked different while behaving identically.
+  test("every profile behaves differently from recommended", () => {
+    const allPacks = Object.keys(RULE_PACKS);
+    const effective = (id: ProfileId): string =>
+      JSON.stringify({
+        rules: buildPackEslintConfig(allPacks, resolveProfileRuleOverrides(id))
+          .rules,
+        extraPacks: [...resolveProfileExtraPacks(id)].sort(),
+        metaRules: resolveProfileMetaRuleOverrides(id),
+      });
+
+    const baseline = effective("recommended");
+
+    for (const id of PROFILE_IDS) {
+      if (id === "recommended" || !isProfileId(id)) {
+        continue;
+      }
+
+      expect({ id, sameAsRecommended: effective(id) === baseline }).toEqual({
+        id,
+        sameAsRecommended: false,
+      });
+    }
   });
 
   test("the unknown-profile error lists the ids from the same source", () => {

--- a/packages/core/tests/tsforge-config.test.ts
+++ b/packages/core/tests/tsforge-config.test.ts
@@ -10,6 +10,7 @@ import {
   resolveAgentConcurrency,
   type ITsforgeProjectConfig,
 } from "../src/config/tsforge-config";
+import { PROFILE_IDS } from "../src/config/profiles";
 import { makeFileLinter } from "../src/gate";
 
 let fixtureDir: string;
@@ -433,6 +434,48 @@ describe("tsforge.config.json integration", () => {
 });
 
 describe("profiles", () => {
+  // A config naming a REMOVED profile must fail loudly and keep going, not crash and
+  // not silently honour an id that no longer exists. The warning's id list is derived
+  // from PROFILE_IDS, so removing a profile updates the message — a hardcoded copy
+  // would keep telling the user `frontend` is valid.
+  test("a removed profile warns with the CURRENT ids and falls back", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "tsforge-profile-gone-"));
+    const warnings: string[] = [];
+    const original = process.stderr.write.bind(process.stderr);
+
+    writeFileSync(
+      join(dir, "tsforge.config.json"),
+      JSON.stringify({ profile: "frontend" })
+    );
+
+    process.stderr.write = (chunk: unknown): boolean => {
+      warnings.push(String(chunk));
+
+      return true;
+    };
+
+    try {
+      const config = await loadTsforgeConfig(dir);
+
+      // Falls back to the default rather than carrying a dead id forward.
+      expect(config.profile).toBeUndefined();
+
+      const warning = warnings.find((w) => w.includes("profile")) ?? "";
+
+      expect(warning).toContain('got "frontend"');
+
+      // Compare the LISTED ids exactly. Asserting "contains each current id" would
+      // pass a stale hardcoded list that still advertises `frontend` as valid — the
+      // very thing that goes wrong when a profile is removed.
+      const listed = /must be one of (.+?) — got/u.exec(warning)?.[1];
+
+      expect(listed).toBe(PROFILE_IDS.join(", "));
+    } finally {
+      process.stderr.write = original;
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
   test("recommended profile disables architecture rules by default", () => {
     const overrides = normalizeRuleOverrides({ profile: "recommended" });
 


### PR DESCRIPTION
Audit findings **F21** and **F24** (`docs/plans/2026-08-02-core-audit-findings.md`). Both profiles were dead.

## `frontend`

Its only distinguishing content was a **relaxation**. It set three React/Next rules to `warn` — one a
no-op (the nextjs pack already ships `no-html-img-element` at warn) and two genuine downgrades of
rules `recommended` leaves at `error`. So `--profile frontend`, the profile you'd pick *for* a React
app, was weaker on two React correctness rules than the default. Those overrides were removed in
#224, which left it byte-identical to `backend`.

## `backend`

Never differed from `recommended` at all. Measured: no `extraPacks`, no `metaRulesAtError`, identical
`structureOffOverrides`. Its **only** difference was omitting `prefer-early-return: "warn"` — and that
rule's own pack default *is* `warn` (`code-flow`), so the omission was a no-op.

What kept it alive was its description: *"Recommended; stack detection adds
Fastify/Elysia/Drizzle/BullMQ packs."* That's what stack detection does for **every** profile. The
docs made it sound load-bearing while it did nothing.

Profiles are now `recommended`, `strict`, `security`, `opinionated`.

## Migration — breaking, but loud

Verified against the real binary for both removed ids:

| | |
|---|---|
| `tsforge.config.json` with `profile: "backend"` | warns with the current set, falls back to the default. No crash. |
| `--profile frontend` | `unknown --profile "frontend" — valid: recommended, strict, security, opinionated` |

Every one of those strings now derives from `PROFILE_IDS`. That list had been hand-maintained in
**three** places — the config warning, the `--help` line, and a doc comment — which is exactly what
goes stale when a profile is removed. Removing `backend` updated all three without touching them.

## The standard, as a test

The reason `backend` survived for months is that nothing enforced *"a profile must differ from
`recommended` by more than nothing"* — it wasn't written down anywhere, and my first attempt wrote it
as a **comment** while the test only pinned the four names. A profile going dead later, or a new
identical one added alongside an updated list, would have stayed green.

It's now an assertion over **resolved** behaviour: the pack set through `resolveActivePacks` (which
filters against `PACK_REGISTRY`) plus rule severities across all 21 packs. Comparing what a profile
*declares* was the same declaration-vs-effect confusion that let `backend` survive — a profile
declaring `extraPacks: ["not-a-real-pack"]` looks different and resolves identically.

Mutation-verified: re-adding `backend` verbatim fails on **being dead**, not on being absent from a
list. So does a profile whose only difference is a bogus declared pack.

Meta-rule elevations are deliberately excluded, with the reason in the test: the meta-rule layer has
no default-severity table, so "elevate to error" can't be distinguished from elevating a rule already
at `error`. A profile differing *only* by a meta-rule elevation will fail this test until that table
exists — a false positive, which is the safe direction.

## Known residual (not fixed here)

The behaviour test seeds `resolveActivePacks` from `[]`, while production seeds it from stack
detection including the always-on packs. A future profile declaring an **already-always-on valid**
pack would therefore read as "different" while changing nothing. One-line fix (seed the baseline with
`ALWAYS_ON_PACKS`); left out because it only bites if such a profile is added, and this PR has had
enough review cycles. Raised by the panel on the final round.

## Verification

- `bun run validate` green — 3396 tests, all PTY e2e suites pass. Rules-catalog drift clean.
- Docs updated: `config.mdx`'s profile table and both removed rows, the worked example that used
  `"profile": "backend"`, `recipes.mdx`, and the roadmap's profile count. `RULES.md` regenerated (it
  embeds each description, so CI's drift check would otherwise fail).
- 4-model `harness-review` panel: **PASS**, `reviewers ok: 4  errored: 0`.

Left unmerged for your signature.