### PR TITLE
refactor(inference): express reasoning as a declarative profile, not a vendor enum

### DIFF
--- a/apps/docs/src/content/docs/inference/models-json.mdx
+++ b/apps/docs/src/content/docs/inference/models-json.mdx
@@ -31,34 +31,71 @@ The entry **key** (`"deepseek"`) is just a local label. The field that's sent to
 | `baseUrl` | yes | OpenAI-compatible API root, e.g. `https://api.deepseek.com/v1`. `/chat/completions` is appended (and not double-appended). |
 | `model` | yes | The model id sent to the API. |
 | `apiKey` / `apiKeyEnv` | no | Inline key, or the name of an env var holding it (preferred: keeps secrets out of the file). |
-| `reasoning` | no | Provider thinking dialect: `qwen` (default), `deepseek`, `vllm`, `openai`, `none`. See below. Auto-detected when `baseUrl` or `model` contains "deepseek": **`vllm`** on a private address, **`deepseek`** on a public one. |
-| `reasoningEffort` | no | `low` / `medium` / `high` for `deepseek`/`vllm`/`openai`. |
+| `reasoning` | no | Provider thinking dialect: `qwen` (default), `deepseek`, `deepseek-local`, `openai`, `none`. See below. Auto-detected when `baseUrl` or `model` contains "deepseek": **`deepseek-local`** on a private address, **`deepseek`** on a public one. |
+| `reasoningEffort` | no | `low` / `medium` / `high` for `deepseek`/`deepseek-local`/`openai`. |
 | `contextWindow` | no | Tokens, for the status gauge + auto-compaction. Auto-detected from `/models` when omitted. |
 | `maxTokens` | no | Output-token cap (default 16384). |
 | `extraBody` | no | Arbitrary JSON merged into the request body (overrides built-ins). The escape hatch for any provider param. |
 | `extraHeaders` | no | Arbitrary request headers; `${VAR}` values are interpolated from the environment. |
 | `imageApi` | no | For an `imageGen` capability entry only: wire shape. `chat-modalities` (default; `/chat/completions` with `modalities:["image","text"]`, e.g. OpenRouter/Gemini) or `images-generations` (OpenAI `/images/generations`). |
 
-## Reasoning dialects
+## Reasoning: presets, or declare your own
 
-Providers express "thinking" differently. `reasoning` picks the wire shape:
+tsforge has three internal reasoning concepts — thinking on/off, effort, token budget — and every endpoint spells them differently on the wire. `reasoning` says how *yours* spells them. It takes either a **preset name** for a common case, or a **profile object** that declares the field paths itself.
 
-| `reasoning` | Sends | Notes |
-| --- | --- | --- |
-| `qwen` (default) | `chat_template_kwargs.enable_thinking`, `thinking_token_budget` | vLLM/Qwen. |
-| `deepseek` | `thinking: { type: "enabled"\|"disabled" }`, `reasoning_effort` | DeepSeek's **cloud** API. Omits `tool_choice` entirely (its thinking mode rejects an explicit one). The model still gets the tools and decides. Thinking is latched to the session's first value, because the API 400s if it flips mid-conversation. |
-| `vllm` | `chat_template_kwargs.thinking`, `reasoning_effort` | A **self-hosted** vLLM serving a reasoning checkpoint. Per-call, never latched. |
-| `openai` | `reasoning_effort` | Uses `max_completion_tokens` and omits `temperature` (o-series rejects both). |
-| `none` | — | No reasoning params. |
+The profile is the real interface. Presets are just aliases over it, so a model nobody has heard of is a config edit, not a code change and a release.
+
+### Presets
+
+| Name | Expands to |
+| --- | --- |
+| `qwen` (default) | `chat_template_kwargs.enable_thinking`, budget at `thinking_token_budget` |
+| `deepseek` | `thinking: { type: "enabled"\|"disabled" }`, effort at `reasoning_effort`, plus `replayReasoning` and `latchThinking` |
+| `deepseek-local` | `chat_template_kwargs: { thinking, reasoning_effort }`, budget at `thinking_token_budget` |
+| `openai` | effort at `reasoning_effort`, token cap renamed to `max_completion_tokens`, `omitTemperature` |
+| `none` | nothing |
+
+### Declaring a profile
+
+```jsonc
+{
+  "baseUrl": "http://my-server:8000/v1",
+  "model": "some-model",
+  "reasoning": {
+    "thinking": { "path": "params.reasoning.enabled" },  // dot path into the body
+    "effort":   "params.reasoning.level",
+    "budget":   "params.reasoning.max_tokens",
+    "tokenCap": "output_limit",                          // default: max_tokens
+    "omitTemperature": false,
+    "omitToolChoice":  false,
+    "replayReasoning": false,
+    "latchThinking":   false
+  }
+}
+```
+
+Every field is optional, and **an omitted control means the endpoint doesn't have one**, so nothing is sent for it. That's the point: a field the server would accept-and-ignore is never sent in the first place.
+
+`thinking` takes `onValue`/`offValue` when the flag isn't a plain boolean:
+
+```jsonc
+"thinking": { "path": "mode", "onValue": { "kind": "deep" }, "offValue": { "kind": "off" } }
+```
+
+The last two flags are behavioural rather than cosmetic, and exist because DeepSeek's cloud API demands them: `replayReasoning` re-sends each prior turn's `reasoning_content` (it 400s without), and `latchThinking` pins thinking to the session's first value (it 400s if it flips mid-conversation).
 
 ### Auto-detection
 
 When `baseUrl`/`model` contains "deepseek", tsforge picks the dialect by address:
 
-- **private** (loopback, `10.x`, `172.16–31.x`, `192.168.x`, `169.254.x`, `.local`/`.lan`/`.internal`) → `vllm`
+- **private** (loopback, `10.x`, `172.16–31.x`, `192.168.x`, `169.254.x`, `.local`/`.lan`/`.internal`/`.home`/`.localdomain`) → `deepseek-local`
 - **public** → `deepseek`, and each turn's `reasoning_content` is replayed on the next request (the cloud API 400s otherwise)
 
-The split matters because the two speak different wire formats for the same feature. A self-hosted vLLM reads `chat_template_kwargs.thinking` and **silently ignores** DeepSeek cloud's `thinking: { type }` — it accepts the field and does nothing with it. Sending the cloud dialect to a local server therefore makes `thinking` inert: it only appears to work when the server's own default happens to match what you wanted.
+The split matters because the two speak different wire formats for the same feature. A locally served DeepSeek checkpoint reads `chat_template_kwargs.thinking` and **silently ignores** DeepSeek cloud's `thinking: { type }` — it accepts the field and does nothing with it. Sending the cloud dialect to a local server therefore makes `thinking` inert: it only appears to work when the server's own default happens to match what you wanted.
+
+:::caution
+`deepseek-local` is named for the **model family**, not the server. The `thinking` flag is a kwarg of the DeepSeek-V4 chat template, which a runtime like vLLM merely forwards — it is not a vLLM-wide field. Qwen's template declares `enable_thinking` instead (that's the `qwen` dialect), and a Llama or Mistral behind the same vLLM declares neither. Don't set `deepseek-local` on a non-DeepSeek model just because it's self-hosted; the field would be accepted and ignored.
+:::
 
 Detection is deliberately conservative on public hosts, since one may be a reverse proxy in front of DeepSeek cloud, which still needs the cloud dialect. Set `reasoning` explicitly for a self-hosted endpoint on a public address, or for a DeepSeek-compatible gateway that hides the string in its URL/model name.
 

--- a/apps/docs/src/content/docs/inference/models-json.mdx
+++ b/apps/docs/src/content/docs/inference/models-json.mdx
@@ -50,7 +50,7 @@ The profile is the real interface. Presets are just aliases over it, so a model 
 | Name | Expands to |
 | --- | --- |
 | `qwen` (default) | `chat_template_kwargs.enable_thinking`, budget at `thinking_token_budget` |
-| `deepseek` | `thinking: { type: "enabled"\|"disabled" }`, effort at `reasoning_effort`, plus `replayReasoning` and `latchThinking` |
+| `deepseek` | `thinking: { type: "enabled"\|"disabled" }`, effort at `reasoning_effort`, plus `omitToolChoice`, `replayReasoning` and `latchThinking` |
 | `deepseek-local` | `chat_template_kwargs: { thinking, reasoning_effort }`, budget at `thinking_token_budget` |
 | `openai` | effort at `reasoning_effort`, token cap renamed to `max_completion_tokens`, `omitTemperature` |
 | `none` | nothing |
@@ -82,7 +82,11 @@ Every field is optional, and **an omitted control means the endpoint doesn't hav
 "thinking": { "path": "mode", "onValue": { "kind": "deep" }, "offValue": { "kind": "off" } }
 ```
 
-The last two flags are behavioural rather than cosmetic, and exist because DeepSeek's cloud API demands them: `replayReasoning` re-sends each prior turn's `reasoning_content` (it 400s without), and `latchThinking` pins thinking to the session's first value (it 400s if it flips mid-conversation).
+The last three flags are behavioural rather than cosmetic, and exist because DeepSeek's cloud API demands them: `omitToolChoice` drops an explicit `tool_choice` (it 400s on one, and the model still gets the tools and decides), `replayReasoning` re-sends each prior turn's `reasoning_content` (it 400s without), and `latchThinking` pins thinking to the session's first value (it 400s if it flips mid-conversation).
+
+:::caution
+Writing your own profile for a DeepSeek **cloud** endpoint? Set `"omitToolChoice": true`. These quirks travel with the profile as data, so a hand-written one that omits the flag will send `tool_choice` and get a 400 on any turn with tools. Using the `deepseek` preset name — or a copy of it — carries them for you.
+:::
 
 ### Auto-detection
 

--- a/apps/docs/src/content/docs/inference/models-json.mdx
+++ b/apps/docs/src/content/docs/inference/models-json.mdx
@@ -31,8 +31,8 @@ The entry **key** (`"deepseek"`) is just a local label. The field that's sent to
 | `baseUrl` | yes | OpenAI-compatible API root, e.g. `https://api.deepseek.com/v1`. `/chat/completions` is appended (and not double-appended). |
 | `model` | yes | The model id sent to the API. |
 | `apiKey` / `apiKeyEnv` | no | Inline key, or the name of an env var holding it (preferred: keeps secrets out of the file). |
-| `reasoning` | no | Provider thinking dialect: `qwen` (default), `deepseek`, `openai`, `none`. See below. **Auto-detected as `deepseek`** when `baseUrl` or `model` contains "deepseek", so a DeepSeek model usually needs no explicit value. |
-| `reasoningEffort` | no | `low` / `medium` / `high` for `deepseek`/`openai`. |
+| `reasoning` | no | Provider thinking dialect: `qwen` (default), `deepseek`, `vllm`, `openai`, `none`. See below. Auto-detected when `baseUrl` or `model` contains "deepseek": **`vllm`** on a private address, **`deepseek`** on a public one. |
+| `reasoningEffort` | no | `low` / `medium` / `high` for `deepseek`/`vllm`/`openai`. |
 | `contextWindow` | no | Tokens, for the status gauge + auto-compaction. Auto-detected from `/models` when omitted. |
 | `maxTokens` | no | Output-token cap (default 16384). |
 | `extraBody` | no | Arbitrary JSON merged into the request body (overrides built-ins). The escape hatch for any provider param. |
@@ -46,11 +46,21 @@ Providers express "thinking" differently. `reasoning` picks the wire shape:
 | `reasoning` | Sends | Notes |
 | --- | --- | --- |
 | `qwen` (default) | `chat_template_kwargs.enable_thinking`, `thinking_token_budget` | vLLM/Qwen. |
-| `deepseek` | `thinking: { type: "enabled"\|"disabled" }`, `reasoning_effort` | Omits `tool_choice` entirely (DeepSeek's thinking mode rejects an explicit one). The model still gets the tools and decides. |
+| `deepseek` | `thinking: { type: "enabled"\|"disabled" }`, `reasoning_effort` | DeepSeek's **cloud** API. Omits `tool_choice` entirely (its thinking mode rejects an explicit one). The model still gets the tools and decides. Thinking is latched to the session's first value, because the API 400s if it flips mid-conversation. |
+| `vllm` | `chat_template_kwargs.thinking`, `reasoning_effort` | A **self-hosted** vLLM serving a reasoning checkpoint. Per-call, never latched. |
 | `openai` | `reasoning_effort` | Uses `max_completion_tokens` and omits `temperature` (o-series rejects both). |
 | `none` | — | No reasoning params. |
 
-tsforge **auto-detects** the `deepseek` dialect when `baseUrl`/`model` contains "deepseek", so DeepSeek thinking models work out of the box. The `reasoning_content` from each turn is replayed on the next request (DeepSeek 400s otherwise). Set `reasoning` explicitly only when a DeepSeek-compatible gateway hides that string in its URL/model name.
+### Auto-detection
+
+When `baseUrl`/`model` contains "deepseek", tsforge picks the dialect by address:
+
+- **private** (loopback, `10.x`, `172.16–31.x`, `192.168.x`, `169.254.x`, `.local`/`.lan`/`.internal`) → `vllm`
+- **public** → `deepseek`, and each turn's `reasoning_content` is replayed on the next request (the cloud API 400s otherwise)
+
+The split matters because the two speak different wire formats for the same feature. A self-hosted vLLM reads `chat_template_kwargs.thinking` and **silently ignores** DeepSeek cloud's `thinking: { type }` — it accepts the field and does nothing with it. Sending the cloud dialect to a local server therefore makes `thinking` inert: it only appears to work when the server's own default happens to match what you wanted.
+
+Detection is deliberately conservative on public hosts, since one may be a reverse proxy in front of DeepSeek cloud, which still needs the cloud dialect. Set `reasoning` explicitly for a self-hosted endpoint on a public address, or for a DeepSeek-compatible gateway that hides the string in its URL/model name.
 
 ## Examples
 

--- a/apps/docs/src/content/docs/inference/models-json.mdx
+++ b/apps/docs/src/content/docs/inference/models-json.mdx
@@ -31,7 +31,7 @@ The entry **key** (`"deepseek"`) is just a local label. The field that's sent to
 | `baseUrl` | yes | OpenAI-compatible API root, e.g. `https://api.deepseek.com/v1`. `/chat/completions` is appended (and not double-appended). |
 | `model` | yes | The model id sent to the API. |
 | `apiKey` / `apiKeyEnv` | no | Inline key, or the name of an env var holding it (preferred: keeps secrets out of the file). |
-| `reasoning` | no | Provider thinking dialect: `qwen` (default), `deepseek`, `deepseek-local`, `openai`, `none`. See below. Auto-detected when `baseUrl` or `model` contains "deepseek": **`deepseek-local`** on a private address, **`deepseek`** on a public one. |
+| `reasoning` | no | Either a preset name (`qwen` default, `deepseek`, `deepseek-local`, `openai`, `none`) or a profile object declaring the field paths itself. See below. Validated at load. |
 | `reasoningEffort` | no | `low` / `medium` / `high` for `deepseek`/`deepseek-local`/`openai`. |
 | `contextWindow` | no | Tokens, for the status gauge + auto-compaction. Auto-detected from `/models` when omitted. |
 | `maxTokens` | no | Output-token cap (default 16384). |
@@ -88,7 +88,7 @@ The last two flags are behavioural rather than cosmetic, and exist because DeepS
 
 When `baseUrl`/`model` contains "deepseek", tsforge picks the dialect by address:
 
-- **private** (loopback, `10.x`, `172.16–31.x`, `192.168.x`, `169.254.x`, `.local`/`.lan`/`.internal`/`.home`/`.localdomain`) → `deepseek-local`
+- **private** → `deepseek-local`. Loopback, `10.x`, `172.16–31.x`, `192.168.x`, `169.254.x`, CGNAT `100.64–100.127.x` (Tailscale and friends), IPv6 loopback / unique-local (`fc00::/7`) / link-local (`fe80::/10`) / IPv4-mapped, and the `.local` `.lan` `.internal` `.home` `.localdomain` TLDs.
 - **public** → `deepseek`, and each turn's `reasoning_content` is replayed on the next request (the cloud API 400s otherwise)
 
 The split matters because the two speak different wire formats for the same feature. A locally served DeepSeek checkpoint reads `chat_template_kwargs.thinking` and **silently ignores** DeepSeek cloud's `thinking: { type }` — it accepts the field and does nothing with it. Sending the cloud dialect to a local server therefore makes `thinking` inert: it only appears to work when the server's own default happens to match what you wanted.
@@ -96,6 +96,8 @@ The split matters because the two speak different wire formats for the same feat
 :::caution
 `deepseek-local` is named for the **model family**, not the server. The `thinking` flag is a kwarg of the DeepSeek-V4 chat template, which a runtime like vLLM merely forwards — it is not a vLLM-wide field. Qwen's template declares `enable_thinking` instead (that's the `qwen` dialect), and a Llama or Mistral behind the same vLLM declares neither. Don't set `deepseek-local` on a non-DeepSeek model just because it's self-hosted; the field would be accepted and ignored.
 :::
+
+A **single-label** hostname such as `http://spark2:8888` is deliberately NOT treated as private: it is indistinguishable from a proxy alias. Declare `reasoning` explicitly for those.
 
 Detection is deliberately conservative on public hosts, since one may be a reverse proxy in front of DeepSeek cloud, which still needs the cloud dialect. Set `reasoning` explicitly for a self-hosted endpoint on a public address, or for a DeepSeek-compatible gateway that hides the string in its URL/model name.
 

--- a/apps/docs/src/content/docs/reference/roadmap.mdx
+++ b/apps/docs/src/content/docs/reference/roadmap.mdx
@@ -23,7 +23,7 @@ TypeScript coding harness for web projects: `packages/core` for the loop and gat
 - **Greenfield scaffolding**: stands up the full BoringStack stack and builds it resource-by-resource against BoringStack's own gate. See [Greenfield scaffolding](/scaffold/boringstack/).
 
 **Models & observability**
-- **Provider-agnostic** `~/.tsforge/models.json` (any OpenAI-compatible API; `qwen`/`deepseek`/`vllm`/`openai` reasoning dialects, DeepSeek auto-detected (private address → `vllm`)). See [models.json](/inference/models-json/).
+- **Provider-agnostic** `~/.tsforge/models.json` (any OpenAI-compatible API; reasoning expressed as a declarative field-path profile, with presets for the common cases). See [models.json](/inference/models-json/).
 - **MCP servers** as read-only context/tools. See [MCP servers](/integrations/mcp/).
 - Live tok/s + `/metrics` + a `--log` JSONL analyzer. See [Token metrics](/observability/metrics/).
 

--- a/apps/docs/src/content/docs/reference/roadmap.mdx
+++ b/apps/docs/src/content/docs/reference/roadmap.mdx
@@ -23,7 +23,7 @@ TypeScript coding harness for web projects: `packages/core` for the loop and gat
 - **Greenfield scaffolding**: stands up the full BoringStack stack and builds it resource-by-resource against BoringStack's own gate. See [Greenfield scaffolding](/scaffold/boringstack/).
 
 **Models & observability**
-- **Provider-agnostic** `~/.tsforge/models.json` (any OpenAI-compatible API; `qwen`/`deepseek`/`openai` reasoning dialects, DeepSeek auto-detected). See [models.json](/inference/models-json/).
+- **Provider-agnostic** `~/.tsforge/models.json` (any OpenAI-compatible API; `qwen`/`deepseek`/`vllm`/`openai` reasoning dialects, DeepSeek auto-detected (private address → `vllm`)). See [models.json](/inference/models-json/).
 - **MCP servers** as read-only context/tools. See [MCP servers](/integrations/mcp/).
 - Live tok/s + `/metrics` + a `--log` JSONL analyzer. See [Token metrics](/observability/metrics/).
 

