### PR TITLE
fix(tools): refuse to read the harness's own source from another workspace

### DIFF
--- a/packages/core/src/lib/scope/harness-self.ts
+++ b/packages/core/src/lib/scope/harness-self.ts
@@ -1,4 +1,4 @@
-import { existsSync, readFileSync } from "node:fs";
+import { existsSync, readFileSync, realpathSync } from "node:fs";
 import { dirname, isAbsolute, join, relative, resolve } from "node:path";
 import { isWin32 } from "../platform";
 
@@ -107,29 +107,49 @@ function contains(parent: string, child: string): boolean {
   return !segments.includes("..");
 }
 
+/** Follow symlinks where possible. A link inside the workspace pointing at the
+ *  harness resolves to the same bytes, and comparing the link's own path would
+ *  miss it. Paths that do not exist keep their resolved form — `run` is checked
+ *  before anything runs, so its targets may legitimately be absent. */
+function realpathOrSelf(path: string): string {
+  try {
+    return realpathSync(path);
+  } catch {
+    return path;
+  }
+}
+
 /**
  * True when reading this path would open the harness's own source from a
  * workspace that is not the harness.
  *
  * `file` may be absolute or relative to `cwd`; both resolve to the same answer.
+ * `roots` is injectable so the install layouts can be tested directly.
  */
