### PR TITLE
fix(rule-packs): no-user-controlled-fetch-url checks the ORIGIN, not literalness

### DIFF
--- a/packages/core/RULES.md
+++ b/packages/core/RULES.md
@@ -20,7 +20,7 @@ Rules are grouped by **adoption tier**. Use `profile` in `tsforge.config.json` t
 - **jwt-cookies/jwt-must-verify-not-decode** [ERROR]: Disallow `jwt.decode` / `decodeJwt` — decoding without verification accepts forged tokens. Use `jwt.verify` or `jwtVerify` instead.
 - **nextjs/no-secret-props-to-client** [WARN]: Warn when Server Components pass secret-looking props to JSX — values may cross the client boundary.
 - **runtime-boundaries/no-prototype-polluting-merge** [ERROR]: Disallow merging request body/query/params into objects — enables prototype pollution.
-- **runtime-boundaries/no-user-controlled-fetch-url** [ERROR]: Disallow fetch/axios requests to non-literal URLs — dynamic URLs enable SSRF.
+- **runtime-boundaries/no-user-controlled-fetch-url** [ERROR]: Disallow fetch/axios requests whose ORIGIN is not fixed at author time — a runtime-controlled host enables SSRF.
 - **runtime-boundaries/no-user-controlled-redirect** [ERROR]: Disallow redirects to non-literal URLs — user-controlled redirects enable open redirects.
 - **runtime-boundaries/upload-must-set-limits** [WARN]: Multipart upload handlers should declare `limits` or `maxFileSize` to bound request size.
 - **runtime-boundaries/webhook-must-verify-signature-before-parse** [WARN]: Webhook handlers must verify signatures before calling `.json()` on the request body.

--- a/packages/core/src/loop/feedback/rule-docs.generated.json
+++ b/packages/core/src/loop/feedback/rule-docs.generated.json
@@ -565,7 +565,7 @@
     "good": ""
   },
   "tsforge/no-user-controlled-fetch-url": {
-    "what": "Disallow fetch/axios requests to non-literal URLs — dynamic URLs enable SSRF.",
+    "what": "Disallow fetch/axios requests whose ORIGIN is not fixed at author time — a runtime-controlled host enables SSRF.",
     "bad": "",
     "good": ""
   },