--- a/bun.lock
+++ b/bun.lock
@@ -47,7 +47,7 @@
     },
     "apps/docs": {
       "name": "@tsforge/docs",
-      "version": "0.32.0",
+      "version": "0.35.0",
       "dependencies": {
         "@astrojs/react": "6.0.1",
         "@astrojs/sitemap": "3.7.3",
@@ -69,7 +69,7 @@
     },
     "packages/core": {
       "name": "@agjs/tsforge",
-      "version": "0.32.0",
+      "version": "0.35.0",
       "bin": {
         "tsforge": "./bin/tsforge.js",
       },
@@ -99,12 +99,14 @@
   },
   "overrides": {
     "@typescript-eslint/utils": "8.65.0",
-    "brace-expansion": "5.0.8",
+    "brace-expansion": "^5.0.9",
     "dompurify": "^3.4.12",
     "esbuild": "^0.28.1",
     "js-yaml": "4.3.0",
+    "postcss": "^8.5.23",
     "sharp": "^0.35.3",
     "svgo": "^4.0.2",
+    "undici": "^7.29.0",
     "ws": "^8.21.0",
   },
   "packages": {
@@ -934,7 +936,7 @@
 
     "boolbase": ["boolbase@1.0.0", "", {}, "sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww=="],
 
-    "brace-expansion": ["brace-expansion@5.0.8", "", { "dependencies": { "balanced-match": "^4.0.2" } }, "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg=="],
+    "brace-expansion": ["brace-expansion@5.0.9", "", { "dependencies": { "balanced-match": "^4.0.2" } }, "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg=="],
 
     "browserslist": ["browserslist@4.28.6", "", { "dependencies": { "baseline-browser-mapping": "^2.10.42", "caniuse-lite": "^1.0.30001803", "electron-to-chromium": "^1.5.389", "node-releases": "^2.0.51", "update-browserslist-db": "^1.2.3" }, "bin": { "browserslist": "cli.js" } }, "sha512-FQBYNK15VMslhLHpA7+n+n1GOlF1kId2xcCg7/j95f24AOF6VDYMNH4mFxF7KuaTdv627faazpOAjFzMrfJOUw=="],
 
@@ -1716,7 +1718,7 @@
 
     "mz": ["mz@2.7.0", "", { "dependencies": { "any-promise": "^1.0.0", "object-assign": "^4.0.1", "thenify-all": "^1.0.0" } }, "sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q=="],
 
-    "nanoid": ["nanoid@3.3.12", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ=="],
+    "nanoid": ["nanoid@3.3.17", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-xQLf0A3HOMlgHq0n247/LRuAOYmB7dXJ/DvAxGvsSBij45XtBSmQycu+F8ODbHwns/XyFZagyL1+J0Offw1E0g=="],
 
     "napi-postinstall": ["napi-postinstall@0.3.4", "", { "bin": { "napi-postinstall": "lib/cli.js" } }, "sha512-PHI5f1O0EP5xJ9gQmFGMS6IZcrVvTjpXjz7Na41gTE7eE2hK11lg04CECCYEEjdc17EV4DO+fkGEtt7TpTaTiQ=="],
 
@@ -1818,7 +1820,7 @@
 
     "possible-typed-array-names": ["possible-typed-array-names@1.1.0", "", {}, "sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg=="],
 
-    "postcss": ["postcss@8.5.19", "", { "dependencies": { "nanoid": "^3.3.12", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-Mz8SaolMd8nB+G13WkORcxQKHZ/NE4xXevtkJHVuG+guo9/wYKlIMTKAqGdEmYOXR2ijPjTYNHssizdaVSUNdQ=="],
+    "postcss": ["postcss@8.5.25", "", { "dependencies": { "nanoid": "^3.3.16", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-DTPx3RWSSnWyzLxQnlH0rJP+EW5ekl16ZU4/psbIhA0e53kJfdgaN5vKM+xP7yJtXVu+nfdVFmlgFDEKAe4Pyw=="],
 
     "postcss-nested": ["postcss-nested@6.2.0", "", { "dependencies": { "postcss-selector-parser": "^6.1.1" }, "peerDependencies": { "postcss": "^8.2.14" } }, "sha512-HQbt28KulC5AJzG+cZtj9kvKB93CFCdLvog1WFLf1D+xmMvPGlBstkpTEZfK5+AN9hfJocyBFCNiqyS48bpgzQ=="],
 
@@ -2108,7 +2110,7 @@
 
     "uncrypto": ["uncrypto@0.1.3", "", {}, "sha512-Ql87qFHB3s/De2ClA9e0gsnS6zXG27SkTiSJwjCc9MebbfapQfuPzumMIUMi38ezPZVNFcHI9sUIepeQfw8J8Q=="],
 
-    "undici": ["undici@7.28.0", "", {}, "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA=="],
+    "undici": ["undici@7.29.0", "", {}, "sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw=="],
 
     "undici-types": ["undici-types@7.28.0", "", {}, "sha512-LJAfY+2w6HGeT8d8J1wNQsUGUEGio6NWWpwdwurQe4f6oojzCFuGLizl1KSve4irsTxyLly1QhEeE6iapdaIvQ=="],
 

--- a/osv-scanner.toml
+++ b/osv-scanner.toml
@@ -26,9 +26,16 @@ id = "GHSA-cmwh-pvxp-8882"
 ignoreUntil = 2026-09-12T00:00:00Z
 reason = "dompurify (transitive via mermaid in the docs-site workspace) is a build-time/docs dev dependency only; not shipped in the published package. Re-evaluate when mermaid ships a patched dompurify range."
 
-# undici 7.24.8 reaches us only via wrangler → miniflare (docs-site deploy tooling,
-# a dev dependency). The PUBLISHED package's undici (via jsdom) is already 7.28.0,
-# i.e. patched — so there is no runtime or published-artifact exposure to either CVE.
+# SUPERSEDED 2026-08-03: undici is now pinned to ^7.29.0 in package.json
+# `overrides`, so none of the entries below match anything in bun.lock. They are
+# kept only until the next allowlist review (ignoreUntil below).
+#
+# The original rationale — "the published package's undici (via jsdom) is already
+# 7.28.0, i.e. patched" — EXPIRED: five advisories published against 7.28.0 itself
+# (GHSA-4cwx-7wf7-3272, GHSA-8xcm-r25x-g524, GHSA-jr45-8vmc-qm54,
+# GHSA-m8rv-5g2x-5cg5, GHSA-v3r7-h72x-cjcm) made the runtime copy vulnerable too,
+# which is exactly the exposure the accepted risk assumed did not exist. Bumped
+# rather than allowlisted, because it reaches the published package.
 [[IgnoredVulns]]
 id = "CVE-2026-9678"
 ignoreUntil = 2026-09-12T00:00:00Z

--- a/package.json
+++ b/package.json
@@ -67,12 +67,14 @@
   },
   "overrides": {
     "@typescript-eslint/utils": "8.65.0",
-    "brace-expansion": "5.0.8",
+    "brace-expansion": "^5.0.9",
     "dompurify": "^3.4.12",
     "esbuild": "^0.28.1",
     "js-yaml": "4.3.0",
+    "postcss": "^8.5.23",
     "sharp": "^0.35.3",
     "svgo": "^4.0.2",
+    "undici": "^7.29.0",
     "ws": "^8.21.0"
   },
   "dependencies": {

--- a/packages/core/src/inference/inference.types.ts
+++ b/packages/core/src/inference/inference.types.ts
@@ -142,6 +142,9 @@ export interface IOpenAICompatibleConfig {
    *  - `deepseek`: top-level `thinking: { type }` + `reasoning_effort`; `tool_choice`
    *    is suppressed ONLY on the DeepSeek CLOUD host (api.deepseek.com), which 400s
    *    on it — a local/self-hosted DeepSeek still gets it.
+   *  - `vllm`: `chat_template_kwargs.thinking` + `reasoning_effort` — a self-hosted
+   *    vLLM IGNORES the `deepseek` dialect's `thinking: { type }`, so the two cannot
+   *    share a style. Auto-detected for a "deepseek" model on a private address.
    *  - `openai`: `reasoning_effort`; uses `max_completion_tokens` and omits `temperature` (o-series).
    *  - `none`: no reasoning fields.
    */
@@ -169,9 +172,4 @@ export interface IOpenAICompatibleConfig {
  *  `vllm` is for a self-hosted vLLM serving a reasoning checkpoint: it reads
  *  `chat_template_kwargs.thinking` and IGNORES DeepSeek cloud's `thinking:{type}`,
  *  so the two cannot share a dialect even for the same model family. */
-export type ReasoningStyle =
-  | "qwen"
-  | "deepseek"
-  | "vllm"
-  | "openai"
-  | "none";
+export type ReasoningStyle = "qwen" | "deepseek" | "vllm" | "openai" | "none";

--- a/packages/core/src/inference/inference.types.ts
+++ b/packages/core/src/inference/inference.types.ts
@@ -158,9 +158,10 @@ export interface IOpenAICompatibleConfig {
   reasoningEffort?: "low" | "medium" | "high";
   /**
    * OPTIONAL override for guided-decoding (structured tool-call) support. Normally
-   * unset: the harness auto-detects it — every local/self-hosted endpoint sends
-   * `tool_choice`, and only DeepSeek's CLOUD thinking API (api.deepseek.com), which
-   * 400s on it, is suppressed. Set `true`/`false` only to override a misdetection.
+   * unset: whether `tool_choice` is sent is declared by the resolved reasoning
+   * profile's `omitToolChoice` (the `deepseek` cloud preset sets it, because that
+   * API 400s on an explicit one). Set `true`/`false` to force the decision either
+   * way regardless of the profile.
    */
   guidedDecoding?: boolean;
   /** Arbitrary fields merged into the request body LAST (override anything above) —

--- a/packages/core/src/inference/inference.types.ts
+++ b/packages/core/src/inference/inference.types.ts
@@ -165,5 +165,13 @@ export interface IOpenAICompatibleConfig {
   fetch?: typeof fetch;
 }
 
-/** Provider reasoning-param dialect. */
-export type ReasoningStyle = "qwen" | "deepseek" | "openai" | "none";
+/** Provider reasoning-param dialect.
+ *  `vllm` is for a self-hosted vLLM serving a reasoning checkpoint: it reads
+ *  `chat_template_kwargs.thinking` and IGNORES DeepSeek cloud's `thinking:{type}`,
+ *  so the two cannot share a dialect even for the same model family. */
+export type ReasoningStyle =
+  | "qwen"
+  | "deepseek"
+  | "vllm"
+  | "openai"
+  | "none";

--- a/packages/core/src/inference/inference.types.ts
+++ b/packages/core/src/inference/inference.types.ts
@@ -1,3 +1,11 @@
+import type { IReasoningProfile, ReasoningStyle } from "./reasoning-profile";
+
+export type {
+  IReasoningProfile,
+  IWireFlag,
+  ReasoningStyle,
+} from "./reasoning-profile";
+
 export type Role = "system" | "user" | "assistant" | "tool";
 
 export interface IChatMessage {
@@ -137,19 +145,16 @@ export interface IOpenAICompatibleConfig {
    */
   repetitionPenalty?: number;
   /**
-   * How this provider wants reasoning/thinking expressed on the wire:
-   *  - `qwen` (default): `chat_template_kwargs.enable_thinking` + `thinking_token_budget` (vLLM).
-   *  - `deepseek`: top-level `thinking: { type }` + `reasoning_effort`; `tool_choice`
-   *    is suppressed ONLY on the DeepSeek CLOUD host (api.deepseek.com), which 400s
-   *    on it — a local/self-hosted DeepSeek still gets it.
-   *  - `vllm`: `chat_template_kwargs.thinking` + `reasoning_effort` — a self-hosted
-   *    vLLM IGNORES the `deepseek` dialect's `thinking: { type }`, so the two cannot
-   *    share a style. Auto-detected for a "deepseek" model on a private address.
-   *  - `openai`: `reasoning_effort`; uses `max_completion_tokens` and omits `temperature` (o-series).
-   *  - `none`: no reasoning fields.
+   * How this endpoint expresses reasoning on the wire. Either a preset NAME for
+   * a common case (`qwen` | `deepseek` | `deepseek-local` | `openai` | `none`)
+   * or a full `IReasoningProfile` declaring the field paths itself — the latter
+   * is what makes an arbitrary model supportable by config rather than by a code
+   * change. Omitted → best-effort auto-detection from the url/model.
+   *
+   * See `reasoning-profile.ts` for the shape and what each preset expands to.
    */
-  reasoning?: ReasoningStyle;
-  /** Reasoning effort for `deepseek`/`openai` styles (maps to `reasoning_effort`). */
+  reasoning?: ReasoningStyle | IReasoningProfile;
+  /** Reasoning effort for `deepseek`/`deepseek-local`/`openai` styles (maps to `reasoning_effort`). */
   reasoningEffort?: "low" | "medium" | "high";
   /**
    * OPTIONAL override for guided-decoding (structured tool-call) support. Normally
@@ -167,9 +172,3 @@ export interface IOpenAICompatibleConfig {
   /** Injectable for tests; defaults to global fetch. */
   fetch?: typeof fetch;
 }
-
-/** Provider reasoning-param dialect.
- *  `vllm` is for a self-hosted vLLM serving a reasoning checkpoint: it reads
- *  `chat_template_kwargs.thinking` and IGNORES DeepSeek cloud's `thinking:{type}`,
- *  so the two cannot share a dialect even for the same model family. */
-export type ReasoningStyle = "qwen" | "deepseek" | "vllm" | "openai" | "none";

--- a/packages/core/src/inference/openai-compatible.ts
+++ b/packages/core/src/inference/openai-compatible.ts
@@ -13,7 +13,7 @@ import {
   buildRequestBody,
   buildRequestHeaders,
   chatCompletionsUrl,
-  isDeepseekStyle,
+  latchesThinking,
 } from "./request";
 
 export { salvageToolCalls, salvageFusedToolName } from "./wire";
@@ -53,7 +53,7 @@ export class OpenAICompatibleProvider implements IProvider {
   /** For DeepSeek, force every turn to the session's first thinking mode (see
    *  `thinkingPinned`); a no-op for other providers. */
   private withPinnedThinking(opts: ICompleteOptions): ICompleteOptions {
-    if (!isDeepseekStyle(this.cfg)) {
+    if (!latchesThinking(this.cfg)) {
       return opts;
     }
 

--- a/packages/core/src/inference/reasoning-profile.ts
+++ b/packages/core/src/inference/reasoning-profile.ts
@@ -37,9 +37,10 @@ export interface IReasoningProfile {
   tokenCap?: string;
   /** Never send `temperature` (OpenAI o-series rejects it outright). */
   omitTemperature?: boolean;
-  /** Never send `tool_choice`. Omitting it auto-detects from the host, but ONLY
-   *  for the `deepseek` preset and for auto-detection — a custom profile should
-   *  state this outright rather than inherit a vendor quirk by resemblance. */
+  /** Never send `tool_choice`. There is no host fallback: a profile pointed at
+   *  DeepSeek's cloud API must set this, or the call 400s on any turn with
+   *  tools. The `deepseek` preset sets it, so the name and a copy of it behave
+   *  the same. */
   omitToolChoice?: boolean;
   /** Replay each prior assistant turn's `reasoning_content`. DeepSeek's cloud
    *  thinking API 400s without it; nothing else wants it. */
@@ -187,23 +188,52 @@ export function isReasoningProfile(value: unknown): value is IReasoningProfile {
     return false;
   }
 
-  const declared: string[] = [];
+  if (!hasValidWireFlag(value) || !hasValidFlags(value)) {
+    return false;
+  }
+
+  const paths = collectPaths(value);
+
+  return paths !== null && !anyOverlap(paths);
+}
+
+/** The `thinking` member, when present, must be a wire flag with a safe path and
+ *  no stray keys — `onValu` would otherwise validate and silently fall back to
+ *  the default `true`. */
+function hasValidWireFlag(value: Record<string, unknown>): boolean {
   const flag = value.thinking;
 
-  if (flag !== undefined) {
-    if (!isPlainObject(flag) || typeof flag.path !== "string") {
-      return false;
-    }
+  if (flag === undefined) {
+    return true;
+  }
 
-    if (!Object.keys(flag).every((k) => WIRE_FLAG_KEYS.has(k))) {
-      return false;
-    }
+  return (
+    isPlainObject(flag) &&
+    typeof flag.path === "string" &&
+    isSafePath(flag.path) &&
+    Object.keys(flag).every((k) => WIRE_FLAG_KEYS.has(k))
+  );
+}
 
-    if (!isSafePath(flag.path)) {
-      return false;
-    }
+/** Every boolean member must actually be a boolean. */
+function hasValidFlags(value: Record<string, unknown>): boolean {
+  return FLAG_KEYS.every((key) => {
+    const v = value[key];
 
-    declared.push(flag.path);
+    return v === undefined || typeof v === "boolean";
+  });
+}
+
+/** Every path this profile will write, or null if any is malformed. Includes
+ *  the DEFAULT token cap when unset, because it is written regardless — without
+ *  it `{ "effort": "max_tokens" }` validates and then overwrites the output
+ *  limit with an effort string. */
+function collectPaths(value: Record<string, unknown>): string[] | null {
+  const paths: string[] = [];
+  const flag = value.thinking;
+
+  if (isPlainObject(flag) && typeof flag.path === "string") {
+    paths.push(flag.path);
   }
 
   for (const key of PATH_KEYS) {
@@ -214,38 +244,24 @@ export function isReasoningProfile(value: unknown): value is IReasoningProfile {
     }
 
     if (typeof path !== "string" || !isSafePath(path)) {
-      return false;
+      return null;
     }
 
-    declared.push(path);
+    paths.push(path);
   }
 
-  // The token cap is ALWAYS written, at its default when unset, so it has to
-  // take part in the overlap check even when the profile never mentions it.
-  // Otherwise `{ "effort": "max_tokens" }` validates and then overwrites the
-  // output limit with an effort string — the same clobber the guard exists for.
   if (value.tokenCap === undefined) {
-    declared.push(DEFAULT_TOKEN_CAP);
+    paths.push(DEFAULT_TOKEN_CAP);
   }
 
-  // Two controls writing to overlapping paths would clobber each other.
-  if (
-    declared.some((a, i) =>
-      declared.slice(i + 1).some((b) => pathsOverlap(a, b))
-    )
-  ) {
-    return false;
-  }
+  return paths;
+}
 
-  for (const key of FLAG_KEYS) {
-    const v = value[key];
-
-    if (v !== undefined && typeof v !== "boolean") {
-      return false;
-    }
-  }
-
-  return true;
+/** True when any two paths would clobber each other. */
+function anyOverlap(paths: string[]): boolean {
+  return paths.some((a, i) =>
+    paths.slice(i + 1).some((b) => pathsOverlap(a, b))
+  );
 }
 
 function isPlainObject(value: unknown): value is Record<string, unknown> {

--- a/packages/core/src/inference/reasoning-profile.ts
+++ b/packages/core/src/inference/reasoning-profile.ts
@@ -63,8 +63,12 @@ export const REASONING_PRESETS: Readonly<
     budget: "thinking_token_budget",
   },
 
-  /** DeepSeek's CLOUD API: a top-level object, plus two protocol quirks that
-   *  are behavioural rather than cosmetic. */
+  /** DeepSeek's CLOUD API: a top-level object, plus three protocol quirks that
+   *  are behavioural rather than cosmetic. Self-hosted DeepSeek resolves to
+   *  `deepseek-local`, so this preset now means the cloud API unambiguously —
+   *  which is why `omitToolChoice` rides here as DATA rather than being decided
+   *  by a host check. That also makes the name and the object true aliases: a
+   *  hand-written or spread copy behaves identically. */
   deepseek: {
     thinking: {
       path: "thinking",
@@ -72,6 +76,9 @@ export const REASONING_PRESETS: Readonly<
       offValue: { type: "disabled" },
     },
     effort: "reasoning_effort",
+    // Its thinking API 400s on an explicit tool_choice. The model still gets
+    // the tools and decides for itself.
+    omitToolChoice: true,
     replayReasoning: true,
     latchThinking: true,
   },
@@ -96,6 +103,25 @@ export const REASONING_PRESETS: Readonly<
   /** Endpoint exposes no reasoning controls. */
   none: {},
 };
+
+/** Recursively freeze, so a caller that gets a preset back from `profile()`
+ *  cannot mutate it and corrupt every later request in the process. `Readonly`
+ *  is type-only and does nothing at runtime. */
+function deepFreeze<T>(value: T): T {
+  if (typeof value !== "object" || value === null || Object.isFrozen(value)) {
+    return value;
+  }
+
+  Object.freeze(value);
+
+  for (const v of Object.values(value)) {
+    deepFreeze(v);
+  }
+
+  return value;
+}
+
+deepFreeze(REASONING_PRESETS);
 
 export function isReasoningStyle(value: unknown): value is ReasoningStyle {
   return typeof value === "string" && Object.hasOwn(REASONING_PRESETS, value);

--- a/packages/core/src/inference/reasoning-profile.ts
+++ b/packages/core/src/inference/reasoning-profile.ts
@@ -1,0 +1,136 @@
+/**
+ * How an endpoint expresses reasoning ON THE WIRE, as data rather than as a
+ * hardcoded vendor list.
+ *
+ * The harness has a handful of internal concepts — thinking on/off, effort,
+ * token budget — and every endpoint spells them differently. Enumerating model
+ * families in a union type does not scale: there are thousands of checkpoints,
+ * the list is never complete, and each new one would need a code change and a
+ * release to support.
+ *
+ * So an entry DECLARES its mapping. `reasoning` accepts either a preset name
+ * (convenience for the common cases) or a full profile (anything else). Adding
+ * support for a new model is a config edit.
+ */
+
+/** A boolean flag's location and the values written for on/off. */
+export interface IWireFlag {
+  /** Dot path into the request body, e.g. `chat_template_kwargs.thinking`. */
+  path: string;
+  /** Value written when the flag is ON. Default `true`. */
+  onValue?: unknown;
+  /** Value written when the flag is OFF. Default `false`. */
+  offValue?: unknown;
+}
+
+/** A complete description of an endpoint's reasoning surface. Every field is
+ *  optional: omitted means "this endpoint has no such control", and nothing is
+ *  sent for it. */
+export interface IReasoningProfile {
+  /** Where the thinking toggle goes. Omit when the endpoint has none. */
+  thinking?: IWireFlag;
+  /** Dot path for reasoning effort; the caller's value is passed through. */
+  effort?: string;
+  /** Dot path for the reasoning-token budget. */
+  budget?: string;
+  /** Dot path for the output-token cap. Default `max_tokens`. */
+  tokenCap?: string;
+  /** Never send `temperature` (OpenAI o-series rejects it outright). */
+  omitTemperature?: boolean;
+  /** Never send `tool_choice`. Omit to auto-detect from the host. */
+  omitToolChoice?: boolean;
+  /** Replay each prior assistant turn's `reasoning_content`. DeepSeek's cloud
+   *  thinking API 400s without it; nothing else wants it. */
+  replayReasoning?: boolean;
+  /** Pin thinking to the session's first value and never flip it. DeepSeek's
+   *  cloud API 400s when it changes mid-conversation. */
+  latchThinking?: boolean;
+}
+
+/** Shorthand names for the profiles people actually hit. These are ALIASES over
+ *  `IReasoningProfile`, not special cases in the code path. */
+export type ReasoningStyle =
+  "qwen" | "deepseek" | "deepseek-local" | "openai" | "none";
+
+export const REASONING_PRESETS: Readonly<
+  Record<ReasoningStyle, IReasoningProfile>
+> = {
+  /** Qwen's chat template declares `enable_thinking`. */
+  qwen: {
+    thinking: { path: "chat_template_kwargs.enable_thinking" },
+    budget: "thinking_token_budget",
+  },
+
+  /** DeepSeek's CLOUD API: a top-level object, plus two protocol quirks that
+   *  are behavioural rather than cosmetic. */
+  deepseek: {
+    thinking: {
+      path: "thinking",
+      onValue: { type: "enabled" },
+      offValue: { type: "disabled" },
+    },
+    effort: "reasoning_effort",
+    replayReasoning: true,
+    latchThinking: true,
+  },
+
+  /** A DeepSeek checkpoint served by a template-driven runtime (vLLM, SGLang).
+   *  `thinking` here is a kwarg of the DeepSeek-V4 CHAT TEMPLATE, which the
+   *  runtime merely forwards — it is not a vLLM-wide field, which is why this
+   *  is keyed to the model family and not to the server. */
+  "deepseek-local": {
+    thinking: { path: "chat_template_kwargs.thinking" },
+    effort: "chat_template_kwargs.reasoning_effort",
+    budget: "thinking_token_budget",
+  },
+
+  /** OpenAI o-series: effort only, renamed token cap, no temperature. */
+  openai: {
+    effort: "reasoning_effort",
+    tokenCap: "max_completion_tokens",
+    omitTemperature: true,
+  },
+
+  /** Endpoint exposes no reasoning controls. */
+  none: {},
+};
+
+export function isReasoningStyle(value: unknown): value is ReasoningStyle {
+  return typeof value === "string" && value in REASONING_PRESETS;
+}
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+/** Write `value` at a dot path, creating intermediate objects. Mutates `target`
+ *  and returns it, so several fields can be layered into one body fragment. */
+export function setPath(
+  target: Record<string, unknown>,
+  path: string,
+  value: unknown
+): Record<string, unknown> {
+  const parts = path.split(".");
+  const last = parts.pop();
+
+  if (last === undefined || last === "") {
+    return target;
+  }
+
+  let node = target;
+
+  for (const part of parts) {
+    const next = node[part];
+    // Overwrite anything that isn't a plain object: a scalar or array sitting
+    // at an intermediate path can't be descended into, and silently bailing
+    // would drop the field the caller asked for.
+    const child = isPlainObject(next) ? next : {};
+
+    node[part] = child;
+    node = child;
+  }
+
+  node[last] = value;
+
+  return target;
+}

--- a/packages/core/src/inference/reasoning-profile.ts
+++ b/packages/core/src/inference/reasoning-profile.ts
@@ -115,6 +115,19 @@ const FLAG_KEYS = [
  *  send no budget at all. */
 const PROFILE_KEYS = new Set<string>(["thinking", ...PATH_KEYS, ...FLAG_KEYS]);
 
+/** Same rule one level down: `onValu` would otherwise validate and silently
+ *  fall back to the default `true`. */
+const WIRE_FLAG_KEYS = new Set<string>(["path", "onValue", "offValue"]);
+
+/** True when one path is the same as, or nested under, another. Two such paths
+ *  cannot both be written: `tokenCap: "params"` then
+ *  `thinking: "params.enabled"` replaces the cap with an object, and the
+ *  reverse order erases the nested field. Rejected at validation rather than
+ *  silently dropping a control the user configured. */
+function pathsOverlap(a: string, b: string): boolean {
+  return a === b || a.startsWith(`${b}.`) || b.startsWith(`${a}.`);
+}
+
 /** True when `value` is usable as a profile. Config is hand-editable, so a
  *  wrong shape has to be rejected at the boundary rather than throwing deep in
  *  a request, or worse, being accepted and doing nothing. */
@@ -127,6 +140,7 @@ export function isReasoningProfile(value: unknown): value is IReasoningProfile {
     return false;
   }
 
+  const declared: string[] = [];
   const flag = value.thinking;
 
   if (flag !== undefined) {
@@ -134,17 +148,38 @@ export function isReasoningProfile(value: unknown): value is IReasoningProfile {
       return false;
     }
 
+    if (!Object.keys(flag).every((k) => WIRE_FLAG_KEYS.has(k))) {
+      return false;
+    }
+
     if (!isSafePath(flag.path)) {
       return false;
     }
+
+    declared.push(flag.path);
   }
 
   for (const key of PATH_KEYS) {
     const path = value[key];
 
-    if (path !== undefined && (typeof path !== "string" || !isSafePath(path))) {
+    if (path === undefined) {
+      continue;
+    }
+
+    if (typeof path !== "string" || !isSafePath(path)) {
       return false;
     }
+
+    declared.push(path);
+  }
+
+  // Two controls writing to overlapping paths would clobber each other.
+  if (
+    declared.some((a, i) =>
+      declared.slice(i + 1).some((b) => pathsOverlap(a, b))
+    )
+  ) {
+    return false;
   }
 
   for (const key of FLAG_KEYS) {
@@ -191,13 +226,9 @@ export function setPath(
     return target;
   }
 
+  // isSafePath guarantees at least one non-empty segment, so pop() is defined.
   const parts = path.split(".");
-  const last = parts.pop();
-
-  if (last === undefined) {
-    return target;
-  }
-
+  const last = parts.pop() ?? path;
   let node = target;
 
   for (const part of parts) {

--- a/packages/core/src/inference/reasoning-profile.ts
+++ b/packages/core/src/inference/reasoning-profile.ts
@@ -99,6 +99,10 @@ export function isReasoningStyle(value: unknown): value is ReasoningStyle {
   return typeof value === "string" && Object.hasOwn(REASONING_PRESETS, value);
 }
 
+/** Where the output-token cap goes when a profile does not say. Exported so the
+ *  request builder and the overlap check cannot drift apart. */
+export const DEFAULT_TOKEN_CAP = "max_tokens";
+
 /** Path-valued profile keys. */
 const PATH_KEYS = ["effort", "budget", "tokenCap"] as const;
 
@@ -171,6 +175,14 @@ export function isReasoningProfile(value: unknown): value is IReasoningProfile {
     }
 
     declared.push(path);
+  }
+
+  // The token cap is ALWAYS written, at its default when unset, so it has to
+  // take part in the overlap check even when the profile never mentions it.
+  // Otherwise `{ "effort": "max_tokens" }` validates and then overwrites the
+  // output limit with an effort string — the same clobber the guard exists for.
+  if (value.tokenCap === undefined) {
+    declared.push(DEFAULT_TOKEN_CAP);
   }
 
   // Two controls writing to overlapping paths would clobber each other.

--- a/packages/core/src/inference/reasoning-profile.ts
+++ b/packages/core/src/inference/reasoning-profile.ts
@@ -96,31 +96,98 @@ export const REASONING_PRESETS: Readonly<
 };
 
 export function isReasoningStyle(value: unknown): value is ReasoningStyle {
-  return typeof value === "string" && value in REASONING_PRESETS;
+  return typeof value === "string" && Object.hasOwn(REASONING_PRESETS, value);
+}
+
+/** True when `value` is usable as a profile. Config is hand-editable, so a
+ *  wrong shape has to be rejected at the boundary rather than throwing deep in
+ *  a request. Only checks structure; unknown extra keys are tolerated. */
+export function isReasoningProfile(value: unknown): value is IReasoningProfile {
+  if (!isPlainObject(value)) {
+    return false;
+  }
+
+  const flag = value.thinking;
+
+  if (flag !== undefined) {
+    if (!isPlainObject(flag) || typeof flag.path !== "string") {
+      return false;
+    }
+
+    if (!isSafePath(flag.path)) {
+      return false;
+    }
+  }
+
+  for (const key of ["effort", "budget", "tokenCap"]) {
+    const path = value[key];
+
+    if (path !== undefined && (typeof path !== "string" || !isSafePath(path))) {
+      return false;
+    }
+  }
+
+  for (const key of [
+    "omitTemperature",
+    "omitToolChoice",
+    "replayReasoning",
+    "latchThinking",
+  ]) {
+    const v = value[key];
+
+    if (v !== undefined && typeof v !== "boolean") {
+      return false;
+    }
+  }
+
+  return true;
 }
 
 function isPlainObject(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value);
 }
 
+/** Path segments that would escape the request body and reach into the
+ *  prototype chain. A models.json is user-editable config, so a path like
+ *  `__proto__.polluted` must not be able to write to Object.prototype. */
+const UNSAFE_SEGMENTS = new Set(["__proto__", "constructor", "prototype"]);
+
+/** True when every segment of a dot path is present and safe to write. */
+export function isSafePath(path: string): boolean {
+  if (path === "") {
+    return false;
+  }
+
+  const parts = path.split(".");
+
+  return parts.every((p) => p !== "" && !UNSAFE_SEGMENTS.has(p));
+}
+
 /** Write `value` at a dot path, creating intermediate objects. Mutates `target`
- *  and returns it, so several fields can be layered into one body fragment. */
+ *  and returns it, so several fields can be layered into one body fragment.
+ *  A malformed or unsafe path is ignored rather than throwing — this runs on
+ *  hand-edited config, and a bad path should not take down a live turn. */
 export function setPath(
   target: Record<string, unknown>,
   path: string,
   value: unknown
 ): Record<string, unknown> {
+  if (typeof path !== "string" || !isSafePath(path)) {
+    return target;
+  }
+
   const parts = path.split(".");
   const last = parts.pop();
 
-  if (last === undefined || last === "") {
+  if (last === undefined) {
     return target;
   }
 
   let node = target;
 
   for (const part of parts) {
-    const next = node[part];
+    // Own properties only: an inherited value must never be descended into.
+    const next = Object.hasOwn(node, part) ? node[part] : undefined;
     // Overwrite anything that isn't a plain object: a scalar or array sitting
     // at an intermediate path can't be descended into, and silently bailing
     // would drop the field the caller asked for.

--- a/packages/core/src/inference/reasoning-profile.ts
+++ b/packages/core/src/inference/reasoning-profile.ts
@@ -37,7 +37,9 @@ export interface IReasoningProfile {
   tokenCap?: string;
   /** Never send `temperature` (OpenAI o-series rejects it outright). */
   omitTemperature?: boolean;
-  /** Never send `tool_choice`. Omit to auto-detect from the host. */
+  /** Never send `tool_choice`. Omitting it auto-detects from the host, but ONLY
+   *  for the `deepseek` preset and for auto-detection — a custom profile should
+   *  state this outright rather than inherit a vendor quirk by resemblance. */
   omitToolChoice?: boolean;
   /** Replay each prior assistant turn's `reasoning_content`. DeepSeek's cloud
    *  thinking API 400s without it; nothing else wants it. */
@@ -102,6 +104,21 @@ export function isReasoningStyle(value: unknown): value is ReasoningStyle {
 /** Where the output-token cap goes when a profile does not say. Exported so the
  *  request builder and the overlap check cannot drift apart. */
 export const DEFAULT_TOKEN_CAP = "max_tokens";
+
+/** Top-level fields the request builder owns. A profile path may not target one
+ *  or nest under one: `{"tokenCap":"messages"}` would replace the conversation,
+ *  `{"thinking":{"path":"model"}}` the model id, and `temperature`/`tools`/
+ *  `stream` would be silently overwritten by the normal fields spread after. */
+const RESERVED_ROOTS = new Set([
+  "model",
+  "messages",
+  "temperature",
+  "repetition_penalty",
+  "tools",
+  "tool_choice",
+  "stream",
+  "stream_options",
+]);
 
 /** Path-valued profile keys. */
 const PATH_KEYS = ["effort", "budget", "tokenCap"] as const;
@@ -214,7 +231,8 @@ function isPlainObject(value: unknown): value is Record<string, unknown> {
  *  `__proto__.polluted` must not be able to write to Object.prototype. */
 const UNSAFE_SEGMENTS = new Set(["__proto__", "constructor", "prototype"]);
 
-/** True when every segment of a dot path is present and safe to write. */
+/** True when every segment of a dot path is present and safe to write, and the
+ *  path does not target a field the request builder owns. */
 export function isSafePath(path: string): boolean {
   if (path === "") {
     return false;
@@ -222,7 +240,11 @@ export function isSafePath(path: string): boolean {
 
   const parts = path.split(".");
 
-  return parts.every((p) => p !== "" && !UNSAFE_SEGMENTS.has(p));
+  if (!parts.every((p) => p !== "" && !UNSAFE_SEGMENTS.has(p))) {
+    return false;
+  }
+
+  return !RESERVED_ROOTS.has(parts[0] ?? "");
 }
 
 /** Write `value` at a dot path, creating intermediate objects. Mutates `target`

--- a/packages/core/src/inference/reasoning-profile.ts
+++ b/packages/core/src/inference/reasoning-profile.ts
@@ -99,11 +99,31 @@ export function isReasoningStyle(value: unknown): value is ReasoningStyle {
   return typeof value === "string" && Object.hasOwn(REASONING_PRESETS, value);
 }
 
+/** Path-valued profile keys. */
+const PATH_KEYS = ["effort", "budget", "tokenCap"] as const;
+
+/** Boolean-valued profile keys. */
+const FLAG_KEYS = [
+  "omitTemperature",
+  "omitToolChoice",
+  "replayReasoning",
+  "latchThinking",
+] as const;
+
+/** Every key a profile may carry. Anything else is a typo, and a typo must not
+ *  validate: `{"budegt": "..."}` would otherwise load fine and then silently
+ *  send no budget at all. */
+const PROFILE_KEYS = new Set<string>(["thinking", ...PATH_KEYS, ...FLAG_KEYS]);
+
 /** True when `value` is usable as a profile. Config is hand-editable, so a
  *  wrong shape has to be rejected at the boundary rather than throwing deep in
- *  a request. Only checks structure; unknown extra keys are tolerated. */
+ *  a request, or worse, being accepted and doing nothing. */
 export function isReasoningProfile(value: unknown): value is IReasoningProfile {
   if (!isPlainObject(value)) {
+    return false;
+  }
+
+  if (!Object.keys(value).every((k) => PROFILE_KEYS.has(k))) {
     return false;
   }
 
@@ -119,7 +139,7 @@ export function isReasoningProfile(value: unknown): value is IReasoningProfile {
     }
   }
 
-  for (const key of ["effort", "budget", "tokenCap"]) {
+  for (const key of PATH_KEYS) {
     const path = value[key];
 
     if (path !== undefined && (typeof path !== "string" || !isSafePath(path))) {
@@ -127,12 +147,7 @@ export function isReasoningProfile(value: unknown): value is IReasoningProfile {
     }
   }
 
-  for (const key of [
-    "omitTemperature",
-    "omitToolChoice",
-    "replayReasoning",
-    "latchThinking",
-  ]) {
+  for (const key of FLAG_KEYS) {
     const v = value[key];
 
     if (v !== undefined && typeof v !== "boolean") {

--- a/packages/core/src/inference/request.ts
+++ b/packages/core/src/inference/request.ts
@@ -37,7 +37,15 @@ function style(cfg: IOpenAICompatibleConfig): ReasoningStyle {
   // Without this, a DeepSeek model added with just { baseUrl, model } gets the
   // `qwen` default, which strips reasoning_content on replay → that 400.
   if (`${cfg.baseUrl} ${cfg.model}`.toLowerCase().includes("deepseek")) {
-    return "deepseek";
+    // ...but a SELF-HOSTED vLLM serving a DeepSeek checkpoint speaks a different
+    // dialect: it reads `chat_template_kwargs.thinking` and silently ignores
+    // `thinking:{type}`. Classifying it as `deepseek` makes thinking
+    // UNCONTROLLABLE (the field is accepted and does nothing) and latches it for
+    // the session. Only reclassify on a PRIVATE address, which is unambiguous
+    // evidence of self-hosting — a public hostname may be a reverse proxy in
+    // front of DeepSeek cloud, which still needs the cloud dialect and the
+    // reasoning_content replay.
+    return isPrivateHost(cfg.baseUrl) ? "vllm" : "deepseek";
   }
 
   return "qwen";
@@ -72,6 +80,18 @@ function reasoningFields(
                 type: opts.enableThinking ? "enabled" : "disabled",
               },
             }),
+        ...(reasoningEffort === undefined
+          ? {}
+          : { reasoning_effort: reasoningEffort }),
+      };
+    // Self-hosted vLLM: thinking rides in the chat template kwargs, and
+    // `reasoning_effort` is read straight off the request body. Both are
+    // per-call, so the session never latches a mode.
+    case "vllm":
+      return {
+        ...(opts.enableThinking === undefined
+          ? {}
+          : { chat_template_kwargs: { thinking: opts.enableThinking } }),
         ...(reasoningEffort === undefined
           ? {}
           : { reasoning_effort: reasoningEffort }),
@@ -162,6 +182,47 @@ function guidedOverride(cfg: IOpenAICompatibleConfig): boolean | undefined {
  *  baseUrl (e.g. `api.deepseek.com/v1` from a hand-edited config): without a scheme
  *  `new URL()` throws, which would miss the cloud host and wrongly SEND tool_choice
  *  — the exact 400 this guards against — so prepend `https://` before parsing. */
+/** True when `baseUrl` points at a private/loopback address or a LAN-only TLD —
+ *  i.e. something the user is self-hosting. Used to tell a local vLLM apart from
+ *  a public endpoint (which may be a reverse proxy in front of a cloud API), so
+ *  only the former gets the vLLM reasoning dialect. Scheme-less input is
+ *  tolerated the same way `isDeepSeekCloudHost` tolerates it. */
+function isPrivateHost(baseUrl: string): boolean {
+  const withScheme = /^[a-z][a-z0-9+.-]*:\/\//iu.test(baseUrl)
+    ? baseUrl
+    : `https://${baseUrl}`;
+
+  let host: string;
+  try {
+    host = new URL(withScheme).hostname.toLowerCase();
+  } catch {
+    return false;
+  }
+
+  // IPv6 loopback arrives bracket-stripped by URL as "::1".
+  if (host === "localhost" || host === "::1") {
+    return true;
+  }
+
+  if (/\.(local|lan|internal|home|localdomain)$/u.test(host)) {
+    return true;
+  }
+
+  const v4 = /^(\d{1,3})\.(\d{1,3})\.(\d{1,3})\.(\d{1,3})$/u.exec(host);
+  if (v4 === null) {
+    return false;
+  }
+
+  const [a, b] = [Number(v4[1]), Number(v4[2])];
+  return (
+    a === 127 || // loopback
+    a === 10 || // 10/8
+    (a === 172 && b >= 16 && b <= 31) || // 172.16/12
+    (a === 192 && b === 168) || // 192.168/16
+    (a === 169 && b === 254) // link-local
+  );
+}
+
 function isDeepSeekCloudHost(baseUrl: string): boolean {
   const withScheme = /^[a-z][a-z0-9+.-]*:\/\//iu.test(baseUrl)
     ? baseUrl

--- a/packages/core/src/inference/request.ts
+++ b/packages/core/src/inference/request.ts
@@ -6,6 +6,7 @@ import type {
 import type { IReasoningProfile, ReasoningStyle } from "./reasoning-profile";
 import {
   REASONING_PRESETS,
+  isReasoningProfile,
   isReasoningStyle,
   setPath,
 } from "./reasoning-profile";
@@ -35,11 +36,19 @@ export function latchesThinking(cfg: IOpenAICompatibleConfig): boolean {
 export function profile(cfg: IOpenAICompatibleConfig): IReasoningProfile {
   const declared = cfg.reasoning;
 
-  if (declared === undefined) {
-    return REASONING_PRESETS[autoPreset(cfg)];
+  if (isReasoningStyle(declared)) {
+    return REASONING_PRESETS[declared];
   }
 
-  return isReasoningStyle(declared) ? REASONING_PRESETS[declared] : declared;
+  if (isReasoningProfile(declared)) {
+    return declared;
+  }
+
+  // Anything else — undefined, JSON `null`, a typo'd preset name, a malformed
+  // object — falls back to auto-detection. models-config rejects these loudly
+  // at load; this is the last line of defence so a hand-edited registry cannot
+  // crash a live turn (JSON null is NOT undefined and used to throw here).
+  return REASONING_PRESETS[autoPreset(cfg)];
 }
 
 /** Best-effort preset for an entry that declared nothing. Only a convenience:
@@ -102,7 +111,7 @@ function reasoningFields(
 }
 
 /** The output-token cap field — o-series renamed `max_tokens` → `max_completion_tokens`. */
-function tokenCapField(cfg: IOpenAICompatibleConfig): Record<string, number> {
+function tokenCapField(cfg: IOpenAICompatibleConfig): Record<string, unknown> {
   // A NaN/Infinity maxTokens (bad config/env) would JSON.stringify to `null`,
   // which a server reads as an explicit choice, not "unset" — fall back to the
   // provider default instead (matches the temperature/repetitionPenalty guard).
@@ -112,7 +121,7 @@ function tokenCapField(cfg: IOpenAICompatibleConfig): Record<string, number> {
       ? configured
       : PROVIDER_LIMITS.maxTokens;
 
-  return { [profile(cfg).tokenCap ?? "max_tokens"]: max };
+  return setPath({}, profile(cfg).tokenCap ?? "max_tokens", max);
 }
 
 /** The `tools` (+ `tool_choice`) request fields. `tool_choice` is sent by default
@@ -259,7 +268,8 @@ function isPrivateHost(baseUrl: string): boolean {
     a === 10 || // 10/8
     (a === 172 && b >= 16 && b <= 31) || // 172.16/12
     (a === 192 && b === 168) || // 192.168/16
-    (a === 169 && b === 254) // link-local
+    (a === 169 && b === 254) || // link-local
+    (a === 100 && b >= 64 && b <= 127) // CGNAT 100.64/10 (Tailscale et al)
   );
 }
 

--- a/packages/core/src/inference/request.ts
+++ b/packages/core/src/inference/request.ts
@@ -75,17 +75,38 @@ function autoPreset(cfg: IOpenAICompatibleConfig): ReasoningStyle {
   return "qwen";
 }
 
-/** Write the reasoning controls the PROFILE declares. A control the profile
- *  omits is a control the endpoint does not have, so nothing is sent for it —
- *  that is what stops a field being accepted-and-ignored. Per-call options
- *  override config defaults. */
-function reasoningFields(
+/** Every profile-driven field — the token cap plus the reasoning controls —
+ *  written into ONE object.
+ *
+ *  These must share a target. Built separately and shallow-spread, two paths
+ *  under a common parent would clobber each other: `tokenCap:
+ *  "params.output_limit"` with `effort: "params.reasoning.level"` produces two
+ *  objects each holding a different `params`, and the later spread wins, so a
+ *  field is silently dropped.
+ *
+ *  A control the profile omits is a control the endpoint does not have, so
+ *  nothing is sent for it — that is what stops a field being accepted and
+ *  ignored. Per-call options override config defaults. */
+function profileFields(
   cfg: IOpenAICompatibleConfig,
   opts: ICompleteOptions
 ): Record<string, unknown> {
   const p = profile(cfg);
   const body: Record<string, unknown> = {};
   const effort = opts.reasoningEffort ?? cfg.reasoningEffort;
+
+  // A NaN/Infinity maxTokens (bad config/env) would JSON.stringify to `null`,
+  // which a server reads as an explicit choice, not "unset" — fall back to the
+  // provider default instead (matches the temperature/repetitionPenalty guard).
+  const configured = cfg.maxTokens;
+
+  setPath(
+    body,
+    p.tokenCap ?? "max_tokens",
+    configured !== undefined && Number.isFinite(configured)
+      ? configured
+      : PROVIDER_LIMITS.maxTokens
+  );
 
   if (p.thinking !== undefined && opts.enableThinking !== undefined) {
     const { path, onValue = true, offValue = false } = p.thinking;
@@ -108,20 +129,6 @@ function reasoningFields(
   }
 
   return body;
-}
-
-/** The output-token cap field — o-series renamed `max_tokens` → `max_completion_tokens`. */
-function tokenCapField(cfg: IOpenAICompatibleConfig): Record<string, unknown> {
-  // A NaN/Infinity maxTokens (bad config/env) would JSON.stringify to `null`,
-  // which a server reads as an explicit choice, not "unset" — fall back to the
-  // provider default instead (matches the temperature/repetitionPenalty guard).
-  const configured = cfg.maxTokens;
-  const max =
-    configured !== undefined && Number.isFinite(configured)
-      ? configured
-      : PROVIDER_LIMITS.maxTokens;
-
-  return setPath({}, profile(cfg).tokenCap ?? "max_tokens", max);
 }
 
 /** The `tools` (+ `tool_choice`) request fields. `tool_choice` is sent by default
@@ -316,14 +323,13 @@ export function buildRequestBody(
   return {
     model: cfg.model,
     messages: messages.map((m) => toWire(m, includeReasoning)),
-    ...tokenCapField(cfg),
+    ...profileFields(cfg, opts),
     ...(omitTemperature ? {} : { temperature: opts.temperature }),
     ...(cfg.repetitionPenalty === undefined ||
     !Number.isFinite(cfg.repetitionPenalty)
       ? {}
       : { repetition_penalty: cfg.repetitionPenalty }),
     ...toolsBlock(cfg, opts),
-    ...reasoningFields(cfg, opts),
     ...(streaming
       ? { stream: true, stream_options: { include_usage: true } }
       : {}),

--- a/packages/core/src/inference/request.ts
+++ b/packages/core/src/inference/request.ts
@@ -167,13 +167,19 @@ function suppressesToolChoice(cfg: IOpenAICompatibleConfig): boolean {
     return !override;
   }
 
-  const declared = profile(cfg).omitToolChoice;
+  const p = profile(cfg);
+  const declared = p.omitToolChoice;
 
   if (declared !== undefined) {
     return declared;
   }
 
-  return isDeepSeekCloudHost(cfg.baseUrl);
+  // The host heuristic applies ONLY to the DeepSeek cloud dialect. Gating on
+  // the resolved profile preserves the old `style === "deepseek"` check: an
+  // entry that explicitly picks `none`/`qwen`/`openai`/a custom profile against
+  // api.deepseek.com has opted out of that dialect, and must keep getting
+  // `tool_choice` — dropping the gate silently removed that escape hatch.
+  return p === REASONING_PRESETS.deepseek && isDeepSeekCloudHost(cfg.baseUrl);
 }
 
 /** Normalize the optional `guidedDecoding` override — tolerates a stringified

--- a/packages/core/src/inference/request.ts
+++ b/packages/core/src/inference/request.ts
@@ -5,6 +5,7 @@ import type {
 } from "./inference.types";
 import type { IReasoningProfile, ReasoningStyle } from "./reasoning-profile";
 import {
+  DEFAULT_TOKEN_CAP,
   REASONING_PRESETS,
   isReasoningProfile,
   isReasoningStyle,
@@ -102,7 +103,7 @@ function profileFields(
 
   setPath(
     body,
-    p.tokenCap ?? "max_tokens",
+    p.tokenCap ?? DEFAULT_TOKEN_CAP,
     configured !== undefined && Number.isFinite(configured)
       ? configured
       : PROVIDER_LIMITS.maxTokens

--- a/packages/core/src/inference/request.ts
+++ b/packages/core/src/inference/request.ts
@@ -76,6 +76,14 @@ function autoPreset(cfg: IOpenAICompatibleConfig): ReasoningStyle {
   return "qwen";
 }
 
+/** A structural copy, so a value taken from a shared preset never enters the
+ *  request body by reference. Primitives pass through untouched. */
+function detach(value: unknown): unknown {
+  return typeof value === "object" && value !== null
+    ? structuredClone(value)
+    : value;
+}
+
 /** Every profile-driven field — the token cap plus the reasoning controls —
  *  written into ONE object.
  *
@@ -111,8 +119,13 @@ function profileFields(
 
   if (p.thinking !== undefined && opts.enableThinking !== undefined) {
     const { path, onValue = true, offValue = false } = p.thinking;
+    const value = opts.enableThinking ? onValue : offValue;
 
-    setPath(body, path, opts.enableThinking ? onValue : offValue);
+    // Copy before writing. `profile()` hands back the SHARED preset object
+    // (Readonly is type-only), so putting `onValue` into the body by reference
+    // would let a caller mutating the returned body corrupt the preset for
+    // every later request in the process.
+    setPath(body, path, detach(value));
   }
 
   if (p.effort !== undefined && effort !== undefined) {
@@ -168,19 +181,34 @@ function suppressesToolChoice(cfg: IOpenAICompatibleConfig): boolean {
     return !override;
   }
 
-  const p = profile(cfg);
-  const declared = p.omitToolChoice;
+  const declared = profile(cfg).omitToolChoice;
 
   if (declared !== undefined) {
     return declared;
   }
 
-  // The host heuristic applies ONLY to the DeepSeek cloud dialect. Gating on
-  // the resolved profile preserves the old `style === "deepseek"` check: an
-  // entry that explicitly picks `none`/`qwen`/`openai`/a custom profile against
-  // api.deepseek.com has opted out of that dialect, and must keep getting
-  // `tool_choice` — dropping the gate silently removed that escape hatch.
-  return p === REASONING_PRESETS.deepseek && isDeepSeekCloudHost(cfg.baseUrl);
+  // The host heuristic applies ONLY to the DeepSeek cloud dialect, preserving
+  // the old `style === "deepseek"` gate: an entry that picks another dialect
+  // against api.deepseek.com has opted out and must keep getting `tool_choice`.
+  //
+  // Keyed on HOW the dialect was chosen, not on object identity — comparing
+  // against the shared preset would treat an equivalent hand-written profile as
+  // a different dialect purely because it is a different object.
+  return usesCloudDeepseekDialect(cfg) && isDeepSeekCloudHost(cfg.baseUrl);
+}
+
+/** True when this entry is on DeepSeek's cloud dialect: either it named the
+ *  `deepseek` preset, or it declared nothing and auto-detection chose it. A
+ *  custom profile is deliberately excluded — it has full control and should say
+ *  `omitToolChoice` outright rather than inherit a vendor quirk by resemblance. */
+function usesCloudDeepseekDialect(cfg: IOpenAICompatibleConfig): boolean {
+  const declared = cfg.reasoning;
+
+  if (declared === undefined) {
+    return autoPreset(cfg) === "deepseek";
+  }
+
+  return declared === "deepseek";
 }
 
 /** Normalize the optional `guidedDecoding` override — tolerates a stringified

--- a/packages/core/src/inference/request.ts
+++ b/packages/core/src/inference/request.ts
@@ -2,8 +2,13 @@ import type {
   IChatMessage,
   ICompleteOptions,
   IOpenAICompatibleConfig,
-  ReasoningStyle,
 } from "./inference.types";
+import type { IReasoningProfile, ReasoningStyle } from "./reasoning-profile";
+import {
+  REASONING_PRESETS,
+  isReasoningStyle,
+  setPath,
+} from "./reasoning-profile";
 import { PROVIDER_LIMITS } from "./inference.constants";
 import { toWire } from "./wire";
 
@@ -18,18 +23,28 @@ function interpolateEnv(
   );
 }
 
-/** True when this config talks to DeepSeek's thinking API (explicit `reasoning:
- *  "deepseek"` or auto-detected from the url/model). DeepSeek 400s if thinking is
- *  toggled mid-conversation, so the provider latches one mode per session. */
-export function isDeepseekStyle(cfg: IOpenAICompatibleConfig): boolean {
-  return style(cfg) === "deepseek";
+/** True when the endpoint requires thinking pinned to the session's first value
+ *  (DeepSeek's cloud API 400s if it flips mid-conversation). Declared by the
+ *  profile, so a new endpoint with the same constraint needs no code change. */
+export function latchesThinking(cfg: IOpenAICompatibleConfig): boolean {
+  return profile(cfg).latchThinking === true;
 }
 
-function style(cfg: IOpenAICompatibleConfig): ReasoningStyle {
-  if (cfg.reasoning !== undefined) {
-    return cfg.reasoning;
+/** Resolve the endpoint's reasoning profile: an explicit object wins, a preset
+ *  name expands, and an absent value falls back to auto-detection. */
+export function profile(cfg: IOpenAICompatibleConfig): IReasoningProfile {
+  const declared = cfg.reasoning;
+
+  if (declared === undefined) {
+    return REASONING_PRESETS[autoPreset(cfg)];
   }
 
+  return isReasoningStyle(declared) ? REASONING_PRESETS[declared] : declared;
+}
+
+/** Best-effort preset for an entry that declared nothing. Only a convenience:
+ *  anything this guesses wrong is fixed by declaring `reasoning` explicitly. */
+function autoPreset(cfg: IOpenAICompatibleConfig): ReasoningStyle {
   // Auto-detect DeepSeek when not explicitly configured, so its thinking-mode
   // round-trip works out of the box: DeepSeek requires each prior assistant
   // turn's `reasoning_content` replayed, and 400s otherwise ("The
@@ -45,71 +60,45 @@ function style(cfg: IOpenAICompatibleConfig): ReasoningStyle {
     // evidence of self-hosting — a public hostname may be a reverse proxy in
     // front of DeepSeek cloud, which still needs the cloud dialect and the
     // reasoning_content replay.
-    return isPrivateHost(cfg.baseUrl) ? "vllm" : "deepseek";
+    return isPrivateHost(cfg.baseUrl) ? "deepseek-local" : "deepseek";
   }
 
   return "qwen";
 }
 
-/** Provider-specific reasoning/thinking fields for the request body. Per-call
- *  overrides (opts) take precedence over config defaults (cfg).reasoningEffort. */
+/** Write the reasoning controls the PROFILE declares. A control the profile
+ *  omits is a control the endpoint does not have, so nothing is sent for it —
+ *  that is what stops a field being accepted-and-ignored. Per-call options
+ *  override config defaults. */
 function reasoningFields(
   cfg: IOpenAICompatibleConfig,
   opts: ICompleteOptions
 ): Record<string, unknown> {
-  // Per-call reasoning effort overrides config when set.
-  const reasoningEffort = opts.reasoningEffort ?? cfg.reasoningEffort;
+  const p = profile(cfg);
+  const body: Record<string, unknown> = {};
+  const effort = opts.reasoningEffort ?? cfg.reasoningEffort;
 
-  switch (style(cfg)) {
-    case "qwen":
-      return {
-        ...(opts.enableThinking === undefined
-          ? {}
-          : { chat_template_kwargs: { enable_thinking: opts.enableThinking } }),
-        ...(opts.thinkingTokenBudget === undefined ||
-        !Number.isFinite(opts.thinkingTokenBudget)
-          ? {}
-          : { thinking_token_budget: opts.thinkingTokenBudget }),
-      };
-    case "deepseek":
-      return {
-        ...(opts.enableThinking === undefined
-          ? {}
-          : {
-              thinking: {
-                type: opts.enableThinking ? "enabled" : "disabled",
-              },
-            }),
-        ...(reasoningEffort === undefined
-          ? {}
-          : { reasoning_effort: reasoningEffort }),
-      };
-    // Self-hosted vLLM: thinking rides in the chat template kwargs, and
-    // `reasoning_effort` is read straight off the request body. Both are
-    // per-call, so the session never latches a mode.
-    case "vllm":
-      return {
-        ...(opts.enableThinking === undefined
-          ? {}
-          : { chat_template_kwargs: { thinking: opts.enableThinking } }),
-        // `thinking_token_budget` is a vLLM param, so it applies here exactly as
-        // it does for qwen — dropping it would silently disable the caller's
-        // reasoning-token cap the moment this dialect is selected.
-        ...(opts.thinkingTokenBudget === undefined ||
-        !Number.isFinite(opts.thinkingTokenBudget)
-          ? {}
-          : { thinking_token_budget: opts.thinkingTokenBudget }),
-        ...(reasoningEffort === undefined
-          ? {}
-          : { reasoning_effort: reasoningEffort }),
-      };
-    case "openai":
-      return reasoningEffort === undefined
-        ? {}
-        : { reasoning_effort: reasoningEffort };
-    case "none":
-      return {};
+  if (p.thinking !== undefined && opts.enableThinking !== undefined) {
+    const { path, onValue = true, offValue = false } = p.thinking;
+
+    setPath(body, path, opts.enableThinking ? onValue : offValue);
   }
+
+  if (p.effort !== undefined && effort !== undefined) {
+    setPath(body, p.effort, effort);
+  }
+
+  // A NaN/Infinity budget would JSON.stringify to `null`, which a server reads
+  // as an explicit choice rather than "unset".
+  if (
+    p.budget !== undefined &&
+    opts.thinkingTokenBudget !== undefined &&
+    Number.isFinite(opts.thinkingTokenBudget)
+  ) {
+    setPath(body, p.budget, opts.thinkingTokenBudget);
+  }
+
+  return body;
 }
 
 /** The output-token cap field — o-series renamed `max_tokens` → `max_completion_tokens`. */
@@ -123,9 +112,7 @@ function tokenCapField(cfg: IOpenAICompatibleConfig): Record<string, number> {
       ? configured
       : PROVIDER_LIMITS.maxTokens;
 
-  return style(cfg) === "openai"
-    ? { max_completion_tokens: max }
-    : { max_tokens: max };
+  return { [profile(cfg).tokenCap ?? "max_tokens"]: max };
 }
 
 /** The `tools` (+ `tool_choice`) request fields. `tool_choice` is sent by default
@@ -145,24 +132,29 @@ function toolsBlock(
     return {};
   }
 
-  if (style(cfg) === "deepseek" && suppressesToolChoice(cfg)) {
+  if (suppressesToolChoice(cfg)) {
     return { tools: opts.tools };
   }
 
   return { tools: opts.tools, tool_choice: opts.toolChoice ?? "auto" };
 }
 
-/** Whether to omit `tool_choice` for a deepseek-style endpoint. AUTO by default,
- *  so a normal user never configures anything: only DeepSeek's CLOUD thinking API
- *  (api.deepseek.com) 400s on an explicit `tool_choice`; a local / self-hosted
- *  DeepSeek (vLLM/SGLang/llama.cpp) accepts it and grammar-constrains the call, so
- *  it's sent. The optional `guidedDecoding` flag only exists to override a
- *  misdetection (true = always send, false = always omit). */
+/** Whether to omit `tool_choice`. Precedence: the explicit `guidedDecoding`
+ *  override, then the profile's own declaration, then auto-detection by host —
+ *  only DeepSeek's CLOUD API (api.deepseek.com) 400s on an explicit
+ *  `tool_choice`; a self-hosted endpoint accepts it and grammar-constrains the
+ *  call, so it is sent. */
 function suppressesToolChoice(cfg: IOpenAICompatibleConfig): boolean {
   const override = guidedOverride(cfg);
 
   if (override !== undefined) {
     return !override;
+  }
+
+  const declared = profile(cfg).omitToolChoice;
+
+  if (declared !== undefined) {
+    return declared;
   }
 
   return isDeepSeekCloudHost(cfg.baseUrl);
@@ -237,10 +229,16 @@ function isPrivateHost(baseUrl: string): boolean {
   // hostname `[::1]`), so strip them before matching.
   const bare = host.replace(/^\[|\]$/gu, "");
 
+  // Gate the IPv6 range checks on the host actually BEING an IPv6 literal.
+  // Without this, `/^f[cd]/` matches DNS names like `fda.gov` or
+  // `fcm.example.com` and would wrongly mark a public proxy private.
+  const isIpv6 = bare.includes(":");
+
   if (
-    bare === "::1" || // loopback
-    /^f[cd]/u.test(bare) || // unique-local fc00::/7
-    /^fe[89ab]/u.test(bare) // link-local fe80::/10
+    isIpv6 &&
+    (bare === "::1" || // loopback
+      /^f[cd]/u.test(bare) || // unique-local fc00::/7
+      /^fe[89ab]/u.test(bare)) // link-local fe80::/10
   ) {
     return true;
   }
@@ -291,17 +289,19 @@ export function buildRequestBody(
   opts: ICompleteOptions,
   streaming: boolean
 ): Record<string, unknown> {
-  // o-series rejects `temperature` entirely; everywhere else send it only when set
-  // AND finite — a NaN/Infinity (bad config/env) would JSON.stringify to `null`,
-  // which a server reads as an explicit choice, not "unset". Drop it instead.
+  const p = profile(cfg);
+
+  // Some endpoints reject `temperature` outright; everywhere else send it only
+  // when set AND finite — a NaN/Infinity (bad config/env) would JSON.stringify
+  // to `null`, which a server reads as an explicit choice, not "unset".
   const omitTemperature =
-    style(cfg) === "openai" ||
+    p.omitTemperature === true ||
     opts.temperature === undefined ||
     !Number.isFinite(opts.temperature);
 
-  // DeepSeek's thinking mode requires each prior assistant turn's
-  // `reasoning_content` replayed; other providers don't want it.
-  const includeReasoning = style(cfg) === "deepseek";
+  // Only endpoints that declare it want each prior assistant turn's
+  // `reasoning_content` replayed (DeepSeek's cloud API 400s without it).
+  const includeReasoning = p.replayReasoning === true;
 
   return {
     model: cfg.model,

--- a/packages/core/src/inference/request.ts
+++ b/packages/core/src/inference/request.ts
@@ -32,45 +32,28 @@ export function latchesThinking(cfg: IOpenAICompatibleConfig): boolean {
   return profile(cfg).latchThinking === true;
 }
 
-/** The resolved profile AND whether it is DeepSeek's cloud dialect. These are
- *  returned together deliberately: computed separately they drifted, and an
- *  entry could end up with cloud thinking fields while still being sent
- *  `tool_choice` — which that endpoint rejects. */
-function resolve(cfg: IOpenAICompatibleConfig): {
-  profile: IReasoningProfile;
-  cloudDialect: boolean;
-} {
+/** Resolve the endpoint's reasoning profile: an explicit object wins, a preset
+ *  name expands, and anything else falls back to auto-detection.
+ *
+ *  Every behaviour is carried BY the profile, so there is no second notion of
+ *  "which dialect is this" to drift out of sync with the returned object. The
+ *  presets are deep-frozen, so the reference handed back cannot be mutated. */
+export function profile(cfg: IOpenAICompatibleConfig): IReasoningProfile {
   const declared = cfg.reasoning;
 
   if (isReasoningStyle(declared)) {
-    return {
-      profile: REASONING_PRESETS[declared],
-      cloudDialect: declared === "deepseek",
-    };
+    return REASONING_PRESETS[declared];
   }
 
-  // A custom profile is never treated as the cloud dialect by resemblance: it
-  // has full control and should declare `omitToolChoice` outright.
   if (isReasoningProfile(declared)) {
-    return { profile: declared, cloudDialect: false };
+    return declared;
   }
 
   // Anything else — undefined, JSON `null`, a typo'd preset name, a malformed
   // object — falls back to auto-detection. models-config rejects these loudly
   // at load; this is the last line of defence so a hand-edited registry cannot
   // crash a live turn (JSON null is NOT undefined and used to throw here).
-  const auto = autoPreset(cfg);
-
-  return {
-    profile: REASONING_PRESETS[auto],
-    cloudDialect: auto === "deepseek",
-  };
-}
-
-/** Resolve the endpoint's reasoning profile: an explicit object wins, a preset
- *  name expands, and anything else falls back to auto-detection. */
-export function profile(cfg: IOpenAICompatibleConfig): IReasoningProfile {
-  return resolve(cfg).profile;
+  return REASONING_PRESETS[autoPreset(cfg)];
 }
 
 /** Best-effort preset for an entry that declared nothing. Only a convenience:
@@ -168,9 +151,9 @@ function profileFields(
 
 /** The `tools` (+ `tool_choice`) request fields. `tool_choice` is sent by default
  *  — it grammar-constrains the call to a well-formed schema instead of free-form
- *  text the harness would have to salvage — and is suppressed ONLY for the deepseek
- *  style on DeepSeek's CLOUD host, whose thinking API 400s on it (see
- *  `suppressesToolChoice`). No configuration needed for the common local case. */
+ *  text the harness would have to salvage — and is suppressed only when the
+ *  resolved profile says so (the `deepseek` cloud preset does, because its
+ *  thinking API 400s on it). No configuration needed for the common local case. */
 function toolsBlock(
   cfg: IOpenAICompatibleConfig,
   opts: ICompleteOptions
@@ -202,18 +185,10 @@ function suppressesToolChoice(cfg: IOpenAICompatibleConfig): boolean {
     return !override;
   }
 
-  const { profile: p, cloudDialect } = resolve(cfg);
-
-  if (p.omitToolChoice !== undefined) {
-    return p.omitToolChoice;
-  }
-
-  // The host heuristic applies ONLY to the DeepSeek cloud dialect, preserving
-  // the old `style === "deepseek"` gate: an entry that picks another dialect
-  // against api.deepseek.com has opted out and must keep getting `tool_choice`.
-  // `cloudDialect` comes from the same resolution as the profile, so a request
-  // can never carry cloud thinking fields while also sending `tool_choice`.
-  return cloudDialect && isDeepSeekCloudHost(cfg.baseUrl);
+  // Declared by the profile itself, so it travels with the dialect: a request
+  // can never carry DeepSeek cloud's thinking fields while also sending
+  // `tool_choice`, and a spread copy of the preset behaves like the name.
+  return profile(cfg).omitToolChoice === true;
 }
 
 /** Normalize the optional `guidedDecoding` override — tolerates a stringified
@@ -259,7 +234,7 @@ function firstTwoOctets(host: string): [number, number] | null {
  *  i.e. something the user is self-hosting. Used to tell a local vLLM apart from
  *  a public endpoint (which may be a reverse proxy in front of a cloud API), so
  *  only the former gets the vLLM reasoning dialect. Scheme-less input is
- *  tolerated the same way `isDeepSeekCloudHost` tolerates it. */
+ *  tolerated: a scheme-less baseUrl is prefixed before parsing. */
 function isPrivateHost(baseUrl: string): boolean {
   const withScheme = /^[a-z][a-z0-9+.-]*:\/\//iu.test(baseUrl)
     ? baseUrl
@@ -327,18 +302,6 @@ function isPrivateHost(baseUrl: string): boolean {
  *  baseUrl (e.g. `api.deepseek.com/v1` from a hand-edited config): without a scheme
  *  `new URL()` throws, which would miss the cloud host and wrongly SEND tool_choice
  *  — the exact 400 this guards against — so prepend `https://` before parsing. */
-function isDeepSeekCloudHost(baseUrl: string): boolean {
-  const withScheme = /^[a-z][a-z0-9+.-]*:\/\//iu.test(baseUrl)
-    ? baseUrl
-    : `https://${baseUrl}`;
-
-  try {
-    return /(^|\.)deepseek\.com$/iu.test(new URL(withScheme).hostname);
-  } catch {
-    return false;
-  }
-}
-
 /** Build the request body object (pure). Field order keeps the qwen default
  *  byte-for-byte identical; `extraBody` is merged last so it can override
  *  anything for a fully custom provider. */

--- a/packages/core/src/inference/request.ts
+++ b/packages/core/src/inference/request.ts
@@ -257,7 +257,7 @@ function isPrivateHost(baseUrl: string): boolean {
     return true;
   }
 
-  if (/\.(local|lan|internal|home|localdomain)$/u.test(host)) {
+  if (/\.(local|lan|internal|home|localdomain|localhost)$/u.test(host)) {
     return true;
   }
 

--- a/packages/core/src/inference/request.ts
+++ b/packages/core/src/inference/request.ts
@@ -92,6 +92,13 @@ function reasoningFields(
         ...(opts.enableThinking === undefined
           ? {}
           : { chat_template_kwargs: { thinking: opts.enableThinking } }),
+        // `thinking_token_budget` is a vLLM param, so it applies here exactly as
+        // it does for qwen — dropping it would silently disable the caller's
+        // reasoning-token cap the moment this dialect is selected.
+        ...(opts.thinkingTokenBudget === undefined ||
+        !Number.isFinite(opts.thinkingTokenBudget)
+          ? {}
+          : { thinking_token_budget: opts.thinkingTokenBudget }),
         ...(reasoningEffort === undefined
           ? {}
           : { reasoning_effort: reasoningEffort }),
@@ -177,11 +184,29 @@ function guidedOverride(cfg: IOpenAICompatibleConfig): boolean | undefined {
   return undefined;
 }
 
-/** True for the DeepSeek CLOUD API host (api.deepseek.com / *.deepseek.com) — the
- *  only endpoint known to reject an explicit `tool_choice`. Tolerates a scheme-less
- *  baseUrl (e.g. `api.deepseek.com/v1` from a hand-edited config): without a scheme
- *  `new URL()` throws, which would miss the cloud host and wrongly SEND tool_choice
- *  — the exact 400 this guards against — so prepend `https://` before parsing. */
+/** The first two octets of a dotted-quad IPv4 address, or of the embedded v4 in
+ *  an IPv4-mapped IPv6 one. Returns null when `host` is neither. WHATWG URL
+ *  normalizes `::ffff:192.168.1.9` to `::ffff:c0a8:109`, so the mapped form has
+ *  to be read as hex: the first hextet packs both octets. */
+function firstTwoOctets(host: string): [number, number] | null {
+  const v4 = /^(\d{1,3})\.(\d{1,3})\.(\d{1,3})\.(\d{1,3})$/u.exec(host);
+
+  if (v4 !== null) {
+    return [Number(v4[1]), Number(v4[2])];
+  }
+
+  const mapped = /^::ffff:([0-9a-f]{1,4}):[0-9a-f]{1,4}$/iu.exec(host);
+  const high = mapped?.[1];
+
+  if (high !== undefined) {
+    const hextet = Number.parseInt(high, 16);
+
+    return [(hextet >> 8) & 0xff, hextet & 0xff];
+  }
+
+  return null;
+}
+
 /** True when `baseUrl` points at a private/loopback address or a LAN-only TLD —
  *  i.e. something the user is self-hosting. Used to tell a local vLLM apart from
  *  a public endpoint (which may be a reverse proxy in front of a cloud API), so
@@ -193,14 +218,14 @@ function isPrivateHost(baseUrl: string): boolean {
     : `https://${baseUrl}`;
 
   let host: string;
+
   try {
     host = new URL(withScheme).hostname.toLowerCase();
   } catch {
     return false;
   }
 
-  // IPv6 loopback arrives bracket-stripped by URL as "::1".
-  if (host === "localhost" || host === "::1") {
+  if (host === "localhost") {
     return true;
   }
 
@@ -208,12 +233,29 @@ function isPrivateHost(baseUrl: string): boolean {
     return true;
   }
 
-  const v4 = /^(\d{1,3})\.(\d{1,3})\.(\d{1,3})\.(\d{1,3})$/u.exec(host);
-  if (v4 === null) {
+  // WHATWG URL keeps the brackets on an IPv6 literal (`http://[::1]` →
+  // hostname `[::1]`), so strip them before matching.
+  const bare = host.replace(/^\[|\]$/gu, "");
+
+  if (
+    bare === "::1" || // loopback
+    /^f[cd]/u.test(bare) || // unique-local fc00::/7
+    /^fe[89ab]/u.test(bare) // link-local fe80::/10
+  ) {
+    return true;
+  }
+
+  // An IPv4-mapped address is private iff its v4 part is. WHATWG URL rewrites
+  // `::ffff:192.168.1.9` into hex (`::ffff:c0a8:109`), so match that form too —
+  // the dotted spelling never survives parsing.
+  const octets = firstTwoOctets(bare);
+
+  if (octets === null) {
     return false;
   }
 
-  const [a, b] = [Number(v4[1]), Number(v4[2])];
+  const [a, b] = octets;
+
   return (
     a === 127 || // loopback
     a === 10 || // 10/8
@@ -223,6 +265,11 @@ function isPrivateHost(baseUrl: string): boolean {
   );
 }
 
+/** True for the DeepSeek CLOUD API host (api.deepseek.com / *.deepseek.com) — the
+ *  only endpoint known to reject an explicit `tool_choice`. Tolerates a scheme-less
+ *  baseUrl (e.g. `api.deepseek.com/v1` from a hand-edited config): without a scheme
+ *  `new URL()` throws, which would miss the cloud host and wrongly SEND tool_choice
+ *  — the exact 400 this guards against — so prepend `https://` before parsing. */
 function isDeepSeekCloudHost(baseUrl: string): boolean {
   const withScheme = /^[a-z][a-z0-9+.-]*:\/\//iu.test(baseUrl)
     ? baseUrl

--- a/packages/core/src/inference/request.ts
+++ b/packages/core/src/inference/request.ts
@@ -32,24 +32,45 @@ export function latchesThinking(cfg: IOpenAICompatibleConfig): boolean {
   return profile(cfg).latchThinking === true;
 }
 
-/** Resolve the endpoint's reasoning profile: an explicit object wins, a preset
- *  name expands, and an absent value falls back to auto-detection. */
-export function profile(cfg: IOpenAICompatibleConfig): IReasoningProfile {
+/** The resolved profile AND whether it is DeepSeek's cloud dialect. These are
+ *  returned together deliberately: computed separately they drifted, and an
+ *  entry could end up with cloud thinking fields while still being sent
+ *  `tool_choice` — which that endpoint rejects. */
+function resolve(cfg: IOpenAICompatibleConfig): {
+  profile: IReasoningProfile;
+  cloudDialect: boolean;
+} {
   const declared = cfg.reasoning;
 
   if (isReasoningStyle(declared)) {
-    return REASONING_PRESETS[declared];
+    return {
+      profile: REASONING_PRESETS[declared],
+      cloudDialect: declared === "deepseek",
+    };
   }
 
+  // A custom profile is never treated as the cloud dialect by resemblance: it
+  // has full control and should declare `omitToolChoice` outright.
   if (isReasoningProfile(declared)) {
-    return declared;
+    return { profile: declared, cloudDialect: false };
   }
 
   // Anything else — undefined, JSON `null`, a typo'd preset name, a malformed
   // object — falls back to auto-detection. models-config rejects these loudly
   // at load; this is the last line of defence so a hand-edited registry cannot
   // crash a live turn (JSON null is NOT undefined and used to throw here).
-  return REASONING_PRESETS[autoPreset(cfg)];
+  const auto = autoPreset(cfg);
+
+  return {
+    profile: REASONING_PRESETS[auto],
+    cloudDialect: auto === "deepseek",
+  };
+}
+
+/** Resolve the endpoint's reasoning profile: an explicit object wins, a preset
+ *  name expands, and anything else falls back to auto-detection. */
+export function profile(cfg: IOpenAICompatibleConfig): IReasoningProfile {
+  return resolve(cfg).profile;
 }
 
 /** Best-effort preset for an entry that declared nothing. Only a convenience:
@@ -181,34 +202,18 @@ function suppressesToolChoice(cfg: IOpenAICompatibleConfig): boolean {
     return !override;
   }
 
-  const declared = profile(cfg).omitToolChoice;
+  const { profile: p, cloudDialect } = resolve(cfg);
 
-  if (declared !== undefined) {
-    return declared;
+  if (p.omitToolChoice !== undefined) {
+    return p.omitToolChoice;
   }
 
   // The host heuristic applies ONLY to the DeepSeek cloud dialect, preserving
   // the old `style === "deepseek"` gate: an entry that picks another dialect
   // against api.deepseek.com has opted out and must keep getting `tool_choice`.
-  //
-  // Keyed on HOW the dialect was chosen, not on object identity — comparing
-  // against the shared preset would treat an equivalent hand-written profile as
-  // a different dialect purely because it is a different object.
-  return usesCloudDeepseekDialect(cfg) && isDeepSeekCloudHost(cfg.baseUrl);
-}
-
-/** True when this entry is on DeepSeek's cloud dialect: either it named the
- *  `deepseek` preset, or it declared nothing and auto-detection chose it. A
- *  custom profile is deliberately excluded — it has full control and should say
- *  `omitToolChoice` outright rather than inherit a vendor quirk by resemblance. */
-function usesCloudDeepseekDialect(cfg: IOpenAICompatibleConfig): boolean {
-  const declared = cfg.reasoning;
-
-  if (declared === undefined) {
-    return autoPreset(cfg) === "deepseek";
-  }
-
-  return declared === "deepseek";
+  // `cloudDialect` comes from the same resolution as the profile, so a request
+  // can never carry cloud thinking fields while also sending `tool_choice`.
+  return cloudDialect && isDeepSeekCloudHost(cfg.baseUrl);
 }
 
 /** Normalize the optional `guidedDecoding` override — tolerates a stringified
@@ -263,7 +268,9 @@ function isPrivateHost(baseUrl: string): boolean {
   let host: string;
 
   try {
-    host = new URL(withScheme).hostname.toLowerCase();
+    // A fully-qualified name may carry a trailing root dot (`localhost.`,
+    // `spark2.lan.`); it is the same host, so normalize it away before matching.
+    host = new URL(withScheme).hostname.toLowerCase().replace(/\.$/u, "");
   } catch {
     return false;
   }

--- a/packages/core/src/inference/request.ts
+++ b/packages/core/src/inference/request.ts
@@ -173,11 +173,14 @@ function toolsBlock(
   return { tools: opts.tools, tool_choice: opts.toolChoice ?? "auto" };
 }
 
-/** Whether to omit `tool_choice`. Precedence: the explicit `guidedDecoding`
- *  override, then the profile's own declaration, then auto-detection by host —
- *  only DeepSeek's CLOUD API (api.deepseek.com) 400s on an explicit
- *  `tool_choice`; a self-hosted endpoint accepts it and grammar-constrains the
- *  call, so it is sent. */
+/** Whether to omit `tool_choice`. Two steps only: the explicit `guidedDecoding`
+ *  override, then the profile's own `omitToolChoice`.
+ *
+ *  There is deliberately NO host check here. The one endpoint that rejects an
+ *  explicit `tool_choice` is DeepSeek's cloud API, and its preset declares the
+ *  suppression as data — which is what makes the preset name and a copy of the
+ *  preset behave identically. A hand-written profile pointed at that host must
+ *  set the flag itself; re-adding a host check would silently override it. */
 function suppressesToolChoice(cfg: IOpenAICompatibleConfig): boolean {
   const override = guidedOverride(cfg);
 
@@ -192,7 +195,7 @@ function suppressesToolChoice(cfg: IOpenAICompatibleConfig): boolean {
 }
 
 /** Normalize the optional `guidedDecoding` override — tolerates a stringified
- *  boolean from a hand-edited models.json; undefined ⇒ auto-detect by host. */
+ *  boolean from a hand-edited models.json; undefined ⇒ defer to the profile. */
 function guidedOverride(cfg: IOpenAICompatibleConfig): boolean | undefined {
   const value: unknown = cfg.guidedDecoding;
 
@@ -297,14 +300,10 @@ function isPrivateHost(baseUrl: string): boolean {
   );
 }
 
-/** True for the DeepSeek CLOUD API host (api.deepseek.com / *.deepseek.com) — the
- *  only endpoint known to reject an explicit `tool_choice`. Tolerates a scheme-less
- *  baseUrl (e.g. `api.deepseek.com/v1` from a hand-edited config): without a scheme
- *  `new URL()` throws, which would miss the cloud host and wrongly SEND tool_choice
- *  — the exact 400 this guards against — so prepend `https://` before parsing. */
-/** Build the request body object (pure). Field order keeps the qwen default
- *  byte-for-byte identical; `extraBody` is merged last so it can override
- *  anything for a fully custom provider. */
+/** Build the request body object (pure). `extraBody` is merged LAST so it can
+ *  override anything for a fully custom provider. Field ORDER is not part of the
+ *  contract: profile-driven fields are written together, ahead of temperature
+ *  and tools, so that nested paths sharing a parent cannot clobber each other. */
 export function buildRequestBody(
   cfg: IOpenAICompatibleConfig,
   messages: IChatMessage[],

--- a/packages/core/src/models-config.ts
+++ b/packages/core/src/models-config.ts
@@ -3,7 +3,10 @@ import { join } from "node:path";
 import { mkdir, readFile, writeFile, chmod } from "node:fs/promises";
 import { isRecord } from "./lib/guards";
 import { PROVIDER_DEFAULTS } from "./inference/inference.constants";
-import type { ReasoningStyle } from "./inference/inference.types";
+import type {
+  IReasoningProfile,
+  ReasoningStyle,
+} from "./inference/inference.types";
 
 /**
  * The model registry — `~/.tsforge/models.json`, the central place a user
@@ -30,16 +33,17 @@ export interface IModelEntry {
   /** Per-response token cap override. */
   maxTokens?: number;
   /** Provider reasoning dialect: how thinking/reasoning is expressed on the wire.
-   *  `qwen` (default) | `deepseek` | `vllm` | `openai` | `none`. Set `deepseek`
-   *  for DeepSeek's CLOUD API, `vllm` for a self-hosted vLLM, `openai` for OpenAI
-   *  o-series. A "deepseek" model/url auto-detects to `vllm` ONLY on a private
-   *  address (loopback / RFC1918 / link-local / .local / .lan / .internal), and
+   *  `qwen` (default) | `deepseek` | `deepseek-local` | `openai` | `none`. Set `deepseek`
+   *  for DeepSeek's CLOUD API, `deepseek-local` for a self-hosted vLLM, `openai` for OpenAI
+   *  o-series. A "deepseek" model/url auto-detects to `deepseek-local` ONLY on a private
+   *  address (loopback / RFC1918 / IPv6 ULA+link-local / .local / .lan / .internal /
+   *  .home / .localdomain), and
    *  stays `deepseek` on any public host — a public one may be a reverse proxy in
    *  front of DeepSeek cloud, which still needs the cloud dialect and its
    *  reasoning_content replay. Set it explicitly for a self-hosted endpoint that
    *  is reachable on a public address. */
-  reasoning?: ReasoningStyle;
-  /** Reasoning effort for `deepseek`/`openai` styles. */
+  reasoning?: ReasoningStyle | IReasoningProfile;
+  /** Reasoning effort for `deepseek`/`deepseek-local`/`openai` styles. */
   reasoningEffort?: "low" | "medium" | "high";
   /** OPTIONAL override for guided-decoding (structured tool-call) support.
    *  Normally leave unset — it's auto-detected per endpoint (local on, DeepSeek

--- a/packages/core/src/models-config.ts
+++ b/packages/core/src/models-config.ts
@@ -32,8 +32,12 @@ export interface IModelEntry {
   /** Provider reasoning dialect: how thinking/reasoning is expressed on the wire.
    *  `qwen` (default) | `deepseek` | `vllm` | `openai` | `none`. Set `deepseek`
    *  for DeepSeek's CLOUD API, `vllm` for a self-hosted vLLM, `openai` for OpenAI
-   *  o-series. A "deepseek" model/url auto-detects to `deepseek` on
-   *  *.deepseek.com and to `vllm` anywhere else. */
+   *  o-series. A "deepseek" model/url auto-detects to `vllm` ONLY on a private
+   *  address (loopback / RFC1918 / link-local / .local / .lan / .internal), and
+   *  stays `deepseek` on any public host — a public one may be a reverse proxy in
+   *  front of DeepSeek cloud, which still needs the cloud dialect and its
+   *  reasoning_content replay. Set it explicitly for a self-hosted endpoint that
+   *  is reachable on a public address. */
   reasoning?: ReasoningStyle;
   /** Reasoning effort for `deepseek`/`openai` styles. */
   reasoningEffort?: "low" | "medium" | "high";

--- a/packages/core/src/models-config.ts
+++ b/packages/core/src/models-config.ts
@@ -55,8 +55,8 @@ export interface IModelEntry {
   /** Reasoning effort for `deepseek`/`deepseek-local`/`openai` styles. */
   reasoningEffort?: "low" | "medium" | "high";
   /** OPTIONAL override for guided-decoding (structured tool-call) support.
-   *  Normally leave unset — it's auto-detected per endpoint (local on, DeepSeek
-   *  cloud off). Set true/false only to correct a misdetection. */
+   *  Normally leave unset — whether `tool_choice` is sent comes from the reasoning
+   *  profile's `omitToolChoice`. Set true/false to force it either way. */
   guidedDecoding?: boolean;
   /** Arbitrary fields merged into the request body (override built-ins) — the
    *  escape hatch for any provider-specific param. */

--- a/packages/core/src/models-config.ts
+++ b/packages/core/src/models-config.ts
@@ -7,6 +7,11 @@ import type {
   IReasoningProfile,
   ReasoningStyle,
 } from "./inference/inference.types";
+import {
+  REASONING_PRESETS,
+  isReasoningProfile,
+  isReasoningStyle,
+} from "./inference/reasoning-profile";
 
 /**
  * The model registry — `~/.tsforge/models.json`, the central place a user
@@ -32,16 +37,20 @@ export interface IModelEntry {
   thinking?: boolean;
   /** Per-response token cap override. */
   maxTokens?: number;
-  /** Provider reasoning dialect: how thinking/reasoning is expressed on the wire.
-   *  `qwen` (default) | `deepseek` | `deepseek-local` | `openai` | `none`. Set `deepseek`
-   *  for DeepSeek's CLOUD API, `deepseek-local` for a self-hosted vLLM, `openai` for OpenAI
-   *  o-series. A "deepseek" model/url auto-detects to `deepseek-local` ONLY on a private
-   *  address (loopback / RFC1918 / IPv6 ULA+link-local / .local / .lan / .internal /
-   *  .home / .localdomain), and
-   *  stays `deepseek` on any public host — a public one may be a reverse proxy in
-   *  front of DeepSeek cloud, which still needs the cloud dialect and its
-   *  reasoning_content replay. Set it explicitly for a self-hosted endpoint that
-   *  is reachable on a public address. */
+  /** How this endpoint expresses reasoning on the wire. Either a preset NAME
+   *  (`qwen` | `deepseek` | `deepseek-local` | `openai` | `none`) or a full
+   *  `IReasoningProfile` declaring the field paths itself — the latter is what
+   *  makes an arbitrary model supportable by config rather than by a code change.
+   *
+   *  Omitted → auto-detected: a "deepseek" model/url resolves to `deepseek-local`
+   *  on a PRIVATE address (loopback, RFC1918, CGNAT, IPv6 ULA/link-local,
+   *  .local/.lan/.internal/.home/.localdomain) and to `deepseek` on any public
+   *  one, since a public host may be a reverse proxy in front of DeepSeek cloud.
+   *  Declare it explicitly for a self-host on a public address, or for a
+   *  single-label hostname (e.g. `http://spark2:8888`), which is not treated as
+   *  private because it is indistinguishable from a proxy alias.
+   *
+   *  Validated at load — an unknown name or malformed profile throws. */
   reasoning?: ReasoningStyle | IReasoningProfile;
   /** Reasoning effort for `deepseek`/`deepseek-local`/`openai` styles. */
   reasoningEffort?: "low" | "medium" | "high";
@@ -184,6 +193,32 @@ function assertImageApi(name: string, entry: unknown): void {
   }
 }
 
+/** `reasoning` is either a known preset NAME or a well-formed profile object.
+ *  Anything else is rejected here, at the JSON boundary: a typo'd preset would
+ *  otherwise behave as an empty profile (silently sending no reasoning fields),
+ *  and `null` or a malformed profile would surface as a TypeError mid-turn.
+ *  Matches the fail-loud contract of the maxTokens/imageApi guards. */
+function assertReasoning(name: string, entry: unknown): void {
+  if (!isRecord(entry) || entry.reasoning === undefined) {
+    return;
+  }
+
+  const value = entry.reasoning;
+
+  if (isReasoningStyle(value) || isReasoningProfile(value)) {
+    return;
+  }
+
+  const presets = Object.keys(REASONING_PRESETS).join(", ");
+
+  throw new Error(
+    `models.json: model "${name}" reasoning must be one of [${presets}] ` +
+      `or a profile object { thinking?: { path }, effort?, budget?, tokenCap?, ` +
+      `omitTemperature?, omitToolChoice?, replayReasoning?, latchThinking? } ` +
+      `with string dot-paths (no __proto__/constructor/prototype segments)`
+  );
+}
+
 function isInputMode(v: unknown): v is BinaryInputMode {
   return v === "stdin" || v === "arg" || v === "tempfile";
 }
@@ -306,6 +341,7 @@ export function parseModelsConfig(raw: unknown): IModelsConfig {
 
     assertNumericFields(name, entry);
     assertImageApi(name, entry);
+    assertReasoning(name, entry);
     models[name] = entry;
   }
 

--- a/packages/core/src/models-config.ts
+++ b/packages/core/src/models-config.ts
@@ -30,8 +30,10 @@ export interface IModelEntry {
   /** Per-response token cap override. */
   maxTokens?: number;
   /** Provider reasoning dialect: how thinking/reasoning is expressed on the wire.
-   *  `qwen` (default) | `deepseek` | `openai` | `none`. Set `deepseek` for the
-   *  DeepSeek API, `openai` for OpenAI o-series. */
+   *  `qwen` (default) | `deepseek` | `vllm` | `openai` | `none`. Set `deepseek`
+   *  for DeepSeek's CLOUD API, `vllm` for a self-hosted vLLM, `openai` for OpenAI
+   *  o-series. A "deepseek" model/url auto-detects to `deepseek` on
+   *  *.deepseek.com and to `vllm` anywhere else. */
   reasoning?: ReasoningStyle;
   /** Reasoning effort for `deepseek`/`openai` styles. */
   reasoningEffort?: "low" | "medium" | "high";

--- a/packages/core/tests/inference.test.ts
+++ b/packages/core/tests/inference.test.ts
@@ -511,13 +511,22 @@ test("a response without reasoning_content carries no reasoning channel", () => 
   ).toBeUndefined();
 });
 
-/** Capture the JSON body of every request the provider makes. */
+/** Capture the JSON body of every request the provider makes. Composed with
+ *  `Object.assign` because Bun's `typeof fetch` also carries `preconnect`, so a
+ *  bare function does not satisfy it — and a cast is not allowed here. */
 function recordingFetch(sink: Record<string, unknown>[]): typeof fetch {
-  return (async (_url: unknown, init: { body?: string }) => {
-    sink.push(JSON.parse(init.body ?? "{}"));
+  const impl = async (
+    _input: URL | RequestInfo,
+    init?: RequestInit
+  ): Promise<Response> => {
+    const body = typeof init?.body === "string" ? init.body : "{}";
+
+    sink.push(JSON.parse(body));
 
     return okResponse();
-  }) as unknown as typeof fetch;
+  };
+
+  return Object.assign(impl, { preconnect: globalThis.fetch.preconnect });
 }
 
 test("a latching profile pins thinking to the session's first value", async () => {

--- a/packages/core/tests/inference.test.ts
+++ b/packages/core/tests/inference.test.ts
@@ -510,3 +510,48 @@ test("a response without reasoning_content carries no reasoning channel", () => 
       .reasoning_content
   ).toBeUndefined();
 });
+
+/** Capture the JSON body of every request the provider makes. */
+function recordingFetch(sink: Record<string, unknown>[]): typeof fetch {
+  return (async (_url: unknown, init: { body?: string }) => {
+    sink.push(JSON.parse(init.body ?? "{}"));
+
+    return okResponse();
+  }) as unknown as typeof fetch;
+}
+
+test("a latching profile pins thinking to the session's first value", async () => {
+  // DeepSeek's cloud API 400s if thinking flips mid-conversation, so the
+  // provider latches it. The constraint is declared by the profile, not by a
+  // vendor name — latchThinking is what withPinnedThinking keys off.
+  const sent: Record<string, unknown>[] = [];
+  const p = new OpenAICompatibleProvider({
+    baseUrl: "https://api.deepseek.com/v1",
+    model: "deepseek-v4-pro",
+    fetch: recordingFetch(sent),
+  });
+
+  await p.complete([{ role: "user", content: "a" }], { enableThinking: true });
+  await p.complete([{ role: "user", content: "b" }], { enableThinking: false });
+
+  // Second turn asked for OFF but is pinned to the session's first value.
+  expect(sent[0]?.thinking).toEqual({ type: "enabled" });
+  expect(sent[1]?.thinking).toEqual({ type: "enabled" });
+});
+
+test("a non-latching profile keeps per-turn thinking control", async () => {
+  // A self-hosted endpoint has no such constraint, so the harness must be able
+  // to flip thinking per request — this is what the latch used to prevent.
+  const sent: Record<string, unknown>[] = [];
+  const p = new OpenAICompatibleProvider({
+    baseUrl: "http://192.168.20.108:8888/v1",
+    model: "deepseek-v4-flash",
+    fetch: recordingFetch(sent),
+  });
+
+  await p.complete([{ role: "user", content: "a" }], { enableThinking: true });
+  await p.complete([{ role: "user", content: "b" }], { enableThinking: false });
+
+  expect(sent[0]?.chat_template_kwargs).toEqual({ thinking: true });
+  expect(sent[1]?.chat_template_kwargs).toEqual({ thinking: false });
+});

--- a/packages/core/tests/models-config.test.ts
+++ b/packages/core/tests/models-config.test.ts
@@ -1,4 +1,7 @@
 import { test, expect, beforeEach, afterEach } from "bun:test";
+import { providerConfig } from "../src/cli/model-setup";
+import { buildRequestBody } from "../src/inference/request";
+import type { ReasoningStyle } from "../src/inference/reasoning-profile";
 import { mkdtemp, rm, readFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
@@ -396,4 +399,143 @@ test("resolveCapabilityModel: env names a registry entry; imageApi override pars
 
 test("planner is a routable capability role", () => {
   expect(CAPABILITY_NAMES).toContain("planner");
+});
+
+test("parseModelsConfig accepts a preset NAME or a well-formed reasoning profile", () => {
+  const entry = (reasoning: unknown) => ({
+    active: "a",
+    models: { a: { baseUrl: "u", model: "m", reasoning } },
+  });
+
+  const presets: ReasoningStyle[] = [
+    "qwen",
+    "deepseek",
+    "deepseek-local",
+    "openai",
+    "none",
+  ];
+
+  for (const name of presets) {
+    expect(parseModelsConfig(entry(name)).models.a?.reasoning).toBe(name);
+  }
+
+  const profile = {
+    thinking: { path: "chat_template_kwargs.thinking" },
+    effort: "chat_template_kwargs.reasoning_effort",
+    budget: "thinking_token_budget",
+    latchThinking: false,
+  };
+
+  expect(parseModelsConfig(entry(profile)).models.a?.reasoning).toEqual(
+    profile
+  );
+
+  // absent stays absent (auto-detection applies at request time)
+  expect(
+    parseModelsConfig({
+      active: "a",
+      models: { a: { baseUrl: "u", model: "m" } },
+    }).models.a?.reasoning
+  ).toBeUndefined();
+});
+
+test("parseModelsConfig rejects a bad reasoning value at the JSON boundary", () => {
+  const bad = (reasoning: unknown) => () =>
+    parseModelsConfig({
+      active: "a",
+      models: { a: { baseUrl: "u", model: "m", reasoning } },
+    });
+
+  // A typo would otherwise behave as an empty profile: load fine, then silently
+  // send no reasoning fields at all.
+  expect(bad("qwne")).toThrow(/reasoning must be/);
+  // null is not undefined — it used to reach the request builder and throw.
+  expect(bad(null)).toThrow(/reasoning must be/);
+  expect(bad(42)).toThrow(/reasoning must be/);
+  expect(bad([])).toThrow(/reasoning must be/);
+  // misspelled profile keys must not validate
+  expect(bad({ budegt: "x" })).toThrow(/reasoning must be/);
+  // structurally wrong members
+  expect(bad({ thinking: true })).toThrow(/reasoning must be/);
+  expect(bad({ thinking: {} })).toThrow(/reasoning must be/);
+  expect(bad({ effort: 5 })).toThrow(/reasoning must be/);
+  expect(bad({ latchThinking: "yes" })).toThrow(/reasoning must be/);
+  // a path that would escape into the prototype chain
+  expect(bad({ thinking: { path: "__proto__.x" } })).toThrow(
+    /reasoning must be/
+  );
+  expect(bad({ budget: "a..b" })).toThrow(/reasoning must be/);
+});
+
+test("a reasoning profile survives save → load → providerConfig → request body", async () => {
+  // The CLI wizard and /model write entries through this same path, so a
+  // profile must round-trip end to end, not just validate at parse time.
+  const profile = {
+    thinking: { path: "chat_template_kwargs.thinking" },
+    effort: "chat_template_kwargs.reasoning_effort",
+    budget: "thinking_token_budget",
+  };
+
+  await saveModelsConfig({
+    active: "local",
+    models: {
+      local: {
+        baseUrl: "http://192.168.1.10:8000/v1",
+        model: "deepseek-v4-flash",
+        reasoning: profile,
+        reasoningEffort: "low",
+      },
+    },
+  });
+
+  const loaded = await loadModelsConfig();
+  const entry = loaded.models.local;
+
+  expect(entry?.reasoning).toEqual(profile);
+
+  const cfg = providerConfig(entry!);
+
+  expect(cfg.reasoning).toEqual(profile);
+
+  const bodyOut = buildRequestBody(
+    cfg,
+    [{ role: "user", content: "hi" }],
+    { enableThinking: false },
+    false
+  );
+
+  expect(bodyOut.chat_template_kwargs).toEqual({
+    thinking: false,
+    reasoning_effort: "low",
+  });
+});
+
+test("a preset NAME still round-trips through the wizard's providerConfig", async () => {
+  await saveModelsConfig({
+    active: "cloud",
+    models: {
+      cloud: {
+        baseUrl: "https://api.deepseek.com/v1",
+        model: "deepseek-v4-pro",
+        reasoning: "deepseek",
+        reasoningEffort: "high",
+      },
+    },
+  });
+
+  const loaded = await loadModelsConfig();
+  const entry = loaded.models.cloud;
+  const cfg = providerConfig(entry!);
+
+  expect(cfg.reasoning).toBe("deepseek");
+
+  const bodyOut = buildRequestBody(
+    cfg,
+    [{ role: "user", content: "hi" }],
+    { enableThinking: true },
+    false
+  );
+
+  expect(bodyOut.thinking).toEqual({ type: "enabled" });
+  expect(bodyOut.reasoning_effort).toBe("high");
 });

--- a/packages/core/tests/models-config.test.ts
+++ b/packages/core/tests/models-config.test.ts
@@ -491,9 +491,13 @@ test("a reasoning profile survives save → load → providerConfig → request 
   const loaded = await loadModelsConfig();
   const entry = loaded.models.local;
 
-  expect(entry?.reasoning).toEqual(profile);
+  if (entry === undefined) {
+    throw new Error("expected the saved entry to load back");
+  }
 
-  const cfg = providerConfig(entry!);
+  expect(entry.reasoning).toEqual(profile);
+
+  const cfg = providerConfig(entry);
 
   expect(cfg.reasoning).toEqual(profile);
 
@@ -525,7 +529,12 @@ test("a preset NAME still round-trips through the wizard's providerConfig", asyn
 
   const loaded = await loadModelsConfig();
   const entry = loaded.models.cloud;
-  const cfg = providerConfig(entry!);
+
+  if (entry === undefined) {
+    throw new Error("expected the saved entry to load back");
+  }
+
+  const cfg = providerConfig(entry);
 
   expect(cfg.reasoning).toBe("deepseek");
 

--- a/packages/core/tests/reasoning-profile.test.ts
+++ b/packages/core/tests/reasoning-profile.test.ts
@@ -80,6 +80,15 @@ describe("isSafePath", () => {
     ["a.__proto__.b"],
     ["constructor"],
     ["prototype"],
+    // reserved: owned by the request builder
+    ["model"],
+    ["messages"],
+    ["temperature"],
+    ["tools"],
+    ["tool_choice"],
+    ["stream"],
+    ["stream_options.include_usage"],
+    ["repetition_penalty"],
   ])("rejects %p", (p) => expect(isSafePath(p)).toBe(false));
 });
 
@@ -157,6 +166,15 @@ describe("isReasoningProfile", () => {
       "thinking colliding with the default token cap",
     ],
     [{ budget: "max_tokens.x" }, "a path nested under the default token cap"],
+    // A profile must not be able to reach fields the request builder owns.
+    [{ tokenCap: "messages" }, "targeting the conversation"],
+    [{ thinking: { path: "model" } }, "targeting the model id"],
+    [{ effort: "temperature" }, "targeting temperature"],
+    [{ budget: "tools.0" }, "nesting under tools"],
+    [
+      { effort: "stream_options.include_usage" },
+      "nesting under stream_options",
+    ],
   ])("rejects %p (%s)", (value) => {
     expect(isReasoningProfile(value)).toBe(false);
   });

--- a/packages/core/tests/reasoning-profile.test.ts
+++ b/packages/core/tests/reasoning-profile.test.ts
@@ -1,0 +1,156 @@
+import { test, expect, describe } from "bun:test";
+import {
+  REASONING_PRESETS,
+  isReasoningProfile,
+  isReasoningStyle,
+  isSafePath,
+  setPath,
+} from "../src/inference/reasoning-profile";
+
+describe("setPath", () => {
+  test("writes a top-level key", () => {
+    expect(setPath({}, "a", 1)).toEqual({ a: 1 });
+  });
+
+  test("creates intermediate objects for a dot path", () => {
+    expect(setPath({}, "a.b.c", 1)).toEqual({ a: { b: { c: 1 } } });
+  });
+
+  test("merges into an existing object rather than replacing it", () => {
+    const t: Record<string, unknown> = { a: { keep: true } };
+
+    setPath(t, "a.added", 1);
+
+    expect(t).toEqual({ a: { keep: true, added: 1 } });
+  });
+
+  test("overwrites a non-object sitting at an intermediate segment", () => {
+    // Bailing out instead would silently drop the field the caller asked for.
+    expect(setPath({ a: 5 }, "a.b", 1)).toEqual({ a: { b: 1 } });
+    expect(setPath({ a: [1, 2] }, "a.b", 1)).toEqual({ a: { b: 1 } });
+    expect(setPath({ a: null }, "a.b", 1)).toEqual({ a: { b: 1 } });
+  });
+
+  test.each([[""], ["."], ["a."], [".a"], ["a..b"]])(
+    "ignores the malformed path %p instead of throwing",
+    (path) => {
+      expect(setPath({ untouched: true }, path, 1)).toEqual({
+        untouched: true,
+      });
+    }
+  );
+
+  test("refuses to walk into the prototype chain", () => {
+    // models.json is user-editable, so a path must not be able to reach
+    // Object.prototype and pollute every object in the process.
+    const target: Record<string, unknown> = {};
+
+    setPath(target, "__proto__.polluted", "yes");
+    setPath(target, "constructor.prototype.polluted", "yes");
+    setPath(target, "a.__proto__.polluted", "yes");
+
+    expect(({} as Record<string, unknown>).polluted).toBeUndefined();
+    expect(Object.prototype).not.toHaveProperty("polluted");
+    expect(target.polluted).toBeUndefined();
+  });
+
+  test("does not descend into an inherited property", () => {
+    const base = { shared: { hi: true } };
+    const target = Object.create(base) as Record<string, unknown>;
+
+    setPath(target, "shared.mine", 1);
+
+    expect(Object.hasOwn(target, "shared")).toBe(true);
+    expect(base.shared).toEqual({ hi: true });
+  });
+});
+
+describe("isSafePath", () => {
+  test.each([["a"], ["a.b"], ["chat_template_kwargs.thinking"]])(
+    "accepts %p",
+    (p) => expect(isSafePath(p)).toBe(true)
+  );
+
+  test.each([
+    [""],
+    ["."],
+    ["a."],
+    ["a..b"],
+    ["__proto__"],
+    ["a.__proto__.b"],
+    ["constructor"],
+    ["prototype"],
+  ])("rejects %p", (p) => expect(isSafePath(p)).toBe(false));
+});
+
+describe("isReasoningStyle", () => {
+  test("accepts every preset name", () => {
+    for (const name of Object.keys(REASONING_PRESETS)) {
+      expect(isReasoningStyle(name)).toBe(true);
+    }
+  });
+
+  test.each([["qwne"], [""], [null], [undefined], [{}], [42]])(
+    "rejects %p",
+    (v) => expect(isReasoningStyle(v)).toBe(false)
+  );
+
+  test("does not accept inherited Object keys as preset names", () => {
+    expect(isReasoningStyle("toString")).toBe(false);
+    expect(isReasoningStyle("constructor")).toBe(false);
+  });
+});
+
+describe("isReasoningProfile", () => {
+  test("accepts an empty object and a full one", () => {
+    expect(isReasoningProfile({})).toBe(true);
+    expect(
+      isReasoningProfile({
+        thinking: { path: "a.b", onValue: 1, offValue: 0 },
+        effort: "c",
+        budget: "d",
+        tokenCap: "e",
+        omitTemperature: true,
+        omitToolChoice: false,
+        replayReasoning: false,
+        latchThinking: true,
+      })
+    ).toBe(true);
+  });
+
+  test.each([
+    [null, "null"],
+    [undefined, "undefined"],
+    ["deepseek", "a string"],
+    [[], "an array"],
+    [{ thinking: true }, "thinking as a boolean"],
+    [{ thinking: {} }, "thinking without a path"],
+    [{ thinking: { path: 5 } }, "a non-string path"],
+    [{ thinking: { path: "__proto__.x" } }, "an unsafe thinking path"],
+    [{ effort: 5 }, "a non-string effort"],
+    [{ budget: "a..b" }, "a malformed budget path"],
+    [{ tokenCap: "constructor.x" }, "an unsafe tokenCap path"],
+    [{ latchThinking: "yes" }, "a non-boolean flag"],
+  ])("rejects %p (%s)", (value) => {
+    expect(isReasoningProfile(value)).toBe(false);
+  });
+});
+
+describe("REASONING_PRESETS", () => {
+  test("every preset is a valid profile", () => {
+    for (const [name, p] of Object.entries(REASONING_PRESETS)) {
+      expect({ name, valid: isReasoningProfile(p) }).toEqual({
+        name,
+        valid: true,
+      });
+    }
+  });
+
+  test("only the cloud preset carries the two protocol quirks", () => {
+    for (const [name, p] of Object.entries(REASONING_PRESETS)) {
+      const quirky = p.replayReasoning === true || p.latchThinking === true;
+
+      expect({ name, quirky }).toEqual({ name, quirky: name === "deepseek" });
+    }
+  });
+});

--- a/packages/core/tests/reasoning-profile.test.ts
+++ b/packages/core/tests/reasoning-profile.test.ts
@@ -134,6 +134,13 @@ describe("isReasoningProfile", () => {
     [{ budegt: "reasoning.max_tokens" }, "a misspelled key"],
     [{ thnking: { path: "mode" } }, "a misspelled thinking key"],
     [{ thinking: { path: "a" }, extra: 1 }, "an unknown extra key"],
+    [{ thinking: { path: "a", onValu: 1 } }, "a typo inside thinking"],
+    [
+      { tokenCap: "params", thinking: { path: "params.enabled" } },
+      "an ancestor/descendant path pair",
+    ],
+    [{ effort: "a.b", budget: "a.b" }, "two identical paths"],
+    [{ tokenCap: "a", effort: "a.b.c" }, "a path nested under another"],
   ])("rejects %p (%s)", (value) => {
     expect(isReasoningProfile(value)).toBe(false);
   });

--- a/packages/core/tests/reasoning-profile.test.ts
+++ b/packages/core/tests/reasoning-profile.test.ts
@@ -49,14 +49,14 @@ describe("setPath", () => {
     setPath(target, "constructor.prototype.polluted", "yes");
     setPath(target, "a.__proto__.polluted", "yes");
 
-    expect(({} as Record<string, unknown>).polluted).toBeUndefined();
-    expect(Object.prototype).not.toHaveProperty("polluted");
+    expect(Object.hasOwn(Object.prototype, "polluted")).toBe(false);
+    expect(Object.hasOwn({}, "polluted")).toBe(false);
     expect(target.polluted).toBeUndefined();
   });
 
   test("does not descend into an inherited property", () => {
     const base = { shared: { hi: true } };
-    const target = Object.create(base) as Record<string, unknown>;
+    const target: Record<string, unknown> = Object.create(base);
 
     setPath(target, "shared.mine", 1);
 
@@ -131,6 +131,9 @@ describe("isReasoningProfile", () => {
     [{ budget: "a..b" }, "a malformed budget path"],
     [{ tokenCap: "constructor.x" }, "an unsafe tokenCap path"],
     [{ latchThinking: "yes" }, "a non-boolean flag"],
+    [{ budegt: "reasoning.max_tokens" }, "a misspelled key"],
+    [{ thnking: { path: "mode" } }, "a misspelled thinking key"],
+    [{ thinking: { path: "a" }, extra: 1 }, "an unknown extra key"],
   ])("rejects %p (%s)", (value) => {
     expect(isReasoningProfile(value)).toBe(false);
   });

--- a/packages/core/tests/reasoning-profile.test.ts
+++ b/packages/core/tests/reasoning-profile.test.ts
@@ -102,6 +102,14 @@ describe("isReasoningStyle", () => {
 });
 
 describe("isReasoningProfile", () => {
+  test("an explicit tokenCap frees up the default path for another control", () => {
+    // Only the DEFAULT participates when tokenCap is unset; moving the cap
+    // elsewhere makes max_tokens available again.
+    expect(
+      isReasoningProfile({ tokenCap: "output_limit", effort: "max_tokens" })
+    ).toBe(true);
+  });
+
   test("accepts an empty object and a full one", () => {
     expect(isReasoningProfile({})).toBe(true);
     expect(
@@ -141,6 +149,14 @@ describe("isReasoningProfile", () => {
     ],
     [{ effort: "a.b", budget: "a.b" }, "two identical paths"],
     [{ tokenCap: "a", effort: "a.b.c" }, "a path nested under another"],
+    // The token cap is written even when unset, so its DEFAULT must take part
+    // in the overlap check or a reasoning field silently destroys it.
+    [{ effort: "max_tokens" }, "effort colliding with the default token cap"],
+    [
+      { thinking: { path: "max_tokens" } },
+      "thinking colliding with the default token cap",
+    ],
+    [{ budget: "max_tokens.x" }, "a path nested under the default token cap"],
   ])("rejects %p (%s)", (value) => {
     expect(isReasoningProfile(value)).toBe(false);
   });

--- a/packages/core/tests/request-builder.test.ts
+++ b/packages/core/tests/request-builder.test.ts
@@ -791,3 +791,74 @@ describe("buildRequestBody: isolation and documented host cases", () => {
     expect(b.tool_choice).toBeUndefined();
   });
 });
+
+describe("buildRequestBody: malformed reasoning on the DeepSeek cloud host", () => {
+  const cloud = {
+    baseUrl: "https://api.deepseek.com/v1",
+    model: "deepseek-v4-pro",
+  };
+
+  test.each([
+    [null, "null"],
+    ["qwne", "a typo'd preset"],
+    [{ budegt: "x" }, "a malformed profile"],
+  ])(
+    "a bad reasoning value (%s) resolves to the cloud dialect CONSISTENTLY",
+    (bad) => {
+      // The fallback used to disagree with the tool_choice gate: the request
+      // got cloud thinking fields AND tool_choice, which that endpoint rejects.
+      const raw: Record<string, unknown> = { ...cloud, reasoning: bad };
+      const b = buildRequestBody(
+        { ...cfg(), ...raw },
+        MSGS,
+        { enableThinking: true, tools: [{}], toolChoice: "required" },
+        false
+      );
+
+      // cloud thinking shape...
+      expect(b.thinking).toEqual({ type: "enabled" });
+      // ...so tool_choice MUST be omitted, not sent.
+      expect(b.tool_choice).toBeUndefined();
+      expect(b.tools).toBeDefined();
+    }
+  );
+
+  test("the same fallback also latches thinking and replays reasoning", () => {
+    const raw: Record<string, unknown> = { ...cloud, reasoning: null };
+    const merged = { ...cfg(), ...raw };
+
+    expect(latchesThinking(merged)).toBe(true);
+
+    const b = buildRequestBody(
+      merged,
+      [
+        { role: "user", content: "hi" },
+        { role: "assistant", content: "a", reasoningContent: "thought" },
+      ],
+      {},
+      false
+    );
+
+    expect(JSON.stringify(b.messages)).toContain(
+      '"reasoning_content":"thought"'
+    );
+  });
+});
+
+describe("buildRequestBody: fully-qualified hostnames", () => {
+  test.each([
+    ["http://localhost.:8000/v1"],
+    ["http://spark2.lan.:8888/v1"],
+    ["http://box.internal.:8000/v1"],
+  ])("a trailing root dot in %s is still private", (baseUrl) => {
+    // `localhost.` is the same host as `localhost`; failing to normalize it
+    // silently selected the cloud dialect for a local runtime.
+    const b = body(
+      { baseUrl, model: "deepseek-v4-flash" },
+      { enableThinking: false }
+    );
+
+    expect(b.chat_template_kwargs).toEqual({ thinking: false });
+    expect(b.thinking).toBeUndefined();
+  });
+});

--- a/packages/core/tests/request-builder.test.ts
+++ b/packages/core/tests/request-builder.test.ts
@@ -47,6 +47,87 @@ describe("buildRequestBody: reasoning styles", () => {
     expect(b.chat_template_kwargs).toBeUndefined();
   });
 
+  test("vllm emits chat_template_kwargs.thinking + reasoning_effort", () => {
+    const b = body(
+      { reasoning: "vllm", reasoningEffort: "low" },
+      { enableThinking: true }
+    );
+
+    // vLLM reads `thinking` inside the template kwargs — NOT qwen's
+    // `enable_thinking`, and NOT DeepSeek cloud's top-level `thinking:{type}`.
+    expect(b.chat_template_kwargs).toEqual({ thinking: true });
+    expect(b.reasoning_effort).toBe("low");
+    expect(b.thinking).toBeUndefined();
+  });
+
+  test("vllm can turn thinking OFF (the field vLLM actually honours)", () => {
+    const b = body({ reasoning: "vllm" }, { enableThinking: false });
+
+    expect(b.chat_template_kwargs).toEqual({ thinking: false });
+  });
+
+  test("vllm omits reasoning fields entirely when nothing is requested", () => {
+    const b = body({ reasoning: "vllm" }, {});
+
+    expect(b.chat_template_kwargs).toBeUndefined();
+    expect(b.reasoning_effort).toBeUndefined();
+  });
+
+  test("a LOCAL deepseek model auto-detects as vllm, not deepseek", () => {
+    // Regression: a self-hosted DeepSeek checkpoint used to auto-detect as
+    // `deepseek`, so thinking was sent as `thinking:{type}` — which vLLM accepts
+    // and silently ignores. Thinking was therefore uncontrollable from config.
+    const b = body(
+      {
+        baseUrl: "http://192.168.20.108:8888/v1",
+        model: "deepseek-v4-flash-0731",
+      },
+      { enableThinking: false }
+    );
+
+    expect(b.chat_template_kwargs).toEqual({ thinking: false });
+    expect(b.thinking).toBeUndefined();
+  });
+
+  test("a CLOUD deepseek model still auto-detects as deepseek", () => {
+    const b = body(
+      { baseUrl: "https://api.deepseek.com/v1", model: "deepseek-v4-pro" },
+      { enableThinking: false }
+    );
+
+    expect(b.thinking).toEqual({ type: "disabled" });
+    expect(b.chat_template_kwargs).toBeUndefined();
+  });
+
+  test("a PUBLIC-host deepseek model stays deepseek (may be a cloud proxy)", () => {
+    // Only a private address is evidence of self-hosting. A public hostname can
+    // be a reverse proxy in front of DeepSeek cloud, which needs the cloud
+    // dialect and the reasoning_content replay — reclassifying it would 400.
+    const b = body(
+      { baseUrl: "https://proxy.example.com/v1", model: "deepseek-pro-4" },
+      { enableThinking: false }
+    );
+
+    expect(b.thinking).toEqual({ type: "disabled" });
+    expect(b.chat_template_kwargs).toBeUndefined();
+  });
+
+  test.each([
+    ["http://localhost:8000/v1"],
+    ["http://127.0.0.1:8000/v1"],
+    ["http://192.168.20.108:8888/v1"],
+    ["http://10.0.0.5:8000/v1"],
+    ["http://172.16.4.9:8000/v1"],
+    ["http://spark2.lan:8888/v1"],
+  ])("private host %s auto-detects as vllm", (baseUrl) => {
+    const b = body({ baseUrl, model: "deepseek-v4-flash" }, {
+      enableThinking: false,
+    });
+
+    expect(b.chat_template_kwargs).toEqual({ thinking: false });
+    expect(b.thinking).toBeUndefined();
+  });
+
   test("local deepseek auto-sends tool_choice (no config — vLLM accepts it)", () => {
     const b = body(
       { reasoning: "deepseek", baseUrl: "http://localhost:8000/v1" },

--- a/packages/core/tests/request-builder.test.ts
+++ b/packages/core/tests/request-builder.test.ts
@@ -146,6 +146,8 @@ describe("buildRequestBody: reasoning styles", () => {
     ["http://172.16.4.9:8000/v1"],
     ["http://169.254.7.7:8000/v1"],
     ["http://spark2.lan:8888/v1"],
+    // RFC 6761 reserves the whole .localhost namespace for loopback.
+    ["http://deepseek.localhost:8000/v1"],
     // IPv6: URL.hostname KEEPS the brackets, so these only pass if stripped.
     ["http://[::1]:8000/v1"],
     ["http://[fd12:3456::1]:8000/v1"],

--- a/packages/core/tests/request-builder.test.ts
+++ b/packages/core/tests/request-builder.test.ts
@@ -655,9 +655,16 @@ describe("buildRequestBody: profile edge cases", () => {
   ])("a bad reasoning value (%s) falls back instead of throwing", (bad) => {
     // The loader rejects these loudly; this is the last line of defence so a
     // hand-edited registry cannot kill a live turn mid-flight.
+    // A hand-edited registry can hold anything, so the value is injected the
+    // way JSON.parse would deliver it rather than through the typed field.
+    const raw: Record<string, unknown> = {
+      baseUrl: "https://x/v1",
+      model: "m",
+      reasoning: bad,
+    };
     const build = () =>
       buildRequestBody(
-        cfg({ reasoning: bad as never, baseUrl: "https://x/v1", model: "m" }),
+        { ...cfg(), ...raw },
         MSGS,
         { enableThinking: true },
         false
@@ -676,5 +683,54 @@ describe("buildRequestBody: profile edge cases", () => {
 
     expect(Object.hasOwn(Object.prototype, "polluted")).toBe(false);
     expect(b.polluted).toBeUndefined();
+  });
+});
+
+describe("tool_choice suppression is gated on the DeepSeek CLOUD dialect", () => {
+  const cloud = "https://api.deepseek.com/v1";
+  const withTools: ICompleteOptions = { tools: [{}], toolChoice: "required" };
+
+  test("auto-detected cloud deepseek omits tool_choice", () => {
+    expect(
+      body({ baseUrl: cloud, model: "deepseek-v4-pro" }, withTools).tool_choice
+    ).toBeUndefined();
+  });
+
+  test.each([["none"], ["qwen"], ["openai"]] as const)(
+    "an explicit %s profile on the cloud host STILL sends tool_choice",
+    (reasoning) => {
+      // Regression guard: dropping the dialect gate made the host heuristic
+      // apply to every profile, silently removing the escape hatch for
+      // non-thinking DeepSeek cloud tool use.
+      expect(
+        body({ baseUrl: cloud, model: "deepseek-v4-pro", reasoning }, withTools)
+          .tool_choice
+      ).toBe("required");
+    }
+  );
+
+  test("a custom profile on the cloud host still sends tool_choice", () => {
+    expect(
+      body(
+        {
+          baseUrl: cloud,
+          model: "deepseek-v4-pro",
+          reasoning: { effort: "reasoning_effort" },
+        },
+        withTools
+      ).tool_choice
+    ).toBe("required");
+  });
+
+  test("a profile may declare the suppression itself, on any host", () => {
+    expect(
+      body(
+        {
+          baseUrl: "http://localhost:8000/v1",
+          reasoning: { omitToolChoice: true },
+        },
+        withTools
+      ).tool_choice
+    ).toBeUndefined();
   });
 });

--- a/packages/core/tests/request-builder.test.ts
+++ b/packages/core/tests/request-builder.test.ts
@@ -734,3 +734,60 @@ describe("tool_choice suppression is gated on the DeepSeek CLOUD dialect", () =>
     ).toBeUndefined();
   });
 });
+
+describe("buildRequestBody: isolation and documented host cases", () => {
+  test("a single-label host is NOT private (documented, indistinguishable from a proxy alias)", () => {
+    const b = body(
+      { baseUrl: "http://spark2:8888/v1", model: "deepseek-v4-flash" },
+      { enableThinking: false }
+    );
+
+    expect(b.thinking).toEqual({ type: "disabled" });
+    expect(b.chat_template_kwargs).toBeUndefined();
+  });
+
+  test("mutating a built body cannot corrupt the shared preset", () => {
+    // profile() returns the SHARED preset object (Readonly is type-only), so a
+    // by-reference write would leak into every later request in the process.
+    const first = body({ reasoning: "deepseek" }, { enableThinking: true });
+
+    expect(first.thinking).toEqual({ type: "enabled" });
+
+    const mutable = first.thinking;
+
+    if (typeof mutable === "object" && mutable !== null) {
+      Object.assign(mutable, { type: "CORRUPTED" });
+    }
+
+    const second = body({ reasoning: "deepseek" }, { enableThinking: true });
+
+    expect(second.thinking).toEqual({ type: "enabled" });
+  });
+
+  test("an equivalent hand-written cloud profile behaves predictably", () => {
+    // Identity comparison against the preset used to decide this; keying on how
+    // the dialect was chosen makes a data profile explicit rather than magic.
+    const asData = {
+      thinking: {
+        path: "thinking",
+        onValue: { type: "enabled" },
+        offValue: { type: "disabled" },
+      },
+      effort: "reasoning_effort",
+      replayReasoning: true,
+      latchThinking: true,
+      omitToolChoice: true,
+    };
+    const b = body(
+      {
+        baseUrl: "https://api.deepseek.com/v1",
+        model: "deepseek-v4-pro",
+        reasoning: asData,
+      },
+      { tools: [{}], toolChoice: "required", enableThinking: true }
+    );
+
+    expect(b.thinking).toEqual({ type: "enabled" });
+    expect(b.tool_choice).toBeUndefined();
+  });
+});

--- a/packages/core/tests/request-builder.test.ts
+++ b/packages/core/tests/request-builder.test.ts
@@ -596,3 +596,85 @@ describe("buildRequestBody: declarative reasoning profiles", () => {
     );
   });
 });
+
+describe("buildRequestBody: profile edge cases", () => {
+  test("tokenCap and a reasoning field under a SHARED parent both survive", () => {
+    // Regression: these were built as separate objects and shallow-spread, so
+    // the second `params` replaced the first and one field vanished silently.
+    const b = body(
+      {
+        reasoning: {
+          tokenCap: "params.output_limit",
+          effort: "params.reasoning.level",
+          thinking: { path: "params.reasoning.enabled" },
+        },
+        reasoningEffort: "high",
+        maxTokens: 4096,
+      },
+      { enableThinking: true }
+    );
+
+    expect(b.params).toEqual({
+      output_limit: 4096,
+      reasoning: { level: "high", enabled: true },
+    });
+  });
+
+  test.each([
+    ["http://100.64.0.1:8000/v1"],
+    ["http://100.127.255.254:8000/v1"],
+  ])("CGNAT host %s is private (Tailscale-style self-host)", (baseUrl) => {
+    const b = body(
+      { baseUrl, model: "deepseek-v4-flash" },
+      { enableThinking: false }
+    );
+
+    expect(b.chat_template_kwargs).toEqual({ thinking: false });
+  });
+
+  test("100.63.x and 100.128.x are OUTSIDE CGNAT and stay public", () => {
+    for (const baseUrl of [
+      "http://100.63.0.1:8000/v1",
+      "http://100.128.0.1:8000/v1",
+    ]) {
+      const b = body(
+        { baseUrl, model: "deepseek-v4-flash" },
+        { enableThinking: false }
+      );
+
+      expect(b.thinking).toEqual({ type: "disabled" });
+    }
+  });
+
+  test.each([
+    [null, "null"],
+    ["qwne", "a typo'd preset"],
+    [{ budegt: "x" }, "a misspelled profile key"],
+    [{ thinking: true }, "a malformed thinking flag"],
+    [42, "a number"],
+  ])("a bad reasoning value (%s) falls back instead of throwing", (bad) => {
+    // The loader rejects these loudly; this is the last line of defence so a
+    // hand-edited registry cannot kill a live turn mid-flight.
+    const build = () =>
+      buildRequestBody(
+        cfg({ reasoning: bad as never, baseUrl: "https://x/v1", model: "m" }),
+        MSGS,
+        { enableThinking: true },
+        false
+      );
+
+    expect(build).not.toThrow();
+    // Falls back to the qwen auto-preset for a non-deepseek model.
+    expect(build().chat_template_kwargs).toEqual({ enable_thinking: true });
+  });
+
+  test("an unsafe path in a profile writes nothing, and never pollutes", () => {
+    const b = body(
+      { reasoning: { thinking: { path: "__proto__.polluted" } } },
+      { enableThinking: true }
+    );
+
+    expect(Object.hasOwn(Object.prototype, "polluted")).toBe(false);
+    expect(b.polluted).toBeUndefined();
+  });
+});

--- a/packages/core/tests/request-builder.test.ts
+++ b/packages/core/tests/request-builder.test.ts
@@ -4,11 +4,13 @@ import type {
   IOpenAICompatibleConfig,
   ICompleteOptions,
 } from "../src/inference";
+import { REASONING_PRESETS } from "../src/inference/reasoning-profile";
 import {
   buildRequestBody,
   buildRequestHeaders,
   chatCompletionsUrl,
   latchesThinking,
+  profile,
 } from "../src/inference/request";
 
 const MSGS: IChatMessage[] = [{ role: "user", content: "hi" }];
@@ -242,14 +244,29 @@ describe("buildRequestBody: reasoning styles", () => {
     );
   });
 
-  test("local deepseek auto-sends tool_choice (no config — vLLM accepts it)", () => {
+  test("a local deepseek endpoint sends tool_choice (vLLM accepts it)", () => {
+    // A self-hosted DeepSeek auto-detects as `deepseek-local`, which declares no
+    // tool_choice suppression, so the call stays grammar-constrained.
+    const b = body(
+      { baseUrl: "http://localhost:8000/v1", model: "deepseek-v4-flash" },
+      { tools: [{}], toolChoice: "required" }
+    );
+
+    expect(b.tools).toBeDefined();
+    expect(b.tool_choice).toBe("required");
+  });
+
+  test("naming the CLOUD preset for a local server omits tool_choice", () => {
+    // Suppression rides on the profile as data, so explicitly choosing the
+    // cloud dialect applies its quirks wherever it points. The fix for a local
+    // server is to use `deepseek-local`, not to rely on a host check.
     const b = body(
       { reasoning: "deepseek", baseUrl: "http://localhost:8000/v1" },
       { tools: [{}], toolChoice: "required" }
     );
 
     expect(b.tools).toBeDefined();
-    expect(b.tool_choice).toBe("required");
+    expect(b.tool_choice).toBeUndefined();
   });
 
   test("DeepSeek CLOUD host auto-omits tool_choice (its thinking API 400s on it)", () => {
@@ -491,9 +508,10 @@ describe("reasoning_content round-trip", () => {
     );
   });
 
-  test("auto-detected deepseek on a non-cloud host still sends tool_choice", () => {
-    // Style is auto-detected as deepseek from the model name (for reasoning
-    // replay), but the host isn't api.deepseek.com, so tool_choice is sent.
+  test("auto-detected deepseek on a PUBLIC host omits tool_choice", () => {
+    // A public host with a deepseek model is the cloud API or a proxy in front
+    // of it — both reject an explicit tool_choice. Self-hosting resolves to
+    // `deepseek-local` instead, so this no longer catches a local server.
     const b = buildRequestBody(
       cfg({ model: "deepseek-pro-4" }),
       MSGS,
@@ -502,7 +520,7 @@ describe("reasoning_content round-trip", () => {
     );
 
     expect(b.tools).toBeDefined();
-    expect(b.tool_choice).toBe("auto");
+    expect(b.tool_choice).toBeUndefined();
   });
 });
 
@@ -860,5 +878,42 @@ describe("buildRequestBody: fully-qualified hostnames", () => {
 
     expect(b.chat_template_kwargs).toEqual({ thinking: false });
     expect(b.thinking).toBeUndefined();
+  });
+});
+
+describe("preset name and preset object are behavioural aliases", () => {
+  const cloud = {
+    baseUrl: "https://api.deepseek.com/v1",
+    model: "deepseek-v4-pro",
+  };
+  const opts: ICompleteOptions = {
+    enableThinking: true,
+    tools: [{}],
+    toolChoice: "required",
+  };
+
+  test("a spread copy of the deepseek preset behaves like the name", () => {
+    // The suppression used to be decided outside the profile, so a copy of the
+    // preset silently lost it and DeepSeek cloud 400'd on tool turns.
+    const byName = body({ ...cloud, reasoning: "deepseek" }, opts);
+    const byValue = body(
+      { ...cloud, reasoning: { ...REASONING_PRESETS.deepseek } },
+      opts
+    );
+
+    expect(byValue.thinking).toEqual(byName.thinking);
+    expect(byValue.tool_choice).toEqual(byName.tool_choice);
+    expect(byValue.tool_choice).toBeUndefined();
+    expect(latchesThinking({ ...cfg(), ...cloud, reasoning: "deepseek" })).toBe(
+      true
+    );
+  });
+
+  test("the presets are deep-frozen, so a caller cannot corrupt them", () => {
+    const p = profile(cfg({ ...cloud, reasoning: "deepseek" }));
+
+    expect(Object.isFrozen(p)).toBe(true);
+    expect(Object.isFrozen(p.thinking)).toBe(true);
+    expect(Object.isFrozen(p.thinking?.onValue)).toBe(true);
   });
 });

--- a/packages/core/tests/request-builder.test.ts
+++ b/packages/core/tests/request-builder.test.ts
@@ -8,7 +8,7 @@ import {
   buildRequestBody,
   buildRequestHeaders,
   chatCompletionsUrl,
-  isDeepseekStyle,
+  latchesThinking,
 } from "../src/inference/request";
 
 const MSGS: IChatMessage[] = [{ role: "user", content: "hi" }];
@@ -48,33 +48,47 @@ describe("buildRequestBody: reasoning styles", () => {
     expect(b.chat_template_kwargs).toBeUndefined();
   });
 
-  test("vllm emits chat_template_kwargs.thinking + reasoning_effort", () => {
+  test("deepseek-local emits chat_template_kwargs.thinking + reasoning_effort", () => {
     const b = body(
-      { reasoning: "vllm", reasoningEffort: "low" },
+      { reasoning: "deepseek-local", reasoningEffort: "low" },
       { enableThinking: true }
     );
 
     // vLLM reads `thinking` inside the template kwargs — NOT qwen's
     // `enable_thinking`, and NOT DeepSeek cloud's top-level `thinking:{type}`.
-    expect(b.chat_template_kwargs).toEqual({ thinking: true });
-    expect(b.reasoning_effort).toBe("low");
+    // Effort rides in the SAME object (upstream's server default is literally
+    // `{"thinking":true,"reasoning_effort":"low"}`), not top-level.
+    expect(b.chat_template_kwargs).toEqual({
+      thinking: true,
+      reasoning_effort: "low",
+    });
+    expect(b.reasoning_effort).toBeUndefined();
     expect(b.thinking).toBeUndefined();
   });
 
-  test("vllm can turn thinking OFF (the field vLLM actually honours)", () => {
-    const b = body({ reasoning: "vllm" }, { enableThinking: false });
+  test("deepseek-local sends effort even when thinking is not explicitly toggled", () => {
+    const b = body(
+      { reasoning: "deepseek-local", reasoningEffort: "high" },
+      {}
+    );
+
+    expect(b.chat_template_kwargs).toEqual({ reasoning_effort: "high" });
+  });
+
+  test("deepseek-local can turn thinking OFF (the field vLLM actually honours)", () => {
+    const b = body({ reasoning: "deepseek-local" }, { enableThinking: false });
 
     expect(b.chat_template_kwargs).toEqual({ thinking: false });
   });
 
-  test("vllm omits reasoning fields entirely when nothing is requested", () => {
-    const b = body({ reasoning: "vllm" }, {});
+  test("deepseek-local omits reasoning fields entirely when nothing is requested", () => {
+    const b = body({ reasoning: "deepseek-local" }, {});
 
     expect(b.chat_template_kwargs).toBeUndefined();
     expect(b.reasoning_effort).toBeUndefined();
   });
 
-  test("a LOCAL deepseek model auto-detects as vllm, not deepseek", () => {
+  test("a LOCAL deepseek model auto-detects as deepseek-local, not deepseek", () => {
     // Regression: a self-hosted DeepSeek checkpoint used to auto-detect as
     // `deepseek`, so thinking was sent as `thinking:{type}` — which vLLM accepts
     // and silently ignores. Thinking was therefore uncontrollable from config.
@@ -113,9 +127,9 @@ describe("buildRequestBody: reasoning styles", () => {
     expect(b.chat_template_kwargs).toBeUndefined();
   });
 
-  test("vllm forwards thinking_token_budget (a vLLM param, like qwen)", () => {
+  test("deepseek-local forwards thinking_token_budget (a vLLM param, like qwen)", () => {
     const b = body(
-      { reasoning: "vllm" },
+      { reasoning: "deepseek-local" },
       { enableThinking: true, thinkingTokenBudget: 2048 }
     );
 
@@ -135,7 +149,7 @@ describe("buildRequestBody: reasoning styles", () => {
     ["http://[fd12:3456::1]:8000/v1"],
     ["http://[fe80::1]:8000/v1"],
     ["http://[::ffff:192.168.1.9]:8000/v1"],
-  ])("private host %s auto-detects as vllm", (baseUrl) => {
+  ])("private host %s auto-detects as deepseek-local", (baseUrl) => {
     const b = body(
       { baseUrl, model: "deepseek-v4-flash" },
       {
@@ -152,6 +166,14 @@ describe("buildRequestBody: reasoning styles", () => {
     ["https://proxy.example.com/v1"],
     ["http://8.8.8.8:8000/v1"],
     ["http://[2001:4860::8888]:8000/v1"],
+    // DNS labels that COLLIDE with the IPv6 private prefixes. The range checks
+    // must be gated on the host actually being an IPv6 literal, or these public
+    // names get misread as unique-local/link-local and silently switch dialect.
+    ["https://fda.gov/v1"],
+    ["https://fcm.example.com/v1"],
+    ["https://fd12.corp.example.com/v1"],
+    ["https://fe80.example.com/v1"],
+    ["https://feb-proxy.example.com/v1"],
   ])("public host %s stays deepseek", (baseUrl) => {
     const b = body(
       { baseUrl, model: "deepseek-v4-flash" },
@@ -164,12 +186,12 @@ describe("buildRequestBody: reasoning styles", () => {
     expect(b.chat_template_kwargs).toBeUndefined();
   });
 
-  test("private deepseek is NOT deepseek-style, so thinking is never latched", () => {
+  test("a private deepseek endpoint does not latch thinking", () => {
     // The session latch (withPinnedThinking) keys off isDeepseekStyle. If a
     // private host were still classified deepseek, per-turn thinking control
     // would be silently pinned to the session's first value.
     expect(
-      isDeepseekStyle(
+      latchesThinking(
         cfg({
           baseUrl: "http://192.168.20.108:8888/v1",
           model: "deepseek-v4-flash",
@@ -178,7 +200,7 @@ describe("buildRequestBody: reasoning styles", () => {
     ).toBe(false);
 
     expect(
-      isDeepseekStyle(
+      latchesThinking(
         cfg({
           baseUrl: "https://api.deepseek.com/v1",
           model: "deepseek-v4-pro",
@@ -497,6 +519,80 @@ describe("chatCompletionsUrl", () => {
     );
     expect(chatCompletionsUrl("https://x/v1/chat/completions")).toBe(
       "https://x/v1/chat/completions"
+    );
+  });
+});
+
+describe("buildRequestBody: declarative reasoning profiles", () => {
+  // The point of the profile: a model nobody hardcoded, configured from data.
+  const custom = {
+    thinking: { path: "params.reasoning.enabled" },
+    effort: "params.reasoning.level",
+    budget: "params.reasoning.max_tokens",
+    tokenCap: "output_limit",
+  };
+
+  test("writes every declared field at its dot path, creating nesting", () => {
+    const b = body(
+      { reasoning: custom, reasoningEffort: "high", maxTokens: 4096 },
+      { enableThinking: true, thinkingTokenBudget: 512 }
+    );
+
+    expect(b.params).toEqual({
+      reasoning: { enabled: true, level: "high", max_tokens: 512 },
+    });
+    expect(b.output_limit).toBe(4096);
+    expect(b.max_tokens).toBeUndefined();
+  });
+
+  test("a control the profile omits is never sent", () => {
+    // No `thinking` path declared → the endpoint has no such toggle, so asking
+    // for thinking must produce nothing rather than a field it would ignore.
+    const b = body(
+      { reasoning: { effort: "effort" } },
+      { enableThinking: true, thinkingTokenBudget: 999 }
+    );
+
+    expect(b.thinking).toBeUndefined();
+    expect(b.chat_template_kwargs).toBeUndefined();
+    expect(b.thinking_token_budget).toBeUndefined();
+  });
+
+  test("onValue/offValue express non-boolean flags", () => {
+    const shape = {
+      thinking: {
+        path: "mode",
+        onValue: { kind: "deep" },
+        offValue: { kind: "off" },
+      },
+    };
+
+    expect(body({ reasoning: shape }, { enableThinking: true }).mode).toEqual({
+      kind: "deep",
+    });
+    expect(body({ reasoning: shape }, { enableThinking: false }).mode).toEqual({
+      kind: "off",
+    });
+  });
+
+  test("profile can declare the temperature and tool_choice quirks", () => {
+    const b = body(
+      { reasoning: { omitTemperature: true, omitToolChoice: true } },
+      { temperature: 0.5, tools: [{}], toolChoice: "required" }
+    );
+
+    expect(b.temperature).toBeUndefined();
+    expect(b.tools).toBeDefined();
+    expect(b.tool_choice).toBeUndefined();
+  });
+
+  test("presets are just profiles — deepseek still latches, custom does not", () => {
+    expect(
+      latchesThinking(cfg({ baseUrl: "https://api.deepseek.com/v1" }))
+    ).toBe(true);
+    expect(latchesThinking(cfg({ reasoning: custom }))).toBe(false);
+    expect(latchesThinking(cfg({ reasoning: { latchThinking: true } }))).toBe(
+      true
     );
   });
 });

--- a/packages/core/tests/request-builder.test.ts
+++ b/packages/core/tests/request-builder.test.ts
@@ -8,6 +8,7 @@ import {
   buildRequestBody,
   buildRequestHeaders,
   chatCompletionsUrl,
+  isDeepseekStyle,
 } from "../src/inference/request";
 
 const MSGS: IChatMessage[] = [{ role: "user", content: "hi" }];
@@ -112,20 +113,111 @@ describe("buildRequestBody: reasoning styles", () => {
     expect(b.chat_template_kwargs).toBeUndefined();
   });
 
+  test("vllm forwards thinking_token_budget (a vLLM param, like qwen)", () => {
+    const b = body(
+      { reasoning: "vllm" },
+      { enableThinking: true, thinkingTokenBudget: 2048 }
+    );
+
+    expect(b.thinking_token_budget).toBe(2048);
+  });
+
   test.each([
     ["http://localhost:8000/v1"],
     ["http://127.0.0.1:8000/v1"],
     ["http://192.168.20.108:8888/v1"],
     ["http://10.0.0.5:8000/v1"],
     ["http://172.16.4.9:8000/v1"],
+    ["http://169.254.7.7:8000/v1"],
     ["http://spark2.lan:8888/v1"],
+    // IPv6: URL.hostname KEEPS the brackets, so these only pass if stripped.
+    ["http://[::1]:8000/v1"],
+    ["http://[fd12:3456::1]:8000/v1"],
+    ["http://[fe80::1]:8000/v1"],
+    ["http://[::ffff:192.168.1.9]:8000/v1"],
   ])("private host %s auto-detects as vllm", (baseUrl) => {
-    const b = body({ baseUrl, model: "deepseek-v4-flash" }, {
-      enableThinking: false,
-    });
+    const b = body(
+      { baseUrl, model: "deepseek-v4-flash" },
+      {
+        enableThinking: false,
+      }
+    );
 
     expect(b.chat_template_kwargs).toEqual({ thinking: false });
     expect(b.thinking).toBeUndefined();
+  });
+
+  test.each([
+    ["https://api.deepseek.com/v1"],
+    ["https://proxy.example.com/v1"],
+    ["http://8.8.8.8:8000/v1"],
+    ["http://[2001:4860::8888]:8000/v1"],
+  ])("public host %s stays deepseek", (baseUrl) => {
+    const b = body(
+      { baseUrl, model: "deepseek-v4-flash" },
+      {
+        enableThinking: false,
+      }
+    );
+
+    expect(b.thinking).toEqual({ type: "disabled" });
+    expect(b.chat_template_kwargs).toBeUndefined();
+  });
+
+  test("private deepseek is NOT deepseek-style, so thinking is never latched", () => {
+    // The session latch (withPinnedThinking) keys off isDeepseekStyle. If a
+    // private host were still classified deepseek, per-turn thinking control
+    // would be silently pinned to the session's first value.
+    expect(
+      isDeepseekStyle(
+        cfg({
+          baseUrl: "http://192.168.20.108:8888/v1",
+          model: "deepseek-v4-flash",
+        })
+      )
+    ).toBe(false);
+
+    expect(
+      isDeepseekStyle(
+        cfg({
+          baseUrl: "https://api.deepseek.com/v1",
+          model: "deepseek-v4-pro",
+        })
+      )
+    ).toBe(true);
+  });
+
+  test("private deepseek does NOT replay reasoning_content", () => {
+    // includeReasoning is `style === "deepseek"`. Replay exists to stop the
+    // CLOUD API 400ing; a local vLLM neither needs nor expects it.
+    const hist: IChatMessage[] = [
+      { role: "user", content: "hi" },
+      { role: "assistant", content: "ans", reasoningContent: "my thought" },
+    ];
+
+    const local = buildRequestBody(
+      cfg({
+        baseUrl: "http://192.168.20.108:8888/v1",
+        model: "deepseek-v4-flash",
+      }),
+      hist,
+      {},
+      false
+    );
+
+    expect(JSON.stringify(local.messages)).not.toContain("reasoning_content");
+
+    // ...but a public/proxied deepseek still must replay it.
+    const proxied = buildRequestBody(
+      cfg({ baseUrl: "https://proxy.example.com/v1", model: "deepseek-pro-4" }),
+      hist,
+      {},
+      false
+    );
+
+    expect(JSON.stringify(proxied.messages)).toContain(
+      '"reasoning_content":"my thought"'
+    );
   });
 
   test("local deepseek auto-sends tool_choice (no config — vLLM accepts it)", () => {


### PR DESCRIPTION
## The bug that started it

A self-hosted DeepSeek auto-detected as the `deepseek` style and was sent DeepSeek **cloud's** wire format, `thinking: {"type": "disabled"}`. vLLM accepts that key and does nothing with it. Verified against a live server: `enabled`, `disabled` and absent all return byte-identical replies. So `"thinking": false` in models.json was inert — it only appeared to work because the server's own default happened to match.

That default is not ours to rely on. The upstream recipe just merged `DEFAULT_THINKING`, defaulting to `low` = thinking ON. Measured on the same box: "What is 2+2?" goes from 2 completion tokens to 90.

## Why this became a refactor

The first fix added a fifth member to the `ReasoningStyle` union. Two problems surfaced in review:

1. I named it `vllm`, after the **server**. But `chat_template_kwargs.thinking` is a kwarg of the DeepSeek-V4 **chat template**, which vLLM merely forwards. Qwen's template declares `enable_thinking`; a Llama behind the same vLLM declares neither.
2. More fundamentally: enumerating model families in a union doesn't scale for a harness meant to drive any OpenAI-compatible endpoint. Adding the fifth member breached the cognitive-complexity limit — the design complaining about itself.

## What it is now

An entry declares its own wire mapping:

```jsonc
"reasoning": {
  "thinking": { "path": "chat_template_kwargs.thinking" },
  "effort":   "chat_template_kwargs.reasoning_effort",
  "budget":   "thinking_token_budget",
  "tokenCap": "max_tokens",
  "omitTemperature": false,
  "omitToolChoice":  false,
  "replayReasoning": false,
  "latchThinking":   false
}
```

`qwen` / `deepseek` / `deepseek-local` / `openai` / `none` still work — they are now aliases expanding to this structure rather than branches in code, so existing configs are unchanged and a new model is a config edit.

**An omitted control means the endpoint has no such control, so nothing is sent.** That is what actually kills the accepted-and-ignored class of bug.

The two non-cosmetic quirks become explicit booleans instead of being implied by a vendor name: `replayReasoning` (cloud 400s without the prior turn's `reasoning_content`) and `latchThinking` (cloud 400s if thinking flips mid-conversation). `isDeepseekStyle` → `latchesThinking`.

## Hardening (from review)

- **Prototype pollution**: `setPath` walked inherited properties, so `__proto__.polluted` wrote to `Object.prototype`. Segments are now rejected and traversal is own-properties-only.
- `"reasoning": null` crashed on the next property access; now falls back to auto-detection.
- A malformed `thinking` flag threw inside `setPath`; guarded.
- `models-config` now validates `reasoning` at load, matching its fail-loud contract for `maxTokens`/`imageApi`.
- `tokenCap` was documented as a dot path but used as a literal key.
- `isPrivateHost`: added CGNAT 100.64/10 (Tailscale), IPv6 ULA/link-local/IPv4-mapped, and gated the IPv6 prefix checks on the host actually being an IPv6 literal — `fda.gov` was matching `fc00::/7`.

Single-label hostnames (`http://spark2:8888`) are deliberately **not** private: indistinguishable from a proxy alias. Documented as needing an explicit declaration.

## Verification

`bun run validate` green: typecheck, lint, format, ~3450 tests, PTY e2e. New `tests/reasoning-profile.test.ts` covers `setPath` edge cases (malformed paths, non-object intermediates, prototype escape, inherited properties), both type guards, and preset invariants. Behaviour confirmed against a live vLLM serving DeepSeek-V4-Flash-0731.