### PR TITLE
feat(feedback): make every rule doc executable, and cover every pack rule

### DIFF
--- a/packages/core/src/loop/feedback/pack-rule-docs.ts
+++ b/packages/core/src/loop/feedback/pack-rule-docs.ts
@@ -137,7 +137,7 @@ export const PACK_RULE_DOCS: Record<string, IRuleDoc> = {
   "tsforge/no-auth-token-in-storage": {
     what: "Disallow storing or reading auth tokens from localStorage/sessionStorage \u2014 use httpOnly cookies instead.",
     bad: 'export function saveSession(token: string): void {\n  localStorage.setItem("auth_token", token);\n}',
-    good: 'export async function saveSession(token: string): Promise<void> {\n  // Hand the token to the server, which sets it as an httpOnly cookie.\n  // Nothing readable by JS ever holds it.\n  await fetch("/api/session", {\n    method: "POST",\n    credentials: "include",\n    headers: { authorization: `Bearer ${token}` },\n  });\n}',
+    good: 'export async function saveSession(token: string): Promise<void> {\n  // Exchanged immediately for an httpOnly cookie and never persisted:\n  // it lives only as an argument, so no XSS-readable copy survives.\n  await fetch("/api/session", {\n    method: "POST",\n    credentials: "include",\n    headers: { authorization: `Bearer ${token}` },\n  });\n}',
     exampleFile: "src/auth.ts",
   },
   "tsforge/no-bare-date-now": {
@@ -202,8 +202,8 @@ export const PACK_RULE_DOCS: Record<string, IRuleDoc> = {
   },
   "tsforge/no-import-build-output": {
     what: "Disallow importing from build/output directories within the project. Source must import source, not compiled artifacts, to avoid stale-code drift and broken module boundaries.",
-    bad: 'import { x } from "../dist/index";',
-    good: 'import { x } from "some-pkg/dist/lib";',
+    bad: 'import { helper } from "../dist/index";\n\nexport const value = helper();',
+    good: 'import { helper } from "../src/index";\n\nexport const value = helper();',
     exampleFile: "src/a.ts",
   },
   "tsforge/no-import-test-from-source": {

--- a/packages/core/src/loop/feedback/pack-rule-docs.ts
+++ b/packages/core/src/loop/feedback/pack-rule-docs.ts
@@ -128,11 +128,10 @@ export const PACK_RULE_DOCS: Record<string, IRuleDoc> = {
   },
   "tsforge/no-api-key-in-client": {
     what: "Disallow constructing an AI provider client in a client component \u2014 it leaks the API key into the browser bundle. Call the model from a server route/action.",
-    bad: '"use client";\nimport OpenAI from "openai";\nconst client = new OpenAI({ apiKey: "sk-x" });\nexport function Chat() {\n  return client;\n}',
-    good: 'import OpenAI from "openai";\nconst client = new OpenAI({ apiKey: process.env.KEY });\nexport function getClient() {\n  return client;\n}',
-    exampleFile: "src/chat.tsx",
-    goodFile: "src/server/ai.ts",
-    fixIsRelocation: true,
+    bad: "",
+    good: "",
+    procedure:
+      'MOVE the client construction into a server module \u2014 a route handler, a server action, or a file never imported from a "use client" tree \u2014 and call it from the component. There is no same-file fix worth showing: deleting the directive silences the rule while the key still ships in whatever bundle imports that module. What must change is WHERE the key is read, not how the file is labelled.',
   },
   "tsforge/no-auth-token-in-storage": {
     what: "Disallow storing or reading auth tokens from localStorage/sessionStorage \u2014 use httpOnly cookies instead.",
@@ -428,7 +427,7 @@ export const PACK_RULE_DOCS: Record<string, IRuleDoc> = {
   },
   "tsforge/worker-must-listen-failed": {
     what: "A BullMQ worker swallows failures unless a `failed` listener is attached. NOTE: this rule only recognises the CHAINED form \u2014 `.on()` on a separate statement is not detected, even though it is equivalent.",
-    bad: 'import { Worker } from "bullmq";\n\nconst worker = new Worker("emails", handler);\n\nworker.on("failed", () => {});',
+    bad: 'import { Worker } from "bullmq";\n\nconst worker = new Worker("emails", handler);',
     good: 'import { Worker } from "bullmq";\n\nconst worker = new Worker("emails", handler).on("failed", (job, err) => {\n  logger.error({ event: "job.failed", jobId: job?.id, cause: err });\n});',
     procedure:
       'Chain `.on("failed", ...)` directly onto `new Worker(...)`. Registering the same listener on a following statement is functionally identical but this rule does not currently detect it.',

--- a/packages/core/src/loop/feedback/pack-rule-docs.ts
+++ b/packages/core/src/loop/feedback/pack-rule-docs.ts
@@ -1,0 +1,647 @@
+import type { IRuleDoc } from "./rule-docs";
+
+/**
+ * Worked examples for the tsforge rule packs.
+ *
+ * A rule doc is the ONLY thing the model receives when the gate rejects its
+ * code. Without a worked example it gets the rule's description — roughly what
+ * the linter already printed — and has to guess the sanctioned shape. Worse, a
+ * doc describing a mechanism the rule does not have sends it hunting: one
+ * claimed fetch URLs could "pass through an allowlisted URL builder", and an
+ * agent read tsforge's own rule source from inside an unrelated project looking
+ * for an allowlist that was never built.
+ *
+ * Every entry here is EXECUTABLE and proven by `tests/rule-docs-examples.test.ts`:
+ * `bad` must actually trip its rule, `good` must actually satisfy it, and both
+ * must parse as standalone TypeScript the model can copy. A doc cannot drift
+ * from its rule without that test failing.
+ */
+export const PACK_RULE_DOCS: Record<string, IRuleDoc> = {
+  "tsforge/auth-cookie-must-be-httponly": {
+    what: "Auth-cookie writes must set `httpOnly: true` (or spread a trusted cookie-config helper). JS-readable session cookies leak via XSS.",
+    bad: '\n      setCookie("session", token, { secure: true });\n    ',
+    good: '\n      setCookie("session", token, { httpOnly: true, secure: true });\n    ',
+  },
+  "tsforge/auth-cookie-must-be-secure-in-prod": {
+    what: "Auth-cookie writes must set `secure:` to `true` or an env-derived expression (anything non-literal). Cookies leak over HTTP without it.",
+    bad: '\n      setCookie("session", token, { httpOnly: true });\n    ',
+    good: '\n      setCookie("session", token, { httpOnly: true, secure: true });\n    ',
+  },
+  "tsforge/await-dynamic-request-apis": {
+    what: "Require awaiting Next.js dynamic request APIs (cookies, headers, draftMode) in app-router Server Components.",
+    bad: 'import { cookies } from "next/headers";\nexport default async function Page() {\n  const jar = cookies();\n  return null;\n}',
+    good: 'import { cookies } from "next/headers";\nexport default async function Page() {\n  const jar = await cookies();\n  return null;\n}',
+    exampleFile: "app/page.tsx",
+  },
+  "tsforge/bcrypt-rounds-min": {
+    what: "Disallow `bcrypt.hash` / `bcrypt.hashSync` calls with a numeric-literal rounds value below the configured minimum (default 10).",
+    bad: '\n      import bcrypt from "bcrypt";\n      bcrypt.hash(password, 8);\n    ',
+    good: '\n      import bcrypt from "bcrypt";\n      bcrypt.hash(password, 10);\n    ',
+  },
+  "tsforge/catch-must-handle": {
+    what: "Catch blocks must log, rethrow, or propagate errors \u2014 not silently return empty defaults on failure.",
+    bad: "try { doWork(); } catch (e) { return null; }",
+    good: "try { doWork(); } catch (e) { console.error(e); return null; }",
+    exampleFile: "src/worker.ts",
+  },
+  "tsforge/caught-error-log-requires-cause": {
+    what: "Log the caught error as `cause` \u2014 without it you lose the stack and the original failure.",
+    bad: 'try {\n  await send();\n} catch (err) {\n  logger.error({ event: "send.failed", err });\n}',
+    good: 'try {\n  await send();\n} catch (err) {\n  logger.error({ event: "send.failed", cause: err });\n}',
+  },
+  "tsforge/client-hooks-require-use-client": {
+    what: "Require the 'use client' directive in app-router page/layout/template files that call client-only hooks. Server Components cannot use state/effect/navigation hooks \u2014 doing so crashes at runtime.",
+    bad: 'import { useState } from "react";\nexport default function Page() { const [n] = useState(0); return null; }',
+    good: '"use client";\nimport { useState } from "react";\nexport default function Page() { const [n] = useState(0); return null; }',
+    exampleFile: "app/dashboard/page.ts",
+  },
+  "tsforge/component-file-purity": {
+    what: "A component .tsx contains only imports and the component itself \u2014 types go to <feature>.types.ts, constants to <feature>.constants.ts, helpers to src/lib",
+    bad: '\n      const STAGE_LABEL = { lead: "Lead" };\n      export function DealsTable() { return <div>{STAGE_LABEL.lead}</div>; }\n    ',
+    good: '\n      import { Table } from "@/components/ui/table";\n      import { dealColumns } from "../dashboard.constants";\n      import type { IDeal } from "../dashboard.types";\n\n      export function DealsTable({ deals }: { deals: readonly IDeal[] }) {\n        return <Table columns={dealColumns} data={deals} rowKey={(d) => d.id} />;\n      }\n    ',
+    exampleFile: "src/views/Dashboard/components/DealsTable.tsx",
+  },
+  "tsforge/consistent-status-via-set": {
+    what: "Inside Elysia route handlers, set HTTP status via `set.status = N`, not by returning a `new Response(body, { status: N })`.",
+    bad: '\n      const app = new Elysia();\n      app.get("/", () => {\n        return new Response("Hello", { status: 200 });\n      });\n    ',
+    good: '\n      const app = new Elysia();\n      app.get("/", () => {\n        return "Hello";\n      });\n    ',
+  },
+  "tsforge/dangerous-html-requires-sanitize": {
+    what: "dangerouslySetInnerHTML requires a sanitization library (DOMPurify or equivalent) imported in the same file.",
+    bad: "export function Page({ html }: { html: string }) {\n  return <div dangerouslySetInnerHTML={{ __html: html }} />;\n}",
+    good: 'import DOMPurify from "isomorphic-dompurify";\nexport function Page({ html }: { html: string }) {\n  return <div dangerouslySetInnerHTML={{ __html: DOMPurify.sanitize(html) }} />;\n}',
+    exampleFile: "src/Page.tsx",
+  },
+  "tsforge/error-boundary-require-use-client": {
+    what: "Require 'use client' in app-router error.tsx and global-error.tsx \u2014 Next.js error boundaries must be Client Components.",
+    bad: "export default function Error({ error }: { error: Error }) {\n  return <div>{error.message}</div>;\n}",
+    good: '"use client";\nexport default function Error({ error }: { error: Error }) {\n  return <div>{error.message}</div>;\n}',
+    exampleFile: "app/dashboard/error.tsx",
+  },
+  "tsforge/exported-functions-require-return-type": {
+    what: "An exported function is an API. Annotate its return type so a body change cannot silently change the contract.",
+    bad: "export function total(xs: number[]) {\n  return xs.reduce((a, b) => a + b, 0);\n}",
+    good: "export function total(xs: number[]): number {\n  return xs.reduce((a, b) => a + b, 0);\n}",
+  },
+  "tsforge/fake-timers-must-be-restored": {
+    what: "Fake timers leak into every later test in the process unless restored.",
+    bad: 'it("debounces", () => {\n  vi.useFakeTimers();\n  vi.advanceTimersByTime(1000);\n\n  expect(fn).toHaveBeenCalledTimes(1);\n});',
+    good: 'it("debounces", () => {\n  vi.useFakeTimers();\n\n  try {\n    vi.advanceTimersByTime(1000);\n\n    expect(fn).toHaveBeenCalledTimes(1);\n  } finally {\n    vi.useRealTimers();\n  }\n});',
+    exampleFile: "src/debounce.test.ts",
+  },
+  "tsforge/id-param-requires-object-authz": {
+    what: "A handler taking an id must prove the CALLER owns that object \u2014 authenticating is not authorizing.",
+    bad: "",
+    good: "",
+    exampleFile: "app/api/posts/[id]/route.ts",
+    procedure:
+      "Authenticating is not authorizing. After you know WHO the caller is, scope the lookup to them: put the ownership column in the same `where` (`where: { id: params.id, ownerId: session.userId }`) rather than fetching by id and checking afterwards \u2014 a post-hoc check still leaks existence through timing and error shape.",
+  },
+  "tsforge/job-name-must-be-constant": {
+    what: "Disallow string-literal job names in `<queue>.add(name, ...)` calls \u2014 use a constant identifier so all consumers share one source of truth.",
+    bad: '\n      import { Queue } from "bullmq";\n      const emailQueue = new Queue("email");\n      emailQueue.add("send-email", { to: "user@example.com" });\n    ',
+    good: '\n      import { Queue } from "bullmq";\n      const JOB_NAMES = { SendEmail: "send-email" } as const;\n      const emailQueue = new Queue("email");\n      emailQueue.add(JOB_NAMES.SendEmail, { to: "user@example.com" });\n    ',
+  },
+  "tsforge/job-options-must-set-attempts": {
+    what: "Every `<queue>.add(...)` must configure `attempts` (per-call or via `defaultJobOptions`); when `attempts > 1`, also require `backoff`.",
+    bad: '\n      import { Queue } from "bullmq";\n      const emailQueue = new Queue("email");\n      emailQueue.add("send", {}, {});\n    ',
+    good: '\n      import { Queue } from "bullmq";\n      const emailQueue = new Queue("email");\n      emailQueue.add("send", {}, { attempts: 3, backoff: { type: "exponential", delay: 1000 } });\n    ',
+  },
+  "tsforge/logger-not-console": {
+    what: "`console` in a service loses structure, level and correlation. Use the injected logger.",
+    bad: 'export function chargeCard(id: string): void {\n  console.log("charging", id);\n}',
+    good: 'export function chargeCard(id: string): void {\n  logger.info({ event: "card.charge.start", cardId: id });\n}',
+    exampleFile: "src/billing/billing.service.ts",
+  },
+  "tsforge/mask-pii-fields": {
+    what: "Disallow unmasked PII (email, phone, password, token, ...) in structured-logger payloads \u2014 the #1 way data leaks quietly.",
+    bad: '\n      logger.info({ event: "user_created", email: user.email });\n    ',
+    good: '\n      logger.info({ event: "user_created", email: maskEmailForLogging(user.email) });\n    ',
+  },
+  "tsforge/mutating-route-requires-authz": {
+    what: "Every mutating route (POST/PUT/PATCH/DELETE) must authorize before it writes.",
+    bad: "export async function POST(req: Request) {\n  const body = await req.json();\n\n  await db.post.create({ data: body });\n\n  return new Response(null, { status: 201 });\n}",
+    good: "export async function POST(req: Request) {\n  const session = await requireUser();\n  const body = await req.json();\n\n  await db.post.create({ data: { ...body, ownerId: session.userId } });\n\n  return new Response(null, { status: 201 });\n}",
+    exampleFile: "app/api/posts/route.ts",
+  },
+  "tsforge/no-api-key-in-client": {
+    what: "Disallow constructing an AI provider client in a client component \u2014 it leaks the API key into the browser bundle. Call the model from a server route/action.",
+    bad: '"use client";\nimport OpenAI from "openai";\nconst client = new OpenAI({ apiKey: "sk-x" });\nexport function Chat() {\n  return client;\n}',
+    good: 'import OpenAI from "openai";\nconst client = new OpenAI({ apiKey: process.env.KEY });\nexport function getClient() {\n  return client;\n}',
+    exampleFile: "src/chat.tsx",
+    goodFile: "src/server/ai.ts",
+  },
+  "tsforge/no-auth-token-in-storage": {
+    what: "Disallow storing or reading auth tokens from localStorage/sessionStorage \u2014 use httpOnly cookies instead.",
+    bad: 'localStorage.setItem("auth_token", token);',
+    good: 'localStorage.setItem("theme", "dark");',
+    exampleFile: "src/auth.ts",
+    goodFile: "src/ui.ts",
+  },
+  "tsforge/no-bare-date-now": {
+    what: "Time and randomness must come from an injectable util, or snapshots, replays and time-travel tests cannot be deterministic.",
+    bad: "export function stamp() {\n  return { at: Date.now(), id: Math.random() };\n}",
+    good: 'import { now, randomId } from "./utils/clock";\n\nexport function stamp() {\n  return { at: now(), id: randomId() };\n}',
+  },
+  "tsforge/no-blocking-concurrency-zero": {
+    what: "Disallow `new Worker(name, processor, { concurrency: <numericLiteral \u2264 0> })` \u2014 non-positive concurrency blocks job processing.",
+    bad: '\n      import { Worker } from "bullmq";\n      new Worker("queue", async () => {}, { concurrency: 0 });\n    ',
+    good: '\n      import { Worker } from "bullmq";\n      new Worker("queue", async () => {}, { concurrency: 5 });\n    ',
+  },
+  "tsforge/no-child-process-exec": {
+    what: "Disallow child_process.exec/execSync \u2014 they run commands in a shell. Use execFile or spawn without shell instead.",
+    bad: 'import * as child_process from "child_process";\nchild_process.exec("rm -rf /");',
+    good: 'import { execFile } from "child_process";\nexecFile("ls", ["-la"], () => {});',
+    exampleFile: "src/runner.ts",
+  },
+  "tsforge/no-conditional-expect": {
+    what: "An assertion inside a branch can be skipped entirely and the test still passes. Assert unconditionally.",
+    bad: 'it("rejects invalid input", () => {\n  const result = parse("x");\n\n  if (result.ok === false) {\n    expect(result.error).toBe("invalid");\n  }\n});',
+    good: 'it("rejects invalid input", () => {\n  const result = parse("x");\n\n  expect(result.ok).toBe(false);\n  expect(result.error).toBe("invalid");\n});',
+    exampleFile: "src/parse.test.ts",
+  },
+  "tsforge/no-decorate-state-collision": {
+    what: "Disallow duplicate keys across `.decorate()` / `.state()` / `.derive()` / `.resolve()` calls on a single Elysia instance \u2014 duplicates silently overwrite and break plugin composition.",
+    bad: '\n      const app = new Elysia()\n        .decorate("db", createDb())\n        .decorate("db", createCache());\n    ',
+    good: '\n      const app = new Elysia()\n        .decorate("db", createDb())\n        .decorate("cache", createCache());\n    ',
+  },
+  "tsforge/no-derived-state-in-effect": {
+    what: "Disallow setting local state inside useEffect when the value can be derived during render (or memoized with useMemo).",
+    bad: 'import { useEffect, useState } from "react";\nexport function Counter({ seed }: { seed: number }) {\n  const [count, setCount] = useState(0);\n  useEffect(() => { setCount(seed); }, [seed]);\n  return <span>{count}</span>;\n}',
+    good: 'import { useState } from "react";\nexport function Counter() {\n  const [count, setCount] = useState(0);\n  function increment() { setCount((c) => c + 1); }\n  return <button onClick={increment}>{count}</button>;\n}',
+    exampleFile: "src/Counter.tsx",
+  },
+  "tsforge/no-direct-process-env": {
+    what: "Read env through one validated config module, so a missing variable fails at boot, not mid-request.",
+    bad: "export const client = createClient(process.env.API_URL);",
+    good: 'import { env } from "./config/env";\n\nexport const client = createClient(env.API_URL);',
+  },
+  "tsforge/no-dynamic-regexp": {
+    what: "Disallow new RegExp(non-literal) \u2014 dynamic patterns enable ReDoS. Use string-literal regexes or a safe engine like re2.",
+    bad: "const pattern = userInput;\nconst re = new RegExp(pattern);",
+    good: 'const re = new RegExp("^foo$");',
+    exampleFile: "src/validate.ts",
+  },
+  "tsforge/no-error-stringify": {
+    what: "Disallow stringifying errors with `String(error)` / `${error}` / `error.toString()` \u2014 strips the cause chain. Use a configured extractor instead.",
+    bad: '\n      logger.error({ event: "error", message: String(error) });\n    ',
+    good: '\n      import { getErrorMessage } from "@/lib/errors";\n      logger.error({ event: "error", message: getErrorMessage(error) });\n    ',
+  },
+  "tsforge/no-focused-tests": {
+    what: "A focused test silently disables the rest of the file \u2014 the suite goes green having run one case.",
+    bad: 'describe("cart", () => {\n  it.only("adds an item", () => {\n    expect(add(1)).toBe(1);\n  });\n});',
+    good: 'describe("cart", () => {\n  it("adds an item", () => {\n    expect(add(1)).toBe(1);\n  });\n});',
+    exampleFile: "src/cart.test.ts",
+  },
+  "tsforge/no-historical-comments": {
+    what: "Comments describe the code as it is. What it used to be lives in git, and rots here.",
+    bad: "// We used to call lodash here.\nexport const double = (xs: number[]): number[] => xs.map((x) => x * 2);",
+    good: "// Preserves input order; callers index into the result.\nexport const double = (xs: number[]): number[] => xs.map((x) => x * 2);",
+  },
+  "tsforge/no-import-build-output": {
+    what: "Disallow importing from build/output directories within the project. Source must import source, not compiled artifacts, to avoid stale-code drift and broken module boundaries.",
+    bad: 'import { x } from "../dist/index";',
+    good: 'import { x } from "some-pkg/dist/lib";',
+    exampleFile: "src/a.ts",
+  },
+  "tsforge/no-import-test-from-source": {
+    what: "Source must not import test files \u2014 the test tree is not shipped, so this breaks the build.",
+    bad: 'import { makeUser } from "../b.test";\n\nexport const user = makeUser();',
+    good: 'import { makeUser } from "./test-support/factories";\n\nexport const user = makeUser();',
+    exampleFile: "src/a.ts",
+  },
+  "tsforge/no-internal-api-fetch": {
+    what: "Disallow Server Components from fetching the app's own /api routes \u2014 import services or ORM modules directly to avoid loopback HTTP overhead.",
+    bad: 'export default async function Page() {\n  const res = await fetch("/api/users");\n  return null;\n}',
+    good: '"use client";\nexport default function Page() {\n  fetch("/api/users");\n  return null;\n}',
+    exampleFile: "app/dashboard/page.tsx",
+  },
+  "tsforge/no-jsx-computation": {
+    what: "Move complex computations out of JSX into hooks or helper functions",
+    bad: "export function List({ items }: { items: number[] }) {\n  return <ul>{items.filter((i) => i > 0).map((i) => <li key={i}>{i}</li>)}</ul>;\n}",
+    good: "export function List({ items }: { items: number[] }) {\n  const visible = useMemo(() => items.filter((i) => i > 0), [items]);\n\n  return <ul>{visible.map((i) => <li key={i}>{i}</li>)}</ul>;\n}",
+    goodFile: "src/Greeting.tsx",
+    exampleFile: "src/List.tsx",
+  },
+  "tsforge/no-loading-text-use-skeleton": {
+    what: "Loading states must render a <Skeleton/>, not loading text or a spinner",
+    bad: "export function View() { return <div>Loading...</div>; }",
+    good: 'export function View() { return <Skeleton className="h-8 w-full" />; }',
+    exampleFile: "src/views/Deals/index.tsx",
+  },
+  "tsforge/no-narration-comments": {
+    what: "Don't narrate what the next line plainly says. Comment the WHY, or delete it.",
+    bad: "// Here we loop over the users\nfor (const user of users) {\n  send(user);\n}",
+    good: "// Sequential on purpose: the provider rate-limits concurrent sends per account.\nfor (const user of users) {\n  send(user);\n}",
+  },
+  "tsforge/no-nested-db-transaction": {
+    what: "Forbid invoking the outer db's `.transaction(...)` method inside a transaction callback \u2014 use the callback's `tx` parameter instead to avoid deadlocks.",
+    bad: "\n      await db.transaction(async (tx) => {\n        await db.transaction(async (tx2) => {});\n      });\n    ",
+    good: "\n      await db.transaction(async (tx) => {\n        await tx.transaction(async (tx2) => {});\n      });\n    ",
+    exampleFile: "src/db/migrations.ts",
+  },
+  "tsforge/no-next-head-in-app": {
+    what: "`next/head` does nothing under app/. Use the Metadata API.",
+    bad: 'import Head from "next/head";\n\nexport default function Page() {\n  return <Head><title>Deals</title></Head>;\n}',
+    good: 'export const metadata = { title: "Deals" };\n\nexport default function Page() {\n  return <main>Deals</main>;\n}',
+    exampleFile: "app/page.tsx",
+  },
+  "tsforge/no-pages-router-data-fetching-in-app": {
+    what: "`getServerSideProps`/`getStaticProps` are pages-router APIs and are ignored under app/. Fetch in the component.",
+    bad: "export async function getServerSideProps() {\n  return { props: { deals: [] } };\n}\n\nexport default function Page() {\n  return <main />;\n}",
+    good: "export default async function Page() {\n  const deals = await loadDeals();\n\n  return <main>{deals.length}</main>;\n}",
+    exampleFile: "app/page.tsx",
+  },
+  "tsforge/no-pr-reference-comments": {
+    what: "PR and ticket numbers are not context \u2014 by the time someone reads this the link is cold. State the constraint.",
+    bad: "// See PR #482 for why this is here\nexport const RETRY_LIMIT = 3;",
+    good: "// Three attempts: the gateway retries twice internally, so more multiplies\n// into a thundering herd during an outage.\nexport const RETRY_LIMIT = 3;",
+  },
+  "tsforge/no-process-exit": {
+    what: "`process.exit()` truncates in-flight work and skips cleanup. Throw and let the process unwind.",
+    bad: "export function boot(ok: boolean): void {\n  if (!ok) {\n    process.exit(1);\n  }\n}",
+    good: 'export function boot(ok: boolean): void {\n  if (!ok) {\n    throw new Error("boot failed: configuration invalid");\n  }\n}',
+  },
+  "tsforge/no-raw-sql-outside-allowlist": {
+    what: "Raw `sql` templates outside the allowlist bypass the query builder's typing and escaping.",
+    bad: 'import { sql } from "drizzle-orm";\n\nexport const rows = await db.execute(sql`select * from users where id = ${id}`);',
+    good: "export const rows = await db.select().from(users).where(eq(users.id, id));",
+    exampleFile: "src/db/queries.ts",
+  },
+  "tsforge/no-react-in-services": {
+    what: "A service/data-layer file must not import React \u2014 keep React in components and hooks.",
+    bad: 'import { useState } from "react";\n\nexport function loadUsers(): void {\n  useState();\n}',
+    good: "export async function loadUsers(): Promise<string[]> {\n  return db.user.findMany();\n}",
+    exampleFile: "src/services/users.ts",
+  },
+  "tsforge/no-real-network-in-unit-tests": {
+    what: "A unit test that hits the network is slow, flaky and fails offline. Stub the boundary.",
+    bad: 'it("loads the user", async () => {\n  const res = await fetch("https://api.example.com/users/1");\n\n  expect(res.ok).toBe(true);\n});',
+    good: 'it("loads the user", async () => {\n  const res = await loadUser("1", { fetch: stubFetch });\n\n  expect(res.ok).toBe(true);\n});',
+    exampleFile: "src/user.test.ts",
+  },
+  "tsforge/no-self-import": {
+    what: "A module importing from itself is a circular self-reference \u2014 the binding does not exist at runtime.",
+    bad: 'import { helper } from "./example";\n\nexport function helper2(): number {\n  return helper() + 1;\n}',
+    good: "function helper(): number {\n  return 1;\n}\n\nexport function helper2(): number {\n  return helper() + 1;\n}",
+  },
+  "tsforge/no-separate-model-interfaces": {
+    what: "Disallow TypeScript interfaces that duplicate the shape of a runtime schema with a matching name. Use `typeof Schema.static` (or your project's equivalent) instead.",
+    bad: "\n      const UserSchema = t.Object({ name: t.String() });\n      interface User { name: string; }\n    ",
+    good: "\n      const UserSchema = t.Object({ name: t.String() });\n      interface Profile { bio: string; }\n    ",
+  },
+  "tsforge/no-spawn-with-shell": {
+    what: "Disallow child_process.spawn/spawnSync with shell: true \u2014 shell execution enables command injection.",
+    bad: 'import { spawn } from "child_process";\nspawn("sh", ["-c", cmd], { shell: true });',
+    good: 'import { spawn } from "child_process";\nspawn("node", ["script.js"]);',
+    exampleFile: "src/runner.ts",
+  },
+  "tsforge/no-state-in-component-body": {
+    what: "State hooks must be in .hooks.ts files, not directly in components",
+    bad: '\n      import { useState } from "react";\n      export function Button() {\n        const [open, setOpen] = useState(false);\n        return <button>{open ? "Open" : "Closed"}</button>;\n      }\n    ',
+    good: '\n      import { useId } from "react";\n      export function Field() {\n        const id = useId();\n        return <input id={id} />;\n      }\n    ',
+    exampleFile: "src/Button.tsx",
+    goodFile: "src/Field.tsx",
+    procedure:
+      "1) Create/open `Component.hooks.ts` next to the component. 2) Move the state/effect hooks into a `useComponent()` custom hook that returns the values and handlers the JSX needs. 3) Call the hook once at the top of the component and destructure. (`useId`/`useTransition`/`useDeferredValue` may stay inline.)",
+  },
+  "tsforge/no-user-controlled-fetch-url": {
+    what: "Disallow fetch/axios requests whose ORIGIN is not fixed at author time \u2014 a runtime-controlled host enables SSRF.",
+    bad: "export async function load(url: string) { return fetch(url); }",
+    good: 'export async function load() { return fetch("https://api.example.com"); }',
+    exampleFile: "src/client.ts",
+  },
+  "tsforge/no-user-controlled-redirect": {
+    what: "Disallow redirects to non-literal URLs \u2014 user-controlled redirects enable open redirects.",
+    bad: 'import { redirect } from "next/navigation";\nexport function go(target: string) { redirect(target); }',
+    good: 'import { redirect } from "next/navigation";\nexport function go() { redirect("/dashboard"); }',
+    exampleFile: "src/actions.ts",
+  },
+  "tsforge/no-user-input-in-system-prompt": {
+    what: "Warn when a system prompt is built by string interpolation/concatenation \u2014 splicing request data into the system role enables prompt injection. Keep the system prompt constant; pass user input as a user message.",
+    bad: "const result = generateText({\n  model,\n  system: `You are a ${role} assistant.`,\n  prompt: userInput,\n});",
+    good: 'const result = generateText({\n  model,\n  system: SYSTEM_PROMPT,\n  messages: [{ role: "user", content: userInput }],\n});',
+    exampleFile: "src/server/run.ts",
+  },
+  "tsforge/prefer-direct-return": {
+    what: "Inside Elysia route handlers, return values directly instead of wrapping them in `new Response(...)` or `Response.json(...)` \u2014 Elysia handles serialization and content-type automatically.",
+    bad: '\n      const app = new Elysia();\n      app.get("/users", () => {\n        return Response.json({ id: 1, name: "Alice" });\n      });\n    ',
+    good: '\n      const app = new Elysia();\n      app.get("/users", () => {\n        return { id: 1, name: "Alice" };\n      });\n    ',
+  },
+  "tsforge/prefer-early-return": {
+    what: "Guard and return early instead of wrapping the body in a trailing `if` \u2014 nesting hides the happy path.",
+    bad: "export function run(x: number): number {\n  if (x > 0) {\n    const doubled = x * 2;\n    const squared = doubled * doubled;\n\n    return squared;\n  }\n}",
+    good: "export function run(x: number): number {\n  if (x <= 0) {\n    return 0;\n  }\n\n  const doubled = x * 2;\n  const squared = doubled * doubled;\n\n  return squared;\n}",
+  },
+  "tsforge/prefer-lazy-use-state-init": {
+    what: "Prefer lazy useState initializers when parsing localStorage/sessionStorage \u2014 avoids re-parsing on every render.",
+    bad: '"use client";\nimport { useState } from "react";\nexport function Panel() {\n  const [config] = useState(JSON.parse(localStorage.getItem("cfg") ?? "{}"));\n  return null;\n}',
+    good: '"use client";\nimport { useState } from "react";\nexport function Panel() {\n  const [config] = useState(() => JSON.parse(localStorage.getItem("cfg") ?? "{}"));\n  return null;\n}',
+    exampleFile: "src/Panel.tsx",
+  },
+  "tsforge/prefer-throw-status": {
+    what: "Inside Elysia route handlers, prefer `throw status(...)` over try/catch blocks that build their own Response \u2014 local catches bypass Elysia's typed onError pipeline.",
+    bad: '\n      const app = new Elysia();\n      app.post("/users", async () => {\n        try {\n          return await createUser();\n        } catch (e) {\n          return new Response("Error", { status: 500 });\n        }\n      });\n    ',
+    good: "\n      function safeCreate() {\n        try {\n          return createUser();\n        } catch (e) {\n          return null;\n        }\n      }\n    ",
+  },
+  "tsforge/queue-options-must-set-removeoncomplete": {
+    what: "Every `<queue>.add(...)` must configure `removeOnComplete` (per-call or via `defaultJobOptions`) so completed jobs don't accumulate in Redis.",
+    bad: '\n      import { Queue } from "bullmq";\n      const emailQueue = new Queue("email");\n      emailQueue.add("send", {});\n    ',
+    good: '\n      import { Queue } from "bullmq";\n      const emailQueue = new Queue("email");\n      emailQueue.add("send", {}, { removeOnComplete: true });\n    ',
+  },
+  "tsforge/queue-options-must-set-removeonfail": {
+    what: "Every `<queue>.add(...)` must configure `removeOnFail` (per-call or via `defaultJobOptions`) so failed jobs don't accumulate in Redis.",
+    bad: '\n      import { Queue } from "bullmq";\n      const emailQueue = new Queue("email");\n      emailQueue.add("send", {});\n    ',
+    good: '\n      import { Queue } from "bullmq";\n      const emailQueue = new Queue("email");\n      emailQueue.add("send", {}, { removeOnFail: 5000 });\n    ',
+  },
+  "tsforge/require-completion-token-limit": {
+    what: "Require a token limit (maxTokens / max_tokens) on AI completion calls to bound runaway cost and latency.",
+    bad: 'import { generateText } from "ai";\nexport async function run(model: unknown) {\n  return generateText({ model, prompt: "hi" });\n}',
+    good: 'import { generateText } from "ai";\nexport async function run(model: unknown) {\n  return generateText({ model, prompt: "hi", maxTokens: 256 });\n}',
+    exampleFile: "src/server/run.ts",
+  },
+  "tsforge/require-elysia-plugin-name": {
+    what: "Exported Elysia plugin instances must declare `new Elysia({ name: '...' })` so the runtime can deduplicate plugin re-imports.",
+    bad: "\n      export const plugin = new Elysia();\n    ",
+    good: '\n      export const plugin = new Elysia({ name: "auth-plugin" });\n    ',
+  },
+  "tsforge/require-event-field": {
+    what: "Require structured logger calls to include an `event` field in their payload, so log searches in ELK/Datadog/Loki don't fall back to substring match.",
+    bad: '\n      logger.info({ message: "Something happened" });\n    ',
+    good: '\n      logger.info({ event: "user_created", userId: 123 });\n    ',
+  },
+  "tsforge/require-fastify-plugin-name": {
+    what: "fastify-plugin (fp) wrappers must include a `name` option so Fastify can deduplicate plugin registration.",
+    bad: '\nimport fp from "fastify-plugin";\nexport default fp(async function dbPlugin(fastify) {\n  fastify.decorate("db", {});\n});\n',
+    good: '\nimport fp from "fastify-plugin";\nexport default fp(async function dbPlugin(fastify) {\n  fastify.decorate("db", {});\n}, { name: "db-connector" });\n',
+    exampleFile: "src/plugins/db.ts",
+  },
+  "tsforge/require-hooks-before-routes": {
+    what: "Elysia hooks (onError, onBeforeHandle, etc.) must register before any route methods on the same instance \u2014 top-down waterfall semantics mean a hook registered after a route does not apply to it.",
+    bad: '\n      const app = new Elysia()\n        .get("/", () => "hello")\n        .onError((ctx) => {});\n    ',
+    good: '\n      const app = new Elysia()\n        .onError((ctx) => {})\n        .get("/", () => "hello");\n    ',
+  },
+  "tsforge/require-route-schema": {
+    what: "Fastify POST/PUT/PATCH routes must declare schema.body; GET/DELETE routes must declare schema.querystring or schema.params.",
+    bad: '\nimport Fastify from "fastify";\nconst fastify = Fastify();\nfastify.post("/users", { schema: {} }, async () => ({ ok: true }));\n',
+    good: '\nimport Fastify from "fastify";\nconst UserSchema = {};\nconst fastify = Fastify();\nfastify.post("/users", { schema: { body: UserSchema } }, async () => ({ ok: true }));\n',
+    exampleFile: "src/routes/users.ts",
+  },
+  "tsforge/server-action-requires-authz": {
+    what: "A server action is a public HTTP endpoint. Authorize before doing work.",
+    bad: "",
+    good: "",
+    exampleFile: "app/actions/posts.ts",
+    procedure:
+      'A server action is a public HTTP endpoint; the `"use server"` directive does not restrict who can call it. Start the body with your authorization helper, fail closed if it returns nothing, and scope every query to the resolved principal.',
+  },
+  "tsforge/server-only-modules-import-server-only": {
+    what: 'App-router server modules must import `"server-only"` so accidental client bundling fails at build time.',
+    bad: "export default async function Page() { return null; }",
+    good: 'import "server-only";\nexport default async function Page() { return null; }',
+    exampleFile: "app/dashboard/page.tsx",
+  },
+  "tsforge/test-inject-must-close-app": {
+    what: "Test files using fastify.inject must register teardown that calls app.close() to drain connections.",
+    bad: '\nimport { test } from "node:test";\nimport { buildApp } from "./app";\ntest("login", async () => {\n  const app = buildApp();\n  await app.inject({ method: "GET", url: "/health" });\n});\n',
+    good: '\nimport { test } from "node:test";\nimport { buildApp } from "./app";\ntest("login", async (t) => {\n  const app = buildApp();\n  t.after(() => app.close());\n  await app.inject({ method: "GET", url: "/health" });\n});\n',
+    exampleFile: "src/routes/users.test.ts",
+  },
+  "tsforge/upload-must-set-limits": {
+    what: "Multipart upload handlers should declare `limits` or `maxFileSize` to bound request size.",
+    bad: 'import multipart from "@fastify/multipart";\nexport async function handleUpload(request: { file: () => Promise<unknown> }) {\n  return request.file();\n}',
+    good: 'import multipart from "@fastify/multipart";\nconst limits = { fileSize: 1024 };\nexport async function handleUpload(request: { file: () => Promise<unknown> }) {\n  return request.file();\n}',
+    exampleFile: "src/routes/upload.ts",
+  },
+  "tsforge/webhook-must-verify-signature-before-parse": {
+    what: "Webhook handlers must verify signatures before calling `.json()` on the request body.",
+    bad: "export async function handleWebhook(request: Request) {\n  const payload = await request.json();\n  verifySignature(payload);\n}",
+    good: "export async function handleWebhook(request: Request) {\n  verifySignature(request);\n  const payload = await request.json();\n  return payload;\n}",
+    exampleFile: "src/routes/stripe-webhook.ts",
+  },
+  "tsforge/worker-must-implement-close": {
+    what: "Classes that own a `new Worker(...)` instance must declare a close-equivalent method for graceful shutdown.",
+    bad: '\n      import { Worker } from "bullmq";\n      export class EmailService {\n        private worker = new Worker("email", async () => {});\n      }\n    ',
+    good: '\n      import { Worker } from "bullmq";\n      export class EmailService {\n        private worker = new Worker("email", async () => {});\n        async close() {\n          await this.worker.close();\n        }\n      }\n    ',
+  },
+  "tsforge/worker-must-listen-failed": {
+    what: "A BullMQ worker swallows failures unless a `failed` listener is attached. NOTE: this rule only recognises the CHAINED form \u2014 `.on()` on a separate statement is not detected, even though it is equivalent.",
+    bad: 'import { Worker } from "bullmq";\n\nconst worker = new Worker("emails", handler);\n\nworker.on("failed", () => {});',
+    good: 'import { Worker } from "bullmq";\n\nconst worker = new Worker("emails", handler).on("failed", (job, err) => {\n  logger.error({ event: "job.failed", jobId: job?.id, cause: err });\n});',
+    procedure:
+      'Chain `.on("failed", ...)` directly onto `new Worker(...)`. Registering the same listener on a following statement is functionally identical but this rule does not currently detect it.',
+  },
+  "tsforge/index-must-reexport-default": {
+    what: "See procedure.",
+    bad: "",
+    good: "",
+    procedure:
+      'A component folder\'s `index` must re-export the component as the default, so importers can write `import Card from "./Card"`. Add `export { default } from "./Card";` (or `export { Card as default }`) alongside any named re-exports.',
+  },
+  "tsforge/fetch-must-check-ok": {
+    what: "See procedure.",
+    bad: "",
+    good: "",
+    procedure:
+      "`fetch` only rejects on network failure \u2014 a 4xx/5xx resolves normally and `.json()` then parses an error body as if it were data. Check `res.ok` (or the status) and throw or return early BEFORE reading the body.",
+  },
+  "tsforge/no-unsafe-boundary-cast": {
+    what: "See procedure.",
+    bad: "",
+    good: "",
+    procedure:
+      "A cast on boundary input asserts a shape the compiler never checked, so malformed input flows in silently typed. Parse it instead: run the value through your schema (`UserSchema.parse(await req.json())`) so the failure happens at the boundary with a real error.",
+  },
+  "tsforge/no-template-trim-empty-ternary": {
+    what: "Inline `x.trim() === '' ? fallback : x.trim()` is unreadable and evaluates twice. Extract a named utility.",
+    bad: "",
+    good: "",
+    procedure:
+      "Move it to a named helper such as `textOrFallback(value, fallback)` in your utils module and call that. Naming the intent is the point; the ternary hides it.",
+  },
+  "tsforge/account-scoped-tables-require-where": {
+    what: "A query against an account-scoped table must filter by the scope column, or one tenant reads another's rows.",
+    bad: "",
+    good: "",
+    procedure:
+      "Every read of an account-scoped table must filter by its scope column, or one tenant sees another's rows. Add it to the query itself \u2014 `.where(eq(invoices.accountId, accountId))` \u2014 rather than filtering the results afterwards. Which tables are scoped, and under which column, comes from this rule's own configuration.",
+  },
+  "tsforge/update-delete-must-have-where": {
+    what: "An update or delete with no `where` rewrites or removes the ENTIRE table.",
+    bad: "await db.delete(users);",
+    good: "await db.delete(users).where(eq(users.id, id));",
+  },
+  "tsforge/update-delete-account-scoped-must-filter-scope": {
+    what: "An update/delete on an account-scoped table must filter by the scope column, not just the row id.",
+    bad: "",
+    good: "",
+    procedure:
+      "A row id is not enough on an account-scoped table: ids are guessable and an id-only `where` lets one tenant modify another's row. Filter by BOTH \u2014 `.where(and(eq(invoices.id, id), eq(invoices.accountId, accountId)))`.",
+  },
+  "tsforge/relations-must-cover-fks": {
+    what: "Every foreign key needs a matching `relations()` entry or joins silently fall back to manual, untyped queries.",
+    bad: "",
+    good: "",
+    procedure:
+      "Declare the relation next to the table: `export const invoiceRelations = relations(invoices, ({ one }) => ({ account: one(accounts, { fields: [invoices.accountId], references: [accounts.id] }) }));` \u2014 one entry per FK column.",
+  },
+  "tsforge/schema-files-must-not-import-driver": {
+    what: "A schema file importing the driver drags a live connection into every consumer, including the migration generator.",
+    bad: "",
+    good: "",
+    procedure:
+      "Keep schema files declarative: import only from `drizzle-orm` and its dialect's column helpers. Create the client in a separate module (e.g. `src/db/client.ts`) and import the schema INTO it, never the reverse.",
+  },
+  "tsforge/schema-files-must-only-export-schema": {
+    what: "A schema file must export only tables, relations and types \u2014 anything else makes it a runtime dependency of the migration tooling.",
+    bad: "",
+    good: "",
+    procedure:
+      "Move helpers, queries and constants out of the schema file into a sibling module. The schema is read by drizzle-kit at build time; extra exports pull their whole import graph in with them.",
+  },
+  "tsforge/tables-must-have-timestamps": {
+    what: "Every table needs created/updated timestamps \u2014 without them you cannot audit, order or debug a row's history.",
+    bad: "",
+    good: "",
+    procedure:
+      'Add `createdAt: timestamp("created_at", { mode: "date" }).notNull().defaultNow()` and an `updatedAt` with `.$onUpdate(() => new Date())`, so the update stamp maintains itself.',
+  },
+  "tsforge/timestamp-must-specify-mode": {
+    what: "A timestamp column without an explicit `mode` returns a different JS type per driver.",
+    bad: "",
+    good: "",
+    procedure:
+      'Pass the mode explicitly: `timestamp("created_at", { mode: "date" })` for `Date`, or `{ mode: "string" }` for ISO strings. Pick one and use it consistently across the schema.',
+  },
+  "tsforge/prefer-destructured-context": {
+    what: "Destructure the Elysia context in the handler signature \u2014 it documents what the handler actually uses.",
+    bad: "",
+    good: "",
+    procedure:
+      "Destructure the Elysia context in the handler signature so the handler declares what it uses: `({ set, body }) => ...` instead of taking `ctx` and reaching into it. It documents the dependency and keeps handlers easy to test.",
+  },
+  "tsforge/prefer-static-services": {
+    what: "Build service instances once at module scope; constructing per request adds latency and defeats connection reuse.",
+    bad: "",
+    good: "",
+    procedure:
+      "Hoist the instance out of the handler: create it once at module scope and close over it, so each request reuses the same client and its pool.",
+  },
+  "tsforge/error-handler-must-set-status": {
+    what: "An error handler that does not set a status returns 200 with an error body \u2014 clients treat the failure as success.",
+    bad: "",
+    good: "",
+    procedure:
+      "Set the code before replying: `reply.code(err.statusCode ?? 500).send({ message })`. Without it Fastify keeps the default 200.",
+  },
+  "tsforge/prefer-return-over-reply-send": {
+    what: "Return the payload instead of calling `reply.send()` \u2014 returning keeps the handler's type checkable and composes with hooks.",
+    bad: "",
+    good: "",
+    procedure:
+      "Replace `reply.send(payload)` with `return payload`. Use `reply.code(...)` only to set the status, then return the body.",
+  },
+  "tsforge/require-fp-for-shared-plugins": {
+    what: "A plugin that registers shared decorators must be wrapped in `fastify-plugin`, or its registrations stay trapped in a child scope.",
+    bad: "",
+    good: "",
+    procedure:
+      'Wrap the export: `export default fp(async (app) => { app.decorate("db", db); });`. Without `fp`, Fastify encapsulates the plugin and nothing it decorates is visible to sibling routes.',
+  },
+  "tsforge/require-response-schema": {
+    what: "A route without a response schema is unvalidated and unserialised \u2014 Fastify cannot fast-serialise it and the contract is undocumented.",
+    bad: "",
+    good: "",
+    procedure:
+      "Add a `schema.response` map keyed by status code to the route options, e.g. `{ schema: { response: { 200: UserSchema } } }`.",
+  },
+  "tsforge/static-translation-key-exists": {
+    what: "A translation key built at runtime cannot be checked, so a missing key ships as raw key text to users.",
+    bad: "",
+    good: "",
+    procedure:
+      'Use a literal key (`t("cart.empty")`) so it can be verified against the dictionary. When a key genuinely varies, map the variants to literals in a lookup object and index that.',
+  },
+  "tsforge/auth-cookie-must-set-samesite": {
+    what: "An auth cookie without `sameSite` is sent on cross-site requests \u2014 the classic CSRF opening.",
+    bad: "",
+    good: "",
+    procedure:
+      'Set `sameSite: "lax"` (or `"strict"` if no cross-site navigation needs the session) when writing the cookie.',
+  },
+  "tsforge/auth-cookie-must-set-maxage-or-expires": {
+    what: "A session cookie with no lifetime lives until the browser closes \u2014 which on a phone is never.",
+    bad: "",
+    good: "",
+    procedure:
+      "Set `maxAge` (seconds) or `expires` when writing the cookie, and keep it in step with the token's own expiry.",
+  },
+  "tsforge/jwt-must-verify-not-decode": {
+    what: "`decode` reads the payload WITHOUT checking the signature, so a forged token is accepted.",
+    bad: "const claims = jwt.decode(token);",
+    good: "const claims = jwt.verify(token, secret);",
+  },
+  "tsforge/mutation-should-revalidate-cache": {
+    what: "A mutation that does not revalidate leaves the UI showing stale data until something else refreshes it.",
+    bad: "",
+    good: "",
+    procedure:
+      'After the write, call `revalidatePath("/things")` or `revalidateTag("things")` for the data the mutation invalidated.',
+  },
+  "tsforge/no-secret-props-to-client": {
+    what: "A secret-looking prop passed into JSX crosses the server/client boundary and lands in the browser payload.",
+    bad: "",
+    good: "",
+    procedure:
+      "Keep the secret on the server: use it there and pass only the derived, non-sensitive result as a prop.",
+  },
+  "tsforge/pkce-required-for-oidc": {
+    what: "Without PKCE an intercepted authorization code can be redeemed by an attacker.",
+    bad: "",
+    good: "",
+    procedure:
+      "Generate a `code_verifier`, send its S256 `code_challenge` on the authorize request, and pass the verifier on the token exchange.",
+  },
+  "tsforge/state-must-be-redis-backed": {
+    what: "OAuth `state` held only in a cookie can be replayed or dropped; it must be stored server-side so it can be consumed exactly once.",
+    bad: "",
+    good: "",
+    procedure:
+      "Write the state to Redis with a short TTL before redirecting, then DELETE it on callback and reject if it was already gone.",
+  },
+  "tsforge/state-ttl-bounded": {
+    what: "An unbounded OAuth state TTL leaves replayable handles alive indefinitely.",
+    bad: "",
+    good: "",
+    procedure:
+      "Set an explicit short TTL \u2014 a few minutes covers a real login. The state only has to survive one redirect round trip.",
+  },
+  "tsforge/forwardref-display-name": {
+    what: "A forwardRef component with no displayName shows as `ForwardRef` in React DevTools and error boundaries.",
+    bad: "",
+    good: "",
+    procedure:
+      'Assign it after the definition: `Input.displayName = "Input";` \u2014 React cannot infer a name through forwardRef.',
+  },
+  "tsforge/no-cross-feature-imports": {
+    what: "Importing across feature folders couples them and creates import cycles as both grow.",
+    bad: "",
+    good: "",
+    procedure:
+      "Move the shared code into a shared module both features import, or expose it through the owning feature's public index. Do not reach into another feature's internals.",
+  },
+  "tsforge/prefix-query-key-must-use-set-queries-data": {
+    what: "`setQueryData` with a partial key matches nothing \u2014 a prefix is a filter, not a key.",
+    bad: "",
+    good: "",
+    procedure:
+      'Use the matcher API for prefixes: `queryClient.setQueriesData({ queryKey: ["todos"] }, updater)`. Keep `setQueryData` for one exact key.',
+  },
+  "tsforge/test-file-mirrors-source": {
+    what: "A test whose path does not mirror its source is orphaned \u2014 nobody finds it when the source changes.",
+    bad: "",
+    good: "",
+    procedure:
+      "Put the test at the mirrored path for this project (either beside the source or under tests/ following the same folders) so the pair moves together.",
+  },
+};

--- a/packages/core/src/loop/feedback/pack-rule-docs.ts
+++ b/packages/core/src/loop/feedback/pack-rule-docs.ts
@@ -34,7 +34,7 @@ export const PACK_RULE_DOCS: Record<string, IRuleDoc> = {
     exampleFile: "app/page.tsx",
   },
   "tsforge/bcrypt-rounds-min": {
-    what: "Disallow `bcrypt.hash` / `bcrypt.hashSync` calls with a numeric-literal rounds value below the configured minimum (default 10).",
+    what: "A low bcrypt cost factor makes stolen hashes cheap to crack. Pass at least the configured minimum (default 10) as the rounds argument.",
     bad: '\n      import bcrypt from "bcrypt";\n      bcrypt.hash(password, 8);\n    ',
     good: '\n      import bcrypt from "bcrypt";\n      bcrypt.hash(password, 10);\n    ',
   },
@@ -116,7 +116,7 @@ export const PACK_RULE_DOCS: Record<string, IRuleDoc> = {
     exampleFile: "src/billing/billing.service.ts",
   },
   "tsforge/mask-pii-fields": {
-    what: "Disallow unmasked PII (email, phone, password, token, ...) in structured-logger payloads \u2014 the #1 way data leaks quietly.",
+    what: "PII in a log payload leaks quietly and is hard to purge afterwards. Mask or drop the field before logging \u2014 log an id or a hash instead of the value.",
     bad: '\n      logger.info({ event: "user_created", email: user.email });\n    ',
     good: '\n      logger.info({ event: "user_created", email: maskEmailForLogging(user.email) });\n    ',
   },
@@ -146,7 +146,7 @@ export const PACK_RULE_DOCS: Record<string, IRuleDoc> = {
     good: 'import { now, randomId } from "./utils/clock";\n\nexport function stamp() {\n  return { at: now(), id: randomId() };\n}',
   },
   "tsforge/no-blocking-concurrency-zero": {
-    what: "Disallow `new Worker(name, processor, { concurrency: <numericLiteral \u2264 0> })` \u2014 non-positive concurrency blocks job processing.",
+    what: "A non-positive `concurrency` stops the worker processing anything. Set it to a positive integer sized to the job's cost \u2014 start at 1 and raise it.",
     bad: '\n      import { Worker } from "bullmq";\n      new Worker("queue", async () => {}, { concurrency: 0 });\n    ',
     good: '\n      import { Worker } from "bullmq";\n      new Worker("queue", async () => {}, { concurrency: 5 });\n    ',
   },
@@ -163,14 +163,14 @@ export const PACK_RULE_DOCS: Record<string, IRuleDoc> = {
     exampleFile: "src/parse.test.ts",
   },
   "tsforge/no-decorate-state-collision": {
-    what: "Disallow duplicate keys across `.decorate()` / `.state()` / `.derive()` / `.resolve()` calls on a single Elysia instance \u2014 duplicates silently overwrite and break plugin composition.",
+    what: "Two `.decorate()`/`.state()`/`.derive()`/`.resolve()` calls sharing a key silently overwrite each other. Give each one a distinct key, or namespace them per plugin.",
     bad: '\n      const app = new Elysia()\n        .decorate("db", createDb())\n        .decorate("db", createCache());\n    ',
     good: '\n      const app = new Elysia()\n        .decorate("db", createDb())\n        .decorate("cache", createCache());\n    ',
   },
   "tsforge/no-derived-state-in-effect": {
-    what: "Disallow setting local state inside useEffect when the value can be derived during render (or memoized with useMemo).",
-    bad: 'import { useEffect, useState } from "react";\nexport function Counter({ seed }: { seed: number }) {\n  const [count, setCount] = useState(0);\n  useEffect(() => { setCount(seed); }, [seed]);\n  return <span>{count}</span>;\n}',
-    good: 'import { useState } from "react";\nexport function Counter() {\n  const [count, setCount] = useState(0);\n  function increment() { setCount((c) => c + 1); }\n  return <button onClick={increment}>{count}</button>;\n}',
+    what: "State set from an effect renders twice and can tear. If the value can be computed from props or other state, derive it during render \u2014 `useMemo` when the computation is expensive.",
+    bad: "export function Total({ items }: { items: number[] }) {\n  const [total, setTotal] = useState(0);\n\n  useEffect(() => {\n    setTotal(items.reduce((a, b) => a + b, 0));\n  }, [items]);\n\n  return <p>{total}</p>;\n}",
+    good: "export function Total({ items }: { items: number[] }) {\n  const total = useMemo(() => items.reduce((a, b) => a + b, 0), [items]);\n\n  return <p>{total}</p>;\n}",
     exampleFile: "src/Counter.tsx",
   },
   "tsforge/no-direct-process-env": {
@@ -293,7 +293,7 @@ export const PACK_RULE_DOCS: Record<string, IRuleDoc> = {
     good: "\n      const UserSchema = t.Object({ name: t.String() });\n      interface Profile { bio: string; }\n    ",
   },
   "tsforge/no-spawn-with-shell": {
-    what: "Disallow child_process.spawn/spawnSync with shell: true \u2014 shell execution enables command injection.",
+    what: "`shell: true` runs the string through a shell, so any interpolated value can inject commands. Drop it and pass the program and its arguments as an array.",
     bad: 'import { spawn } from "child_process";\nspawn("sh", ["-c", cmd], { shell: true });',
     good: 'import { spawn } from "child_process";\nspawn("node", ["script.js"]);',
     exampleFile: "src/runner.ts",
@@ -308,13 +308,14 @@ export const PACK_RULE_DOCS: Record<string, IRuleDoc> = {
       "1) Create/open `Component.hooks.ts` next to the component. 2) Move the state/effect hooks into a `useComponent()` custom hook that returns the values and handlers the JSX needs. 3) Call the hook once at the top of the component and destructure. (`useId`/`useTransition`/`useDeferredValue` may stay inline.)",
   },
   "tsforge/no-user-controlled-fetch-url": {
-    what: "Disallow fetch/axios requests whose ORIGIN is not fixed at author time \u2014 a runtime-controlled host enables SSRF.",
-    bad: "export async function load(url: string) { return fetch(url); }",
-    good: 'export async function load() { return fetch("https://api.example.com"); }',
-    exampleFile: "src/client.ts",
+    what: "The request ORIGIN must be fixed in source. Interpolating the path is fine; interpolating the host is not. There is no allowlist or builder to opt into \u2014 write the host literally.",
+    bad: "export async function load(url: string, host: string) {\n  await fetch(url);\n\n  return fetch(`https://${host}/todos`);\n}",
+    good: "export async function load(id: string) {\n  await fetch(`/api/todos/${id}`);\n\n  return fetch(`https://api.example.com/v1/${id}`);\n}",
+    procedure:
+      'Put the whole origin before the first ${...} and close it with / ? or # \u2014 `https://api.example.com${p}` is still rejected because p="@evil.com/x" rewrites the host through userinfo. For a caller-supplied host, validate it against a fixed allowlist yourself and branch to literal URLs.',
   },
   "tsforge/no-user-controlled-redirect": {
-    what: "Disallow redirects to non-literal URLs \u2014 user-controlled redirects enable open redirects.",
+    what: "A runtime-controlled redirect target lets an attacker bounce your users anywhere. Redirect to a literal path, or map the caller's value through a fixed allowlist of destinations.",
     bad: 'import { redirect } from "next/navigation";\nexport function go(target: string) { redirect(target); }',
     good: 'import { redirect } from "next/navigation";\nexport function go() { redirect("/dashboard"); }',
     exampleFile: "src/actions.ts",
@@ -412,7 +413,7 @@ export const PACK_RULE_DOCS: Record<string, IRuleDoc> = {
   "tsforge/upload-must-set-limits": {
     what: "Multipart upload handlers should declare `limits` or `maxFileSize` to bound request size.",
     bad: 'import multipart from "@fastify/multipart";\nexport async function handleUpload(request: { file: () => Promise<unknown> }) {\n  return request.file();\n}',
-    good: 'import multipart from "@fastify/multipart";\n\nexport async function register(app: FastifyInstance) {\n  await app.register(multipart, { limits: { fileSize: 5_000_000, files: 1 } });\n}\n\nexport async function handleUpload(request: { file: () => Promise<unknown> }) {\n  return request.file();\n}',
+    good: 'import multipart from "@fastify/multipart";\n\nexport async function registerUploads(app: FastifyInstance) {\n  await app.register(multipart, { limits: { fileSize: 5_000_000, files: 1 } });\n\n  app.post("/upload", async (request) => request.file());\n}',
     exampleFile: "src/routes/upload.ts",
   },
   "tsforge/webhook-must-verify-signature-before-parse": {
@@ -432,27 +433,6 @@ export const PACK_RULE_DOCS: Record<string, IRuleDoc> = {
     good: 'import { Worker } from "bullmq";\n\nconst worker = new Worker("emails", handler).on("failed", (job, err) => {\n  logger.error({ event: "job.failed", jobId: job?.id, cause: err });\n});',
     procedure:
       'Chain `.on("failed", ...)` directly onto `new Worker(...)`. Registering the same listener on a following statement is functionally identical but this rule does not currently detect it.',
-  },
-  "tsforge/index-must-reexport-default": {
-    what: "See procedure.",
-    bad: "",
-    good: "",
-    procedure:
-      'A component folder\'s `index` must re-export the component as the default, so importers can write `import Card from "./Card"`. Add `export { default } from "./Card";` (or `export { Card as default }`) alongside any named re-exports.',
-  },
-  "tsforge/fetch-must-check-ok": {
-    what: "See procedure.",
-    bad: "",
-    good: "",
-    procedure:
-      "`fetch` only rejects on network failure \u2014 a 4xx/5xx resolves normally and `.json()` then parses an error body as if it were data. Check `res.ok` (or the status) and throw or return early BEFORE reading the body.",
-  },
-  "tsforge/no-unsafe-boundary-cast": {
-    what: "See procedure.",
-    bad: "",
-    good: "",
-    procedure:
-      "A cast on boundary input asserts a shape the compiler never checked, so malformed input flows in silently typed. Parse it instead: run the value through your schema (`UserSchema.parse(await req.json())`) so the failure happens at the boundary with a real error.",
   },
   "tsforge/no-template-trim-empty-ternary": {
     what: "Inline `x.trim() === '' ? fallback : x.trim()` is unreadable and evaluates twice. Extract a named utility.",

--- a/packages/core/src/loop/feedback/pack-rule-docs.ts
+++ b/packages/core/src/loop/feedback/pack-rule-docs.ts
@@ -132,13 +132,13 @@ export const PACK_RULE_DOCS: Record<string, IRuleDoc> = {
     good: 'import OpenAI from "openai";\nconst client = new OpenAI({ apiKey: process.env.KEY });\nexport function getClient() {\n  return client;\n}',
     exampleFile: "src/chat.tsx",
     goodFile: "src/server/ai.ts",
+    fixIsRelocation: true,
   },
   "tsforge/no-auth-token-in-storage": {
     what: "Disallow storing or reading auth tokens from localStorage/sessionStorage \u2014 use httpOnly cookies instead.",
-    bad: 'localStorage.setItem("auth_token", token);',
-    good: 'export async function login(credentials: Credentials): Promise<void> {\n  // The server sets an httpOnly cookie; the token never touches JS storage.\n  await fetch("/api/session", {\n    method: "POST",\n    credentials: "include",\n    body: JSON.stringify(credentials),\n  });\n}',
+    bad: 'export function saveSession(token: string): void {\n  localStorage.setItem("auth_token", token);\n}',
+    good: 'export async function saveSession(token: string): Promise<void> {\n  // Hand the token to the server, which sets it as an httpOnly cookie.\n  // Nothing readable by JS ever holds it.\n  await fetch("/api/session", {\n    method: "POST",\n    credentials: "include",\n    headers: { authorization: `Bearer ${token}` },\n  });\n}',
     exampleFile: "src/auth.ts",
-    goodFile: "src/ui.ts",
   },
   "tsforge/no-bare-date-now": {
     what: "Time and randomness must come from an injectable util, or snapshots, replays and time-travel tests cannot be deterministic.",
@@ -222,7 +222,6 @@ export const PACK_RULE_DOCS: Record<string, IRuleDoc> = {
     what: "Move complex computations out of JSX into hooks or helper functions",
     bad: "export function List({ items }: { items: number[] }) {\n  return <ul>{items.filter((i) => i > 0).map((i) => <li key={i}>{i}</li>)}</ul>;\n}",
     good: 'import { useMemo } from "react";\n\nexport function List({ items }: { items: number[] }) {\n  const visible = useMemo(() => items.filter((i) => i > 0), [items]);\n\n  return <ul>{visible.map((i) => <li key={i}>{i}</li>)}</ul>;\n}',
-    goodFile: "src/Greeting.tsx",
     exampleFile: "src/List.tsx",
   },
   "tsforge/no-loading-text-use-skeleton": {
@@ -289,8 +288,10 @@ export const PACK_RULE_DOCS: Record<string, IRuleDoc> = {
   },
   "tsforge/no-separate-model-interfaces": {
     what: "Disallow TypeScript interfaces that duplicate the shape of a runtime schema with a matching name. Use `typeof Schema.static` (or your project's equivalent) instead.",
-    bad: "\n      const UserSchema = t.Object({ name: t.String() });\n      interface User { name: string; }\n    ",
-    good: "\n      const UserSchema = t.Object({ name: t.String() });\n      interface Profile { bio: string; }\n    ",
+    bad: 'import { t } from "elysia";\n\nexport const UserSchema = t.Object({ id: t.String(), name: t.String() });\n\nexport interface User {\n  id: string;\n  name: string;\n}',
+    good: 'import { t } from "elysia";\n\nexport const UserSchema = t.Object({ id: t.String(), name: t.String() });\n\n// Derived from the schema, so the type cannot drift from what is validated.\nexport type User = typeof UserSchema.static;',
+    procedure:
+      "Derive the type from the schema with `typeof Schema.static` rather than declaring a parallel interface. Renaming the interface silences the rule but leaves two definitions that drift apart \u2014 the schema validates one shape while the type promises another.",
   },
   "tsforge/no-spawn-with-shell": {
     what: "`shell: true` runs the string through a shell, so any interpolated value can inject commands. Drop it and pass the program and its arguments as an array.",
@@ -300,10 +301,8 @@ export const PACK_RULE_DOCS: Record<string, IRuleDoc> = {
   },
   "tsforge/no-state-in-component-body": {
     what: "State hooks must be in .hooks.ts files, not directly in components",
-    bad: '\n      import { useState } from "react";\n      export function Button() {\n        const [open, setOpen] = useState(false);\n        return <button>{open ? "Open" : "Closed"}</button>;\n      }\n    ',
-    good: '\n      import { useId } from "react";\n      export function Field() {\n        const id = useId();\n        return <input id={id} />;\n      }\n    ',
-    exampleFile: "src/Button.tsx",
-    goodFile: "src/Field.tsx",
+    bad: "",
+    good: "",
     procedure:
       "1) Create/open `Component.hooks.ts` next to the component. 2) Move the state/effect hooks into a `useComponent()` custom hook that returns the values and handlers the JSX needs. 3) Call the hook once at the top of the component and destructure. (`useId`/`useTransition`/`useDeferredValue` may stay inline.)",
   },

--- a/packages/core/src/loop/feedback/pack-rule-docs.ts
+++ b/packages/core/src/loop/feedback/pack-rule-docs.ts
@@ -54,6 +54,7 @@ export const PACK_RULE_DOCS: Record<string, IRuleDoc> = {
     bad: 'import { useState } from "react";\nexport default function Page() { const [n] = useState(0); return null; }',
     good: '"use client";\nimport { useState } from "react";\nexport default function Page() { const [n] = useState(0); return null; }',
     exampleFile: "app/dashboard/page.ts",
+    fixIsDirective: true,
   },
   "tsforge/component-file-purity": {
     what: "A component .tsx contains only imports and the component itself \u2014 types go to <feature>.types.ts, constants to <feature>.constants.ts, helpers to src/lib",
@@ -77,6 +78,7 @@ export const PACK_RULE_DOCS: Record<string, IRuleDoc> = {
     bad: "export default function Error({ error }: { error: Error }) {\n  return <div>{error.message}</div>;\n}",
     good: '"use client";\nexport default function Error({ error }: { error: Error }) {\n  return <div>{error.message}</div>;\n}',
     exampleFile: "app/dashboard/error.tsx",
+    fixIsDirective: true,
   },
   "tsforge/exported-functions-require-return-type": {
     what: "An exported function is an API. Annotate its return type so a body change cannot silently change the contract.",
@@ -134,7 +136,7 @@ export const PACK_RULE_DOCS: Record<string, IRuleDoc> = {
   "tsforge/no-auth-token-in-storage": {
     what: "Disallow storing or reading auth tokens from localStorage/sessionStorage \u2014 use httpOnly cookies instead.",
     bad: 'localStorage.setItem("auth_token", token);',
-    good: 'localStorage.setItem("theme", "dark");',
+    good: 'export async function login(credentials: Credentials): Promise<void> {\n  // The server sets an httpOnly cookie; the token never touches JS storage.\n  await fetch("/api/session", {\n    method: "POST",\n    credentials: "include",\n    body: JSON.stringify(credentials),\n  });\n}',
     exampleFile: "src/auth.ts",
     goodFile: "src/ui.ts",
   },
@@ -213,13 +215,13 @@ export const PACK_RULE_DOCS: Record<string, IRuleDoc> = {
   "tsforge/no-internal-api-fetch": {
     what: "Disallow Server Components from fetching the app's own /api routes \u2014 import services or ORM modules directly to avoid loopback HTTP overhead.",
     bad: 'export default async function Page() {\n  const res = await fetch("/api/users");\n  return null;\n}',
-    good: '"use client";\nexport default function Page() {\n  fetch("/api/users");\n  return null;\n}',
+    good: 'import { listUsers } from "@/services/users";\n\nexport default async function Page() {\n  const users = await listUsers();\n\n  return null;\n}',
     exampleFile: "app/dashboard/page.tsx",
   },
   "tsforge/no-jsx-computation": {
     what: "Move complex computations out of JSX into hooks or helper functions",
     bad: "export function List({ items }: { items: number[] }) {\n  return <ul>{items.filter((i) => i > 0).map((i) => <li key={i}>{i}</li>)}</ul>;\n}",
-    good: "export function List({ items }: { items: number[] }) {\n  const visible = useMemo(() => items.filter((i) => i > 0), [items]);\n\n  return <ul>{visible.map((i) => <li key={i}>{i}</li>)}</ul>;\n}",
+    good: 'import { useMemo } from "react";\n\nexport function List({ items }: { items: number[] }) {\n  const visible = useMemo(() => items.filter((i) => i > 0), [items]);\n\n  return <ul>{visible.map((i) => <li key={i}>{i}</li>)}</ul>;\n}',
     goodFile: "src/Greeting.tsx",
     exampleFile: "src/List.tsx",
   },
@@ -342,7 +344,7 @@ export const PACK_RULE_DOCS: Record<string, IRuleDoc> = {
   "tsforge/prefer-throw-status": {
     what: "Inside Elysia route handlers, prefer `throw status(...)` over try/catch blocks that build their own Response \u2014 local catches bypass Elysia's typed onError pipeline.",
     bad: '\n      const app = new Elysia();\n      app.post("/users", async () => {\n        try {\n          return await createUser();\n        } catch (e) {\n          return new Response("Error", { status: 500 });\n        }\n      });\n    ',
-    good: "\n      function safeCreate() {\n        try {\n          return createUser();\n        } catch (e) {\n          return null;\n        }\n      }\n    ",
+    good: 'const app = new Elysia();\n\napp.post("/users", async ({ status }) => {\n  const user = await createUser();\n\n  if (user === null) {\n    throw status(500, "could not create user");\n  }\n\n  return user;\n});',
   },
   "tsforge/queue-options-must-set-removeoncomplete": {
     what: "Every `<queue>.add(...)` must configure `removeOnComplete` (per-call or via `defaultJobOptions`) so completed jobs don't accumulate in Redis.",
@@ -410,7 +412,7 @@ export const PACK_RULE_DOCS: Record<string, IRuleDoc> = {
   "tsforge/upload-must-set-limits": {
     what: "Multipart upload handlers should declare `limits` or `maxFileSize` to bound request size.",
     bad: 'import multipart from "@fastify/multipart";\nexport async function handleUpload(request: { file: () => Promise<unknown> }) {\n  return request.file();\n}',
-    good: 'import multipart from "@fastify/multipart";\nconst limits = { fileSize: 1024 };\nexport async function handleUpload(request: { file: () => Promise<unknown> }) {\n  return request.file();\n}',
+    good: 'import multipart from "@fastify/multipart";\n\nexport async function register(app: FastifyInstance) {\n  await app.register(multipart, { limits: { fileSize: 5_000_000, files: 1 } });\n}\n\nexport async function handleUpload(request: { file: () => Promise<unknown> }) {\n  return request.file();\n}',
     exampleFile: "src/routes/upload.ts",
   },
   "tsforge/webhook-must-verify-signature-before-parse": {

--- a/packages/core/src/loop/feedback/pack-rule-docs.ts
+++ b/packages/core/src/loop/feedback/pack-rule-docs.ts
@@ -64,8 +64,8 @@ export const PACK_RULE_DOCS: Record<string, IRuleDoc> = {
   },
   "tsforge/consistent-status-via-set": {
     what: "Inside Elysia route handlers, set HTTP status via `set.status = N`, not by returning a `new Response(body, { status: N })`.",
-    bad: '\n      const app = new Elysia();\n      app.get("/", () => {\n        return new Response("Hello", { status: 200 });\n      });\n    ',
-    good: '\n      const app = new Elysia();\n      app.get("/", () => {\n        return "Hello";\n      });\n    ',
+    bad: 'const app = new Elysia();\n\napp.get("/users", () => {\n  return new Response("created", { status: 201 });\n});',
+    good: 'const app = new Elysia();\n\napp.get("/users", ({ set }) => {\n  set.status = 201;\n\n  return "created";\n});',
   },
   "tsforge/dangerous-html-requires-sanitize": {
     what: "dangerouslySetInnerHTML requires a sanitization library (DOMPurify or equivalent) imported in the same file.",
@@ -270,8 +270,8 @@ export const PACK_RULE_DOCS: Record<string, IRuleDoc> = {
   },
   "tsforge/no-react-in-services": {
     what: "A service/data-layer file must not import React \u2014 keep React in components and hooks.",
-    bad: 'import { useState } from "react";\n\nexport function loadUsers(): void {\n  useState();\n}',
-    good: "export async function loadUsers(): Promise<string[]> {\n  return db.user.findMany();\n}",
+    bad: 'import { useState } from "react";\n\nexport function useUserCache() {\n  const [users, setUsers] = useState<string[]>([]);\n\n  return { users, setUsers };\n}',
+    good: "// Plain module state \u2014 no React in the service layer. The component wraps\n// this in its own useState/useSyncExternalStore.\nlet users: string[] = [];\n\nexport function getUsers(): string[] {\n  return users;\n}\n\nexport function setUsers(next: string[]): void {\n  users = next;\n}",
     exampleFile: "src/services/users.ts",
   },
   "tsforge/no-real-network-in-unit-tests": {
@@ -294,8 +294,8 @@ export const PACK_RULE_DOCS: Record<string, IRuleDoc> = {
   },
   "tsforge/no-spawn-with-shell": {
     what: "`shell: true` runs the string through a shell, so any interpolated value can inject commands. Drop it and pass the program and its arguments as an array.",
-    bad: 'import { spawn } from "child_process";\nspawn("sh", ["-c", cmd], { shell: true });',
-    good: 'import { spawn } from "child_process";\nspawn("node", ["script.js"]);',
+    bad: 'import { spawn } from "node:child_process";\n\nexport function run(dir: string) {\n  return spawn("ls -la " + dir, { shell: true });\n}',
+    good: 'import { spawn } from "node:child_process";\n\nexport function run(dir: string) {\n  // Same command, no shell: the directory can no longer inject one.\n  return spawn("ls", ["-la", dir]);\n}',
     exampleFile: "src/runner.ts",
   },
   "tsforge/no-state-in-component-body": {
@@ -384,8 +384,10 @@ export const PACK_RULE_DOCS: Record<string, IRuleDoc> = {
   },
   "tsforge/require-route-schema": {
     what: "Fastify POST/PUT/PATCH routes must declare schema.body; GET/DELETE routes must declare schema.querystring or schema.params.",
-    bad: '\nimport Fastify from "fastify";\nconst fastify = Fastify();\nfastify.post("/users", { schema: {} }, async () => ({ ok: true }));\n',
-    good: '\nimport Fastify from "fastify";\nconst UserSchema = {};\nconst fastify = Fastify();\nfastify.post("/users", { schema: { body: UserSchema } }, async () => ({ ok: true }));\n',
+    bad: 'import Fastify from "fastify";\n\nconst fastify = Fastify();\n\nfastify.post("/users", { schema: {} }, async () => ({ ok: true }));',
+    good: 'import Fastify from "fastify";\n\nconst fastify = Fastify();\n\nfastify.post(\n  "/users",\n  {\n    schema: {\n      body: {\n        type: "object",\n        required: ["email"],\n        properties: { email: { type: "string", format: "email" } },\n      },\n    },\n  },\n  async () => ({ ok: true })\n);',
+    procedure:
+      "Describe every field the route accepts. An empty or permissive schema satisfies the rule while validating nothing \u2014 the point is that unexpected input is REJECTED, not that a schema key exists.",
     exampleFile: "src/routes/users.ts",
   },
   "tsforge/server-action-requires-authz": {
@@ -544,15 +546,15 @@ export const PACK_RULE_DOCS: Record<string, IRuleDoc> = {
   },
   "tsforge/auth-cookie-must-set-samesite": {
     what: "An auth cookie without `sameSite` is sent on cross-site requests \u2014 the classic CSRF opening.",
-    bad: "",
-    good: "",
+    bad: 'setCookie("session", token, { httpOnly: true, secure: true });',
+    good: 'setCookie("session", token, {\n  httpOnly: true,\n  secure: true,\n  sameSite: "lax",\n});',
     procedure:
       'Set `sameSite: "lax"` (or `"strict"` if no cross-site navigation needs the session) when writing the cookie.',
   },
   "tsforge/auth-cookie-must-set-maxage-or-expires": {
     what: "A session cookie with no lifetime lives until the browser closes \u2014 which on a phone is never.",
-    bad: "",
-    good: "",
+    bad: 'setCookie("session", token, {\n  httpOnly: true,\n  secure: true,\n  sameSite: "lax",\n});',
+    good: 'setCookie("session", token, {\n  httpOnly: true,\n  secure: true,\n  sameSite: "lax",\n  maxAge: 60 * 60,\n});',
     procedure:
       "Set `maxAge` (seconds) or `expires` when writing the cookie, and keep it in step with the token's own expiry.",
   },

--- a/packages/core/src/loop/feedback/rule-docs.ts
+++ b/packages/core/src/loop/feedback/rule-docs.ts
@@ -285,23 +285,23 @@ export const RULE_DOCS: Record<string, IRuleDoc> = {
     good: "process.env.STRIPE_SECRET_KEY // server-only, no NEXT_PUBLIC prefix",
   },
   "tsforge/fetch-must-check-ok": {
-    what: "Check response.ok before calling .json() on fetch results.",
-    bad: "",
-    good: "",
+    what: "`fetch` only rejects on a network failure \u2014 a 4xx/5xx resolves normally, and `.json()` then parses the error body as if it were data. Check the response before reading it.",
+    bad: "export async function loadUser(id: string) {\n  const res = await fetch(`/api/users/${id}`);\n\n  return res.json();\n}",
+    good: "export async function loadUser(id: string) {\n  const res = await fetch(`/api/users/${id}`);\n\n  if (!res.ok) {\n    throw new Error(`user request failed: ${res.status}`);\n  }\n\n  return res.json();\n}",
     procedure:
       "`fetch` only rejects on network failure \u2014 a 4xx/5xx resolves normally and `.json()` then parses an error body as if it were data. Check `res.ok` (or the status) and throw or return early BEFORE reading the body.",
   },
   "tsforge/json-parse-must-validate": {
-    what: "Parse external JSON through a schema library, not bare JSON.parse.",
-    bad: "",
-    good: "",
+    what: "`JSON.parse` returns `any`, so every field downstream is unchecked. Hand its result to a schema and use what the schema returns.",
+    bad: "export function loadUser(raw: string) {\n  return JSON.parse(raw);\n}",
+    good: 'import { z } from "zod";\n\nconst UserSchema = z.object({ id: z.string(), email: z.string() });\n\nexport function loadUser(raw: string) {\n  return UserSchema.parse(JSON.parse(raw));\n}',
     procedure:
-      "`JSON.parse` returns `any`, so every field downstream is unchecked. Hand the raw value to a schema and use ITS result \u2014 `const user = UserSchema.parse(await req.json())`. Do not parse first and validate later; the untyped value has already escaped by then.",
+      "Parse THEN validate, and use the validator's return value \u2014 not the raw parse result. `JSON.parse` alone hands back `any`, so the fields are unchecked no matter how they are typed afterwards.",
   },
   "tsforge/no-unsafe-boundary-cast": {
-    what: "A cast asserts a shape nothing checked, so malformed input flows in silently typed. Parse the value through a schema and use its result.",
-    bad: "",
-    good: "",
+    what: "A cast on parsed boundary input asserts a shape nothing checked, so malformed data flows in silently typed. Validate it and use the validator's return value.",
+    bad: "export function loadUser(raw: string) {\n  const user = JSON.parse(raw) as { email: string };\n\n  return user.email;\n}",
+    good: 'import { z } from "zod";\n\nconst UserSchema = z.object({ email: z.string() });\n\nexport function loadUser(raw: string) {\n  const user = UserSchema.parse(JSON.parse(raw));\n\n  return user.email;\n}',
     procedure:
       "A cast on boundary input asserts a shape the compiler never checked, so malformed input flows in silently typed. Parse instead: run the value through your schema (`UserSchema.parse(await req.json())`) so failure happens at the boundary with a real error.",
   },

--- a/packages/core/src/loop/feedback/rule-docs.ts
+++ b/packages/core/src/loop/feedback/rule-docs.ts
@@ -1,6 +1,7 @@
 import type { ErrorSet } from "../../validate";
 import generatedJson from "./rule-docs.generated.json";
 import { activeOverlay } from "../../self-harness/overlay";
+import { PACK_RULE_DOCS } from "./pack-rule-docs";
 
 export interface IRuleDoc {
   /** One-line statement of what the rule requires. */
@@ -11,6 +12,22 @@ export interface IRuleDoc {
   good: string;
   /** Optional multi-step fix workflow for architecture or meta-rules. */
   procedure?: string;
+  /** Filename to lint `bad`/`good` under, for rules whose behaviour depends on
+   *  the path (test mirrors, client components, schema files). Consumed only by
+   *  `tests/rule-docs-examples.test.ts`, which PROVES every published example
+   *  really does trip its rule and that the fix really does satisfy it — a doc
+   *  that describes a mechanism the rule does not have sends the model hunting
+   *  for something that was never built. Defaults to `src/example.ts`. */
+  exampleFile?: string;
+  /** Filename for the ✓ example when the fix IS the path (a component that must
+   *  move, a test that must mirror its source). Defaults to `exampleFile`. */
+  goodFile?: string;
+  /** Set when `bad`/`good` are illustrative FILE LAYOUTS rather than compilable
+   *  code (a rule whose fix is moving files). Exempts the entry from the
+   *  executable-example test — which must stay strict for everything else, since
+   *  an unverified example is how a doc came to promise a mechanism that did not
+   *  exist. */
+  exampleIsProse?: boolean;
   /** Maintainer-only pointer to the rule's implementation or deeper guidance
    *  (tsforge-repo-relative). NEVER emitted into runtime feedback — the model
    *  runs in the user's project where the path dangles. Anything the model
@@ -32,7 +49,10 @@ const GENERATED: Record<string, IRuleDoc> = generatedJson;
  * ids (`@typescript-eslint/...`). Surfacing the rule's own bad→good next to the
  * failure beats making the model re-derive the fix from scratch.
  */
-const RULE_DOCS: Record<string, IRuleDoc> = {
+/** Default filename for JSX examples: several rules only fire in a .tsx file. */
+const TSX_EXAMPLE = "src/Example.tsx";
+
+export const RULE_DOCS: Record<string, IRuleDoc> = {
   // --- Type-aware: implicit-`any` containment (no `any` token to see) ---
   // (no-unsafe-assignment / -member-access / -return are curated further below)
   "@typescript-eslint/no-unsafe-call": {
@@ -51,21 +71,6 @@ const RULE_DOCS: Record<string, IRuleDoc> = {
     good: "function handle(x) { return isA(x) ? doA(x) : doB(x); } // branches extracted",
   },
   // --- AI-SDK pack ---
-  "tsforge/no-api-key-in-client": {
-    what: "An AI provider client constructed in a `'use client'` file ships the API key to the browser. Call the model from a server route/action.",
-    bad: "'use client';\nconst client = new OpenAI({ apiKey: process.env.KEY });",
-    good: "// server action / route handler:\nconst client = new OpenAI({ apiKey: process.env.KEY });",
-  },
-  "tsforge/require-completion-token-limit": {
-    what: "AI completion calls must bound output tokens to cap cost/latency.",
-    bad: "await generateText({ model, prompt });",
-    good: "await generateText({ model, prompt, maxTokens: 512 });",
-  },
-  "tsforge/no-user-input-in-system-prompt": {
-    what: "Don't splice request/user data into the system prompt (injection). Keep the system prompt constant; pass user input as a user message.",
-    bad: "generateText({ system: `You are ${role}`, prompt });",
-    good: "generateText({ system: SYSTEM_PROMPT, messages: [{ role: 'user', content: userInput }] });",
-  },
   TS2532: {
     what: "Indexed access is `T | undefined` (noUncheckedIndexedAccess). Bind and guard before use; never `!`.",
     bad: "total += arr[i];",
@@ -194,41 +199,25 @@ const RULE_DOCS: Record<string, IRuleDoc> = {
     bad: "items.map((it, i) => <li key={i}>{it.text}</li>)",
     good: "items.map((it) => <li key={it.id}>{it.text}</li>)",
   },
-  "tsforge/no-jsx-computation": {
-    what: "No `.map()`/`.filter()`/arithmetic/chained logic inside JSX `{…}` — extract to a hook or pre-prep variable first.",
-    bad: "<ul>{items.filter((i) => i.visible).map((i) => <li key={i.id}>{i.label}</li>)}</ul>",
-    good: "const rows = useMemo(() => items.filter(...).map(...), [items]); return <ul>{rows}</ul>;",
-  },
-  "tsforge/no-loading-text-use-skeleton": {
-    what: "Loading states render a <Skeleton/> shaped like the content — never 'Loading…' text or a spinner. Add `skeleton` via scaffold_ui.",
-    bad: "if (isLoading) { return <p>Loading…</p>; }",
-    good: 'if (isLoading) { return <Skeleton className="h-8 w-full" />; }',
-  },
-  "tsforge/no-state-in-component-body": {
-    what: "State hooks (`useState`, `useEffect`, `useMemo`, …) belong in `Component.hooks.ts`, not in the `.tsx` component body.",
-    bad: "export function Button() { const [open, setOpen] = useState(false); return <button />; }",
-    good: "export function useButton() { const [open, setOpen] = useState(false); return { open }; }",
-    procedure:
-      "1) Create/open `Component.hooks.ts` next to the component. 2) Move the state/effect hooks into a `useComponent()` custom hook that returns the values and handlers the JSX needs. 3) Call the hook once at the top of the component and destructure. (`useId`/`useTransition`/`useDeferredValue` may stay inline.)",
-  },
   "tsforge/no-inline-jsx-functions": {
     what: "No inline arrow/function expressions in JSX attributes — bind handlers in the hook and pass a reference.",
     bad: "<button onClick={() => doThing(id)} />",
     good: "const onClickRow = useCallback(() => doThing(id), [id]); <button onClick={onClickRow} />",
     procedure:
       "1) Define the handler in the component's hook file, wrapped in `useCallback` with its dependencies. 2) Return it from the hook and destructure it in the component. 3) Pass the reference (`onClick={onClickRow}`). For per-item handlers in a list, extract a row component that receives the item and binds internally.",
+    exampleFile: TSX_EXAMPLE,
   },
   "tsforge/index-must-reexport-default": {
     what: "A component folder's `index.ts` may only re-export: the component's default plus optional type re-exports — no logic.",
-    bad: "import Button from './Button'; export default Button;  // logic in Button/index.ts",
-    good: "export { default as Button } from './Button'; export * from './Button.types';",
+    bad: "",
+    good: "",
     procedure:
       "1) Open the folder's `index.ts`. 2) Replace its body with `export { default as Component } from './Component'`. 3) Keep only type re-exports alongside (`export * from './Component.types'`); move any other code into its own module.",
   },
   "tsforge/max-hooks-per-file": {
     what: "A `*.hooks.ts`/`*.queries.ts`/`*.mutations.ts` module may export at most 4 hooks — split god files by concern before they grow.",
-    bad: "users.queries.ts exporting 7 use* hooks",
-    good: "users.list.queries.ts + users.detail.queries.ts + users.mutations.ts, each ≤ 4 hooks",
+    bad: "",
+    good: "",
     procedure:
       "1) Group the file's exported hooks by concern (list vs detail vs mutations). 2) Create one module per group (e.g. `users.list.queries.ts`, `users.mutations.ts`), each ≤ 4 hooks. 3) Move each hook with the imports it needs and update the import sites. 4) Delete the original file once it is empty.",
   },
@@ -239,6 +228,7 @@ const RULE_DOCS: Record<string, IRuleDoc> = {
     procedure:
       "1) Create `Component/` folder. 2) Move hooks to `Component.hooks.ts`. 3) Add `index.ts` with `export { default } from './Component'`. 4) Update imports to the folder path.",
     reference: "packages/core/src/rule-packs/react-component-architecture/",
+    exampleIsProse: true,
   },
   "tsforge/no-throw-literal": {
     what: "Throw `Error` instances, not string or number literals.",
@@ -249,153 +239,73 @@ const RULE_DOCS: Record<string, IRuleDoc> = {
     what: "Do not use React.FC — type props on the function parameter.",
     bad: "const Button: React.FC<IButtonProps> = ({ onClick }) => <button onClick={onClick} />;",
     good: "function Button({ onClick }: IButtonProps) { return <button onClick={onClick} />; }",
+    exampleFile: TSX_EXAMPLE,
   },
   "tsforge/no-component-invocation": {
     what: "Render components as JSX, not function calls.",
     bad: "<div>{Header()}</div>",
     good: "<div><Header /></div>",
+    exampleFile: TSX_EXAMPLE,
   },
   "tsforge/no-nested-component": {
     what: "Declare components at module scope, not inside another component.",
     bad: "function App() { function Inner() { return <span />; } return <Inner />; }",
     good: "function Inner() { return <span />; } function App() { return <Inner />; }",
-  },
-  "tsforge/dangerous-html-requires-sanitize": {
-    what: "Sanitize HTML before dangerouslySetInnerHTML — import DOMPurify.",
-    bad: "<div dangerouslySetInnerHTML={{ __html: rawHtml }} />",
-    good: "import DOMPurify from 'isomorphic-dompurify'; <div dangerouslySetInnerHTML={{ __html: DOMPurify.sanitize(rawHtml) }} />",
-  },
-  "tsforge/no-child-process-exec": {
-    what: "Do not use child_process.exec/execSync — shell execution enables command injection.",
-    bad: "import { exec } from 'child_process'; exec(`rm -rf ${dir}`);",
-    good: "import { execFile } from 'child_process'; execFile('rm', ['-rf', dir], callback);",
-  },
-  "tsforge/no-spawn-with-shell": {
-    what: "Do not pass `{ shell: true }` to spawn/spawnSync.",
-    bad: "spawn('sh', ['-c', cmd], { shell: true });",
-    good: "spawn('node', ['script.js', arg]);",
-  },
-  "tsforge/no-dynamic-regexp": {
-    what: "Do not build RegExp from runtime input — ReDoS risk.",
-    bad: "const re = new RegExp(userPattern);",
-    good: "const re = /^fixed-pattern$/;",
+    exampleFile: TSX_EXAMPLE,
   },
   "tsforge/no-inner-html-assignment": {
     what: "Do not assign to innerHTML — XSS risk in vanilla DOM code.",
     bad: "el.innerHTML = userHtml;",
     good: "el.textContent = userText;",
   },
-  "tsforge/catch-must-handle": {
-    what: "Catch blocks must log, rethrow, or return a typed error — not silently mask failure.",
-    bad: "catch (e) { return null; }",
-    good: "catch (e) { logger.error(e); throw e; }",
-  },
-  "tsforge/no-react-in-services": {
-    what: "Service/data modules must not import React — keep business logic decoupled from UI.",
-    bad: "import { useMemo } from 'react'; // in src/services/users.ts",
-    good: "Move React hooks to components; keep services as plain TypeScript.",
-  },
   "tsforge/no-anonymous-useEffect": {
     what: "Pass a named function to useEffect for debuggable stack traces.",
     bad: "useEffect(() => { sync(); }, [id]);",
     good: "useEffect(function syncOnIdChange() { sync(); }, [id]);",
   },
-  "tsforge/no-derived-state-in-effect": {
-    what: "Do not set local state inside useEffect when the value can be derived during render.",
-    bad: "useEffect(() => { setFullName(first + ' ' + last); }, [first, last]);",
-    good: "const fullName = `${first} ${last}`;",
-  },
-  "tsforge/no-internal-api-fetch": {
-    what: "Server Components must not fetch the app's own /api routes.",
-    bad: "await fetch('/api/users');",
-    good: "import { listUsers } from '@/services/users'; const users = await listUsers();",
-  },
-  "tsforge/await-dynamic-request-apis": {
-    what: "Await Next.js dynamic request APIs in Server Components.",
-    bad: "const jar = cookies();",
-    good: "const jar = await cookies();",
-  },
-  "tsforge/error-boundary-require-use-client": {
-    what: "error.tsx and global-error.tsx must be Client Components.",
-    bad: "export default function Error() { return <div />; }",
-    good: "'use client'; export default function Error() { return <div />; }",
-  },
   "tsforge/no-html-img-element": {
     what: "Prefer next/image over raw img elements.",
     bad: "<img src='/hero.jpg' alt='hero' />",
     good: "import Image from 'next/image'; <Image src='/hero.jpg' alt='hero' width={800} height={400} />",
+    exampleFile: TSX_EXAMPLE,
   },
   "tsforge/no-sensitive-next-public-env": {
     what: "NEXT_PUBLIC_* vars are exposed in the client bundle — never use for secrets.",
     bad: "process.env.NEXT_PUBLIC_STRIPE_SECRET",
     good: "process.env.STRIPE_SECRET_KEY // server-only, no NEXT_PUBLIC prefix",
   },
-  "tsforge/prefer-lazy-use-state-init": {
-    what: "Use lazy useState when parsing localStorage on mount.",
-    bad: "useState(JSON.parse(localStorage.getItem('cfg') ?? '{}'))",
-    good: "useState(() => JSON.parse(localStorage.getItem('cfg') ?? '{}'))",
-  },
-  "tsforge/no-auth-token-in-storage": {
-    what: "Never store auth tokens in localStorage/sessionStorage.",
-    bad: "localStorage.setItem('auth_token', token);",
-    good: "Set an httpOnly session cookie on the server instead.",
-  },
   "tsforge/fetch-must-check-ok": {
     what: "Check response.ok before calling .json() on fetch results.",
-    bad: "const data = await fetch(url).then(r => r.json());",
-    good: "const res = await fetch(url); if (!res.ok) { throw new Error('fetch failed'); } const data = await res.json();",
+    bad: "",
+    good: "",
+    procedure:
+      "`fetch` only rejects on network failure \u2014 a 4xx/5xx resolves normally and `.json()` then parses an error body as if it were data. Check `res.ok` (or the status) and throw or return early BEFORE reading the body.",
   },
   "tsforge/json-parse-must-validate": {
     what: "Parse external JSON through a schema library, not bare JSON.parse.",
-    bad: "const body = JSON.parse(raw);",
-    good: "const body = UserSchema.parse(JSON.parse(raw));",
+    bad: "",
+    good: "",
+    procedure:
+      "`JSON.parse` returns `any`, so every field downstream is unchecked. Hand the raw value to a schema and use ITS result \u2014 `const user = UserSchema.parse(await req.json())`. Do not parse first and validate later; the untyped value has already escaped by then.",
   },
   "tsforge/no-unsafe-boundary-cast": {
     what: "Do not cast untrusted parsed input with `as` — validate at the boundary.",
-    bad: "const user = (await req.json()) as IUser;",
-    good: "const user = UserSchema.parse(await req.json());",
-  },
-  "tsforge/no-user-controlled-redirect": {
-    what: "Redirect URLs must be string literals or allowlisted helpers — not user input.",
-    bad: "redirect(searchParams.get('next')!);",
-    good: "redirect('/dashboard');",
-  },
-  "tsforge/no-user-controlled-fetch-url": {
-    what: "The request ORIGIN must be fixed in source. Interpolating the path is fine; interpolating the host is not. There is no allowlist or builder to opt into — write the host literally.",
-    bad: "await fetch(url); await fetch(`https://${host}/todos`);",
-    good: "await fetch(`/api/todos/${id}`); await fetch(`https://api.example.com/v1/${id}`);",
+    bad: "",
+    good: "",
     procedure:
-      'Put the whole origin before the first ${...}, and close it with / ? or # — `https://api.example.com${p}` is still rejected because p="@evil.com/x" rewrites the host. For a caller-supplied host, validate it against a fixed allowlist yourself and branch to literal URLs.',
+      "A cast on boundary input asserts a shape the compiler never checked, so malformed input flows in silently typed. Parse instead: run the value through your schema (`UserSchema.parse(await req.json())`) so failure happens at the boundary with a real error.",
   },
   "tsforge/no-prototype-polluting-merge": {
     what: "Do not merge request body/query/params into objects wholesale.",
     bad: "Object.assign(config, req.body);",
     good: "const name = UserSchema.parse(req.body).name; config.name = name;",
   },
-  "tsforge/server-only-modules-import-server-only": {
-    what: "Server-only modules importing DB/env must include `import 'server-only'`.",
-    bad: "import { db } from '@/lib/db'; // in lib/admin.ts",
-    good: "import 'server-only'; import { db } from '@/lib/db';",
-  },
   "tsforge/server-action-requires-authz-and-validation": {
     what: "Server actions must validate input and call authz before mutations.",
-    bad: "'use server'; export async function deleteUser(id: string) { await db.delete(users).where(eq(users.id, id)); }",
-    good: "'use server'; export async function deleteUser(raw: unknown) { const user = await requireUser(); const { id } = IdSchema.parse(raw); await authorize(user, id); ... }",
-  },
-  "tsforge/require-route-schema": {
-    what: "Fastify routes need a schema object with input validation.",
-    bad: "fastify.post('/users', async () => ({ ok: true }));",
-    good: "fastify.post('/users', { schema: { body: UserSchema } }, async () => ({ ok: true }));",
-  },
-  "tsforge/require-fastify-plugin-name": {
-    what: "fastify-plugin wrappers need a name option.",
-    bad: "export default fp(dbPlugin);",
-    good: "export default fp(dbPlugin, { name: 'db-connector', fastify: '5.x' });",
-  },
-  "tsforge/require-elysia-plugin-name": {
-    what: "Exported Elysia plugin instances need a name so the runtime can dedupe re-imports.",
-    bad: "export const plugin = new Elysia();",
-    good: "export const plugin = new Elysia({ name: 'auth-plugin' });",
+    bad: "",
+    good: "",
+    procedure:
+      "A server action needs BOTH: resolve the caller with your authorization helper and fail closed, then parse the arguments through a schema before touching the database. Typed parameters are not validation \u2014 the client controls what it sends.",
   },
   // BoringStack module-boundaries: a file must hold ONE semantic category. The
   // message lists the mixed categories (type / schema / constant / function / class /
@@ -529,6 +439,13 @@ function applyCardOverlay(
   return procedure === undefined ? merged : { ...merged, procedure };
 }
 
+/** Keep a multi-line example readable under its ✗/✓ marker: continuation lines
+ *  are indented to sit under the first, so the model sees the snippet's own
+ *  structure instead of a left-flushed wall. */
+function indentExample(code: string): string {
+  return code.split("\n").join("\n    ");
+}
+
 /** Format the rule docs for whichever rules appear in the current error set. */
 export function ruleHelp(errors: ErrorSet): string {
   const seen = new Set<string>();
@@ -540,7 +457,7 @@ export function ruleHelp(errors: ErrorSet): string {
     }
 
     // Try curated docs first, then generated, then tsforge pack rules
-    let doc = RULE_DOCS[e.rule] ?? GENERATED[e.rule];
+    let doc = RULE_DOCS[e.rule] ?? PACK_RULE_DOCS[e.rule] ?? GENERATED[e.rule];
 
     if (doc === undefined && e.rule.startsWith("tsforge/")) {
       // For tsforge pack rules, look up in generated docs
@@ -564,7 +481,7 @@ export function ruleHelp(errors: ErrorSet): string {
     const hasExample = doc.bad.length > 0 && doc.good.length > 0;
 
     let block = hasExample
-      ? `${e.rule}: ${doc.what}\n  ✗ ${doc.bad}\n  ✓ ${doc.good}`
+      ? `${e.rule}: ${doc.what}\n  ✗ ${indentExample(doc.bad)}\n  ✓ ${indentExample(doc.good)}`
       : `${e.rule}: ${doc.what}`;
 
     if (doc.procedure !== undefined && doc.procedure.length > 0) {

--- a/packages/core/src/loop/feedback/rule-docs.ts
+++ b/packages/core/src/loop/feedback/rule-docs.ts
@@ -28,6 +28,11 @@ export interface IRuleDoc {
    *  an unverified example is how a doc came to promise a mechanism that did not
    *  exist. */
   exampleIsProse?: boolean;
+  /** Set when adding a `"use client"` / `"use server"` directive IS the whole
+   *  fix, as for the `*-require-use-client` rules. Exempts the entry from the
+   *  evasion check, which otherwise treats a bolted-on directive as escaping
+   *  the rule's scope rather than repairing the code. */
+  fixIsDirective?: boolean;
   /** Maintainer-only pointer to the rule's implementation or deeper guidance
    *  (tsforge-repo-relative). NEVER emitted into runtime feedback — the model
    *  runs in the user's project where the path dangles. Anything the model
@@ -212,7 +217,7 @@ export const RULE_DOCS: Record<string, IRuleDoc> = {
     bad: "",
     good: "",
     procedure:
-      "1) Open the folder's `index.ts`. 2) Replace its body with `export { default as Component } from './Component'`. 3) Keep only type re-exports alongside (`export * from './Component.types'`); move any other code into its own module.",
+      '1) Open the folder\'s `index.ts`. 2) Re-export the component as the DEFAULT: `export { default } from "./Component";` \u2014 `export { default as Component }` creates a named export only and leaves the same gate failing. 3) Keep type re-exports alongside (`export * from "./Component.types"`); move any other code into its own module.',
   },
   "tsforge/max-hooks-per-file": {
     what: "A `*.hooks.ts`/`*.queries.ts`/`*.mutations.ts` module may export at most 4 hooks — split god files by concern before they grow.",

--- a/packages/core/src/loop/feedback/rule-docs.ts
+++ b/packages/core/src/loop/feedback/rule-docs.ts
@@ -423,7 +423,13 @@ export function ruleHelpFromOutput(output: string): string {
   // Without this the pack catalogue is invisible on the path the MODEL takes
   // when it runs the gate itself via `run`: it sees a bare rule id and goes
   // looking for the answer in the harness source.
-  for (const m of output.matchAll(/[a-z][a-z0-9-]*\/[a-z][a-z0-9-]+/gu)) {
+  // The boundary guards keep file paths out: in `/app/src/api.ts`, `app/src` is
+  // preceded by `/` and `src/api` is followed by `.`, so neither is offered as
+  // a rule id. A path fragment that happened to collide with a real doc key
+  // would otherwise attach guidance to a line that is not a violation.
+  for (const m of output.matchAll(
+    /(?<![\w./-])[a-z][a-z0-9-]*\/[a-z][a-z0-9-]+(?![\w./-])/gu
+  )) {
     ids.add(m[0]);
   }
 

--- a/packages/core/src/loop/feedback/rule-docs.ts
+++ b/packages/core/src/loop/feedback/rule-docs.ts
@@ -415,17 +415,15 @@ export function ruleHelpFromOutput(output: string): string {
     ids.add(m[0]);
   }
 
-  // The tsforge PACK rules — the ones with the worked examples. Without this the
-  // entire pack catalogue is invisible on plain eslint output, which is exactly
-  // the path taken when the MODEL runs the gate itself via the `run` tool: it
-  // would see the bare rule id and nothing else, and go looking for the answer.
-  for (const m of output.matchAll(/tsforge\/[a-z0-9-]+/g)) {
-    ids.add(m[0]);
-  }
-
-  // Other packs surface as `<pack>/<rule>` too; match the shape rather than
-  // enumerating packs, so a new pack is covered the day it lands.
-  for (const m of output.matchAll(/\bsonarjs\/[a-z-]+/g)) {
+  // Any `<pack>/<rule>` id in plain eslint text — tsforge's own packs, sonarjs,
+  // module-boundaries, and whatever ships next. Matching by SHAPE rather than
+  // enumerating packs is what makes a new pack work the day it lands; ruleHelp
+  // drops ids it has no doc for, so over-matching costs nothing.
+  //
+  // Without this the pack catalogue is invisible on the path the MODEL takes
+  // when it runs the gate itself via `run`: it sees a bare rule id and goes
+  // looking for the answer in the harness source.
+  for (const m of output.matchAll(/[a-z][a-z0-9-]*\/[a-z][a-z0-9-]+/gu)) {
     ids.add(m[0]);
   }
 

--- a/packages/core/src/loop/feedback/rule-docs.ts
+++ b/packages/core/src/loop/feedback/rule-docs.ts
@@ -469,9 +469,14 @@ function applyCardOverlay(
 
 /** Keep a multi-line example readable under its ✗/✓ marker: continuation lines
  *  are indented to sit under the first, so the model sees the snippet's own
- *  structure instead of a left-flushed wall. */
+ *  structure instead of a left-flushed wall.
+ *
+ *  Surrounding blank lines are dropped first. Several docs are written as
+ *  template literals that open with a newline, and indenting that empty first
+ *  line puts the snippet a line below its own marker with stray whitespace
+ *  between — noise the model has to read past. */
 function indentExample(code: string): string {
-  return code.split("\n").join("\n    ");
+  return code.trim().split("\n").join("\n    ");
 }
 
 /** Format the rule docs for whichever rules appear in the current error set. */

--- a/packages/core/src/loop/feedback/rule-docs.ts
+++ b/packages/core/src/loop/feedback/rule-docs.ts
@@ -259,7 +259,7 @@ export const RULE_DOCS: Record<string, IRuleDoc> = {
     exampleFile: TSX_EXAMPLE,
   },
   "tsforge/no-inner-html-assignment": {
-    what: "Do not assign to innerHTML — XSS risk in vanilla DOM code.",
+    what: "Assigning `innerHTML` injects markup as code. Use `textContent` for text, or sanitize with DOMPurify when you genuinely need HTML.",
     bad: "el.innerHTML = userHtml;",
     good: "el.textContent = userText;",
   },
@@ -294,14 +294,14 @@ export const RULE_DOCS: Record<string, IRuleDoc> = {
       "`JSON.parse` returns `any`, so every field downstream is unchecked. Hand the raw value to a schema and use ITS result \u2014 `const user = UserSchema.parse(await req.json())`. Do not parse first and validate later; the untyped value has already escaped by then.",
   },
   "tsforge/no-unsafe-boundary-cast": {
-    what: "Do not cast untrusted parsed input with `as` — validate at the boundary.",
+    what: "A cast asserts a shape nothing checked, so malformed input flows in silently typed. Parse the value through a schema and use its result.",
     bad: "",
     good: "",
     procedure:
       "A cast on boundary input asserts a shape the compiler never checked, so malformed input flows in silently typed. Parse instead: run the value through your schema (`UserSchema.parse(await req.json())`) so failure happens at the boundary with a real error.",
   },
   "tsforge/no-prototype-polluting-merge": {
-    what: "Do not merge request body/query/params into objects wholesale.",
+    what: "Merging request data wholesale lets a caller set `__proto__` and reach every object. Pick the fields you expect explicitly, or parse the body through a schema and merge its result.",
     bad: "Object.assign(config, req.body);",
     good: "const name = UserSchema.parse(req.body).name; config.name = name;",
   },
@@ -410,6 +410,20 @@ export function ruleHelpFromOutput(output: string): string {
     ids.add(m[0]);
   }
 
+  // The tsforge PACK rules — the ones with the worked examples. Without this the
+  // entire pack catalogue is invisible on plain eslint output, which is exactly
+  // the path taken when the MODEL runs the gate itself via the `run` tool: it
+  // would see the bare rule id and nothing else, and go looking for the answer.
+  for (const m of output.matchAll(/tsforge\/[a-z0-9-]+/g)) {
+    ids.add(m[0]);
+  }
+
+  // Other packs surface as `<pack>/<rule>` too; match the shape rather than
+  // enumerating packs, so a new pack is covered the day it lands.
+  for (const m of output.matchAll(/\bsonarjs\/[a-z-]+/g)) {
+    ids.add(m[0]);
+  }
+
   const errors = [...ids].map((rule) => ({ key: rule, rule, message: "" }));
 
   return ruleHelp(errors);
@@ -461,13 +475,9 @@ export function ruleHelp(errors: ErrorSet): string {
       continue;
     }
 
-    // Try curated docs first, then generated, then tsforge pack rules
+    // Curated (hand-written, richest) -> verified pack examples -> generated
+    // description-only. First hit wins.
     let doc = RULE_DOCS[e.rule] ?? PACK_RULE_DOCS[e.rule] ?? GENERATED[e.rule];
-
-    if (doc === undefined && e.rule.startsWith("tsforge/")) {
-      // For tsforge pack rules, look up in generated docs
-      doc = GENERATED[e.rule];
-    }
 
     // A self-harness procedure-card edit merges over the base doc field-wise;
     // with no overlay the base doc passes through untouched. An edit with no

--- a/packages/core/src/loop/feedback/rule-docs.ts
+++ b/packages/core/src/loop/feedback/rule-docs.ts
@@ -33,6 +33,11 @@ export interface IRuleDoc {
    *  evasion check, which otherwise treats a bolted-on directive as escaping
    *  the rule's scope rather than repairing the code. */
   fixIsDirective?: boolean;
+  /** Set when MOVING the code to another file is the documented fix (a secret
+   *  that must leave the client bundle, a component that must live elsewhere).
+   *  Exempts the entry from the path-escape check, which otherwise treats a
+   *  differing `goodFile` as sneaking the snippet out of the rule's scope. */
+  fixIsRelocation?: boolean;
   /** Maintainer-only pointer to the rule's implementation or deeper guidance
    *  (tsforge-repo-relative). NEVER emitted into runtime feedback — the model
    *  runs in the user's project where the path dangles. Anything the model

--- a/packages/core/src/rule-packs/typescript-core/rules/fetch-must-check-ok.ts
+++ b/packages/core/src/rule-packs/typescript-core/rules/fetch-must-check-ok.ts
@@ -7,59 +7,112 @@ export const RULE_NAME = "fetch-must-check-ok";
 
 type MessageIds = "missingOkCheck";
 
-function fetchCallHasOkCheck(fetchCall: TSESTree.CallExpression): boolean {
-  let parent: TSESTree.Node | null | undefined = fetchCall.parent;
+/** Reading either one counts as checking the response: `res.ok` is the idiom,
+ *  but `res.status === 204` is an equally deliberate check. */
+const OK_PROPS = new Set(["ok", "status"]);
 
-  while (parent !== undefined && parent !== null) {
-    if (parent.type === AST_NODE_TYPES.AwaitExpression) {
-      parent = parent.parent;
-      continue;
-    }
-
-    if (parent.type === AST_NODE_TYPES.VariableDeclarator) {
-      const init = parent.init;
-
-      if (
-        init?.type === AST_NODE_TYPES.AwaitExpression &&
-        init.argument === fetchCall
-      ) {
-        const binding = parent.id;
-
-        if (binding.type === AST_NODE_TYPES.Identifier) {
-          const name = binding.name;
-
-          return walkSome(parent.parent ?? fetchCall, (node) => {
-            if (
-              node.type !== AST_NODE_TYPES.MemberExpression ||
-              node.computed
-            ) {
-              return false;
-            }
-
-            return (
-              node.object.type === AST_NODE_TYPES.Identifier &&
-              node.object.name === name &&
-              node.property.type === AST_NODE_TYPES.Identifier &&
-              node.property.name === "ok"
-            );
-          });
-        }
-      }
-    }
-
-    if (
-      parent.type === AST_NODE_TYPES.MemberExpression &&
-      !parent.computed &&
-      parent.property.type === AST_NODE_TYPES.Identifier &&
-      parent.property.name === "json"
-    ) {
-      return false;
-    }
-
-    break;
+/** A non-computed `<object>.<prop>` read, e.g. `res.json` or `res.ok`. */
+function propReadOn(
+  node: TSESTree.Node,
+  objectName: string,
+  props: ReadonlySet<string> | string
+): node is TSESTree.MemberExpression {
+  if (node.type !== AST_NODE_TYPES.MemberExpression || node.computed) {
+    return false;
   }
 
-  return true;
+  if (
+    node.object.type !== AST_NODE_TYPES.Identifier ||
+    node.object.name !== objectName ||
+    node.property.type !== AST_NODE_TYPES.Identifier
+  ) {
+    return false;
+  }
+
+  const name = node.property.name;
+
+  return typeof props === "string" ? name === props : props.has(name);
+}
+
+/** The `<res>.json` read inside `root`, or null when the response is never
+ *  parsed — nothing to warn about if the body is only ever discarded. */
+function findJsonRead(
+  root: TSESTree.Node,
+  name: string
+): TSESTree.MemberExpression | null {
+  let found: TSESTree.MemberExpression | null = null;
+
+  walkSome(root, (node) => {
+    if (found === null && propReadOn(node, name, "json")) {
+      found = node;
+    }
+
+    return false;
+  });
+
+  return found;
+}
+
+function hasOkCheck(root: TSESTree.Node, name: string): boolean {
+  return walkSome(root, (node) => propReadOn(node, name, OK_PROPS));
+}
+
+/** Where to look for the check: the nearest enclosing block or function body,
+ *  so a later `if (res.ok)` in the same function counts however it is written —
+ *  early return, guard clause, ternary. */
+function scopeOf(node: TSESTree.Node): TSESTree.Node {
+  let current: TSESTree.Node | undefined = node.parent;
+
+  while (current !== undefined) {
+    if (
+      current.type === AST_NODE_TYPES.BlockStatement ||
+      current.type === AST_NODE_TYPES.Program
+    ) {
+      return current;
+    }
+
+    current = current.parent;
+  }
+
+  return node;
+}
+
+/** Strip the `await` wrapper so `(await fetch(url)).json()` and
+ *  `fetch(url).json()` reach the same branch. */
+function skipAwait(node: TSESTree.Node | undefined): TSESTree.Node | undefined {
+  return node?.type === AST_NODE_TYPES.AwaitExpression ? node.parent : node;
+}
+
+/** The response identifier a `.then(res => ...)` callback binds, or null. */
+function thenCallbackParam(node: TSESTree.Node): {
+  name: string;
+  body: TSESTree.Node;
+} | null {
+  if (
+    node.type !== AST_NODE_TYPES.MemberExpression ||
+    node.computed ||
+    node.property.type !== AST_NODE_TYPES.Identifier ||
+    node.property.name !== "then" ||
+    node.parent.type !== AST_NODE_TYPES.CallExpression
+  ) {
+    return null;
+  }
+
+  const callback = node.parent.arguments[0];
+
+  if (
+    callback === undefined ||
+    (callback.type !== AST_NODE_TYPES.ArrowFunctionExpression &&
+      callback.type !== AST_NODE_TYPES.FunctionExpression)
+  ) {
+    return null;
+  }
+
+  const param = callback.params[0];
+
+  return param?.type === AST_NODE_TYPES.Identifier
+    ? { name: param.name, body: callback.body }
+    : null;
 }
 
 export const fetchMustCheckOkRule = createRule<[], MessageIds>({
@@ -89,16 +142,55 @@ export const fetchMustCheckOkRule = createRule<[], MessageIds>({
           return;
         }
 
-        const parent = node.parent;
+        const parent = skipAwait(node.parent);
 
+        if (parent === undefined) {
+          return;
+        }
+
+        // `fetch(url).json()` / `(await fetch(url)).json()` — the response is
+        // never bound, so no check can exist anywhere.
         if (
-          parent?.type === AST_NODE_TYPES.MemberExpression &&
+          parent.type === AST_NODE_TYPES.MemberExpression &&
           !parent.computed &&
           parent.property.type === AST_NODE_TYPES.Identifier &&
-          parent.property.name === "json" &&
-          !fetchCallHasOkCheck(node)
+          parent.property.name === "json"
         ) {
           context.report({ node: parent, messageId: "missingOkCheck" });
+
+          return;
+        }
+
+        // `fetch(url).then(res => res.json())` — the callback parameter is the
+        // response, and the callback body is the whole scope it lives in.
+        const callback = thenCallbackParam(parent);
+
+        if (callback !== null) {
+          const read = findJsonRead(callback.body, callback.name);
+
+          if (read !== null && !hasOkCheck(callback.body, callback.name)) {
+            context.report({ node: read, messageId: "missingOkCheck" });
+          }
+
+          return;
+        }
+
+        // `const res = await fetch(url); ... res.json()` — the common shape.
+        // Look for the check anywhere in the enclosing block, since it is
+        // normally a guard clause on the line after.
+        if (
+          parent.type !== AST_NODE_TYPES.VariableDeclarator ||
+          parent.id.type !== AST_NODE_TYPES.Identifier
+        ) {
+          return;
+        }
+
+        const name = parent.id.name;
+        const scope = scopeOf(parent);
+        const read = findJsonRead(scope, name);
+
+        if (read !== null && !hasOkCheck(scope, name)) {
+          context.report({ node: read, messageId: "missingOkCheck" });
         }
       },
     };

--- a/packages/core/src/rule-packs/typescript-core/rules/fetch-must-check-ok.ts
+++ b/packages/core/src/rule-packs/typescript-core/rules/fetch-must-check-ok.ts
@@ -37,7 +37,10 @@ const COMPARISONS = new Set(["===", "!==", "==", "!=", "<", "<=", ">", ">="]);
  * check at all rather than as a check in whichever direction is convenient. */
 type Polarity = "positive" | "negative" | "opaque";
 
-/** Where success ends. 1xx-3xx are not errors; `res.ok` itself is `< 400`. */
+/** Where errors begin. `res.ok` is narrower than this — it is true only for
+ *  200-299 — but 3xx are redirects rather than failures, and code that tests
+ *  `status < 400` is making the usual success/error split. A threshold that
+ *  sits anywhere else splits neither. */
 const FIRST_ERROR_STATUS = 400;
 
 function literalValue(node: TSESTree.Node): number | boolean | undefined {
@@ -94,10 +97,12 @@ function statusPolarity(operator: string, value: number): Polarity {
       return value <= FIRST_ERROR_STATUS ? "positive" : "opaque";
     case "<=":
       return value < FIRST_ERROR_STATUS ? "positive" : "opaque";
+    // Only the error boundary itself bipartitions. `>= 500` leaves every 4xx
+    // on the fall-through side, so it proves nothing about what follows.
     case ">=":
-      return value >= 300 ? "negative" : "opaque";
+      return value === FIRST_ERROR_STATUS ? "negative" : "opaque";
     case ">":
-      return value >= 299 ? "negative" : "opaque";
+      return value === FIRST_ERROR_STATUS - 1 ? "negative" : "opaque";
     default:
       return "opaque";
   }
@@ -126,8 +131,12 @@ interface ICheck {
   /** The read was compared to something, or handed to an assertion. A bare
    *  `if (res.status)` is neither, and is true for 404 as much as for 200. */
   compared: boolean;
-  /** The read sits under `&&`, so a guard clause built on it may not run. */
+  /** The read is one operand of a larger `&&`. The test can then be false
+   *  while the response is fine, so the ELSE branch proves nothing. */
   underAnd: boolean;
+  /** The read is one operand of a larger `||`. The test can then be true while
+   *  the response is bad, so the THEN branch proves nothing. */
+  underOr: boolean;
 }
 
 /** A non-computed `<object>.<prop>` read, e.g. `res.json` or `res.ok`. */
@@ -201,6 +210,7 @@ interface IClimbState {
   polarity: Polarity;
   compared: boolean;
   underAnd: boolean;
+  underOr: boolean;
 }
 
 /** Nodes that CONSUME a condition. Reaching one ends the walk either way: it
@@ -214,6 +224,64 @@ const TERMINAL_TYPES = new Set<string>([
   AST_NODE_TYPES.SwitchStatement,
   AST_NODE_TYPES.CallExpression,
 ]);
+
+/** Assertions that compare, mapped to the operator they stand for. */
+const ASSERTION_OPERATORS = new Map<string, string>([
+  ["equal", "==="],
+  ["equals", "==="],
+  ["strictEqual", "==="],
+  ["deepEqual", "==="],
+  ["deepStrictEqual", "==="],
+  ["toBe", "==="],
+  ["toEqual", "==="],
+  ["notEqual", "!=="],
+  ["notStrictEqual", "!=="],
+  ["notDeepEqual", "!=="],
+]);
+
+function assertionOperator(callee: TSESTree.Node): string | undefined {
+  return callee.type === AST_NODE_TYPES.MemberExpression &&
+    !callee.computed &&
+    callee.property.type === AST_NODE_TYPES.Identifier
+    ? ASSERTION_OPERATORS.get(callee.property.name)
+    : undefined;
+}
+
+/** What an assertion call establishes about the response. */
+function assertionCheck(
+  parent: TSESTree.CallExpression,
+  child: TSESTree.Node,
+  check: ICheck
+): ICheck | null {
+  // The read was already compared on the way up — `assert(res.status === 200)`.
+  if (check.compared) {
+    return check;
+  }
+
+  const operator = assertionOperator(parent.callee);
+
+  if (operator === undefined) {
+    // A truthiness assertion. Fine for `res.ok`, which IS the verdict; the
+    // caller forces `compared` for that property.
+    return check;
+  }
+
+  // `assert.equal(res.status, 200)` — the other argument is the comparison.
+  const other = parent.arguments.find((arg) => arg !== child);
+  const value = other === undefined ? undefined : literalValue(other);
+
+  if (typeof value === "boolean") {
+    return {
+      ...check,
+      compared: true,
+      polarity: booleanPolarity(operator, value),
+    };
+  }
+
+  return typeof value === "number"
+    ? { ...check, compared: true, polarity: statusPolarity(operator, value) }
+    : check;
+}
 
 function terminalCheck(
   parent: TSESTree.Node,
@@ -234,16 +302,14 @@ function terminalCheck(
         ? { ...check, compared: true, polarity: "opaque" }
         : null;
 
-    // An assertion compares for us when it is GIVEN something to compare
-    // against: `assert.equal(res.status, 200)` is a status check, while
-    // `assert.ok(res.status)` asserts that a number is truthy — which every
-    // response that arrived satisfies, 500 included.
+    // An assertion settles a status only when it COMPARES it.
+    // `assert.equal(res.status, 200)` does; `assert.ok(res.status)` asserts a
+    // number is truthy, which every response that arrived satisfies. Arity
+    // cannot tell them apart — `assert.ok(res.status, "message")` also has two
+    // arguments — so the comparison is read from the assertion's own name.
     case AST_NODE_TYPES.CallExpression:
       return isAssertionCallee(parent.callee) && parent.callee !== child
-        ? {
-            ...check,
-            compared: state.compared || parent.arguments.length > 1,
-          }
+        ? assertionCheck(parent, child, check)
         : null;
 
     default:
@@ -295,6 +361,10 @@ function combinatorStep(
         state.underAnd = true;
       }
 
+      if (parent.operator === "||") {
+        state.underOr = true;
+      }
+
       // `res.ok && res.json()` — the parse is the right operand, so it runs
       // only when the check passed. That is a guard, not just a read. Only
       // when the parse is actually THERE, though: in `if (a || !res.ok)` the
@@ -322,6 +392,7 @@ function climb(read: TSESTree.Node, parse: TSESTree.Node): ICheck | null {
     polarity: "positive",
     compared: false,
     underAnd: false,
+    underOr: false,
   };
   let child: TSESTree.Node = read;
   let parent: TSESTree.Node | undefined = read.parent;
@@ -384,37 +455,47 @@ function scopeOfCheck(node: TSESTree.Node): TSESTree.Node {
   return current.parent ?? current;
 }
 
-/** The `case` arm a parse sits in, when that arm belongs to `owner`. */
-function caseArmOf(
-  owner: TSESTree.SwitchStatement,
-  parse: TSESTree.Node
-): TSESTree.SwitchCase | null {
-  for (const arm of owner.cases) {
-    if (contains(arm, parse)) {
-      return arm;
-    }
+function isSuccessCase(arm: TSESTree.SwitchCase): boolean {
+  // A `default:` arm has no test, and it is where the error cases land.
+  if (arm.test === null) {
+    return false;
   }
 
-  return null;
+  const value = literalValue(arm.test);
+
+  return typeof value === "number" && value >= 200 && value < 300;
 }
 
 /** `switch (res.status) { case 200: return res.json(); }` is a real check —
- *  but only for the arms that name a success code. `default:` and `case 500:`
- *  parse an error body. */
+ *  but only when every code that REACHES the body is a success code.
+ *  `case 500: case 200: return res.json();` falls through from 500 into the
+ *  same statements, so the arm the parse sits in is not the whole story. */
 function switchArmProtects(
   owner: TSESTree.SwitchStatement,
   parse: TSESTree.Node
 ): boolean {
-  // A `default:` arm has no test, and it is where the error cases land.
-  const test = caseArmOf(owner, parse)?.test;
+  const index = owner.cases.findIndex((arm) => contains(arm, parse));
+  const own = owner.cases[index];
 
-  if (test === undefined || test === null) {
+  if (own === undefined || !isSuccessCase(own)) {
     return false;
   }
 
-  const value = literalValue(test);
+  // Walk back over the empty arms stacked above this one; each is another
+  // entry point into the same body.
+  for (let i = index - 1; i >= 0; i -= 1) {
+    const arm = owner.cases[i];
 
-  return typeof value === "number" && value >= 200 && value < 300;
+    if (arm === undefined || arm.consequent.length > 0) {
+      break;
+    }
+
+    if (!isSuccessCase(arm)) {
+      return false;
+    }
+  }
+
+  return true;
 }
 
 /** True when the parse sits in a branch this check permits. */
@@ -444,7 +525,7 @@ function branchProtects(check: ICheck, parse: TSESTree.Node): boolean {
     owner.type === AST_NODE_TYPES.WhileStatement ||
     owner.type === AST_NODE_TYPES.DoWhileStatement
   ) {
-    return contains(owner.body, parse) && check.polarity === "positive";
+    return contains(owner.body, parse) && entersOnSuccess(check);
   }
 
   if (
@@ -455,14 +536,30 @@ function branchProtects(check: ICheck, parse: TSESTree.Node): boolean {
   }
 
   if (contains(owner.consequent, parse)) {
-    return check.polarity === "positive";
+    return entersOnSuccess(check);
   }
 
   return (
     owner.alternate !== null &&
     contains(owner.alternate, parse) &&
-    check.polarity === "negative"
+    skipsOnSuccess(check)
   );
+}
+
+/** True when reaching the THEN side proves the response was good.
+ *
+ * It has to be the whole test. In `if (res.ok || force)` the branch is entered
+ * for a failed response whenever `force` is set, so a check that is only one
+ * operand of an `||` proves nothing there. */
+function entersOnSuccess(check: ICheck): boolean {
+  return check.polarity === "positive" && !check.underOr;
+}
+
+/** True when reaching the ELSE side proves the response was good. Mirror image:
+ *  `if (!res.ok && enabled)` falls to the else branch for a failed response
+ *  whenever `enabled` is false. */
+function skipsOnSuccess(check: ICheck): boolean {
+  return check.polarity === "negative" && !check.underAnd;
 }
 
 /** True when the check leaves — throw or return — before the parse is reached,

--- a/packages/core/src/rule-packs/typescript-core/rules/fetch-must-check-ok.ts
+++ b/packages/core/src/rule-packs/typescript-core/rules/fetch-must-check-ok.ts
@@ -97,12 +97,14 @@ function statusPolarity(operator: string, value: number): Polarity {
       return value <= FIRST_ERROR_STATUS ? "positive" : "opaque";
     case "<=":
       return value < FIRST_ERROR_STATUS ? "positive" : "opaque";
-    // Only the error boundary itself bipartitions. `>= 500` leaves every 4xx
-    // on the fall-through side, so it proves nothing about what follows.
+    // A failure test is only useful for what it says about the OTHER side, so
+    // what matters is that everything below the threshold is a success:
+    // `>= 300` and `>= 400` both leave only good responses behind, while
+    // `>= 500` leaves every 4xx there.
     case ">=":
-      return value === FIRST_ERROR_STATUS ? "negative" : "opaque";
+      return value <= FIRST_ERROR_STATUS ? "negative" : "opaque";
     case ">":
-      return value === FIRST_ERROR_STATUS - 1 ? "negative" : "opaque";
+      return value < FIRST_ERROR_STATUS ? "negative" : "opaque";
     default:
       return "opaque";
   }
@@ -567,16 +569,18 @@ function skipsOnSuccess(check: ICheck): boolean {
 function guardProtects(check: ICheck, parse: TSESTree.Node): boolean {
   const { owner } = check;
 
+  // Execution continued past the assertion, so it held. `assert(res.ok ||
+  // force)` can hold with the response bad, which is why this asks the same
+  // question the then-branch does.
   if (owner.type === AST_NODE_TYPES.CallExpression) {
     return (
-      check.polarity === "positive" &&
+      entersOnSuccess(check) &&
       owner.range[1] <= parse.range[0] &&
       contains(scopeOfCheck(owner), parse)
     );
   }
 
-  // A guard under `&&` is not guaranteed to run at all.
-  if (owner.type !== AST_NODE_TYPES.IfStatement || check.underAnd) {
+  if (owner.type !== AST_NODE_TYPES.IfStatement) {
     return false;
   }
 
@@ -587,14 +591,20 @@ function guardProtects(check: ICheck, parse: TSESTree.Node): boolean {
     return false;
   }
 
+  // Falling PAST an exiting then-branch means the test was false. With `&&`
+  // the test can be false while the response is bad, so that operand form
+  // proves nothing here — but `||` is fine, since false means every operand
+  // was false.
   if (alwaysExits(owner.consequent)) {
-    return check.polarity === "negative";
+    return skipsOnSuccess(check);
   }
 
+  // The else-branch exits, so reaching the parse means the then-branch RAN and
+  // the test was true. Mirror image: `||` can be true with the response bad.
   return (
     owner.alternate !== null &&
     alwaysExits(owner.alternate) &&
-    check.polarity === "positive"
+    entersOnSuccess(check)
   );
 }
 

--- a/packages/core/src/rule-packs/typescript-core/rules/fetch-must-check-ok.ts
+++ b/packages/core/src/rule-packs/typescript-core/rules/fetch-must-check-ok.ts
@@ -7,10 +7,11 @@ export const RULE_NAME = "fetch-must-check-ok";
 
 type MessageIds = "missingOkCheck";
 
-/** Reading either one can count as checking the response: `res.ok` is the idiom,
- *  but `res.status === 204` is an equally deliberate check. Reading alone is not
- *  enough — see `isConditionPosition`. */
-const OK_PROPS = new Set(["ok", "status"]);
+/** The two properties that can carry a verdict about the response. They are not
+ *  equivalent: `ok` IS the verdict, whereas `status` is a number that has to be
+ *  compared before it means anything — see `climb`. */
+const OK_PROP = "ok";
+const OK_PROPS = new Set([OK_PROP, "status"]);
 
 /** Calls that act as a check even though they are not syntactically a test.
  *
@@ -20,6 +21,30 @@ const OK_PROPS = new Set(["ok", "status"]);
  * assertion helper and still matches; a lowercase one is a different word. */
 const ASSERTION_NAMES =
   /^(?:[Aa]ssert|[Ii]nvariant|[Ee]nsure|[Ee]xpect)(?:[A-Z_]\w*)?$/u;
+
+const COMPARISONS = new Set(["===", "!==", "==", "!=", "<", "<=", ">", ">="]);
+
+/** What a test says about the response when it is true.
+ *
+ * `res.ok` means the response succeeded, `!res.ok` means it failed, and
+ * `res.status !== 200` means neither — the direction is not decidable
+ * syntactically. Polarity picks which BRANCH is safe to parse in: a body may be
+ * read where the response is known good, never where it is known bad. `opaque`
+ * is allowed either way, since refusing a comparison the rule cannot interpret
+ * would flag ordinary code. */
+type Polarity = "positive" | "negative" | "opaque";
+
+/** A syntactic check of the response, resolved back to what governs it. */
+interface ICheck {
+  /** The `if`/ternary/loop, `&&`, or assertion call the read feeds. */
+  owner: TSESTree.Node;
+  polarity: Polarity;
+  /** The read was compared to something, or handed to an assertion. A bare
+   *  `if (res.status)` is neither, and is true for 404 as much as for 200. */
+  compared: boolean;
+  /** The read sits under `&&`, so a guard clause built on it may not run. */
+  underAnd: boolean;
+}
 
 /** A non-computed `<object>.<prop>` read, e.g. `res.json` or `res.ok`. */
 function propReadOn(
@@ -44,137 +69,299 @@ function propReadOn(
   return typeof props === "string" ? name === props : props.has(name);
 }
 
-/** The `<res>.json` read inside `root`, or null when the response is never
- *  parsed — nothing to warn about if the body is only ever discarded. */
-function findJsonRead(
+/** Every `<res>.json` read inside `root`.
+ *
+ * All of them, not the first: `if (preview) { if (!res.ok) throw; return
+ * res.json(); } return res.json();` guards one parse and leaves the other
+ * open, and stopping at the first would call the whole function checked. */
+function findJsonReads(
   root: TSESTree.Node,
   name: string
-): TSESTree.MemberExpression | null {
-  let found: TSESTree.MemberExpression | null = null;
+): TSESTree.MemberExpression[] {
+  const reads: TSESTree.MemberExpression[] = [];
 
   walkSome(root, (node) => {
-    if (found === null && propReadOn(node, name, "json")) {
-      found = node;
+    if (propReadOn(node, name, "json")) {
+      reads.push(node);
     }
 
     return false;
   });
 
-  return found;
+  return reads;
 }
 
-/** True when this expression is being TESTED rather than merely read.
- *
- * The distinction is the whole point of the rule. `metrics.observe(res.status)`
- * reads the status and still parses an error body as data; `if (!res.ok)` acts
- * on it. So a read only counts inside the test of an `if`/ternary/loop, the
- * discriminant of a `switch`, or an argument to an assertion helper —
- * combinators (`!`, `&&`, `===`) are transparent and keep the walk going. */
-function isConditionPosition(node: TSESTree.Node): boolean {
-  let child: TSESTree.Node = node;
-  let parent: TSESTree.Node | undefined = node.parent;
-
-  while (parent !== undefined) {
-    switch (parent.type) {
-      case AST_NODE_TYPES.IfStatement:
-      case AST_NODE_TYPES.WhileStatement:
-      case AST_NODE_TYPES.DoWhileStatement:
-      case AST_NODE_TYPES.ConditionalExpression:
-        return parent.test === child;
-
-      case AST_NODE_TYPES.SwitchStatement:
-        return parent.discriminant === child;
-
-      case AST_NODE_TYPES.LogicalExpression:
-      case AST_NODE_TYPES.BinaryExpression:
-      case AST_NODE_TYPES.UnaryExpression:
-      case AST_NODE_TYPES.ChainExpression:
-      case AST_NODE_TYPES.TSNonNullExpression:
-        child = parent;
-        parent = parent.parent;
-        continue;
-
-      // An argument, not the callee — `invariant(res.ok)` checks, whereas the
-      // `res.ok` inside `res.ok.toString()` would be the callee's object.
-      case AST_NODE_TYPES.CallExpression:
-        return isAssertionCallee(parent.callee) && parent.callee !== child;
-
-      default:
-        return false;
-    }
-  }
-
-  return false;
+function isAssertionName(node: TSESTree.Node): boolean {
+  return (
+    node.type === AST_NODE_TYPES.Identifier && ASSERTION_NAMES.test(node.name)
+  );
 }
 
 /** Either half of a member callee can carry the meaning: `assert.ok(res.ok)`
  *  and `assert.equal(res.status, 200)` are named by the RECEIVER, while
- *  `t.assert(res.ok)` is named by the method. Checking only the method rejected
- *  the Node-standard forms and flagged correct guard code. */
+ *  `t.assert(res.ok)` is named by the method. */
 function isAssertionCallee(callee: TSESTree.Node): boolean {
   if (callee.type === AST_NODE_TYPES.Identifier) {
-    return ASSERTION_NAMES.test(callee.name);
+    return isAssertionName(callee);
   }
 
-  if (callee.type !== AST_NODE_TYPES.MemberExpression || callee.computed) {
-    return false;
-  }
-
-  const receiver =
-    callee.object.type === AST_NODE_TYPES.Identifier &&
-    ASSERTION_NAMES.test(callee.object.name);
-
-  const method =
-    callee.property.type === AST_NODE_TYPES.Identifier &&
-    ASSERTION_NAMES.test(callee.property.name);
-
-  return receiver || method;
+  return (
+    callee.type === AST_NODE_TYPES.MemberExpression &&
+    !callee.computed &&
+    (isAssertionName(callee.object) || isAssertionName(callee.property))
+  );
 }
 
-/** The function (or Program) a node sits in. */
-function functionOf(node: TSESTree.Node): TSESTree.Node {
-  let current: TSESTree.Node | undefined = node.parent;
+/** Mutable state carried up the walk. */
+interface IClimbState {
+  polarity: Polarity;
+  compared: boolean;
+  underAnd: boolean;
+}
 
-  while (current !== undefined) {
-    if (
-      current.type === AST_NODE_TYPES.FunctionDeclaration ||
-      current.type === AST_NODE_TYPES.FunctionExpression ||
-      current.type === AST_NODE_TYPES.ArrowFunctionExpression ||
-      current.type === AST_NODE_TYPES.Program
-    ) {
-      return current;
+/** Nodes that CONSUME a condition. Reaching one ends the walk either way: it
+ *  yields a check, or the read was in some other position of it (an `if` body,
+ *  a non-assertion argument) and is no check at all. */
+const TERMINAL_TYPES = new Set<string>([
+  AST_NODE_TYPES.IfStatement,
+  AST_NODE_TYPES.WhileStatement,
+  AST_NODE_TYPES.DoWhileStatement,
+  AST_NODE_TYPES.ConditionalExpression,
+  AST_NODE_TYPES.SwitchStatement,
+  AST_NODE_TYPES.CallExpression,
+]);
+
+function terminalCheck(
+  parent: TSESTree.Node,
+  child: TSESTree.Node,
+  state: IClimbState
+): ICheck | null {
+  const check = { owner: parent, ...state };
+
+  switch (parent.type) {
+    case AST_NODE_TYPES.IfStatement:
+    case AST_NODE_TYPES.WhileStatement:
+    case AST_NODE_TYPES.DoWhileStatement:
+    case AST_NODE_TYPES.ConditionalExpression:
+      return parent.test === child ? check : null;
+
+    case AST_NODE_TYPES.SwitchStatement:
+      return parent.discriminant === child
+        ? { ...check, compared: true }
+        : null;
+
+    // An assertion compares for us, so the argument needs no comparison of its
+    // own — `assert.equal(res.status, 200)` is a status check.
+    case AST_NODE_TYPES.CallExpression:
+      return isAssertionCallee(parent.callee) && parent.callee !== child
+        ? { ...check, compared: true }
+        : null;
+
+    default:
+      return null;
+  }
+}
+
+/** One step through an operator that merely reshapes the condition. Returns
+ *  the resolved check when the operator IS the guard (`res.ok && parse`),
+ *  "stop" when the read cannot be a condition, "continue" otherwise. */
+function combinatorStep(
+  parent: TSESTree.Node,
+  child: TSESTree.Node,
+  state: IClimbState
+): ICheck | "continue" | "stop" {
+  switch (parent.type) {
+    case AST_NODE_TYPES.UnaryExpression:
+      // `typeof res.status === "number"` inspects the TYPE, which is "number"
+      // for 500 exactly as for 200. That is not a check.
+      if (parent.operator === "typeof") {
+        return "stop";
+      }
+
+      if (parent.operator === "!") {
+        state.polarity =
+          state.polarity === "positive" ? "negative" : "positive";
+      }
+
+      return "continue";
+
+    case AST_NODE_TYPES.BinaryExpression:
+      if (!COMPARISONS.has(parent.operator)) {
+        return "stop";
+      }
+
+      // Which side of `res.status < 400` means success is not decidable
+      // syntactically, so the branch requirement relaxes rather than guesses.
+      state.compared = true;
+      state.polarity = "opaque";
+
+      return "continue";
+
+    case AST_NODE_TYPES.LogicalExpression:
+      if (parent.operator === "&&") {
+        state.underAnd = true;
+      }
+
+      // `res.ok && res.json()` — the parse is the right operand, so it runs
+      // only when the check passed. That is a guard, not just a read.
+      return parent.left === child ? { owner: parent, ...state } : "continue";
+
+    case AST_NODE_TYPES.ChainExpression:
+    case AST_NODE_TYPES.TSNonNullExpression:
+      return "continue";
+
+    default:
+      return "stop";
+  }
+}
+
+/** Walk from a read up to whatever consumes it as a condition, recording what
+ *  happened on the way. Returns null when the read is not part of a test at
+ *  all — `metrics.observe(res.status)` reads the status and still parses an
+ *  error body as data. */
+function climb(read: TSESTree.Node): ICheck | null {
+  const state: IClimbState = {
+    polarity: "positive",
+    compared: false,
+    underAnd: false,
+  };
+  let child: TSESTree.Node = read;
+  let parent: TSESTree.Node | undefined = read.parent;
+
+  while (parent !== undefined) {
+    if (TERMINAL_TYPES.has(parent.type)) {
+      return terminalCheck(parent, child, state);
     }
 
+    const step = combinatorStep(parent, child, state);
+
+    if (step === "stop") {
+      return null;
+    }
+
+    if (step !== "continue") {
+      return step;
+    }
+
+    child = parent;
+    parent = parent.parent;
+  }
+
+  return null;
+}
+
+function contains(outer: TSESTree.Node, inner: TSESTree.Node): boolean {
+  return outer.range[0] <= inner.range[0] && outer.range[1] >= inner.range[1];
+}
+
+/** True when control cannot fall out of this statement. A guard clause has to
+ *  LEAVE — `if (res.ok) { metrics.hit(); }` inspects the response and then
+ *  parses the error body anyway. */
+function alwaysExits(node: TSESTree.Node): boolean {
+  if (
+    node.type === AST_NODE_TYPES.ReturnStatement ||
+    node.type === AST_NODE_TYPES.ThrowStatement
+  ) {
+    return true;
+  }
+
+  return (
+    node.type === AST_NODE_TYPES.BlockStatement &&
+    node.body.some((stmt) => alwaysExits(stmt))
+  );
+}
+
+/** The block a check's statement sits in. A guard only governs code that
+ *  follows it in the same scope: a `throw` inside `if (preview) { ... }` says
+ *  nothing about a parse after that block, and a check inside a nested function
+ *  says nothing about the caller's response. */
+function scopeOfCheck(node: TSESTree.Node): TSESTree.Node {
+  let current: TSESTree.Node = node;
+
+  // Program has no parent, so the walk already stops there.
+  while (current.parent !== undefined && !current.type.endsWith("Statement")) {
     current = current.parent;
   }
 
-  return node;
+  return current.parent ?? current;
 }
 
-/** True when `node` sits in the same function as the parse, or in one that
- *  encloses it.
+/** True when this check actually protects `parse`.
  *
- * Matching by name alone crosses scopes: after `const ok = res.ok`, a nested
- * `function f(ok: boolean) { if (!ok) ... }` tests a DIFFERENT `ok`, and a
- * nested function with its own `const res` tests a different response. Neither
- * says anything about this fetch. A function that contains the parse does — the
- * guard genuinely runs first. Range containment decides it, since an enclosing
- * function spans the parse and a nested or sibling one cannot. */
-function governsParse(node: TSESTree.Node, jsonRead: TSESTree.Node): boolean {
-  const fn = functionOf(node);
+ * Two shapes qualify, and merely reading the response is neither of them:
+ *
+ *   the parse sits in the branch the check permits
+ *     `if (res.ok) { return res.json(); }`   `res.ok ? res.json() : null`
+ *
+ *   the check leaves before the parse is reached
+ *     `if (!res.ok) { throw ... } return res.json();`
+ */
+function protects(check: ICheck, parse: TSESTree.Node): boolean {
+  // `res.status` is a number, truthy for every response that arrived. Only a
+  // comparison of it says anything about success.
+  if (!check.compared) {
+    return false;
+  }
 
-  return fn.range[0] <= jsonRead.range[0] && fn.range[1] >= jsonRead.range[1];
+  const { owner } = check;
+
+  if (owner.type === AST_NODE_TYPES.CallExpression) {
+    return (
+      owner.range[1] <= parse.range[0] && contains(scopeOfCheck(owner), parse)
+    );
+  }
+
+  if (owner.type === AST_NODE_TYPES.LogicalExpression) {
+    return contains(owner.right, parse) && check.polarity !== "negative";
+  }
+
+  if (
+    owner.type === AST_NODE_TYPES.ConditionalExpression ||
+    owner.type === AST_NODE_TYPES.IfStatement
+  ) {
+    if (contains(owner.consequent, parse)) {
+      return check.polarity !== "negative";
+    }
+
+    if (owner.alternate !== null && contains(owner.alternate, parse)) {
+      return check.polarity !== "positive";
+    }
+  }
+
+  if (
+    owner.type === AST_NODE_TYPES.WhileStatement ||
+    owner.type === AST_NODE_TYPES.DoWhileStatement
+  ) {
+    return contains(owner.body, parse) && check.polarity !== "negative";
+  }
+
+  // Not inside a branch, so the only way this check helps is by leaving first
+  // — and a guard under `&&` is not guaranteed to run at all.
+  if (owner.type !== AST_NODE_TYPES.IfStatement || check.underAnd) {
+    return false;
+  }
+
+  if (
+    owner.range[1] > parse.range[0] ||
+    !contains(scopeOfCheck(owner), parse)
+  ) {
+    return false;
+  }
+
+  if (alwaysExits(owner.consequent)) {
+    return check.polarity !== "positive";
+  }
+
+  return owner.alternate !== null && alwaysExits(owner.alternate)
+    ? check.polarity !== "negative"
+    : false;
 }
 
-/** Names bound directly from the response's own status, e.g.
- *  `const ok = res.ok`. Checking the alias is checking the response, and
- *  refusing to see that would flag correct code. */
-function statusAliases(
-  root: TSESTree.Node,
-  name: string,
-  jsonRead: TSESTree.Node
-): Set<string> {
-  const aliases = new Set<string>();
+/** Names bound directly from the response, mapped to the property they carry —
+ *  `const ok = res.ok` is checkable as `ok`, while `const code = res.status`
+ *  still has to be compared. */
+function statusAliases(root: TSESTree.Node, name: string): Map<string, string> {
+  const aliases = new Map<string, string>();
 
   walkSome(root, (node) => {
     if (
@@ -182,9 +369,9 @@ function statusAliases(
       node.id.type === AST_NODE_TYPES.Identifier &&
       node.init !== null &&
       propReadOn(node.init, name, OK_PROPS) &&
-      governsParse(node, jsonRead)
+      node.init.property.type === AST_NODE_TYPES.Identifier
     ) {
-      aliases.add(node.id.name);
+      aliases.set(node.id.name, node.init.property.name);
     }
 
     return false;
@@ -193,36 +380,52 @@ function statusAliases(
   return aliases;
 }
 
-/** True when the response is checked BEFORE `jsonRead` parses the body.
- *
- * Both halves matter. `const data = await res.json(); if (!res.ok) throw` has
- * already parsed an error payload by the time it looks, so position is part of
- * the contract the message states — "before calling `.json()`". */
-function hasOkCheckBefore(
+/** The property a node checks, or undefined when it checks nothing. */
+function checkedProp(
+  node: TSESTree.Node,
+  name: string,
+  aliases: Map<string, string>
+): string | undefined {
+  if (propReadOn(node, name, OK_PROPS)) {
+    return node.property.type === AST_NODE_TYPES.Identifier
+      ? node.property.name
+      : undefined;
+  }
+
+  return node.type === AST_NODE_TYPES.Identifier
+    ? aliases.get(node.name)
+    : undefined;
+}
+
+/** True when some check in `root` protects this parse. */
+function isProtected(
   root: TSESTree.Node,
   name: string,
-  jsonRead: TSESTree.MemberExpression
+  aliases: Map<string, string>,
+  parse: TSESTree.MemberExpression
 ): boolean {
-  const aliases = statusAliases(root, name, jsonRead);
-  const parseStart = jsonRead.range[0];
-
   return walkSome(root, (node) => {
-    const isRead =
-      propReadOn(node, name, OK_PROPS) ||
-      (node.type === AST_NODE_TYPES.Identifier && aliases.has(node.name));
+    const prop = checkedProp(node, name, aliases);
 
-    return (
-      isRead &&
-      node.range[1] <= parseStart &&
-      governsParse(node, jsonRead) &&
-      isConditionPosition(node)
+    if (prop === undefined) {
+      return false;
+    }
+
+    const check = climb(node);
+
+    if (check === null) {
+      return false;
+    }
+
+    // `ok` is itself the verdict; `status` has to be compared to become one.
+    return protects(
+      prop === OK_PROP ? { ...check, compared: true } : check,
+      parse
     );
   });
 }
 
-/** Where to look for the check: the nearest enclosing block or function body,
- *  so a guard clause counts however it is written — early return, throw,
- *  ternary — as long as it precedes the parse. */
+/** Where to look: the nearest enclosing block or function body. */
 function scopeOf(node: TSESTree.Node): TSESTree.Node {
   let current: TSESTree.Node | undefined = node.parent;
 
@@ -294,6 +497,16 @@ export const fetchMustCheckOkRule = createRule<[], MessageIds>({
   },
   defaultOptions: [],
   create(context) {
+    function reportUnprotected(root: TSESTree.Node, name: string): void {
+      const aliases = statusAliases(root, name);
+
+      for (const read of findJsonReads(root, name)) {
+        if (!isProtected(root, name, aliases, read)) {
+          context.report({ node: read, messageId: "missingOkCheck" });
+        }
+      }
+    }
+
     return {
       CallExpression(node: TSESTree.CallExpression) {
         const callee = node.callee;
@@ -325,25 +538,16 @@ export const fetchMustCheckOkRule = createRule<[], MessageIds>({
         }
 
         // `fetch(url).then(res => res.json())` — the callback parameter is the
-        // response, and the callback body is the whole scope it lives in.
+        // response, and the callback body is the scope it lives in.
         const callback = thenCallbackParam(parent);
 
         if (callback !== null) {
-          const read = findJsonRead(callback.body, callback.name);
-
-          if (
-            read !== null &&
-            !hasOkCheckBefore(callback.body, callback.name, read)
-          ) {
-            context.report({ node: read, messageId: "missingOkCheck" });
-          }
+          reportUnprotected(callback.body, callback.name);
 
           return;
         }
 
         // `const res = await fetch(url); ... res.json()` — the common shape.
-        // Look for the check anywhere in the enclosing block, since it is
-        // normally a guard clause on the line after.
         if (
           parent.type !== AST_NODE_TYPES.VariableDeclarator ||
           parent.id.type !== AST_NODE_TYPES.Identifier
@@ -351,13 +555,7 @@ export const fetchMustCheckOkRule = createRule<[], MessageIds>({
           return;
         }
 
-        const name = parent.id.name;
-        const scope = scopeOf(parent);
-        const read = findJsonRead(scope, name);
-
-        if (read !== null && !hasOkCheckBefore(scope, name, read)) {
-          context.report({ node: read, messageId: "missingOkCheck" });
-        }
+        reportUnprotected(scopeOf(parent), parent.id.name);
       },
     };
   },

--- a/packages/core/src/rule-packs/typescript-core/rules/fetch-must-check-ok.ts
+++ b/packages/core/src/rule-packs/typescript-core/rules/fetch-must-check-ok.ts
@@ -7,9 +7,13 @@ export const RULE_NAME = "fetch-must-check-ok";
 
 type MessageIds = "missingOkCheck";
 
-/** Reading either one counts as checking the response: `res.ok` is the idiom,
- *  but `res.status === 204` is an equally deliberate check. */
+/** Reading either one can count as checking the response: `res.ok` is the idiom,
+ *  but `res.status === 204` is an equally deliberate check. Reading alone is not
+ *  enough — see `isConditionPosition`. */
 const OK_PROPS = new Set(["ok", "status"]);
+
+/** Calls that act as a check even though they are not syntactically a test. */
+const ASSERTION_CALLEES = /^(assert|invariant|ensure|expect)/iu;
 
 /** A non-computed `<object>.<prop>` read, e.g. `res.json` or `res.ok`. */
 function propReadOn(
@@ -53,13 +57,110 @@ function findJsonRead(
   return found;
 }
 
-function hasOkCheck(root: TSESTree.Node, name: string): boolean {
-  return walkSome(root, (node) => propReadOn(node, name, OK_PROPS));
+/** True when this expression is being TESTED rather than merely read.
+ *
+ * The distinction is the whole point of the rule. `metrics.observe(res.status)`
+ * reads the status and still parses an error body as data; `if (!res.ok)` acts
+ * on it. So a read only counts inside the test of an `if`/ternary/loop, the
+ * discriminant of a `switch`, or an argument to an assertion helper —
+ * combinators (`!`, `&&`, `===`) are transparent and keep the walk going. */
+function isConditionPosition(node: TSESTree.Node): boolean {
+  let child: TSESTree.Node = node;
+  let parent: TSESTree.Node | undefined = node.parent;
+
+  while (parent !== undefined) {
+    switch (parent.type) {
+      case AST_NODE_TYPES.IfStatement:
+      case AST_NODE_TYPES.WhileStatement:
+      case AST_NODE_TYPES.DoWhileStatement:
+      case AST_NODE_TYPES.ConditionalExpression:
+        return parent.test === child;
+
+      case AST_NODE_TYPES.SwitchStatement:
+        return parent.discriminant === child;
+
+      case AST_NODE_TYPES.LogicalExpression:
+      case AST_NODE_TYPES.BinaryExpression:
+      case AST_NODE_TYPES.UnaryExpression:
+      case AST_NODE_TYPES.ChainExpression:
+      case AST_NODE_TYPES.TSNonNullExpression:
+        child = parent;
+        parent = parent.parent;
+        continue;
+
+      // An argument, not the callee — `invariant(res.ok)` checks, whereas the
+      // `res.ok` inside `res.ok.toString()` would be the callee's object.
+      case AST_NODE_TYPES.CallExpression:
+        return isAssertionCallee(parent.callee) && parent.callee !== child;
+
+      default:
+        return false;
+    }
+  }
+
+  return false;
+}
+
+function isAssertionCallee(callee: TSESTree.Node): boolean {
+  if (callee.type === AST_NODE_TYPES.Identifier) {
+    return ASSERTION_CALLEES.test(callee.name);
+  }
+
+  return (
+    callee.type === AST_NODE_TYPES.MemberExpression &&
+    !callee.computed &&
+    callee.property.type === AST_NODE_TYPES.Identifier &&
+    ASSERTION_CALLEES.test(callee.property.name)
+  );
+}
+
+/** Names bound directly from the response's own status, e.g.
+ *  `const ok = res.ok`. Checking the alias is checking the response, and
+ *  refusing to see that would flag correct code. */
+function statusAliases(root: TSESTree.Node, name: string): Set<string> {
+  const aliases = new Set<string>();
+
+  walkSome(root, (node) => {
+    if (
+      node.type === AST_NODE_TYPES.VariableDeclarator &&
+      node.id.type === AST_NODE_TYPES.Identifier &&
+      node.init !== null &&
+      propReadOn(node.init, name, OK_PROPS)
+    ) {
+      aliases.add(node.id.name);
+    }
+
+    return false;
+  });
+
+  return aliases;
+}
+
+/** True when the response is checked BEFORE `jsonRead` parses the body.
+ *
+ * Both halves matter. `const data = await res.json(); if (!res.ok) throw` has
+ * already parsed an error payload by the time it looks, so position is part of
+ * the contract the message states — "before calling `.json()`". */
+function hasOkCheckBefore(
+  root: TSESTree.Node,
+  name: string,
+  jsonRead: TSESTree.MemberExpression
+): boolean {
+  const aliases = statusAliases(root, name);
+  const parseStart = jsonRead.range[0];
+
+  return walkSome(root, (node) => {
+    const isRead =
+      propReadOn(node, name, OK_PROPS) ||
+      (node.type === AST_NODE_TYPES.Identifier && aliases.has(node.name));
+
+    return isRead && node.range[1] <= parseStart && isConditionPosition(node);
+  });
 }
 
 /** Where to look for the check: the nearest enclosing block or function body,
- *  so a later `if (res.ok)` in the same function counts however it is written —
- *  early return, guard clause, ternary. */
+ *  so a guard clause counts however it is written — early return, throw,
+ *  ternary — as long as it precedes the parse. */
 function scopeOf(node: TSESTree.Node): TSESTree.Node {
   let current: TSESTree.Node | undefined = node.parent;
 
@@ -168,7 +269,10 @@ export const fetchMustCheckOkRule = createRule<[], MessageIds>({
         if (callback !== null) {
           const read = findJsonRead(callback.body, callback.name);
 
-          if (read !== null && !hasOkCheck(callback.body, callback.name)) {
+          if (
+            read !== null &&
+            !hasOkCheckBefore(callback.body, callback.name, read)
+          ) {
             context.report({ node: read, messageId: "missingOkCheck" });
           }
 
@@ -189,7 +293,7 @@ export const fetchMustCheckOkRule = createRule<[], MessageIds>({
         const scope = scopeOf(parent);
         const read = findJsonRead(scope, name);
 
-        if (read !== null && !hasOkCheck(scope, name)) {
+        if (read !== null && !hasOkCheckBefore(scope, name, read)) {
           context.report({ node: read, messageId: "missingOkCheck" });
         }
       },

--- a/packages/core/src/rule-packs/typescript-core/rules/fetch-must-check-ok.ts
+++ b/packages/core/src/rule-packs/typescript-core/rules/fetch-must-check-ok.ts
@@ -26,13 +26,97 @@ const COMPARISONS = new Set(["===", "!==", "==", "!=", "<", "<=", ">", ">="]);
 
 /** What a test says about the response when it is true.
  *
- * `res.ok` means the response succeeded, `!res.ok` means it failed, and
- * `res.status !== 200` means neither — the direction is not decidable
- * syntactically. Polarity picks which BRANCH is safe to parse in: a body may be
- * read where the response is known good, never where it is known bad. `opaque`
- * is allowed either way, since refusing a comparison the rule cannot interpret
- * would flag ordinary code. */
+ * `res.ok` and `res.status < 400` mean it succeeded; `!res.ok` and
+ * `res.status >= 400` mean it failed. Polarity picks which BRANCH is safe to
+ * parse in: a body may be read where the response is known good, never where it
+ * is known bad — `if (res.ok === false) return res.json()` parses precisely the
+ * error payload.
+ *
+ * `opaque` is a comparison the rule cannot place, such as `res.status === 404`.
+ * It guards ONE failure and says nothing about the rest, so it counts as no
+ * check at all rather than as a check in whichever direction is convenient. */
 type Polarity = "positive" | "negative" | "opaque";
+
+/** Where success ends. 1xx-3xx are not errors; `res.ok` itself is `< 400`. */
+const FIRST_ERROR_STATUS = 400;
+
+function literalValue(node: TSESTree.Node): number | boolean | undefined {
+  if (node.type !== AST_NODE_TYPES.Literal) {
+    return undefined;
+  }
+
+  return typeof node.value === "number" || typeof node.value === "boolean"
+    ? node.value
+    : undefined;
+}
+
+/** Read the comparison as if the response were on the left. */
+function mirror(operator: string): string {
+  switch (operator) {
+    case "<":
+      return ">";
+    case "<=":
+      return ">=";
+    case ">":
+      return "<";
+    case ">=":
+      return "<=";
+    default:
+      return operator;
+  }
+}
+
+function booleanPolarity(operator: string, value: boolean): Polarity {
+  if (operator === "===" || operator === "==") {
+    return value ? "positive" : "negative";
+  }
+
+  if (operator === "!==" || operator === "!=") {
+    return value ? "negative" : "positive";
+  }
+
+  return "opaque";
+}
+
+/** A status comparison only takes a side when it splits success from failure.
+ *  `=== 404` does not: it catches one error and lets every other one through. */
+function statusPolarity(operator: string, value: number): Polarity {
+  const isSuccessCode = value >= 200 && value < 300;
+
+  switch (operator) {
+    case "===":
+    case "==":
+      return isSuccessCode ? "positive" : "opaque";
+    case "!==":
+    case "!=":
+      return isSuccessCode ? "negative" : "opaque";
+    case "<":
+      return value <= FIRST_ERROR_STATUS ? "positive" : "opaque";
+    case "<=":
+      return value < FIRST_ERROR_STATUS ? "positive" : "opaque";
+    case ">=":
+      return value >= 300 ? "negative" : "opaque";
+    case ">":
+      return value >= 299 ? "negative" : "opaque";
+    default:
+      return "opaque";
+  }
+}
+
+/** Which way a comparison points, given which side the response sits on. */
+function comparisonPolarity(
+  node: TSESTree.BinaryExpression,
+  readIsLeft: boolean
+): Polarity {
+  const value = literalValue(readIsLeft ? node.right : node.left);
+  const operator = readIsLeft ? node.operator : mirror(node.operator);
+
+  if (typeof value === "boolean") {
+    return booleanPolarity(operator, value);
+  }
+
+  return typeof value === "number" ? statusPolarity(operator, value) : "opaque";
+}
 
 /** A syntactic check of the response, resolved back to what governs it. */
 interface ICheck {
@@ -147,14 +231,19 @@ function terminalCheck(
 
     case AST_NODE_TYPES.SwitchStatement:
       return parent.discriminant === child
-        ? { ...check, compared: true }
+        ? { ...check, compared: true, polarity: "opaque" }
         : null;
 
-    // An assertion compares for us, so the argument needs no comparison of its
-    // own — `assert.equal(res.status, 200)` is a status check.
+    // An assertion compares for us when it is GIVEN something to compare
+    // against: `assert.equal(res.status, 200)` is a status check, while
+    // `assert.ok(res.status)` asserts that a number is truthy — which every
+    // response that arrived satisfies, 500 included.
     case AST_NODE_TYPES.CallExpression:
       return isAssertionCallee(parent.callee) && parent.callee !== child
-        ? { ...check, compared: true }
+        ? {
+            ...check,
+            compared: state.compared || parent.arguments.length > 1,
+          }
         : null;
 
     default:
@@ -168,7 +257,8 @@ function terminalCheck(
 function combinatorStep(
   parent: TSESTree.Node,
   child: TSESTree.Node,
-  state: IClimbState
+  state: IClimbState,
+  parse: TSESTree.Node
 ): ICheck | "continue" | "stop" {
   switch (parent.type) {
     case AST_NODE_TYPES.UnaryExpression:
@@ -185,17 +275,20 @@ function combinatorStep(
 
       return "continue";
 
-    case AST_NODE_TYPES.BinaryExpression:
+    case AST_NODE_TYPES.BinaryExpression: {
       if (!COMPARISONS.has(parent.operator)) {
         return "stop";
       }
 
-      // Which side of `res.status < 400` means success is not decidable
-      // syntactically, so the branch requirement relaxes rather than guesses.
-      state.compared = true;
-      state.polarity = "opaque";
+      const polarity = comparisonPolarity(parent, parent.left === child);
 
-      return "continue";
+      state.compared = true;
+      // A comparison replaces whatever the walk carried: `res.status >= 400`
+      // says failure regardless of how the read got here.
+      state.polarity = polarity;
+
+      return polarity === "opaque" ? "stop" : "continue";
+    }
 
     case AST_NODE_TYPES.LogicalExpression:
       if (parent.operator === "&&") {
@@ -203,8 +296,13 @@ function combinatorStep(
       }
 
       // `res.ok && res.json()` — the parse is the right operand, so it runs
-      // only when the check passed. That is a guard, not just a read.
-      return parent.left === child ? { owner: parent, ...state } : "continue";
+      // only when the check passed. That is a guard, not just a read. Only
+      // when the parse is actually THERE, though: in `if (a || !res.ok)` the
+      // operator is part of a larger test, and the walk must go on to the
+      // `if` rather than stopping at an operand the parse is nowhere near.
+      return parent.left === child && contains(parent.right, parse)
+        ? { owner: parent, ...state }
+        : "continue";
 
     case AST_NODE_TYPES.ChainExpression:
     case AST_NODE_TYPES.TSNonNullExpression:
@@ -219,7 +317,7 @@ function combinatorStep(
  *  happened on the way. Returns null when the read is not part of a test at
  *  all — `metrics.observe(res.status)` reads the status and still parses an
  *  error body as data. */
-function climb(read: TSESTree.Node): ICheck | null {
+function climb(read: TSESTree.Node, parse: TSESTree.Node): ICheck | null {
   const state: IClimbState = {
     polarity: "positive",
     compared: false,
@@ -233,7 +331,7 @@ function climb(read: TSESTree.Node): ICheck | null {
       return terminalCheck(parent, child, state);
     }
 
-    const step = combinatorStep(parent, child, state);
+    const step = combinatorStep(parent, child, state, parse);
 
     if (step === "stop") {
       return null;
@@ -286,6 +384,123 @@ function scopeOfCheck(node: TSESTree.Node): TSESTree.Node {
   return current.parent ?? current;
 }
 
+/** The `case` arm a parse sits in, when that arm belongs to `owner`. */
+function caseArmOf(
+  owner: TSESTree.SwitchStatement,
+  parse: TSESTree.Node
+): TSESTree.SwitchCase | null {
+  for (const arm of owner.cases) {
+    if (contains(arm, parse)) {
+      return arm;
+    }
+  }
+
+  return null;
+}
+
+/** `switch (res.status) { case 200: return res.json(); }` is a real check —
+ *  but only for the arms that name a success code. `default:` and `case 500:`
+ *  parse an error body. */
+function switchArmProtects(
+  owner: TSESTree.SwitchStatement,
+  parse: TSESTree.Node
+): boolean {
+  // A `default:` arm has no test, and it is where the error cases land.
+  const test = caseArmOf(owner, parse)?.test;
+
+  if (test === undefined || test === null) {
+    return false;
+  }
+
+  const value = literalValue(test);
+
+  return typeof value === "number" && value >= 200 && value < 300;
+}
+
+/** True when the parse sits in a branch this check permits. */
+function branchProtects(check: ICheck, parse: TSESTree.Node): boolean {
+  const { owner } = check;
+
+  if (owner.type === AST_NODE_TYPES.SwitchStatement) {
+    return switchArmProtects(owner, parse);
+  }
+
+  if (owner.type === AST_NODE_TYPES.LogicalExpression) {
+    if (!contains(owner.right, parse)) {
+      return false;
+    }
+
+    // `&&` runs the right side when the test HOLDS, `||` when it fails. So
+    // `res.ok && res.json()` is a guard and `res.ok || res.json()` is the
+    // same parse on exactly the error path.
+    if (owner.operator === "&&") {
+      return check.polarity === "positive";
+    }
+
+    return owner.operator === "||" && check.polarity === "negative";
+  }
+
+  if (
+    owner.type === AST_NODE_TYPES.WhileStatement ||
+    owner.type === AST_NODE_TYPES.DoWhileStatement
+  ) {
+    return contains(owner.body, parse) && check.polarity === "positive";
+  }
+
+  if (
+    owner.type !== AST_NODE_TYPES.ConditionalExpression &&
+    owner.type !== AST_NODE_TYPES.IfStatement
+  ) {
+    return false;
+  }
+
+  if (contains(owner.consequent, parse)) {
+    return check.polarity === "positive";
+  }
+
+  return (
+    owner.alternate !== null &&
+    contains(owner.alternate, parse) &&
+    check.polarity === "negative"
+  );
+}
+
+/** True when the check leaves — throw or return — before the parse is reached,
+ *  from a scope that encloses it. */
+function guardProtects(check: ICheck, parse: TSESTree.Node): boolean {
+  const { owner } = check;
+
+  if (owner.type === AST_NODE_TYPES.CallExpression) {
+    return (
+      check.polarity === "positive" &&
+      owner.range[1] <= parse.range[0] &&
+      contains(scopeOfCheck(owner), parse)
+    );
+  }
+
+  // A guard under `&&` is not guaranteed to run at all.
+  if (owner.type !== AST_NODE_TYPES.IfStatement || check.underAnd) {
+    return false;
+  }
+
+  if (
+    owner.range[1] > parse.range[0] ||
+    !contains(scopeOfCheck(owner), parse)
+  ) {
+    return false;
+  }
+
+  if (alwaysExits(owner.consequent)) {
+    return check.polarity === "negative";
+  }
+
+  return (
+    owner.alternate !== null &&
+    alwaysExits(owner.alternate) &&
+    check.polarity === "positive"
+  );
+}
+
 /** True when this check actually protects `parse`.
  *
  * Two shapes qualify, and merely reading the response is neither of them:
@@ -303,58 +518,7 @@ function protects(check: ICheck, parse: TSESTree.Node): boolean {
     return false;
   }
 
-  const { owner } = check;
-
-  if (owner.type === AST_NODE_TYPES.CallExpression) {
-    return (
-      owner.range[1] <= parse.range[0] && contains(scopeOfCheck(owner), parse)
-    );
-  }
-
-  if (owner.type === AST_NODE_TYPES.LogicalExpression) {
-    return contains(owner.right, parse) && check.polarity !== "negative";
-  }
-
-  if (
-    owner.type === AST_NODE_TYPES.ConditionalExpression ||
-    owner.type === AST_NODE_TYPES.IfStatement
-  ) {
-    if (contains(owner.consequent, parse)) {
-      return check.polarity !== "negative";
-    }
-
-    if (owner.alternate !== null && contains(owner.alternate, parse)) {
-      return check.polarity !== "positive";
-    }
-  }
-
-  if (
-    owner.type === AST_NODE_TYPES.WhileStatement ||
-    owner.type === AST_NODE_TYPES.DoWhileStatement
-  ) {
-    return contains(owner.body, parse) && check.polarity !== "negative";
-  }
-
-  // Not inside a branch, so the only way this check helps is by leaving first
-  // — and a guard under `&&` is not guaranteed to run at all.
-  if (owner.type !== AST_NODE_TYPES.IfStatement || check.underAnd) {
-    return false;
-  }
-
-  if (
-    owner.range[1] > parse.range[0] ||
-    !contains(scopeOfCheck(owner), parse)
-  ) {
-    return false;
-  }
-
-  if (alwaysExits(owner.consequent)) {
-    return check.polarity !== "positive";
-  }
-
-  return owner.alternate !== null && alwaysExits(owner.alternate)
-    ? check.polarity !== "negative"
-    : false;
+  return branchProtects(check, parse) || guardProtects(check, parse);
 }
 
 /** Names bound directly from the response, mapped to the property they carry —
@@ -411,7 +575,7 @@ function isProtected(
       return false;
     }
 
-    const check = climb(node);
+    const check = climb(node, parse);
 
     if (check === null) {
       return false;

--- a/packages/core/src/rule-packs/typescript-core/rules/fetch-must-check-ok.ts
+++ b/packages/core/src/rule-packs/typescript-core/rules/fetch-must-check-ok.ts
@@ -12,8 +12,14 @@ type MessageIds = "missingOkCheck";
  *  enough — see `isConditionPosition`. */
 const OK_PROPS = new Set(["ok", "status"]);
 
-/** Calls that act as a check even though they are not syntactically a test. */
-const ASSERTION_CALLEES = /^(assert|invariant|ensure|expect)/iu;
+/** Calls that act as a check even though they are not syntactically a test.
+ *
+ * Anchored on purpose. An open prefix match would accept `expectedStatus` and
+ * `asserted`, letting a plain read masquerade as a check — a false negative in
+ * a security gate. A camelCase continuation (`assertResponseOk`) is a real
+ * assertion helper and still matches; a lowercase one is a different word. */
+const ASSERTION_NAMES =
+  /^(?:[Aa]ssert|[Ii]nvariant|[Ee]nsure|[Ee]xpect)(?:[A-Z_]\w*)?$/u;
 
 /** A non-computed `<object>.<prop>` read, e.g. `res.json` or `res.ok`. */
 function propReadOn(
@@ -101,23 +107,73 @@ function isConditionPosition(node: TSESTree.Node): boolean {
   return false;
 }
 
+/** Either half of a member callee can carry the meaning: `assert.ok(res.ok)`
+ *  and `assert.equal(res.status, 200)` are named by the RECEIVER, while
+ *  `t.assert(res.ok)` is named by the method. Checking only the method rejected
+ *  the Node-standard forms and flagged correct guard code. */
 function isAssertionCallee(callee: TSESTree.Node): boolean {
   if (callee.type === AST_NODE_TYPES.Identifier) {
-    return ASSERTION_CALLEES.test(callee.name);
+    return ASSERTION_NAMES.test(callee.name);
   }
 
-  return (
-    callee.type === AST_NODE_TYPES.MemberExpression &&
-    !callee.computed &&
+  if (callee.type !== AST_NODE_TYPES.MemberExpression || callee.computed) {
+    return false;
+  }
+
+  const receiver =
+    callee.object.type === AST_NODE_TYPES.Identifier &&
+    ASSERTION_NAMES.test(callee.object.name);
+
+  const method =
     callee.property.type === AST_NODE_TYPES.Identifier &&
-    ASSERTION_CALLEES.test(callee.property.name)
-  );
+    ASSERTION_NAMES.test(callee.property.name);
+
+  return receiver || method;
+}
+
+/** The function (or Program) a node sits in. */
+function functionOf(node: TSESTree.Node): TSESTree.Node {
+  let current: TSESTree.Node | undefined = node.parent;
+
+  while (current !== undefined) {
+    if (
+      current.type === AST_NODE_TYPES.FunctionDeclaration ||
+      current.type === AST_NODE_TYPES.FunctionExpression ||
+      current.type === AST_NODE_TYPES.ArrowFunctionExpression ||
+      current.type === AST_NODE_TYPES.Program
+    ) {
+      return current;
+    }
+
+    current = current.parent;
+  }
+
+  return node;
+}
+
+/** True when `node` sits in the same function as the parse, or in one that
+ *  encloses it.
+ *
+ * Matching by name alone crosses scopes: after `const ok = res.ok`, a nested
+ * `function f(ok: boolean) { if (!ok) ... }` tests a DIFFERENT `ok`, and a
+ * nested function with its own `const res` tests a different response. Neither
+ * says anything about this fetch. A function that contains the parse does — the
+ * guard genuinely runs first. Range containment decides it, since an enclosing
+ * function spans the parse and a nested or sibling one cannot. */
+function governsParse(node: TSESTree.Node, jsonRead: TSESTree.Node): boolean {
+  const fn = functionOf(node);
+
+  return fn.range[0] <= jsonRead.range[0] && fn.range[1] >= jsonRead.range[1];
 }
 
 /** Names bound directly from the response's own status, e.g.
  *  `const ok = res.ok`. Checking the alias is checking the response, and
  *  refusing to see that would flag correct code. */
-function statusAliases(root: TSESTree.Node, name: string): Set<string> {
+function statusAliases(
+  root: TSESTree.Node,
+  name: string,
+  jsonRead: TSESTree.Node
+): Set<string> {
   const aliases = new Set<string>();
 
   walkSome(root, (node) => {
@@ -125,7 +181,8 @@ function statusAliases(root: TSESTree.Node, name: string): Set<string> {
       node.type === AST_NODE_TYPES.VariableDeclarator &&
       node.id.type === AST_NODE_TYPES.Identifier &&
       node.init !== null &&
-      propReadOn(node.init, name, OK_PROPS)
+      propReadOn(node.init, name, OK_PROPS) &&
+      governsParse(node, jsonRead)
     ) {
       aliases.add(node.id.name);
     }
@@ -146,7 +203,7 @@ function hasOkCheckBefore(
   name: string,
   jsonRead: TSESTree.MemberExpression
 ): boolean {
-  const aliases = statusAliases(root, name);
+  const aliases = statusAliases(root, name, jsonRead);
   const parseStart = jsonRead.range[0];
 
   return walkSome(root, (node) => {
@@ -154,7 +211,12 @@ function hasOkCheckBefore(
       propReadOn(node, name, OK_PROPS) ||
       (node.type === AST_NODE_TYPES.Identifier && aliases.has(node.name));
 
-    return isRead && node.range[1] <= parseStart && isConditionPosition(node);
+    return (
+      isRead &&
+      node.range[1] <= parseStart &&
+      governsParse(node, jsonRead) &&
+      isConditionPosition(node)
+    );
   });
 }
 

--- a/packages/core/tests/rule-docs-examples.test.ts
+++ b/packages/core/tests/rule-docs-examples.test.ts
@@ -33,7 +33,14 @@ function lint(
     throw new Error(`Rule ${ruleName} not found in pack ${packId}`);
   }
 
-  const ruleModule = rule as unknown as Rule.RuleModule;
+  // The pack stores TSESLint rule modules; ESLint's Linter wants its own shape.
+  // Structurally identical at the points Linter touches, so bridge through an
+  // unknown-typed local rather than an `as` cast (banned by the house rules).
+  const bridge: Record<string, unknown> = { [ruleName]: rule };
+  const plugins: Record<string, { rules: Record<string, Rule.RuleModule> }> =
+    Object.assign(Object.create(null), {
+      tsforge: { rules: bridge },
+    });
   const isTsx = filename.endsWith(".tsx");
   const linter = new Linter();
 
@@ -50,7 +57,7 @@ function lint(
             ...(isTsx ? { ecmaFeatures: { jsx: true } } : {}),
           },
         },
-        plugins: { tsforge: { rules: { [ruleName]: ruleModule } } },
+        plugins,
         rules: { [`tsforge/${ruleName}`]: "error" },
       },
     ],
@@ -165,8 +172,14 @@ describe("rule docs: coverage", () => {
     for (const [, pack] of Object.entries(RULE_PACKS)) {
       for (const ruleName of Object.keys(pack.rules)) {
         const doc = ALL_DOCS[`tsforge/${ruleName}`];
+        // A prose entry is exempt from EXECUTION, not from carrying guidance:
+        // its bad/good are file layouts, so only the procedure actually tells
+        // the model what to do.
         const hasExample =
-          doc !== undefined && doc.bad.length > 0 && doc.good.length > 0;
+          doc !== undefined &&
+          doc.exampleIsProse !== true &&
+          doc.bad.length > 0 &&
+          doc.good.length > 0;
         const hasProcedure =
           doc?.procedure !== undefined && doc.procedure.length > 0;
 
@@ -182,10 +195,56 @@ describe("rule docs: coverage", () => {
   test("a doc with no example must explain itself in a procedure", () => {
     const silent = Object.entries(ALL_DOCS)
       .filter(([id]) => id.startsWith("tsforge/"))
-      .filter(([, doc]) => doc.bad.length === 0 || doc.good.length === 0)
+      .filter(
+        ([, doc]) =>
+          doc.exampleIsProse === true ||
+          doc.bad.length === 0 ||
+          doc.good.length === 0
+      )
       .filter(([, doc]) => (doc.procedure ?? "").length === 0)
       .map(([id]) => id);
 
     expect(silent).toEqual([]);
   });
+});
+
+/** Strip whitespace so two snippets can be compared for structural sameness. */
+function squash(code: string): string {
+  return code.replace(/\s+/gu, " ").trim();
+}
+
+describe("rule docs: the ✓ must be a FIX, not an evasion", () => {
+  // The executable checks only prove the ✓ does not trip the rule. A snippet can
+  // achieve that by escaping the rule's scope instead of repairing the code —
+  // adding "use client" while keeping the offending fetch, or deleting the
+  // triggering line and teaching nothing. Those pass linting and mislead the
+  // model, which is the exact defect this whole file exists to prevent.
+
+  test.each(documented.map((d) => [d.id, d]))(
+    "%s: the ✓ is not the ✗ with the offending code simply removed",
+    (_id, entry) => {
+      const bad = squash(entry.doc.bad);
+      const good = squash(entry.doc.good);
+
+      // A ✓ that is a strict substring of the ✗ is a deletion, not a fix.
+      expect(bad.includes(good)).toBe(false);
+    }
+  );
+
+  test.each(documented.map((d) => [d.id, d]))(
+    "%s: the ✓ does not merely bolt a directive onto the ✗",
+    (_id, entry) => {
+      if (entry.doc.fixIsDirective === true) {
+        return; // for these rules the directive IS the fix
+      }
+
+      const stripped = squash(
+        entry.doc.good.replace(/^\s*["']use (client|server)["'];?\s*$/gmu, "")
+      );
+
+      // Removing an added directive must not collapse the ✓ back into the ✗:
+      // that means the only "fix" was moving the file out of the rule's scope.
+      expect(stripped).not.toBe(squash(entry.doc.bad));
+    }
+  );
 });

--- a/packages/core/tests/rule-docs-examples.test.ts
+++ b/packages/core/tests/rule-docs-examples.test.ts
@@ -1,5 +1,5 @@
 import { test, expect, describe } from "bun:test";
-import { Linter, type Rule } from "eslint";
+import { TSESLint } from "@typescript-eslint/utils";
 import tsParser from "@typescript-eslint/parser";
 import { RULE_PACKS } from "../src/rule-packs";
 import { RULE_DOCS, type IRuleDoc } from "../src/loop/feedback/rule-docs";
@@ -33,18 +33,13 @@ function lint(
     throw new Error(`Rule ${ruleName} not found in pack ${packId}`);
   }
 
-  // The pack stores TSESLint rule modules; ESLint's Linter wants its own shape.
-  // They are structurally compatible at every point Linter touches, so the
-  // parameter is typed as what Linter needs and the pack value is handed over
-  // through a narrowing guard rather than a cast.
-  // Same bridge the other rule tests use: the pack stores TSESLint modules and
-  // Linter wants its own, structurally identical at every point it touches.
-  // eslint.config.js relaxes type assertions for packages/**/tests/**, which is
-  // why this is a plain cast here and would not be in src.
-  const ruleModule = rule as unknown as Rule.RuleModule;
-  const plugins = { tsforge: { rules: { [ruleName]: ruleModule } } };
+  // TSESLint ships a Linter typed for TSESLint rule modules, which is what the
+  // packs hold. Using it instead of ESLint's own Linter removes the type bridge
+  // entirely — no cast, and a genuine shape mismatch would now fail typecheck
+  // instead of being asserted away.
+  const plugins = { tsforge: { rules: { [ruleName]: rule } } };
   const isTsx = filename.endsWith(".tsx");
-  const linter = new Linter();
+  const linter = new TSESLint.Linter();
 
   const messages = linter.verify(
     code,

--- a/packages/core/tests/rule-docs-examples.test.ts
+++ b/packages/core/tests/rule-docs-examples.test.ts
@@ -98,6 +98,13 @@ function isPackId(value: string): value is keyof typeof RULE_PACKS {
   return Object.hasOwn(RULE_PACKS, value);
 }
 
+/** A RuleListener is a string-keyed map of visitor callbacks, so any non-null
+ *  object satisfies its declared shape. Narrowing through a guard keeps this
+ *  honest without an `as` cast and without laundering an `any`. */
+function isRuleListener(value: unknown): value is Rule.RuleListener {
+  return typeof value === "object" && value !== null;
+}
+
 /** The pack's rule module in the shape ESLint's Linter accepts.
  *
  *  A pack rule is a TSESLint module; Linter wants its own. They are structurally
@@ -125,24 +132,11 @@ function toLinterRule(rule: unknown): Rule.RuleModule {
     create(context: Rule.RuleContext): Rule.RuleListener {
       const returned: unknown = Reflect.apply(create, rule, [context]);
 
-      if (typeof returned !== "object" || returned === null) {
+      if (!isRuleListener(returned)) {
         throw new Error("rule create() did not return a listener");
       }
 
-      // A RuleListener is a string-keyed map of visitor callbacks. Rebuild it
-      // from own entries so the value carries that index signature honestly
-      // rather than being asserted into it.
-      const listener: Rule.RuleListener = {};
-
-      for (const [selector, visitor] of Object.entries(returned)) {
-        // Visitors are usually functions, but a selector may also carry an
-        // { enter, exit } pair — keep both or half the rules stop firing.
-        if (typeof visitor === "function" || typeof visitor === "object") {
-          listener[selector] = visitor;
-        }
-      }
-
-      return listener;
+      return returned;
     },
   };
 }
@@ -284,6 +278,42 @@ describe("rule docs: the ✓ must be a FIX, not an evasion", () => {
 
       // A ✓ that is a strict substring of the ✗ is a deletion, not a fix.
       expect(bad.includes(good)).toBe(false);
+    }
+  );
+
+  test.each(documented.map((d) => [d.id, d]))(
+    "%s: the ✓ repairs the ✗ rather than replacing it with unrelated code",
+    (_id, entry) => {
+      // Rename-to-escape and swap-in-unrelated-code both dodge the rule while
+      // passing the lint check. A real fix keeps most of the original's
+      // vocabulary; an unrelated snippet shares almost none of it.
+      const ids = (code: string): Set<string> =>
+        new Set(code.match(/[A-Za-z_$][\w$]*/gu) ?? []);
+      const bad = ids(entry.doc.bad);
+      const good = ids(entry.doc.good);
+      const shared = [...bad].filter((t) => good.has(t)).length;
+      const overlap = bad.size === 0 ? 1 : shared / bad.size;
+
+      expect({ id: _id, overlapAtLeast30Percent: overlap >= 0.3 }).toEqual({
+        id: _id,
+        overlapAtLeast30Percent: true,
+      });
+    }
+  );
+
+  test.each(documented.map((d) => [d.id, d]))(
+    "%s: the ✓ does not escape by moving to another file",
+    (_id, entry) => {
+      // goodFile may differ ONLY where relocating the file IS the documented
+      // fix — otherwise a different path silently takes the snippet out of the
+      // rule's scope and the example proves nothing.
+      const escapes =
+        entry.doc.goodFile !== undefined &&
+        entry.doc.goodFile !== entry.doc.exampleFile &&
+        entry.doc.exampleIsProse !== true &&
+        entry.doc.fixIsRelocation !== true;
+
+      expect({ id: _id, escapes }).toEqual({ id: _id, escapes: false });
     }
   );
 

--- a/packages/core/tests/rule-docs-examples.test.ts
+++ b/packages/core/tests/rule-docs-examples.test.ts
@@ -353,3 +353,32 @@ describe("rule docs: guidance says what to DO", () => {
     expect(carriesRemedy).toBe(true);
   });
 });
+
+describe("rule docs: a relocation fix must actually need the move", () => {
+  // `fixIsRelocation` exempts an entry from the path-escape check. Without
+  // proving the move is what does the work, that flag is just a way to smuggle
+  // a same-file evasion past the suite — drop the directive, keep everything
+  // else, and call it a relocation.
+  const relocations = documented.filter(
+    (d) => d.doc.fixIsRelocation === true && d.doc.goodFile !== undefined
+  );
+
+  test.each(relocations.map((d) => [d.id, d]))(
+    "%s: the ✓ still trips the rule at the ORIGINAL path",
+    (_id, entry) => {
+      const atOriginal = lint(
+        entry.packId,
+        entry.ruleName,
+        entry.doc.good,
+        entry.doc.exampleFile ?? "src/example.ts"
+      );
+
+      // If the ✓ passes where the ✗ lived, the move was decorative and the real
+      // change was something else — which the reader is not being shown.
+      expect({ id: _id, needsTheMove: atOriginal.length > 0 }).toEqual({
+        id: _id,
+        needsTheMove: true,
+      });
+    }
+  );
+});

--- a/packages/core/tests/rule-docs-examples.test.ts
+++ b/packages/core/tests/rule-docs-examples.test.ts
@@ -1,0 +1,191 @@
+import { test, expect, describe } from "bun:test";
+import { Linter, type Rule } from "eslint";
+import tsParser from "@typescript-eslint/parser";
+import { RULE_PACKS } from "../src/rule-packs";
+import { RULE_DOCS, type IRuleDoc } from "../src/loop/feedback/rule-docs";
+import { PACK_RULE_DOCS } from "../src/loop/feedback/pack-rule-docs";
+
+/**
+ * Every published example must be TRUE.
+ *
+ * A rule doc is the only thing the model gets when the gate rejects its code.
+ * When one describes a mechanism the rule does not have, the model does not
+ * fail loudly — it goes looking for the mechanism. One such doc claimed fetch
+ * URLs could "pass through an allowlisted URL builder"; no allowlist existed,
+ * and an agent read tsforge's own rule source from inside an unrelated project
+ * trying to find it.
+ *
+ * So the examples are executable: `bad` must actually trip its rule, and `good`
+ * must actually satisfy it. A doc cannot drift from its rule without this
+ * failing.
+ */
+
+function lint(
+  packId: keyof typeof RULE_PACKS,
+  ruleName: string,
+  code: string,
+  filename: string
+): string[] {
+  const pack = RULE_PACKS[packId];
+  const rule = pack.rules[ruleName];
+
+  if (!rule) {
+    throw new Error(`Rule ${ruleName} not found in pack ${packId}`);
+  }
+
+  const ruleModule = rule as unknown as Rule.RuleModule;
+  const isTsx = filename.endsWith(".tsx");
+  const linter = new Linter();
+
+  const messages = linter.verify(
+    code,
+    [
+      {
+        files: [isTsx ? "**/*.tsx" : "**/*.ts"],
+        languageOptions: {
+          parser: tsParser,
+          parserOptions: {
+            ecmaVersion: "latest",
+            sourceType: "module",
+            ...(isTsx ? { ecmaFeatures: { jsx: true } } : {}),
+          },
+        },
+        plugins: { tsforge: { rules: { [ruleName]: ruleModule } } },
+        rules: { [`tsforge/${ruleName}`]: "error" },
+      },
+    ],
+    filename
+  );
+
+  return messages.map((m) => m.message);
+}
+
+/** A snippet that does not parse is not an example — and a parse error would
+ *  otherwise satisfy "the ✗ example produced a message" for entirely the wrong
+ *  reason, letting a broken fragment pass as a verified doc. */
+function assertParses(messages: string[], label: string): void {
+  const parseError = messages.find((m) => m.startsWith("Parsing error:"));
+
+  if (parseError !== undefined) {
+    throw new Error(
+      `${label} is not valid standalone TypeScript — the model is meant to be able to copy it. ${parseError}`
+    );
+  }
+}
+
+/** Which pack owns a rule name (rule ids are unique across packs). */
+function packOf(ruleName: string): keyof typeof RULE_PACKS | undefined {
+  for (const [packId, pack] of Object.entries(RULE_PACKS)) {
+    if (ruleName in pack.rules) {
+      return packId as keyof typeof RULE_PACKS;
+    }
+  }
+
+  return undefined;
+}
+
+interface IDocumented {
+  id: string;
+  ruleName: string;
+  packId: keyof typeof RULE_PACKS;
+  doc: IRuleDoc;
+}
+
+const documented: IDocumented[] = [];
+
+const ALL_DOCS: Record<string, IRuleDoc> = { ...PACK_RULE_DOCS, ...RULE_DOCS };
+
+for (const [id, doc] of Object.entries(ALL_DOCS)) {
+  if (!id.startsWith("tsforge/")) {
+    continue; // TS diagnostics and eslint-core rules aren't lintable here
+  }
+
+  if (doc.bad.length === 0 || doc.good.length === 0) {
+    continue;
+  }
+
+  if (doc.exampleIsProse === true) {
+    continue; // file-layout illustration, not compilable code
+  }
+
+  const ruleName = id.slice("tsforge/".length);
+  const packId = packOf(ruleName);
+
+  if (packId !== undefined) {
+    documented.push({ id, ruleName, packId, doc });
+  }
+}
+
+describe("rule docs: every published example is executable", () => {
+  test("there is something to check", () => {
+    expect(documented.length).toBeGreaterThan(0);
+  });
+
+  test.each(documented.map((d) => [d.id, d]))(
+    "%s: the ✗ example really trips the rule",
+    (_id, entry) => {
+      const { packId, ruleName, doc } = entry;
+      const messages = lint(
+        packId,
+        ruleName,
+        doc.bad,
+        doc.exampleFile ?? "src/example.ts"
+      );
+
+      assertParses(messages, `${_id} ✗ example`);
+      expect(messages.length).toBeGreaterThan(0);
+    }
+  );
+
+  test.each(documented.map((d) => [d.id, d]))(
+    "%s: the ✓ example really satisfies it",
+    (_id, entry) => {
+      const { packId, ruleName, doc } = entry;
+      const messages = lint(
+        packId,
+        ruleName,
+        doc.good,
+        doc.goodFile ?? doc.exampleFile ?? "src/example.ts"
+      );
+
+      assertParses(messages, `${_id} ✓ example`);
+      expect(messages).toEqual([]);
+    }
+  );
+});
+
+describe("rule docs: coverage", () => {
+  test("every pack rule tells the model something actionable", () => {
+    // The guarantee is NOT "every rule has an example" — an invented example is
+    // worse than none, which is how a doc came to promise an "allowlisted URL
+    // builder" that did not exist. It is: every rule the gate can fail on ships
+    // either a VERIFIED bad→good pair or a hand-written procedure.
+    const bare: string[] = [];
+
+    for (const [, pack] of Object.entries(RULE_PACKS)) {
+      for (const ruleName of Object.keys(pack.rules)) {
+        const doc = ALL_DOCS[`tsforge/${ruleName}`];
+        const hasExample =
+          doc !== undefined && doc.bad.length > 0 && doc.good.length > 0;
+        const hasProcedure =
+          doc?.procedure !== undefined && doc.procedure.length > 0;
+
+        if (!hasExample && !hasProcedure) {
+          bare.push(ruleName);
+        }
+      }
+    }
+
+    expect(bare).toEqual([]);
+  });
+
+  test("a doc with no example must explain itself in a procedure", () => {
+    const silent = Object.entries(ALL_DOCS)
+      .filter(([id]) => id.startsWith("tsforge/"))
+      .filter(([, doc]) => doc.bad.length === 0 || doc.good.length === 0)
+      .filter(([, doc]) => (doc.procedure ?? "").length === 0)
+      .map(([id]) => id);
+
+    expect(silent).toEqual([]);
+  });
+});

--- a/packages/core/tests/rule-docs-examples.test.ts
+++ b/packages/core/tests/rule-docs-examples.test.ts
@@ -37,7 +37,12 @@ function lint(
   // They are structurally compatible at every point Linter touches, so the
   // parameter is typed as what Linter needs and the pack value is handed over
   // through a narrowing guard rather than a cast.
-  const plugins = { tsforge: { rules: { [ruleName]: toLinterRule(rule) } } };
+  // Same bridge the other rule tests use: the pack stores TSESLint modules and
+  // Linter wants its own, structurally identical at every point it touches.
+  // eslint.config.js relaxes type assertions for packages/**/tests/**, which is
+  // why this is a plain cast here and would not be in src.
+  const ruleModule = rule as unknown as Rule.RuleModule;
+  const plugins = { tsforge: { rules: { [ruleName]: ruleModule } } };
   const isTsx = filename.endsWith(".tsx");
   const linter = new Linter();
 
@@ -96,49 +101,6 @@ function packOf(ruleName: string): keyof typeof RULE_PACKS | undefined {
 
 function isPackId(value: string): value is keyof typeof RULE_PACKS {
   return Object.hasOwn(RULE_PACKS, value);
-}
-
-/** A RuleListener is a string-keyed map of visitor callbacks, so any non-null
- *  object satisfies its declared shape. Narrowing through a guard keeps this
- *  honest without an `as` cast and without laundering an `any`. */
-function isRuleListener(value: unknown): value is Rule.RuleListener {
-  return typeof value === "object" && value !== null;
-}
-
-/** The pack's rule module in the shape ESLint's Linter accepts.
- *
- *  A pack rule is a TSESLint module; Linter wants its own. They are structurally
- *  compatible at every point Linter touches, but the two `create` signatures are
- *  nominally different, so this re-declares the one member Linter calls and
- *  forwards to it. No `as`, and no laundering through an `any`-returning helper —
- *  dodging the cast ban that way is worse than the cast itself. */
-function toLinterRule(rule: unknown): Rule.RuleModule {
-  if (typeof rule !== "object" || rule === null || !("create" in rule)) {
-    throw new Error("rule module has no create()");
-  }
-
-  const create: unknown = Reflect.get(rule, "create");
-
-  if (typeof create !== "function") {
-    throw new Error("rule module create() is not callable");
-  }
-
-  // `meta` carries the messages table; without it a rule reporting by messageId
-  // throws instead of producing a diagnostic.
-  const meta: unknown = Reflect.get(rule, "meta");
-
-  return {
-    ...(typeof meta === "object" && meta !== null ? { meta } : {}),
-    create(context: Rule.RuleContext): Rule.RuleListener {
-      const returned: unknown = Reflect.apply(create, rule, [context]);
-
-      if (!isRuleListener(returned)) {
-        throw new Error("rule create() did not return a listener");
-      }
-
-      return returned;
-    },
-  };
 }
 
 interface IDocumented {
@@ -381,4 +343,25 @@ describe("rule docs: a relocation fix must actually need the move", () => {
       });
     }
   );
+});
+
+describe("rule docs: no orphaned entries", () => {
+  test("every tsforge doc key names a rule that actually exists", () => {
+    // A doc for a renamed or deleted rule is never looked up: no error will
+    // carry that id, so it rots unnoticed. The coverage test iterates rules,
+    // not doc keys, so it cannot see this.
+    const real = new Set<string>();
+
+    for (const pack of Object.values(RULE_PACKS)) {
+      for (const ruleName of Object.keys(pack.rules)) {
+        real.add(`tsforge/${ruleName}`);
+      }
+    }
+
+    const orphans = Object.keys(ALL_DOCS)
+      .filter((id) => id.startsWith("tsforge/"))
+      .filter((id) => !real.has(id));
+
+    expect(orphans).toEqual([]);
+  });
 });

--- a/packages/core/tests/rule-docs-examples.test.ts
+++ b/packages/core/tests/rule-docs-examples.test.ts
@@ -34,13 +34,10 @@ function lint(
   }
 
   // The pack stores TSESLint rule modules; ESLint's Linter wants its own shape.
-  // Structurally identical at the points Linter touches, so bridge through an
-  // unknown-typed local rather than an `as` cast (banned by the house rules).
-  const bridge: Record<string, unknown> = { [ruleName]: rule };
-  const plugins: Record<string, { rules: Record<string, Rule.RuleModule> }> =
-    Object.assign(Object.create(null), {
-      tsforge: { rules: bridge },
-    });
+  // They are structurally compatible at every point Linter touches, so the
+  // parameter is typed as what Linter needs and the pack value is handed over
+  // through a narrowing guard rather than a cast.
+  const plugins = { tsforge: { rules: { [ruleName]: toLinterRule(rule) } } };
   const isTsx = filename.endsWith(".tsx");
   const linter = new Linter();
 
@@ -82,13 +79,72 @@ function assertParses(messages: string[], label: string): void {
 
 /** Which pack owns a rule name (rule ids are unique across packs). */
 function packOf(ruleName: string): keyof typeof RULE_PACKS | undefined {
-  for (const [packId, pack] of Object.entries(RULE_PACKS)) {
-    if (ruleName in pack.rules) {
-      return packId as keyof typeof RULE_PACKS;
+  // Iterate the KEYS of the typed record, so packId is already narrowed and no
+  // cast is needed to widen Object.entries' `string` back to the union.
+  for (const packId of Object.keys(RULE_PACKS)) {
+    if (!isPackId(packId)) {
+      continue;
+    }
+
+    if (ruleName in RULE_PACKS[packId].rules) {
+      return packId;
     }
   }
 
   return undefined;
+}
+
+function isPackId(value: string): value is keyof typeof RULE_PACKS {
+  return Object.hasOwn(RULE_PACKS, value);
+}
+
+/** The pack's rule module in the shape ESLint's Linter accepts.
+ *
+ *  A pack rule is a TSESLint module; Linter wants its own. They are structurally
+ *  compatible at every point Linter touches, but the two `create` signatures are
+ *  nominally different, so this re-declares the one member Linter calls and
+ *  forwards to it. No `as`, and no laundering through an `any`-returning helper —
+ *  dodging the cast ban that way is worse than the cast itself. */
+function toLinterRule(rule: unknown): Rule.RuleModule {
+  if (typeof rule !== "object" || rule === null || !("create" in rule)) {
+    throw new Error("rule module has no create()");
+  }
+
+  const create: unknown = Reflect.get(rule, "create");
+
+  if (typeof create !== "function") {
+    throw new Error("rule module create() is not callable");
+  }
+
+  // `meta` carries the messages table; without it a rule reporting by messageId
+  // throws instead of producing a diagnostic.
+  const meta: unknown = Reflect.get(rule, "meta");
+
+  return {
+    ...(typeof meta === "object" && meta !== null ? { meta } : {}),
+    create(context: Rule.RuleContext): Rule.RuleListener {
+      const returned: unknown = Reflect.apply(create, rule, [context]);
+
+      if (typeof returned !== "object" || returned === null) {
+        throw new Error("rule create() did not return a listener");
+      }
+
+      // A RuleListener is a string-keyed map of visitor callbacks. Rebuild it
+      // from own entries so the value carries that index signature honestly
+      // rather than being asserted into it.
+      const listener: Rule.RuleListener = {};
+
+      for (const [selector, visitor] of Object.entries(returned)) {
+        // Visitors are usually functions, but a selector may also carry an
+        // { enter, exit } pair — keep both or half the rules stop firing.
+        if (typeof visitor === "function" || typeof visitor === "object") {
+          listener[selector] = visitor;
+        }
+      }
+
+      return listener;
+    },
+  };
 }
 
 interface IDocumented {
@@ -247,4 +303,23 @@ describe("rule docs: the ✓ must be a FIX, not an evasion", () => {
       expect(stripped).not.toBe(squash(entry.doc.bad));
     }
   );
+});
+
+describe("rule docs: guidance says what to DO", () => {
+  // "Disallow X" restates the linter. The model already knows what it did
+  // wrong; what it needs is the sanctioned shape. Every entry must therefore
+  // name a remedy somewhere — in the `what`, the ✓, or the procedure.
+  const REMEDY =
+    /\b(use|instead|prefer|move|add|wrap|return|pass|import|call|set|declare|extract|split|parse|mask|derive|sanitize|scope|filter|guard|throw|chain|annotate|revalidate|register|write|assign|put|store|name|create|replace|delete|configure|close|bound|keep|give|drop|pick|redirect)\b/iu;
+
+  test.each(
+    Object.entries(ALL_DOCS).filter(([id]) => id.startsWith("tsforge/"))
+  )("%s: names a remedy, not just a prohibition", (_id, doc) => {
+    const carriesRemedy =
+      REMEDY.test(doc.what) ||
+      REMEDY.test(doc.procedure ?? "") ||
+      doc.good.length > 0;
+
+    expect(carriesRemedy).toBe(true);
+  });
 });

--- a/packages/core/tests/rule-docs.test.ts
+++ b/packages/core/tests/rule-docs.test.ts
@@ -5,6 +5,7 @@ import {
   parseRuleMdx,
 } from "../src/loop/feedback/rule-docs";
 import generatedDocs from "../src/loop/feedback/rule-docs.generated.json";
+import { RULE_PACKS } from "../src/rule-packs";
 
 const SAMPLE_MDX = `---
 description: 'Disallow returning a value with type \`any\` from a function.'
@@ -281,4 +282,27 @@ test("ruleHelp: a multi-line example keeps its indentation under the marker", ()
 
   expect(continuation).toBeDefined();
   expect(continuation?.startsWith("    ")).toBe(true);
+});
+
+test("ruleHelp: test-only metadata never reaches the model", () => {
+  // exampleFile / goodFile / exampleIsProse / fixIsDirective exist so the
+  // verification test can lint path-sensitive examples. Like `reference`, they
+  // are maintainer data: a tsforge-relative path dangles in the user's project
+  // and would waste a repair turn.
+  const h = ruleHelp(
+    Object.values(RULE_PACKS).flatMap((pack) =>
+      Object.keys(pack.rules).map((rule) => ({
+        key: rule,
+        rule: `tsforge/${rule}`,
+        message: "",
+      }))
+    )
+  );
+
+  expect(h).not.toContain("exampleFile");
+  expect(h).not.toContain("goodFile");
+  expect(h).not.toContain("exampleIsProse");
+  expect(h).not.toContain("fixIsDirective");
+  expect(h).not.toContain("src/example.ts");
+  expect(h).not.toContain("packages/core");
 });

--- a/packages/core/tests/rule-docs.test.ts
+++ b/packages/core/tests/rule-docs.test.ts
@@ -265,3 +265,20 @@ test("generated docs the reader imports include the tsforge pack rules (guards t
   expect(tsforgeKeys.length).toBeGreaterThan(50);
   expect(keys).toContain("tsforge/component-folder-structure");
 });
+
+test("ruleHelp: a multi-line example keeps its indentation under the marker", () => {
+  // Model-facing formatting: left-flushing continuation lines destroys the
+  // snippet's own structure and makes a multi-statement fix hard to read.
+  const h = ruleHelp([
+    { key: "k", rule: "tsforge/logger-not-console", message: "" },
+  ]);
+  const lines = h.split("\n");
+  const markerAt = lines.findIndex((l) => l.includes("✗"));
+
+  expect(markerAt).toBeGreaterThan(-1);
+
+  const continuation = lines[markerAt + 1];
+
+  expect(continuation).toBeDefined();
+  expect(continuation?.startsWith("    ")).toBe(true);
+});

--- a/packages/core/tests/rule-docs.test.ts
+++ b/packages/core/tests/rule-docs.test.ts
@@ -244,13 +244,15 @@ test("ruleHelp: i18n-locale-keys-used steers WIRE-UP, never delete-what-you-wrot
 test("ruleHelp: a pack rule with no worked example shows only its description (no fake ✗/✓)", () => {
   // A rule whose fix is structural carries a procedure INSTEAD of an example —
   // a fabricated ✗/✓ is worse than none, which is how one doc came to promise
-  // an "allowlisted URL builder" the rule never had. (job-name-must-be-constant
-  // used to sit here; it now ships a verified example of its own.)
+  // an "allowlisted URL builder" the rule never had. Moving a file cannot be
+  // shown as a same-file before/after, so this rule stays procedure-only.
+  // (job-name-must-be-constant and fetch-must-check-ok used to sit here; both
+  // now ship verified examples of their own.)
   const h = ruleHelp([
-    { key: "k", rule: "tsforge/fetch-must-check-ok", message: "" },
+    { key: "k", rule: "tsforge/test-file-mirrors-source", message: "" },
   ]);
 
-  expect(h).toContain("tsforge/fetch-must-check-ok");
+  expect(h).toContain("tsforge/test-file-mirrors-source");
   expect(h).toContain("procedure:");
   expect(h).not.toContain("✗");
   expect(h).not.toContain("✓");

--- a/packages/core/tests/rule-docs.test.ts
+++ b/packages/core/tests/rule-docs.test.ts
@@ -241,12 +241,16 @@ test("ruleHelp: i18n-locale-keys-used steers WIRE-UP, never delete-what-you-wrot
 });
 
 test("ruleHelp: a pack rule with no worked example shows only its description (no fake ✗/✓)", () => {
-  // job-name-must-be-constant has a generated (empty bad/good) entry, no curated one.
+  // A rule whose fix is structural carries a procedure INSTEAD of an example —
+  // a fabricated ✗/✓ is worse than none, which is how one doc came to promise
+  // an "allowlisted URL builder" the rule never had. (job-name-must-be-constant
+  // used to sit here; it now ships a verified example of its own.)
   const h = ruleHelp([
-    { key: "k", rule: "tsforge/job-name-must-be-constant", message: "" },
+    { key: "k", rule: "tsforge/fetch-must-check-ok", message: "" },
   ]);
 
-  expect(h).toContain("tsforge/job-name-must-be-constant");
+  expect(h).toContain("tsforge/fetch-must-check-ok");
+  expect(h).toContain("procedure:");
   expect(h).not.toContain("✗");
   expect(h).not.toContain("✓");
 });

--- a/packages/core/tests/rule-docs.test.ts
+++ b/packages/core/tests/rule-docs.test.ts
@@ -337,3 +337,15 @@ test("ruleHelpFromOutput: still recovers TS codes and eslint-core ids", () => {
   expect(h).toContain("TS2532");
   expect(h).toContain("@typescript-eslint/no-explicit-any");
 });
+
+test("ruleHelpFromOutput: a file path is never mistaken for a rule id", () => {
+  // `/app/src/api.ts` contains `app/src` and `src/api`, both rule-id shaped.
+  // Only the real id on the line should pull guidance.
+  const h = ruleHelpFromOutput(
+    "/app/src/api.ts\n  12:3  error  Something  tsforge/no-unsafe-boundary-cast"
+  );
+
+  expect(h).toContain("tsforge/no-unsafe-boundary-cast");
+  expect(h).not.toContain("app/src");
+  expect(h).not.toContain("src/api");
+});

--- a/packages/core/tests/rule-docs.test.ts
+++ b/packages/core/tests/rule-docs.test.ts
@@ -349,3 +349,15 @@ test("ruleHelpFromOutput: a file path is never mistaken for a rule id", () => {
   expect(h).not.toContain("app/src");
   expect(h).not.toContain("src/api");
 });
+
+test("ruleHelp: an example written with a leading newline shows no blank line", () => {
+  // Several pack docs are template literals that open with a newline. Indenting
+  // that empty line puts the snippet a row below its marker behind stray
+  // whitespace, which reads as part of the example.
+  const h = ruleHelp([
+    { key: "k", rule: "tsforge/auth-cookie-must-be-httponly", message: "" },
+  ]);
+
+  expect(h).not.toMatch(/✗\s*\n\s*\n/u);
+  expect(h).not.toMatch(/✗ *\n/u);
+});

--- a/packages/core/tests/rule-docs.test.ts
+++ b/packages/core/tests/rule-docs.test.ts
@@ -303,6 +303,7 @@ test("ruleHelp: test-only metadata never reaches the model", () => {
   expect(h).not.toContain("goodFile");
   expect(h).not.toContain("exampleIsProse");
   expect(h).not.toContain("fixIsDirective");
+  expect(h).not.toContain("fixIsRelocation");
   expect(h).not.toContain("src/example.ts");
   expect(h).not.toContain("packages/core");
 });

--- a/packages/core/tests/rule-docs.test.ts
+++ b/packages/core/tests/rule-docs.test.ts
@@ -306,3 +306,31 @@ test("ruleHelp: test-only metadata never reaches the model", () => {
   expect(h).not.toContain("src/example.ts");
   expect(h).not.toContain("packages/core");
 });
+
+test("ruleHelpFromOutput: recovers pack docs from PLAIN eslint text", () => {
+  // The path the MODEL takes when it runs the gate itself via the `run` tool.
+  // Before this, only TS codes, JSON ruleId fields and @typescript-eslint ids
+  // were matched, so the entire tsforge catalogue was invisible here — the model
+  // saw a bare rule id and went looking for the answer in the harness source.
+  const plain = [
+    "/app/src/api.ts",
+    "  12:3  error  HTTP request URL must have a fixed origin  tsforge/no-user-controlled-fetch-url",
+    "  20:1  error  console in a service                       tsforge/logger-not-console",
+  ].join("\n");
+
+  const h = ruleHelpFromOutput(plain);
+
+  expect(h).toContain("tsforge/no-user-controlled-fetch-url");
+  expect(h).toContain("tsforge/logger-not-console");
+  // and it carries the worked example, not just the id
+  expect(h).toContain("✓");
+});
+
+test("ruleHelpFromOutput: still recovers TS codes and eslint-core ids", () => {
+  const h = ruleHelpFromOutput(
+    "error TS2532: Object is possibly undefined\n  @typescript-eslint/no-explicit-any"
+  );
+
+  expect(h).toContain("TS2532");
+  expect(h).toContain("@typescript-eslint/no-explicit-any");
+});

--- a/packages/core/tests/rule-packs.test.ts
+++ b/packages/core/tests/rule-packs.test.ts
@@ -1,5 +1,5 @@
 import { test, expect, describe } from "bun:test";
-import { Linter, type Rule } from "eslint";
+import { TSESLint } from "@typescript-eslint/utils";
 import tsParser from "@typescript-eslint/parser";
 
 import { RULE_PACKS, buildPackEslintConfig } from "../src/rule-packs";
@@ -16,7 +16,7 @@ function lint(
   filename = "src/example.ts",
   options?: unknown[]
 ) {
-  const linter = new Linter();
+  const linter = new TSESLint.Linter();
   const pack = RULE_PACKS[packId];
   const rule = pack.rules[ruleName];
 
@@ -24,15 +24,14 @@ function lint(
     throw new Error(`Rule ${ruleName} not found in pack ${packId}`);
   }
 
-  // Bridge the type gap: cast the TSESLint.RuleModule to ESLint's Rule.RuleModule
-  // (The eslint.config.js override at lines 185 relaxes type assertions for test files,
-  // and this single bridge point is within that scope.)
-  const ruleModule = rule as unknown as Rule.RuleModule;
+  // TSESLint's own Linter is typed for the rule modules the packs hold, so the
+  // rule goes in as-is — no cast to bridge, and no way to assert away a real
+  // shape mismatch.
   const isTsx = filename.endsWith(".tsx");
 
   const config = {
     files: [isTsx ? "**/*.tsx" : "**/*.ts"],
-    plugins: { tsforge: { rules: { [ruleName]: ruleModule } } },
+    plugins: { tsforge: { rules: { [ruleName]: rule } } },
     rules: {
       [`tsforge/${ruleName}`]: options ? ["error", ...options] : "error",
     },
@@ -44,7 +43,7 @@ function lint(
         ecmaFeatures: isTsx ? { jsx: true } : undefined,
       },
     },
-  } as unknown as Linter.Config;
+  } satisfies TSESLint.FlatConfig.Config;
 
   return linter.verify(code, config, filename);
 }
@@ -4083,6 +4082,66 @@ describe("typescript-core: fetch-must-check-ok", () => {
     );
 
     expect(messages).toHaveLength(0);
+  });
+
+  test("reports a check that only happens after the body is parsed", () => {
+    const messages = lint(
+      "typescript-core",
+      "fetch-must-check-ok",
+      'async function load() { const res = await fetch("/api/users"); const data = await res.json(); if (!res.ok) { throw new Error("failed"); } return data; }'
+    );
+
+    expect(messages.map((m) => m.messageId)).toContain("missingOkCheck");
+  });
+
+  test("reports a status read that is recorded rather than acted on", () => {
+    const messages = lint(
+      "typescript-core",
+      "fetch-must-check-ok",
+      'async function load() { const res = await fetch("/api/users"); metrics.observe(res.status); return res.json(); }'
+    );
+
+    expect(messages.map((m) => m.messageId)).toContain("missingOkCheck");
+  });
+
+  test("reports an ok read bound to a variable and never tested", () => {
+    const messages = lint(
+      "typescript-core",
+      "fetch-must-check-ok",
+      'async function load() { const res = await fetch("/api/users"); const ok = res.ok; log(ok); return res.json(); }'
+    );
+
+    expect(messages.map((m) => m.messageId)).toContain("missingOkCheck");
+  });
+
+  test("allows an ok read bound to a variable and then tested", () => {
+    const messages = lint(
+      "typescript-core",
+      "fetch-must-check-ok",
+      'async function load() { const res = await fetch("/api/users"); const ok = res.ok; if (!ok) { throw new Error("failed"); } return res.json(); }'
+    );
+
+    expect(messages).toHaveLength(0);
+  });
+
+  test("allows an assertion helper as the check", () => {
+    const messages = lint(
+      "typescript-core",
+      "fetch-must-check-ok",
+      'async function load() { const res = await fetch("/api/users"); invariant(res.ok, "failed"); return res.json(); }'
+    );
+
+    expect(messages).toHaveLength(0);
+  });
+
+  test("reports a then-callback that parses before it checks", () => {
+    const messages = lint(
+      "typescript-core",
+      "fetch-must-check-ok",
+      'const data = fetch("/api/users").then((res) => { const body = res.json(); if (!res.ok) { throw new Error("failed"); } return body; });'
+    );
+
+    expect(messages.map((m) => m.messageId)).toContain("missingOkCheck");
   });
 
   test("ignores a response whose body is never parsed", () => {

--- a/packages/core/tests/rule-packs.test.ts
+++ b/packages/core/tests/rule-packs.test.ts
@@ -4023,3 +4023,75 @@ describe("typescript-core: no-self-import", () => {
     expect(messages.map((m) => m.messageId)).toContain("selfImport");
   });
 });
+
+describe("typescript-core: fetch-must-check-ok", () => {
+  test("reports a bound response parsed without a check", () => {
+    const messages = lint(
+      "typescript-core",
+      "fetch-must-check-ok",
+      'async function load() { const res = await fetch("/api/users"); return res.json(); }'
+    );
+
+    expect(messages.map((m) => m.messageId)).toContain("missingOkCheck");
+  });
+
+  test("reports an inline parse with no binding at all", () => {
+    const messages = lint(
+      "typescript-core",
+      "fetch-must-check-ok",
+      'async function load() { return (await fetch("/api/users")).json(); }'
+    );
+
+    expect(messages.map((m) => m.messageId)).toContain("missingOkCheck");
+  });
+
+  test("reports a then-callback that parses without a check", () => {
+    const messages = lint(
+      "typescript-core",
+      "fetch-must-check-ok",
+      'const data = fetch("/api/users").then((res) => res.json());'
+    );
+
+    expect(messages.map((m) => m.messageId)).toContain("missingOkCheck");
+  });
+
+  test("allows a guard clause on res.ok", () => {
+    const messages = lint(
+      "typescript-core",
+      "fetch-must-check-ok",
+      'async function load() { const res = await fetch("/api/users"); if (!res.ok) { throw new Error("failed"); } return res.json(); }'
+    );
+
+    expect(messages).toHaveLength(0);
+  });
+
+  test("allows a status comparison instead of ok", () => {
+    const messages = lint(
+      "typescript-core",
+      "fetch-must-check-ok",
+      'async function load() { const res = await fetch("/api/users"); if (res.status !== 200) { return null; } return res.json(); }'
+    );
+
+    expect(messages).toHaveLength(0);
+  });
+
+  test("allows a then-callback that checks ok", () => {
+    const messages = lint(
+      "typescript-core",
+      "fetch-must-check-ok",
+      'const data = fetch("/api/users").then((res) => (res.ok ? res.json() : null));'
+    );
+
+    expect(messages).toHaveLength(0);
+  });
+
+  test("ignores a response whose body is never parsed", () => {
+    const messages = lint(
+      "typescript-core",
+      "fetch-must-check-ok",
+      'async function ping() { const res = await fetch("/api/health"); return res.text(); }'
+    );
+
+    expect(messages).toHaveLength(0);
+  });
+});

--- a/packages/core/tests/rule-packs.test.ts
+++ b/packages/core/tests/rule-packs.test.ts
@@ -4514,6 +4514,66 @@ describe("typescript-core: fetch-must-check-ok", () => {
     expect(messages.map((m) => m.messageId)).toContain("missingOkCheck");
   });
 
+  test("reports an exiting else whose test another operand can satisfy", () => {
+    const messages = lint(
+      "typescript-core",
+      "fetch-must-check-ok",
+      'async function load() { const res = await fetch("/api/users"); if (res.ok || force) { log(); } else { throw new Error("failed"); } return res.json(); }'
+    );
+
+    expect(messages.map((m) => m.messageId)).toContain("missingOkCheck");
+  });
+
+  test("reports an assertion another operand can satisfy", () => {
+    const messages = lint(
+      "typescript-core",
+      "fetch-must-check-ok",
+      'async function load() { const res = await fetch("/api/users"); assert(res.ok || force); return res.json(); }'
+    );
+
+    expect(messages.map((m) => m.messageId)).toContain("missingOkCheck");
+  });
+
+  test("allows an exiting guard where either operand means failure", () => {
+    const messages = lint(
+      "typescript-core",
+      "fetch-must-check-ok",
+      'async function load() { const res = await fetch("/api/users"); if (!res.ok || force) { throw new Error("failed"); } return res.json(); }'
+    );
+
+    expect(messages).toHaveLength(0);
+  });
+
+  test("allows an exiting else whose test requires success", () => {
+    const messages = lint(
+      "typescript-core",
+      "fetch-must-check-ok",
+      'async function load() { const res = await fetch("/api/users"); if (res.ok && enabled) { log(); } else { throw new Error("failed"); } return res.json(); }'
+    );
+
+    expect(messages).toHaveLength(0);
+  });
+
+  test("allows a complementary guard below the error boundary", () => {
+    const messages = lint(
+      "typescript-core",
+      "fetch-must-check-ok",
+      'async function load() { const res = await fetch("/api/users"); if (res.status >= 300) { return null; } return res.json(); }'
+    );
+
+    expect(messages).toHaveLength(0);
+  });
+
+  test("allows a strict complementary guard below the error boundary", () => {
+    const messages = lint(
+      "typescript-core",
+      "fetch-must-check-ok",
+      'async function load() { const res = await fetch("/api/users"); if (res.status > 350) { return null; } return res.json(); }'
+    );
+
+    expect(messages).toHaveLength(0);
+  });
+
   test("ignores a response whose body is never parsed", () => {
     const messages = lint(
       "typescript-core",

--- a/packages/core/tests/rule-packs.test.ts
+++ b/packages/core/tests/rule-packs.test.ts
@@ -4144,6 +4144,66 @@ describe("typescript-core: fetch-must-check-ok", () => {
     expect(messages.map((m) => m.messageId)).toContain("missingOkCheck");
   });
 
+  test("allows assert.ok on the response", () => {
+    const messages = lint(
+      "typescript-core",
+      "fetch-must-check-ok",
+      'async function load() { const res = await fetch("/api/users"); assert.ok(res.ok); return res.json(); }'
+    );
+
+    expect(messages).toHaveLength(0);
+  });
+
+  test("allows assert.equal on the status", () => {
+    const messages = lint(
+      "typescript-core",
+      "fetch-must-check-ok",
+      'async function load() { const res = await fetch("/api/users"); assert.equal(res.status, 200); return res.json(); }'
+    );
+
+    expect(messages).toHaveLength(0);
+  });
+
+  test("reports a helper whose name merely starts with an assertion word", () => {
+    const messages = lint(
+      "typescript-core",
+      "fetch-must-check-ok",
+      'async function load() { const res = await fetch("/api/users"); expectedStatus(res.status); return res.json(); }'
+    );
+
+    expect(messages.map((m) => m.messageId)).toContain("missingOkCheck");
+  });
+
+  test("reports when a nested function tests a shadowed alias name", () => {
+    const messages = lint(
+      "typescript-core",
+      "fetch-must-check-ok",
+      'async function load() { const res = await fetch("/api/users"); const ok = res.ok; function guard(ok: boolean) { if (!ok) { throw new Error("nope"); } } return res.json(); }'
+    );
+
+    expect(messages.map((m) => m.messageId)).toContain("missingOkCheck");
+  });
+
+  test("reports when only a nested function checks its own response", () => {
+    const messages = lint(
+      "typescript-core",
+      "fetch-must-check-ok",
+      'async function load() { const res = await fetch("/api/users"); function other(res: Response) { if (!res.ok) { throw new Error("nope"); } } return res.json(); }'
+    );
+
+    expect(messages.map((m) => m.messageId)).toContain("missingOkCheck");
+  });
+
+  test("allows a check in an enclosing function around the parse", () => {
+    const messages = lint(
+      "typescript-core",
+      "fetch-must-check-ok",
+      'async function load() { const res = await fetch("/api/users"); if (!res.ok) { throw new Error("failed"); } return () => res.json(); }'
+    );
+
+    expect(messages).toHaveLength(0);
+  });
+
   test("ignores a response whose body is never parsed", () => {
     const messages = lint(
       "typescript-core",

--- a/packages/core/tests/rule-packs.test.ts
+++ b/packages/core/tests/rule-packs.test.ts
@@ -4204,6 +4204,116 @@ describe("typescript-core: fetch-must-check-ok", () => {
     expect(messages).toHaveLength(0);
   });
 
+  test("reports a check whose branch does not prevent the parse", () => {
+    const messages = lint(
+      "typescript-core",
+      "fetch-must-check-ok",
+      'async function load() { const res = await fetch("/api/users"); if (res.ok) { metrics.hit(); } return res.json(); }'
+    );
+
+    expect(messages.map((m) => m.messageId)).toContain("missingOkCheck");
+  });
+
+  test("reports a guard that only runs when another flag is set", () => {
+    const messages = lint(
+      "typescript-core",
+      "fetch-must-check-ok",
+      'async function load() { const res = await fetch("/api/users"); if (debug && !res.ok) { throw new Error("failed"); } return res.json(); }'
+    );
+
+    expect(messages.map((m) => m.messageId)).toContain("missingOkCheck");
+  });
+
+  test("reports a bare truthiness test of the status", () => {
+    const messages = lint(
+      "typescript-core",
+      "fetch-must-check-ok",
+      'async function load() { const res = await fetch("/api/users"); if (res.status) { return res.json(); } return null; }'
+    );
+
+    expect(messages.map((m) => m.messageId)).toContain("missingOkCheck");
+  });
+
+  test("reports a typeof test of the status", () => {
+    const messages = lint(
+      "typescript-core",
+      "fetch-must-check-ok",
+      'async function load() { const res = await fetch("/api/users"); if (typeof res.status === "number") { return res.json(); } return null; }'
+    );
+
+    expect(messages.map((m) => m.messageId)).toContain("missingOkCheck");
+  });
+
+  test("reports a second parse that the guard does not reach", () => {
+    const messages = lint(
+      "typescript-core",
+      "fetch-must-check-ok",
+      'async function load(preview: boolean) { const res = await fetch("/api/users"); if (preview) { if (!res.ok) { throw new Error("failed"); } return res.json(); } return res.json(); }'
+    );
+
+    expect(messages).toHaveLength(1);
+  });
+
+  test("reports a parse in the failure branch of a check", () => {
+    const messages = lint(
+      "typescript-core",
+      "fetch-must-check-ok",
+      'async function load() { const res = await fetch("/api/users"); if (!res.ok) { return res.json(); } return null; }'
+    );
+
+    expect(messages.map((m) => m.messageId)).toContain("missingOkCheck");
+  });
+
+  test("allows a short-circuit guard", () => {
+    const messages = lint(
+      "typescript-core",
+      "fetch-must-check-ok",
+      'async function load() { const res = await fetch("/api/users"); return res.ok && res.json(); }'
+    );
+
+    expect(messages).toHaveLength(0);
+  });
+
+  test("allows a parse in the success branch of a check", () => {
+    const messages = lint(
+      "typescript-core",
+      "fetch-must-check-ok",
+      'async function load() { const res = await fetch("/api/users"); if (res.ok) { return res.json(); } return null; }'
+    );
+
+    expect(messages).toHaveLength(0);
+  });
+
+  test("allows a parse in the else branch of a failure check", () => {
+    const messages = lint(
+      "typescript-core",
+      "fetch-must-check-ok",
+      'async function load() { const res = await fetch("/api/users"); if (!res.ok) { return null; } else { return res.json(); } }'
+    );
+
+    expect(messages).toHaveLength(0);
+  });
+
+  test("allows a status comparison guard for a status alias", () => {
+    const messages = lint(
+      "typescript-core",
+      "fetch-must-check-ok",
+      'async function load() { const res = await fetch("/api/users"); const code = res.status; if (code >= 400) { throw new Error("failed"); } return res.json(); }'
+    );
+
+    expect(messages).toHaveLength(0);
+  });
+
+  test("reports a bare truthiness test of a status alias", () => {
+    const messages = lint(
+      "typescript-core",
+      "fetch-must-check-ok",
+      'async function load() { const res = await fetch("/api/users"); const code = res.status; if (code) { return res.json(); } return null; }'
+    );
+
+    expect(messages.map((m) => m.messageId)).toContain("missingOkCheck");
+  });
+
   test("ignores a response whose body is never parsed", () => {
     const messages = lint(
       "typescript-core",

--- a/packages/core/tests/rule-packs.test.ts
+++ b/packages/core/tests/rule-packs.test.ts
@@ -4314,6 +4314,116 @@ describe("typescript-core: fetch-must-check-ok", () => {
     expect(messages.map((m) => m.messageId)).toContain("missingOkCheck");
   });
 
+  test("reports an or-short-circuit, which parses on the failure path", () => {
+    const messages = lint(
+      "typescript-core",
+      "fetch-must-check-ok",
+      'async function load() { const res = await fetch("/api/users"); return res.ok || res.json(); }'
+    );
+
+    expect(messages.map((m) => m.messageId)).toContain("missingOkCheck");
+  });
+
+  test("reports an or-short-circuit on a status comparison", () => {
+    const messages = lint(
+      "typescript-core",
+      "fetch-must-check-ok",
+      'async function load() { const res = await fetch("/api/users"); return res.status === 200 || res.json(); }'
+    );
+
+    expect(messages.map((m) => m.messageId)).toContain("missingOkCheck");
+  });
+
+  test("allows an or-short-circuit whose left side is the failure case", () => {
+    const messages = lint(
+      "typescript-core",
+      "fetch-must-check-ok",
+      'async function load() { const res = await fetch("/api/users"); return !res.ok || res.json(); }'
+    );
+
+    expect(messages).toHaveLength(0);
+  });
+
+  test("reports a parse guarded by an explicit ok === false test", () => {
+    const messages = lint(
+      "typescript-core",
+      "fetch-must-check-ok",
+      'async function load() { const res = await fetch("/api/users"); if (res.ok === false) { return res.json(); } return null; }'
+    );
+
+    expect(messages.map((m) => m.messageId)).toContain("missingOkCheck");
+  });
+
+  test("reports a parse in the error branch of a status threshold", () => {
+    const messages = lint(
+      "typescript-core",
+      "fetch-must-check-ok",
+      'async function load() { const res = await fetch("/api/users"); if (res.status >= 400) { return res.json(); } return null; }'
+    );
+
+    expect(messages.map((m) => m.messageId)).toContain("missingOkCheck");
+  });
+
+  test("reports a truthiness assertion on the status", () => {
+    const messages = lint(
+      "typescript-core",
+      "fetch-must-check-ok",
+      'async function load() { const res = await fetch("/api/users"); assert.ok(res.status); return res.json(); }'
+    );
+
+    expect(messages.map((m) => m.messageId)).toContain("missingOkCheck");
+  });
+
+  test("reports a single-code guard that lets every other error through", () => {
+    const messages = lint(
+      "typescript-core",
+      "fetch-must-check-ok",
+      'async function load() { const res = await fetch("/api/users"); if (res.status === 404) { return null; } return res.json(); }'
+    );
+
+    expect(messages.map((m) => m.messageId)).toContain("missingOkCheck");
+  });
+
+  test("allows a compound guard where either side means failure", () => {
+    const messages = lint(
+      "typescript-core",
+      "fetch-must-check-ok",
+      'async function load() { const res = await fetch("/api/users"); if (aborted || !res.ok) { throw new Error("failed"); } return res.json(); }'
+    );
+
+    expect(messages).toHaveLength(0);
+  });
+
+  test("allows a status threshold below the error range", () => {
+    const messages = lint(
+      "typescript-core",
+      "fetch-must-check-ok",
+      'async function load() { const res = await fetch("/api/users"); if (res.status < 400) { return res.json(); } return null; }'
+    );
+
+    expect(messages).toHaveLength(0);
+  });
+
+  test("allows a switch arm on a success code", () => {
+    const messages = lint(
+      "typescript-core",
+      "fetch-must-check-ok",
+      'async function load() { const res = await fetch("/api/users"); switch (res.status) { case 200: return res.json(); default: return null; } }'
+    );
+
+    expect(messages).toHaveLength(0);
+  });
+
+  test("reports a switch default arm that parses", () => {
+    const messages = lint(
+      "typescript-core",
+      "fetch-must-check-ok",
+      'async function load() { const res = await fetch("/api/users"); switch (res.status) { case 204: return null; default: return res.json(); } }'
+    );
+
+    expect(messages.map((m) => m.messageId)).toContain("missingOkCheck");
+  });
+
   test("ignores a response whose body is never parsed", () => {
     const messages = lint(
       "typescript-core",

--- a/packages/core/tests/rule-packs.test.ts
+++ b/packages/core/tests/rule-packs.test.ts
@@ -4424,6 +4424,96 @@ describe("typescript-core: fetch-must-check-ok", () => {
     expect(messages.map((m) => m.messageId)).toContain("missingOkCheck");
   });
 
+  test("reports a then-branch that another operand can also enter", () => {
+    const messages = lint(
+      "typescript-core",
+      "fetch-must-check-ok",
+      'async function load() { const res = await fetch("/api/users"); if (res.ok || force) { return res.json(); } return null; }'
+    );
+
+    expect(messages.map((m) => m.messageId)).toContain("missingOkCheck");
+  });
+
+  test("reports an else-branch reachable with the response still bad", () => {
+    const messages = lint(
+      "typescript-core",
+      "fetch-must-check-ok",
+      'async function load() { const res = await fetch("/api/users"); if (!res.ok && enabled) { return null; } else { return res.json(); } }'
+    );
+
+    expect(messages.map((m) => m.messageId)).toContain("missingOkCheck");
+  });
+
+  test("reports a threshold above the error boundary", () => {
+    const messages = lint(
+      "typescript-core",
+      "fetch-must-check-ok",
+      'async function load() { const res = await fetch("/api/users"); if (res.status >= 500) { throw new Error("failed"); } return res.json(); }'
+    );
+
+    expect(messages.map((m) => m.messageId)).toContain("missingOkCheck");
+  });
+
+  test("reports a truthiness assertion carrying a message argument", () => {
+    const messages = lint(
+      "typescript-core",
+      "fetch-must-check-ok",
+      'async function load() { const res = await fetch("/api/users"); assert.ok(res.status, "expected a status"); return res.json(); }'
+    );
+
+    expect(messages.map((m) => m.messageId)).toContain("missingOkCheck");
+  });
+
+  test("reports a switch body reachable by falling through an error code", () => {
+    const messages = lint(
+      "typescript-core",
+      "fetch-must-check-ok",
+      'async function load() { const res = await fetch("/api/users"); switch (res.status) { case 500: case 200: return res.json(); default: return null; } }'
+    );
+
+    expect(messages.map((m) => m.messageId)).toContain("missingOkCheck");
+  });
+
+  test("allows a switch body reached only by success codes", () => {
+    const messages = lint(
+      "typescript-core",
+      "fetch-must-check-ok",
+      'async function load() { const res = await fetch("/api/users"); switch (res.status) { case 201: case 200: return res.json(); default: return null; } }'
+    );
+
+    expect(messages).toHaveLength(0);
+  });
+
+  test("allows a mirrored status comparison", () => {
+    const messages = lint(
+      "typescript-core",
+      "fetch-must-check-ok",
+      'async function load() { const res = await fetch("/api/users"); if (400 > res.status) { return res.json(); } return null; }'
+    );
+
+    expect(messages).toHaveLength(0);
+  });
+
+  test("allows an equality assertion against a success code", () => {
+    const messages = lint(
+      "typescript-core",
+      "fetch-must-check-ok",
+      'async function load() { const res = await fetch("/api/users"); assert.equal(res.status, 200); return res.json(); }'
+    );
+
+    expect(messages).toHaveLength(0);
+  });
+
+  test("reports an equality assertion against an error code", () => {
+    const messages = lint(
+      "typescript-core",
+      "fetch-must-check-ok",
+      'async function load() { const res = await fetch("/api/users"); assert.equal(res.status, 404); return res.json(); }'
+    );
+
+    expect(messages.map((m) => m.messageId)).toContain("missingOkCheck");
+  });
+
   test("ignores a response whose body is never parsed", () => {
     const messages = lint(
       "typescript-core",


### PR DESCRIPTION
## Why

A rule doc is the **only** thing the model receives when the gate rejects its code. Two things were wrong with them.

**Missing.** 76 of 117 pack rules shipped no worked example. The model got the rule description — roughly what the linter already printed — and had to guess the sanctioned shape.

**Wrong, which is worse.** Of the 41 rules that *did* have examples, **39 failed their own rule** once actually executed. Several weren't valid code at all (`catch (e) {}` with no `try`, bare JSX). One had identical `bad` and `good`. And one claimed fetch URLs could "pass through an allowlisted URL builder" — no allowlist existed, so an agent went reading tsforge's own rule source from inside an unrelated project trying to find it.

## The fix is a test, not prose

`tests/rule-docs-examples.test.ts` lints every published example:

- the ✗ must **actually trip** its rule
- the ✓ must **actually satisfy** it
- both must parse as standalone TypeScript the model can copy

A doc can no longer drift from its rule without CI failing. This is the part with lasting value; the examples are downstream of it.

## Coverage, stated honestly

| | count |
|---|---|
| pack rules | 117 |
| verified bad→good example | 83 |
| hand-written procedure | 34 |
| **nothing actionable** | **0** |

The guarantee is deliberately *not* "every rule has an example". For rules whose trigger I could not reproduce, inventing one would repeat the exact defect this PR removes — so they carry real guidance instead. The coverage test enforces **example OR procedure**, and a second test enforces that a doc without an example must explain itself.

Examples come from the rules' own tests where those exist (verified code, not intuition) and are hand-authored otherwise.

## Also

- multi-line examples keep their indentation under the ✗/✓ markers instead of rendering as a left-flushed wall
- `exampleFile`/`goodFile` are **test-only** metadata for path-sensitive rules (`*.service.ts`, `app/page.tsx`, `route.ts`). Like the existing `reference` field, they are never emitted to the model — verified by assertion, not assumption
- `exampleIsProse` marks the single rule whose "examples" are file layouts rather than code, so the executable test stays strict everywhere else
- entries live in a new `pack-rule-docs.ts`; lookup is curated → pack → generated, so richer hand-written docs still win

## A rule bug found while writing this

`worker-must-listen-failed` only recognises the **chained** form:

```ts
new Worker("emails", h).on("failed", ...)   // passes
const w = new Worker("emails", h);
w.on("failed", ...)                          // still fails
```

The second is equivalent and idiomatic. Same class as the fetch-url defect — a rule rejecting correct code. The doc describes the accepted form and flags the limitation; the rule itself is left for a separate change.

## Verification

`bun run validate` green: typecheck, lint, format, 3718 tests, PTY e2e. Four pre-existing tests changed, each for a stated reason — one asserted a rule had *no* example, which is no longer true by design.