--- a/packages/core/src/loop/feedback/rule-docs.ts
+++ b/packages/core/src/loop/feedback/rule-docs.ts
@@ -361,9 +361,11 @@ const RULE_DOCS: Record<string, IRuleDoc> = {
     good: "redirect('/dashboard');",
   },
   "tsforge/no-user-controlled-fetch-url": {
-    what: "fetch/axios URLs must be literals or pass through an allowlisted URL builder.",
-    bad: "await fetch(userSuppliedUrl);",
-    good: "await fetch('https://api.example.com/v1/status');",
+    what: "The request ORIGIN must be fixed in source. Interpolating the path is fine; interpolating the host is not. There is no allowlist or builder to opt into — write the host literally.",
+    bad: "await fetch(url); await fetch(`https://${host}/todos`);",
+    good: "await fetch(`/api/todos/${id}`); await fetch(`https://api.example.com/v1/${id}`);",
+    procedure:
+      'Put the whole origin before the first ${...}, and close it with / ? or # — `https://api.example.com${p}` is still rejected because p="@evil.com/x" rewrites the host. For a caller-supplied host, validate it against a fixed allowlist yourself and branch to literal URLs.',
   },
   "tsforge/no-prototype-polluting-merge": {
     what: "Do not merge request body/query/params into objects wholesale.",

--- a/packages/core/src/rule-packs/boundary-utils.ts
+++ b/packages/core/src/rule-packs/boundary-utils.ts
@@ -11,3 +11,65 @@ export function isStringLiteral(node: TSESTree.Expression): boolean {
 export function isIdentifierNamed(node: TSESTree.Node, name: string): boolean {
   return node.type === AST_NODE_TYPES.Identifier && node.name === name;
 }
+
+/**
+ * True when a URL expression's ORIGIN is fixed at author time, so no runtime
+ * value can redirect the request to a different host.
+ *
+ * SSRF is control of the *host*, not the path. `fetch(`/api/todos/${id}`)` can
+ * only ever reach the current origin however hostile `id` is, so requiring a
+ * plain literal forbids the ordinary resource-by-id call for no security gain —
+ * and leaves no way to write a REST client at all.
+ *
+ * What decides it is the FIRST template quasi, because everything before the
+ * first `${}` is author-written text:
+ *
+ *   ok    `/api/todos/${id}`          relative, same origin
+ *   ok    `api/todos/${id}`           relative, same origin
+ *   ok    `https://api.example.com/v${n}`   authority closed by `/` before `${}`
+ *   FLAG  `${base}/api/todos`         empty first quasi — the whole URL is runtime
+ *   FLAG  `https://${host}/todos`     expression sits in the host position
+ *   FLAG  `//${host}/todos`           protocol-relative: host is still runtime
+ *   FLAG  `https://api.example.com${p}`  authority not closed; `p` can start `@evil`
+ *
+ * The last one is the subtle case: `https://api.example.com${p}` with
+ * `p = "@evil.com/x"` resolves to host `evil.com`, because everything before an
+ * `@` in the authority is userinfo. So the authority must be terminated by `/`,
+ * `?` or `#` inside the literal text.
+ */
+export function hasFixedOrigin(node: TSESTree.Expression): boolean {
+  if (isStringLiteral(node)) {
+    return true;
+  }
+
+  if (node.type !== AST_NODE_TYPES.TemplateLiteral) {
+    return false;
+  }
+
+  // No interpolation at all — a template literal that is really just a literal.
+  if (node.expressions.length === 0) {
+    return true;
+  }
+
+  return prefixPinsOrigin(node.quasis[0]?.value.cooked ?? "");
+}
+
+/** Whether author-written text before the first `${}` fully determines the origin. */
+function prefixPinsOrigin(prefix: string): boolean {
+  if (prefix === "") {
+    return false;
+  }
+
+  const scheme = /^[a-z][a-z0-9+.-]*:\/\//iu.exec(prefix);
+  const authorityStart =
+    scheme === null ? (prefix.startsWith("//") ? 2 : -1) : scheme[0].length;
+
+  // Relative URL (no scheme, no leading `//`) — cannot change origin.
+  if (authorityStart === -1) {
+    return true;
+  }
+
+  // Absolute or protocol-relative: the authority must END inside the literal
+  // text, otherwise the interpolation can extend or hijack the host.
+  return /[/?#]/u.test(prefix.slice(authorityStart));
+}

--- a/packages/core/src/rule-packs/runtime-boundaries/rules/no-user-controlled-fetch-url.ts
+++ b/packages/core/src/rule-packs/runtime-boundaries/rules/no-user-controlled-fetch-url.ts
@@ -1,6 +1,6 @@
 import { AST_NODE_TYPES, type TSESTree } from "@typescript-eslint/utils";
 
-import { isExpression, isStringLiteral } from "../../boundary-utils";
+import { hasFixedOrigin, isExpression } from "../../boundary-utils";
 import { createRule } from "../../create-rule";
 
 export const RULE_NAME = "no-user-controlled-fetch-url";
@@ -38,12 +38,12 @@ export const noUserControlledFetchUrlRule = createRule<[], MessageIds>({
     type: "problem",
     docs: {
       description:
-        "Disallow fetch/axios requests to non-literal URLs — dynamic URLs enable SSRF.",
+        "Disallow fetch/axios requests whose ORIGIN is not fixed at author time — a runtime-controlled host enables SSRF.",
     },
     schema: [],
     messages: {
       userControlledFetchUrl:
-        "HTTP request URL must be a string literal — do not pass user-controlled values to `fetch()` or `axios`.",
+        "HTTP request URL must have a fixed origin. Use a literal, or a template whose host is author-written before the first `${...}` — `fetch(`/api/todos/${id}`)` is fine; `fetch(url)` and `fetch(`https://${host}/x`)` are not.",
     },
   },
   defaultOptions: [],
@@ -60,7 +60,7 @@ export const noUserControlledFetchUrlRule = createRule<[], MessageIds>({
           return;
         }
 
-        if (!isStringLiteral(urlArg)) {
+        if (!hasFixedOrigin(urlArg)) {
           context.report({ node, messageId: "userControlledFetchUrl" });
         }
       },

--- a/packages/core/tests/rule-packs.test.ts
+++ b/packages/core/tests/rule-packs.test.ts
@@ -3587,6 +3587,78 @@ export function go() { redirect("/dashboard"); }`;
     expect(messages).toHaveLength(0);
   });
 
+  test.each([
+    ["`/api/todos/${id}`", "a relative path with an interpolated segment"],
+    ["`api/todos/${id}`", "a relative path without a leading slash"],
+    ["`https://api.example.com/v1/${id}`", "a fixed host, interpolated path"],
+    ["`https://api.example.com/?q=${q}`", "a fixed host, interpolated query"],
+    [
+      "`https://api.example.com/#${frag}`",
+      "a fixed host, interpolated fragment",
+    ],
+    ["`/api/todos`", "a template with no interpolation at all"],
+  ])("no-user-controlled-fetch-url: ALLOWS %s (%s)", (url) => {
+    // SSRF is control of the HOST. These cannot reach another origin however
+    // hostile the interpolated value is, and forbidding them made an ordinary
+    // resource-by-id client impossible to write.
+    const code = `export async function load(id: string, q: string, frag: string) { return fetch(${url}); }`;
+    const messages = lint(
+      "runtime-boundaries",
+      "no-user-controlled-fetch-url",
+      code,
+      "src/client.ts"
+    );
+
+    expect(messages).toHaveLength(0);
+  });
+
+  test.each([
+    ["url", "a bare identifier"],
+    ["`${base}/api/todos`", "an empty first quasi — the whole URL is runtime"],
+    ["`https://${host}/todos`", "an expression in the host position"],
+    ["`//${host}/todos`", "protocol-relative with a runtime host"],
+    [
+      "`https://api.example.com${path}`",
+      "an unterminated authority — `@evil.com/x` rewrites the host via userinfo",
+    ],
+    [
+      "`https://api.example.com:${port}`",
+      "an unterminated authority in the port position",
+    ],
+  ])("no-user-controlled-fetch-url: FLAGS %s (%s)", (url) => {
+    const code = `export async function load(url: string, base: string, host: string, path: string, port: string) { return fetch(${url}); }`;
+    const messages = lint(
+      "runtime-boundaries",
+      "no-user-controlled-fetch-url",
+      code,
+      "src/client.ts"
+    );
+
+    expect(messages.map((m) => m.messageId)).toContain(
+      "userControlledFetchUrl"
+    );
+  });
+
+  test("no-user-controlled-fetch-url: the origin rule applies to axios too", () => {
+    const ok = lint(
+      "runtime-boundaries",
+      "no-user-controlled-fetch-url",
+      "export const go = (id: string) => axios.get(`/api/todos/${id}`);",
+      "src/client.ts"
+    );
+
+    expect(ok).toHaveLength(0);
+
+    const bad = lint(
+      "runtime-boundaries",
+      "no-user-controlled-fetch-url",
+      "export const go = (h: string) => axios.get(`https://${h}/todos`);",
+      "src/client.ts"
+    );
+
+    expect(bad.map((m) => m.messageId)).toContain("userControlledFetchUrl");
+  });
+
   test("no-prototype-polluting-merge: reports Object.assign with req.body", () => {
     const code = `export function merge(req: { body: object }, target: object) {
   return Object.assign(target, req.body);


### PR DESCRIPTION
## What went wrong

An agent building an app in an unrelated project hit this rule and started reading **tsforge's own source** to understand it — grepping the rule pack, `boundary-utils.ts`, `RULES.md`, and the rule's tests.

It wasn't being nosy. The curated feedback told it there was an escape hatch:

> fetch/axios URLs must be literals **or pass through an allowlisted URL builder**

There is no allowlist and no builder. The rule is `schema: []` with a single `isStringLiteral` check. The model went looking for a documented feature that was never built, found nothing, tried `eslint-disable`, and was stopped by TTSR. Every step was reasonable against a system that lied to it.

## The underlying defect

Requiring `AST_NODE_TYPES.Literal` makes a parameterised HTTP client impossible:

```ts
fetch(`/api/todos/${id}`)             // flagged
fetch("/api/todos/" + id)              // flagged
fetch(new URL(path, base))              // flagged
const get = (u: string) => fetch(u)     // flagged
```

SSRF is control of the **host**, not the path. `/api/todos/${id}` can only ever reach the current origin. The rule rejected safe code while offering no sanctioned alternative.

## The fix

`hasFixedOrigin()`: a string literal, or a template whose author-written prefix pins the origin.

Still flagged, deliberately:

| Input | Why |
|---|---|
| `url` | bare identifier, origin unknown |
| `` `${base}/api` `` | empty first quasi — the whole URL is runtime |
| `` `https://${host}/x` `` | expression in host position |
| `` `//${host}/x` `` | protocol-relative, host still runtime |
| `` `https://api.example.com${p}` `` | **unterminated authority** — `p = "@evil.com/x"` rewrites the host via userinfo |
| `` `https://api.example.com:${port}` `` | unterminated authority, port position |

The userinfo case is the one worth reviewing closely: the authority must be closed by `/`, `?` or `#` **inside the literal text**, or interpolation can extend it.

## Docs

The `what` now describes what exists, and a `procedure` covers the userinfo trap and what to do when the host genuinely is caller-supplied (validate against your own allowlist, branch to literal URLs).

## Tests

Six allow cases, six flag cases including both authority attacks, plus axios. 315 rule-pack tests green, `bun run validate` green.

## Not addressed here

Reads are unscoped: `src/lib/scope/scope.ts` exports only `writable()`, and `insideWorkspace()` has no callers outside that file. Nothing stops a read or a shell command from leaving the workspace — which is *how* the agent could reach tsforge's source, even though the misleading doc is *why* it wanted to. Worth its own change.