-export function isForeignHarnessRead(cwd: string, file: string): boolean {
-  const roots = harnessRoots();
-  const target = resolve(cwd, file);
-  const workspace = resolve(cwd);
+export function isForeignRead(
+  roots: readonly string[],
+  cwd: string,
+  file: string
+): boolean {
+  const target = realpathOrSelf(resolve(cwd, file));
+  const workspace = realpathOrSelf(resolve(cwd));
 
   const insideHarness = roots.some((root) => contains(root, target));
 
-  // Overlap with ANY root, in EITHER direction, means the harness is the
-  // project in hand: the workspace may be the monorepo root, the shipped
-  // package, or a sibling package beside it. Asking this per-root and OR-ing
-  // the refusals instead would flag a sibling package, which is disjoint from
-  // `packages/core` while plainly being harness work.
-  const workingOnHarness = roots.some(
-    (root) => contains(workspace, root) || contains(root, workspace)
-  );
+  // The workspace must be INSIDE a root — the monorepo root, the package, or
+  // anything under them, which covers a sibling package and the repo root
+  // itself since that is a root. Accepting "the workspace CONTAINS a root" as
+  // well is what disabled the guard where it matters most: a consumer project
+  // contains `node_modules/tsforge`, and so would have been treated as harness
+  // development. A directory that merely sits above the harness is not working
+  // on it either.
+  const workingOnHarness = roots.some((root) => contains(root, workspace));
 
   return insideHarness && !workingOnHarness;
+}
+
+export function isForeignHarnessRead(cwd: string, file: string): boolean {
+  return isForeignRead(harnessRoots(), cwd, file);
 }
 
 /** What to say instead of the file. The model reached for the source because

--- a/packages/core/src/lib/scope/harness-self.ts
+++ b/packages/core/src/lib/scope/harness-self.ts
@@ -1,5 +1,6 @@
-import { existsSync } from "node:fs";
-import { dirname, join, relative, resolve } from "node:path";
+import { existsSync, readFileSync } from "node:fs";
+import { dirname, isAbsolute, join, relative, resolve } from "node:path";
+import { isWin32 } from "../platform";
 
 /**
  * Stop the harness reading its OWN implementation while it works on someone
@@ -19,16 +20,33 @@ import { dirname, join, relative, resolve } from "node:path";
  * in hand, not about which files they are.
  */
 
-/** The harness's own package root(s), computed once from this module's location.
- *
- * Walks up while ancestors keep declaring themselves packages, so both layouts
- * are covered: an installed single package, and this monorepo, where
- * `packages/core` and the repo root each carry a `package.json`. */
+/** The monorepo root's package name. Climbing "while ancestors have manifests"
+ *  does not reach it — `packages/` carries none — and climbing past that would
+ *  swallow a CONSUMER's repo when tsforge is installed as a dependency, turning
+ *  the guard off exactly where it is needed. Matching the name is precise. */
+const HARNESS_PACKAGE_NAME = "tsforge";
+
+function manifestName(dir: string): string | undefined {
+  try {
+    const raw: unknown = JSON.parse(
+      readFileSync(join(dir, "package.json"), "utf8")
+    );
+
+    return typeof raw === "object" && raw !== null && "name" in raw
+      ? String(raw.name)
+      : undefined;
+  } catch {
+    // No manifest, or one that does not parse. Neither identifies a root.
+    return undefined;
+  }
+}
+
+/** The harness's own roots, computed once from this module's location: the
+ *  package it ships in, plus the monorepo root when running from source. */
 function computeHarnessRoots(): string[] {
   const roots: string[] = [];
   let dir = import.meta.dir;
 
-  // Find the nearest package root.
   while (!existsSync(join(dir, "package.json"))) {
     const parent = dirname(dir);
 
@@ -41,16 +59,20 @@ function computeHarnessRoots(): string[] {
 
   roots.push(dir);
 
-  // Then keep climbing while the ancestors are packages too (a workspace root).
-  for (;;) {
-    const parent = dirname(dir);
+  for (let cur = dir; ;) {
+    const parent = dirname(cur);
 
-    if (parent === dir || !existsSync(join(parent, "package.json"))) {
+    if (parent === cur) {
       return roots;
     }
 
-    dir = parent;
-    roots.push(dir);
+    cur = parent;
+
+    if (manifestName(cur) === HARNESS_PACKAGE_NAME) {
+      roots.push(cur);
+
+      return roots;
+    }
   }
 }
 
@@ -62,13 +84,27 @@ function harnessRoots(): string[] {
   return cachedRoots;
 }
 
-/** True when `child` is `parent` or sits underneath it. Segment-wise via
- *  `relative`, so a sibling directory whose name merely starts the same
- *  (`/code/tsforge-notes` next to `/code/tsforge`) is not a match. */
+/** True when `child` is `parent` or sits underneath it.
+ *
+ * Segment-wise, so a sibling whose name merely starts the same
+ * (`/code/tsforge-notes` next to `/code/tsforge`) is not a match, and a name
+ * that merely begins with two dots (`..notes.ts`) is not read as an escape.
+ * An ABSOLUTE result means no relative path exists at all — Windows returns one
+ * for a cross-drive pair — which is the opposite of containment. */
 function contains(parent: string, child: string): boolean {
   const rel = relative(parent, child);
 
-  return rel === "" || (!rel.startsWith("..") && !rel.startsWith("/"));
+  if (rel === "") {
+    return true;
+  }
+
+  if (isAbsolute(rel)) {
+    return false;
+  }
+
+  const segments = isWin32() ? rel.split(/[\\/]/u) : rel.split("/");
+
+  return !segments.includes("..");
 }
 
 /**
@@ -78,18 +114,22 @@ function contains(parent: string, child: string): boolean {
  * `file` may be absolute or relative to `cwd`; both resolve to the same answer.
  */
 export function isForeignHarnessRead(cwd: string, file: string): boolean {
+  const roots = harnessRoots();
   const target = resolve(cwd, file);
   const workspace = resolve(cwd);
 
-  return harnessRoots().some(
-    // Overlap in EITHER direction means the harness is the project in hand:
-    // the workspace may be the repo root, or a package inside it. Only a
-    // workspace disjoint from the harness is reaching outside its own work.
-    (root) =>
-      contains(root, target) &&
-      !contains(workspace, root) &&
-      !contains(root, workspace)
+  const insideHarness = roots.some((root) => contains(root, target));
+
+  // Overlap with ANY root, in EITHER direction, means the harness is the
+  // project in hand: the workspace may be the monorepo root, the shipped
+  // package, or a sibling package beside it. Asking this per-root and OR-ing
+  // the refusals instead would flag a sibling package, which is disjoint from
+  // `packages/core` while plainly being harness work.
+  const workingOnHarness = roots.some(
+    (root) => contains(workspace, root) || contains(root, workspace)
   );
+
+  return insideHarness && !workingOnHarness;
 }
 
 /** What to say instead of the file. The model reached for the source because
@@ -104,4 +144,33 @@ export function foreignHarnessReadRefusal(file: string): string {
     `guidance is the bug. Say so in your answer, take the closest correct ` +
     `approach the rule does allow, and leave the rule alone.`
   );
+}
+
+/** A shell token that looks like a filesystem path rather than a flag, an
+ *  operator, or a bare command name. */
+function isPathLike(token: string): boolean {
+  if (token === "" || token.startsWith("-")) {
+    return false;
+  }
+
+  return token.includes("/") || token.includes("\\");
+}
+
+/**
+ * The harness path a shell command would read, if any.
+ *
+ * `read` refusing while `cat` succeeds would be theatre — the same bytes, one
+ * door over. Every path-shaped token is checked, not just the ones belonging to
+ * known readers, because the argument order of an arbitrary command is not
+ * knowable and a token pointing INTO the harness has no other purpose here.
+ */
+export function foreignHarnessShellRead(
+  cwd: string,
+  command: string
+): string | null {
+  const tokens = command
+    .split(/[\s;|&<>()"']+/u)
+    .filter((token) => isPathLike(token));
+
+  return tokens.find((token) => isForeignHarnessRead(cwd, token)) ?? null;
 }

--- a/packages/core/src/lib/scope/harness-self.ts
+++ b/packages/core/src/lib/scope/harness-self.ts
@@ -1,0 +1,107 @@
+import { existsSync } from "node:fs";
+import { dirname, join, relative, resolve } from "node:path";
+
+/**
+ * Stop the harness reading its OWN implementation while it works on someone
+ * else's code.
+ *
+ * This is not a general sandbox — reads are otherwise unrestricted, and a path
+ * the user names stays readable. It closes one specific failure that was
+ * observed: a rule's guidance promised an escape hatch the rule did not have,
+ * the model could not satisfy the gate, and it went looking for the answer in
+ * tsforge's own source. That is never the fix. The rule's real behaviour has to
+ * reach the model through its feedback, and when it does not, reading the
+ * implementation only produces a workaround shaped around a bug.
+ *
+ * The exception that makes this safe: when the workspace IS the harness, every
+ * read is ordinary work. Developing tsforge with tsforge is the normal case
+ * here, so the check is about whether the harness source belongs to the project
+ * in hand, not about which files they are.
+ */
+
+/** The harness's own package root(s), computed once from this module's location.
+ *
+ * Walks up while ancestors keep declaring themselves packages, so both layouts
+ * are covered: an installed single package, and this monorepo, where
+ * `packages/core` and the repo root each carry a `package.json`. */
+function computeHarnessRoots(): string[] {
+  const roots: string[] = [];
+  let dir = import.meta.dir;
+
+  // Find the nearest package root.
+  while (!existsSync(join(dir, "package.json"))) {
+    const parent = dirname(dir);
+
+    if (parent === dir) {
+      return roots;
+    }
+
+    dir = parent;
+  }
+
+  roots.push(dir);
+
+  // Then keep climbing while the ancestors are packages too (a workspace root).
+  for (;;) {
+    const parent = dirname(dir);
+
+    if (parent === dir || !existsSync(join(parent, "package.json"))) {
+      return roots;
+    }
+
+    dir = parent;
+    roots.push(dir);
+  }
+}
+
+let cachedRoots: string[] | null = null;
+
+function harnessRoots(): string[] {
+  cachedRoots ??= computeHarnessRoots();
+
+  return cachedRoots;
+}
+
+/** True when `child` is `parent` or sits underneath it. Segment-wise via
+ *  `relative`, so a sibling directory whose name merely starts the same
+ *  (`/code/tsforge-notes` next to `/code/tsforge`) is not a match. */
+function contains(parent: string, child: string): boolean {
+  const rel = relative(parent, child);
+
+  return rel === "" || (!rel.startsWith("..") && !rel.startsWith("/"));
+}
+
+/**
+ * True when reading this path would open the harness's own source from a
+ * workspace that is not the harness.
+ *
+ * `file` may be absolute or relative to `cwd`; both resolve to the same answer.
+ */
+export function isForeignHarnessRead(cwd: string, file: string): boolean {
+  const target = resolve(cwd, file);
+  const workspace = resolve(cwd);
+
+  return harnessRoots().some(
+    // Overlap in EITHER direction means the harness is the project in hand:
+    // the workspace may be the repo root, or a package inside it. Only a
+    // workspace disjoint from the harness is reaching outside its own work.
+    (root) =>
+      contains(root, target) &&
+      !contains(workspace, root) &&
+      !contains(root, workspace)
+  );
+}
+
+/** What to say instead of the file. The model reached for the source because
+ *  the feedback it had was not enough, so pointing it back at the same feedback
+ *  is useless — this names the two things that ARE actionable. */
+export function foreignHarnessReadRefusal(file: string): string {
+  return (
+    `read: ${file} is tsforge's own source, not part of this workspace.\n` +
+    `Reading it cannot fix the task: the gate runs the rule as it is, so a ` +
+    `workaround shaped around the implementation still fails.\n` +
+    `If a rule's message and guidance are not enough to satisfy it, the ` +
+    `guidance is the bug. Say so in your answer, take the closest correct ` +
+    `approach the rule does allow, and leave the rule alone.`
+  );
+}

--- a/packages/core/src/lib/scope/index.ts
+++ b/packages/core/src/lib/scope/index.ts
@@ -1,2 +1,3 @@
 export * from "./scope";
 export * from "./scope.constants";
+export * from "./harness-self";

--- a/packages/core/src/loop/tools/file-ops.ts
+++ b/packages/core/src/loop/tools/file-ops.ts
@@ -4,7 +4,11 @@ import { applyEdits } from "../../files/edit";
 import type { EditsResult } from "../../files/files.types";
 import { applyCreate } from "../../files/create";
 import { EDIT_FAIL_REASON } from "../../files";
-import { normalizeWorkspacePath } from "../../lib/scope";
+import {
+  normalizeWorkspacePath,
+  isForeignHarnessRead,
+  foreignHarnessReadRefusal,
+} from "../../lib/scope";
 import { LOOP_LIMITS } from "../loop.constants";
 import { toEdits, toCreate, toRun, toRead, runCommand } from "../../agent";
 import { ruleHelpFromOutput } from "../feedback/rule-docs";
@@ -44,6 +48,18 @@ export async function readFile(
   }
 
   r.file = normalizeWorkspacePath(ctx.cwd, r.file);
+
+  // The one read the harness refuses: its own implementation, from a workspace
+  // that is not the harness. See `isForeignHarnessRead`.
+  if (isForeignHarnessRead(ctx.cwd, r.file)) {
+    ctx.report({
+      kind: "tool",
+      task: ctx.task,
+      message: `read ${r.file} — refused (harness source)`,
+    });
+
+    return foreignHarnessReadRefusal(r.file);
+  }
 
   ctx.report({ kind: "tool", task: ctx.task, message: `read ${r.file}` });
 

--- a/packages/core/src/loop/tools/file-ops.ts
+++ b/packages/core/src/loop/tools/file-ops.ts
@@ -8,6 +8,7 @@ import {
   normalizeWorkspacePath,
   isForeignHarnessRead,
   foreignHarnessReadRefusal,
+  foreignHarnessShellRead,
 } from "../../lib/scope";
 import { LOOP_LIMITS } from "../loop.constants";
 import { toEdits, toCreate, toRun, toRead, runCommand } from "../../agent";
@@ -501,6 +502,15 @@ export async function runShell(
     }
 
     return "run: malformed args (need `command`)";
+  }
+
+  // Same refusal as `read`. Leaving the shell open would make the read guard
+  // theatre: `cat`, `rg`, `sed` and friends fetch the same bytes one door over,
+  // and the plan-mode allowlist is made of exactly those commands.
+  const harnessPath = foreignHarnessShellRead(ctx.cwd, r.command);
+
+  if (harnessPath !== null) {
+    return reject(ctx, "run", foreignHarnessReadRefusal(harnessPath));
   }
 
   if (ctx.readOnly === true && !isReadOnlyCommand(r.command)) {

--- a/packages/core/tests/harness-self-read.test.ts
+++ b/packages/core/tests/harness-self-read.test.ts
@@ -1,9 +1,10 @@
 import { test, expect } from "bun:test";
-import { mkdtemp, rm, mkdir } from "node:fs/promises";
+import { mkdtemp, rm, mkdir, symlink } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";
 import {
   isForeignHarnessRead,
+  isForeignRead,
   foreignHarnessReadRefusal,
 } from "../src/lib/scope";
 import { readFile, runShell } from "../src/loop/tools/file-ops";
@@ -165,6 +166,67 @@ test("the read tool still reads an ordinary workspace file", async () => {
     const out = await readFile({ file: "src/a.ts" }, ctx(dir));
 
     expect(out).toContain("export const a = 1;");
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+/** The layout that matters most: tsforge as a dependency of the project being
+ *  worked on. Roots are injected so the real install location is irrelevant. */
+const INSTALLED = ["/proj/node_modules/tsforge"];
+
+test("an installed harness is refused from the consumer project", () => {
+  // The consumer workspace CONTAINS node_modules/tsforge. Counting that as
+  // harness development switched the guard off in the one scenario it exists
+  // for — a real project, with tsforge pulled in as a dependency.
+  expect(
+    isForeignRead(INSTALLED, "/proj", "/proj/node_modules/tsforge/src/cli.ts")
+  ).toBe(true);
+});
+
+test("an installed harness is refused from a subdirectory of the consumer", () => {
+  expect(
+    isForeignRead(
+      INSTALLED,
+      "/proj/src/features",
+      "/proj/node_modules/tsforge/src/cli.ts"
+    )
+  ).toBe(true);
+});
+
+test("a directory merely sitting above the harness is not harness work", () => {
+  // `~/Documents/Code` holds every project; running there does not make
+  // tsforge's source part of the task.
+  expect(
+    isForeignRead(["/code/tsforge"], "/code", "/code/tsforge/src/a.ts")
+  ).toBe(true);
+});
+
+test("the consumer's own files are untouched by an installed harness", () => {
+  expect(isForeignRead(INSTALLED, "/proj", "/proj/src/index.ts")).toBe(false);
+});
+
+test("working inside an installed copy still reads it", () => {
+  expect(
+    isForeignRead(
+      INSTALLED,
+      "/proj/node_modules/tsforge",
+      "/proj/node_modules/tsforge/src/cli.ts"
+    )
+  ).toBe(false);
+});
+
+test("a symlink into the harness is followed, not taken at face value", async () => {
+  const dir = await mkdtemp(join(tmpdir(), "tsforge-symlink-"));
+
+  try {
+    // A link inside the workspace resolves to the same bytes; comparing the
+    // link's own path would call it a workspace file.
+    await symlink(join(HARNESS_ROOT, "src"), join(dir, "peek"));
+
+    expect(isForeignHarnessRead(dir, "peek/loop/feedback/rule-docs.ts")).toBe(
+      true
+    );
   } finally {
     await rm(dir, { recursive: true, force: true });
   }

--- a/packages/core/tests/harness-self-read.test.ts
+++ b/packages/core/tests/harness-self-read.test.ts
@@ -6,12 +6,14 @@ import {
   isForeignHarnessRead,
   foreignHarnessReadRefusal,
 } from "../src/lib/scope";
-import { readFile } from "../src/loop/tools/file-ops";
+import { readFile, runShell } from "../src/loop/tools/file-ops";
 
 /** This test file lives inside the harness, so its own directory is a path the
  *  predicate must treat as harness source. */
 const HARNESS_FILE = "src/loop/feedback/rule-docs.ts";
 const HARNESS_ROOT = resolve(import.meta.dir, "..");
+/** The monorepo root — `packages/core` is only one of the harness's roots. */
+const REPO_ROOT = resolve(import.meta.dir, "..", "..", "..");
 
 function ctx(cwd: string) {
   return {
@@ -57,9 +59,74 @@ test("an ordinary project file is unaffected", () => {
 test("a sibling directory sharing the harness's name prefix is not harness source", () => {
   // `contains` compares segments: `/code/tsforge-notes` is not inside
   // `/code/tsforge`, and a prefix test would have wrongly refused it.
-  expect(isForeignHarnessRead("/tmp/other", `${HARNESS_ROOT}-notes/a.ts`)).toBe(
+  expect(isForeignHarnessRead("/tmp/other", `${REPO_ROOT}-notes/a.ts`)).toBe(
     false
   );
+});
+
+test("files at the monorepo root are harness source too", () => {
+  // `packages/` carries no manifest, so climbing "while ancestors are packages"
+  // stopped at packages/core and left the repo root readable.
+  expect(isForeignHarnessRead("/tmp/other", join(REPO_ROOT, "README.md"))).toBe(
+    true
+  );
+});
+
+test("a sibling package inside the monorepo may read the harness", () => {
+  // Disjoint from packages/core, but plainly harness work — the overlap test
+  // has to consider every root, not each one in isolation.
+  expect(
+    isForeignHarnessRead(
+      join(REPO_ROOT, "packages", "other"),
+      join(HARNESS_ROOT, HARNESS_FILE)
+    )
+  ).toBe(false);
+});
+
+test("the run tool refuses a shell command that reads the harness source", async () => {
+  const dir = await mkdtemp(join(tmpdir(), "tsforge-shell-read-"));
+
+  try {
+    const out = await runShell(
+      { command: `cat ${join(HARNESS_ROOT, HARNESS_FILE)}` },
+      ctx(dir)
+    );
+
+    expect(out).toContain("not part of this workspace");
+    expect(out).not.toContain("export function ruleHelp");
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test("the run tool refuses a grep into the harness source", async () => {
+  const dir = await mkdtemp(join(tmpdir(), "tsforge-shell-grep-"));
+
+  try {
+    const out = await runShell(
+      { command: `rg ruleHelp ${join(HARNESS_ROOT, "src")}` },
+      ctx(dir)
+    );
+
+    expect(out).toContain("not part of this workspace");
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test("the run tool still runs an ordinary workspace command", async () => {
+  const dir = await mkdtemp(join(tmpdir(), "tsforge-shell-ok-"));
+
+  try {
+    await mkdir(join(dir, "src"), { recursive: true });
+    await Bun.write(join(dir, "src", "a.ts"), "export const a = 1;\n");
+
+    const out = await runShell({ command: "cat src/a.ts" }, ctx(dir));
+
+    expect(out).toContain("export const a = 1;");
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
 });
 
 test("the refusal names what to do instead of reading the source", () => {

--- a/packages/core/tests/harness-self-read.test.ts
+++ b/packages/core/tests/harness-self-read.test.ts
@@ -1,0 +1,104 @@
+import { test, expect } from "bun:test";
+import { mkdtemp, rm, mkdir } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import {
+  isForeignHarnessRead,
+  foreignHarnessReadRefusal,
+} from "../src/lib/scope";
+import { readFile } from "../src/loop/tools/file-ops";
+
+/** This test file lives inside the harness, so its own directory is a path the
+ *  predicate must treat as harness source. */
+const HARNESS_FILE = "src/loop/feedback/rule-docs.ts";
+const HARNESS_ROOT = resolve(import.meta.dir, "..");
+
+function ctx(cwd: string) {
+  return {
+    cwd,
+    files: ["**/*"],
+    task: "t",
+    report: () => {
+      // The refusal is asserted through the returned text, not the transcript.
+    },
+  };
+}
+
+test("reading the harness's own source from another workspace is refused", () => {
+  expect(
+    isForeignHarnessRead(
+      "/tmp/some-other-project",
+      join(HARNESS_ROOT, HARNESS_FILE)
+    )
+  ).toBe(true);
+});
+
+test("the same read is allowed when the harness IS the workspace", () => {
+  // Developing tsforge with tsforge is the normal case here — its source is the
+  // project in hand, not an escape hatch out of a gate.
+  expect(isForeignHarnessRead(HARNESS_ROOT, HARNESS_FILE)).toBe(false);
+});
+
+test("a workspace nested inside the harness may still read it", () => {
+  expect(
+    isForeignHarnessRead(
+      join(HARNESS_ROOT, "src"),
+      join(HARNESS_ROOT, HARNESS_FILE)
+    )
+  ).toBe(false);
+});
+
+test("an ordinary project file is unaffected", () => {
+  expect(isForeignHarnessRead("/tmp/some-other-project", "src/index.ts")).toBe(
+    false
+  );
+});
+
+test("a sibling directory sharing the harness's name prefix is not harness source", () => {
+  // `contains` compares segments: `/code/tsforge-notes` is not inside
+  // `/code/tsforge`, and a prefix test would have wrongly refused it.
+  expect(isForeignHarnessRead("/tmp/other", `${HARNESS_ROOT}-notes/a.ts`)).toBe(
+    false
+  );
+});
+
+test("the refusal names what to do instead of reading the source", () => {
+  const message = foreignHarnessReadRefusal("src/rule-packs/x.ts");
+
+  // Pointing the model back at the feedback it already had is what fails; the
+  // refusal has to say the guidance is the bug and to report it.
+  expect(message).toContain("guidance is the bug");
+  expect(message.toLowerCase()).toContain("closest correct approach");
+});
+
+test("the read tool returns the refusal instead of the file's bytes", async () => {
+  const dir = await mkdtemp(join(tmpdir(), "tsforge-foreign-read-"));
+
+  try {
+    const out = await readFile(
+      { file: join(HARNESS_ROOT, HARNESS_FILE) },
+      ctx(dir)
+    );
+
+    expect(out).toContain("not part of this workspace");
+    // The real file opens with its imports; none of it may leak through.
+    expect(out).not.toContain("export function ruleHelp");
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test("the read tool still reads an ordinary workspace file", async () => {
+  const dir = await mkdtemp(join(tmpdir(), "tsforge-ordinary-read-"));
+
+  try {
+    await mkdir(join(dir, "src"), { recursive: true });
+    await Bun.write(join(dir, "src", "a.ts"), "export const a = 1;\n");
+
+    const out = await readFile({ file: "src/a.ts" }, ctx(dir));
+
+    expect(out).toContain("export const a = 1;");
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
## What

`read` now refuses one specific path: tsforge's own source, and only when the workspace is disjoint from it.

## Why

This is the root cause of the incident that started the rule-docs work. `no-user-controlled-fetch-url`'s guidance promised an "allowlisted URL builder" the rule never had. The model could not satisfy the gate, so it went looking for the answer in the harness's own source — while working on an unrelated project.

Reading the implementation is never the fix. The gate runs the rule as it is, so a workaround shaped around the code still fails, and the budget goes on a codebase nobody asked to change.

## What this is not

Not a sandbox. Every other path still reads — other repos, siblings, absolute or relative, whatever you name. Only the harness's own package roots are refused.

Developing tsforge with tsforge is unaffected: overlap in either direction (workspace inside the harness, or the harness inside the workspace) means the source is the project in hand.

## The refusal message

Pointing the model back at the feedback it already had is useless — insufficient feedback is *why* it reached for the source. The refusal instead names the guidance as the bug, asks for that to be reported, and points at the closest correct approach the rule does allow.

## Not answered here

General read scoping — an allowlist of roots covering everything outside the workspace — is a larger question with real workflow cost (sibling repos, node_modules, configs). This change deliberately does not decide it.

## Tests

8 tests: refusal from a foreign workspace, both dogfooding directions, ordinary project files, the `tsforge-notes` prefix case, the refusal's content, and both read-tool paths end to end.