### PR TITLE
feat(self-harness): unstarve the loop — valid proposals, paper repeats, tool wiring

### DIFF
--- a/packages/core/scripts/self-harness-campaign.ts
+++ b/packages/core/scripts/self-harness-campaign.ts
@@ -16,7 +16,7 @@
 // traffic is sequential (single-connection endpoint).
 //
 // Run:  bun packages/core/scripts/self-harness-campaign.ts
-//         [--max-sessions N] [--proof-every 3] [--rounds 3] [--width 3]
+//         [--max-sessions N] [--proof-every 3] [--rounds 3] [--width 3] [--repeats 2]
 // Stop: touch evals/self-harness/campaign/STOP  (in-flight session finishes)
 import { mkdir, rename } from "node:fs/promises";
 import { existsSync } from "node:fs";
@@ -71,6 +71,9 @@ const maxSessions = Number(argValue("max-sessions") ?? "1000");
 const proofEvery = Number(argValue("proof-every") ?? "3");
 const rounds = argValue("rounds") ?? "3";
 const width = argValue("width") ?? "3";
+// Mining repeats. Matches the proof split's 2 so a session verdict and the
+// campaign's own exam are measured on the same footing.
+const repeats = argValue("repeats") ?? "2";
 // Concurrent mining sessions per batch. The endpoint batches up to 10 seqs on
 // recipe-stock config; 2 leaves headroom for the human user's own coding.
 const parallel = Math.max(
@@ -389,6 +392,10 @@ async function runSession(index: number): Promise<ISessionOutcome> {
     rounds,
     "--width",
     width,
+    // Explicit rather than inherited: the proof split is measured at 2, and a
+    // mining session judged at a different repeat count is not comparable to it.
+    "--repeats",
+    repeats,
     "--held-in",
     rotation.heldIn,
     "--held-out",

--- a/packages/core/scripts/self-harness-campaign.ts
+++ b/packages/core/scripts/self-harness-campaign.ts
@@ -27,13 +27,18 @@ import { resolveActiveModel, resolveApiKey } from "../src/models-config";
 import { providerConfig } from "../src/cli";
 import {
   evaluateHarness,
+  installOverlay,
+  overlayPathFor,
+  promotionVerdict,
+  regressed,
+  revertOverlay,
   parseOverlay,
   isEmptyPatch,
   mergeOverlay,
   emptyOverlay,
   type IHarnessOverlay,
 } from "../src/self-harness";
-import type { IRunRecord } from "../src/eval";
+import type { IRunRecord, ISweepReport } from "../src/eval";
 import { buildSweepReport, renderSweepReportMarkdown } from "../src/eval";
 import { isRecord } from "../src/lib/guards";
 
@@ -338,6 +343,57 @@ async function writeProof(
 
   await Bun.write(proofPath, md);
   say(`proof → ${proofPath}`);
+
+  await settlePromotion(report, overlay, sessionsDone);
+}
+
+/**
+ * Act on the proof measurement: install, roll back, or leave live use alone.
+ *
+ * This is the only place the campaign touches `~/.tsforge`. Everything before
+ * it operates on the campaign's own overlay, so a run that never clears the bar
+ * cannot change what the human's interactive sessions use.
+ */
+async function settlePromotion(
+  report: ISweepReport,
+  overlay: IHarnessOverlay,
+  sessionsDone: number
+): Promise<void> {
+  const live = overlayPathFor(entry.model);
+  const installed = existsSync(live);
+
+  if (installed) {
+    const { yes, reason } = regressed(report);
+
+    if (yes) {
+      const restored = await revertOverlay(entry.model);
+
+      await appendLog(
+        `| — | ${now()} | ROLLBACK | — | — | installed overlay regressed on the proof split (${reason}); ${restored ? "restored the previous overlay" : "removed it — base harness"}; campaign halted |`
+      );
+      say(`ROLLBACK: ${reason} — halting`);
+      await Bun.write(stopFile, "");
+
+      return;
+    }
+  }
+
+  const { promote, reason } = promotionVerdict(report);
+
+  if (!promote) {
+    say(`promotion withheld: ${reason}`);
+    await appendLog(
+      `| — | ${now()} | proof after ${String(sessionsDone)} session(s) | — | — | not promoted: ${reason} |`
+    );
+
+    return;
+  }
+
+  await installOverlay(entry.model, overlay);
+  say(`PROMOTED → ${live} (${reason})`);
+  await appendLog(
+    `| — | ${now()} | proof after ${String(sessionsDone)} session(s) | — | — | PROMOTED to live use: ${reason} |`
+  );
 }
 
 interface ISessionOutcome {

--- a/packages/core/scripts/self-harness-campaign.ts
+++ b/packages/core/scripts/self-harness-campaign.ts
@@ -452,6 +452,9 @@ async function runSession(index: number): Promise<ISessionOutcome> {
     // mining session judged at a different repeat count is not comparable to it.
     "--repeats",
     repeats,
+    // Mine the model's own build logs alongside the corpus. The corpus is the
+    // measuring instrument; real work is where the failures are.
+    "--build-logs",
     "--held-in",
     rotation.heldIn,
     "--held-out",

--- a/packages/core/scripts/self-harness.ts
+++ b/packages/core/scripts/self-harness.ts
@@ -6,14 +6,16 @@
 //
 // Run:  bun packages/core/scripts/self-harness.ts [--rounds 3] [--width 3]
 //         [--repeats 2] [--held-in a,b,..] [--held-out c,d,..]
-//         [--dry-run] [--no-judge]
+//         [--dry-run] [--no-judge] [--build-logs [dir]] [--build-logs-limit 40]
 // Judge override (else the active model judges): TSFORGE_JUDGE_URL/MODEL/KEY.
 import { mkdir } from "node:fs/promises";
 import { join } from "node:path";
+import { homedir } from "node:os";
 import { OpenAICompatibleProvider } from "../src/inference";
 import { resolveActiveModel, resolveApiKey } from "../src/models-config";
 import { providerConfig } from "../src/cli";
 import {
+  buildEvidenceFrom,
   emitReport,
   evaluateHarness,
   mineWeaknesses,
@@ -68,6 +70,17 @@ const repeats = Number(argValue("repeats") ?? "2");
 const dryRun = hasFlag("dry-run");
 const useJudge = !hasFlag("no-judge");
 const initialOverlayPath = argValue("initial-overlay");
+// Mine the model's OWN build logs alongside the corpus. `--build-logs` with no
+// value means the default log directory; omit the flag entirely for
+// corpus-only evidence (the paper's setup).
+const buildLogsRaw = argValue("build-logs");
+const buildLogsDir = hasFlag("build-logs")
+  ? (buildLogsRaw ?? join(homedir(), ".tsforge", "logs"))
+  : undefined;
+// Newest N logs. This is also what keeps the evidence current: as new builds
+// land they push older ones out, so a campaign that has already fixed something
+// stops mining the failures it fixed.
+const buildEvidenceLimit = Number(argValue("build-logs-limit") ?? "40");
 
 /** Continue a lineage: start from a previous session's accepted overlay so
  *  improvements COMPOUND across sessions. Fails loudly on a bad path/file —
@@ -380,6 +393,12 @@ const lineage = await runSelfHarness({
   provider,
   evaluator,
   ...(initialOverlay === undefined ? {} : { initialOverlay }),
+  ...(buildLogsDir === undefined
+    ? {}
+    : {
+        extraEvidence: () =>
+          buildEvidenceFrom(buildLogsDir, { limit: buildEvidenceLimit }),
+      }),
   waitHealthy,
   log: say,
 });

--- a/packages/core/scripts/self-harness.ts
+++ b/packages/core/scripts/self-harness.ts
@@ -5,7 +5,7 @@
 // is auto-installed.
 //
 // Run:  bun packages/core/scripts/self-harness.ts [--rounds 3] [--width 3]
-//         [--repeats 1] [--held-in a,b,..] [--held-out c,d,..]
+//         [--repeats 2] [--held-in a,b,..] [--held-out c,d,..]
 //         [--dry-run] [--no-judge]
 // Judge override (else the active model judges): TSFORGE_JUDGE_URL/MODEL/KEY.
 import { mkdir } from "node:fs/promises";
@@ -60,7 +60,11 @@ function stamp(): string {
 
 const rounds = Number(argValue("rounds") ?? "3");
 const width = Number(argValue("width") ?? "3");
-const repeats = Number(argValue("repeats") ?? "1");
+// Two, matching the paper: "Pass (%) computed over two repeated attempts for
+// each harness candidate". At one attempt a single flaky task is
+// indistinguishable from a real gain, and the acceptance rule compares integer
+// pass counts — so noise reads as signal in both directions.
+const repeats = Number(argValue("repeats") ?? "2");
 const dryRun = hasFlag("dry-run");
 const useJudge = !hasFlag("no-judge");
 const initialOverlayPath = argValue("initial-overlay");

--- a/packages/core/src/inference/inference.types.ts
+++ b/packages/core/src/inference/inference.types.ts
@@ -88,7 +88,33 @@ export interface ICompleteOptions {
   signal?: AbortSignal;
   /** TTSR watcher for stream-interrupting rules (wired by the loop, not the provider). */
   ttsrManager?: ITtsrWatcher;
+  /**
+   * Constrain the reply to JSON — `json_object` for "valid JSON", or
+   * `json_schema` to pin the SHAPE as well. Runtimes that support it (vLLM,
+   * SGLang, OpenAI) enforce this during decoding, so the answer parses by
+   * construction rather than by luck.
+   *
+   * The self-harness proposer needs this: asking DeepSeek for "a JSON patch,
+   * no prose" lost 4 of 6 candidates to `unparseable proposer response`, which
+   * silently cut the paper's proposal width K from 3 to 1.
+   *
+   * Endpoints that do not understand the field ignore it, so a caller must
+   * still handle a non-JSON reply.
+   */
+  responseFormat?: IResponseFormat;
 }
+
+/** How a reply is constrained. `schema` is an opaque JSON Schema — the shape
+ *  belongs to the caller, and the inference layer only forwards it. */
+export type IResponseFormat =
+  | { readonly type: "json_object" }
+  | {
+      readonly type: "json_schema";
+      readonly name: string;
+      readonly schema: unknown;
+      /** Reject anything the schema does not allow, rather than best-effort. */
+      readonly strict?: boolean;
+    };
 
 /** Structural view of the loop's TtsrManager — keeps the inference layer free of
  *  a hard dependency on loop internals while staying fully typed. */

--- a/packages/core/src/inference/inference.types.ts
+++ b/packages/core/src/inference/inference.types.ts
@@ -199,3 +199,39 @@ export interface IOpenAICompatibleConfig {
   /** Injectable for tests; defaults to global fetch. */
   fetch?: typeof fetch;
 }
+
+/**
+ * A model endpoint answered with an HTTP error.
+ *
+ * Carries the status so callers can tell a PERMANENT rejection (a malformed or
+ * unsupported request — retrying changes nothing) from a transient one. Before
+ * this existed, a 400 was an ordinary Error and the loop retried it like a
+ * blip: vLLM's V2 runner rejecting `thinking_token_budget` turned every
+ * from-scratch build into nine silent no-op turns that read as the model
+ * refusing to work.
+ */
+export class ModelRequestError extends Error {
+  readonly status: number;
+  /** The server's own explanation, which usually names the offending field. */
+  readonly detail: string;
+
+  constructor(status: number, detail: string) {
+    super(
+      `model request failed: ${String(status)}${detail.length > 0 ? ` ${detail}` : ""}`
+    );
+    this.name = "ModelRequestError";
+    this.status = status;
+    this.detail = detail;
+  }
+
+  /** 4xx means the request itself is wrong — except 408/429, which are the
+   *  server asking for the same request again later. */
+  get isPermanent(): boolean {
+    return (
+      this.status >= 400 &&
+      this.status < 500 &&
+      this.status !== 408 &&
+      this.status !== 429
+    );
+  }
+}

--- a/packages/core/src/inference/openai-compatible.ts
+++ b/packages/core/src/inference/openai-compatible.ts
@@ -5,6 +5,7 @@ import type {
   IProvider,
   IOpenAICompatibleConfig,
 } from "./inference.types";
+import { ModelRequestError } from "./inference.types";
 import { PROVIDER_LIMITS } from "./inference.constants";
 import { fetchWithRetry } from "./transport";
 import { parseResponse } from "./wire";
@@ -81,6 +82,28 @@ export class OpenAICompatibleProvider implements IProvider {
     messages: IChatMessage[],
     opts: ICompleteOptions = {}
   ): Promise<IModelResponse> {
+    try {
+      return await this.send(messages, opts);
+    } catch (err) {
+      // An endpoint that rejects ONE optional field would otherwise fail every
+      // call for the life of the process. vLLM's V2 model runner does exactly
+      // this with `thinking_token_budget`, which the scratch path sets by
+      // default — so every from-scratch build 400s, and (before this) each
+      // failure looked like the model simply saying nothing.
+      const retry = withoutUnsupportedField(opts, err);
+
+      if (retry === null) {
+        throw err;
+      }
+
+      return await this.send(messages, retry);
+    }
+  }
+
+  private async send(
+    messages: IChatMessage[],
+    opts: ICompleteOptions
+  ): Promise<IModelResponse> {
     const effectiveOpts = this.withPinnedThinking(opts);
     const doFetch = this.cfg.fetch ?? fetch;
     const streaming = effectiveOpts.onToken !== undefined;
@@ -107,11 +130,7 @@ export class OpenAICompatibleProvider implements IProvider {
     );
 
     if (!res.ok) {
-      const detail = await responseDetail(res);
-
-      throw new Error(
-        `model request failed: ${res.status}${detail.length > 0 ? ` ${detail}` : ""}`
-      );
+      throw new ModelRequestError(res.status, await responseDetail(res));
     }
 
     if (effectiveOpts.onToken !== undefined) {
@@ -126,6 +145,57 @@ export class OpenAICompatibleProvider implements IProvider {
 
     return parseResponse(data);
   }
+}
+
+/** Optional request fields, paired with the option that produces them, so a
+ *  "not supported" rejection can be answered by dropping just that one. */
+const OPTIONAL_FIELDS: readonly {
+  wire: string;
+  option: keyof ICompleteOptions;
+}[] = [
+  { wire: "thinking_token_budget", option: "thinkingTokenBudget" },
+  { wire: "response_format", option: "responseFormat" },
+  { wire: "reasoning_effort", option: "reasoningEffort" },
+];
+
+/**
+ * The same options minus one field the server just said it does not support,
+ * or null when this error is not that.
+ *
+ * Deliberately narrow: only a 4xx that NAMES a field we sent, and only fields
+ * that are optimisations rather than instructions. Retrying blind would hide
+ * real request errors; dropping `messages` or `tools` would silently change
+ * what was asked.
+ */
+function withoutUnsupportedField(
+  opts: ICompleteOptions,
+  err: unknown
+): ICompleteOptions | null {
+  if (!(err instanceof ModelRequestError) || !err.isPermanent) {
+    return null;
+  }
+
+  const detail = err.detail.toLowerCase();
+  const offending = OPTIONAL_FIELDS.find(
+    (f) =>
+      opts[f.option] !== undefined &&
+      detail.includes(f.wire) &&
+      (detail.includes("not supported") ||
+        detail.includes("unsupported") ||
+        detail.includes("not yet supported") ||
+        detail.includes("unrecognized") ||
+        detail.includes("unknown"))
+  );
+
+  if (offending === undefined) {
+    return null;
+  }
+
+  // Rebuilt without the key rather than deleted, so the retry carries exactly
+  // the fields we still intend to send.
+  return Object.fromEntries(
+    Object.entries(opts).filter(([key]) => key !== offending.option)
+  );
 }
 
 async function responseDetail(res: Response): Promise<string> {

--- a/packages/core/src/inference/request.ts
+++ b/packages/core/src/inference/request.ts
@@ -334,10 +334,37 @@ export function buildRequestBody(
       ? {}
       : { repetition_penalty: cfg.repetitionPenalty }),
     ...toolsBlock(cfg, opts),
+    ...responseFormatBlock(opts),
     ...(streaming
       ? { stream: true, stream_options: { include_usage: true } }
       : {}),
     ...(cfg.extraBody ?? {}),
+  };
+}
+
+/** Wire form of {@link IResponseFormat}. Written ahead of `extraBody` so a
+ *  per-model override can still replace it for an endpoint with its own
+ *  spelling (some want `guided_json` instead). */
+function responseFormatBlock(opts: ICompleteOptions): Record<string, unknown> {
+  const format = opts.responseFormat;
+
+  if (format === undefined) {
+    return {};
+  }
+
+  if (format.type === "json_object") {
+    return { response_format: { type: "json_object" } };
+  }
+
+  return {
+    response_format: {
+      type: "json_schema",
+      json_schema: {
+        name: format.name,
+        schema: format.schema,
+        ...(format.strict === undefined ? {} : { strict: format.strict }),
+      },
+    },
   };
 }
 

--- a/packages/core/src/inference/stream.ts
+++ b/packages/core/src/inference/stream.ts
@@ -5,6 +5,7 @@ import type {
   ITtsrWatcher,
   TokenChannel,
 } from "./inference.types";
+import { ModelRequestError } from "./inference.types";
 import { isArray, isRecord } from "../lib/guards";
 import {
   parseArgs,
@@ -226,6 +227,22 @@ function assemble(acc: IStreamAcc, degenerated: boolean): IModelResponse {
   };
 }
 
+/** Raise a stream-borne error, preserving the server's own status code so a
+ *  caller can tell a permanent rejection from a transient one. */
+function throwIfStreamError(parsed: Record<string, unknown>): void {
+  const error = parsed.error;
+
+  if (!isRecord(error)) {
+    return;
+  }
+
+  const message =
+    typeof error.message === "string" ? error.message : JSON.stringify(error);
+  const status = typeof error.code === "number" ? error.code : 502;
+
+  throw new ModelRequestError(status, message);
+}
+
 function parseSseLine(line: string): IStreamDelta | null {
   const trimmed = line.trim();
 
@@ -250,6 +267,14 @@ function parseSseLine(line: string): IStreamDelta | null {
   if (!isRecord(parsed)) {
     return null;
   }
+
+  // An SSE stream can carry a SERVER ERROR with a 200 status: vLLM answers a
+  // rejected parameter with `data: {"error": {...}}` and then `[DONE]`.
+  // Ignoring it produced the worst possible outcome — an empty completion that
+  // reads as "the model chose to say nothing", so the loop retried the same
+  // doomed request for its whole turn budget and the task failed as if the
+  // model could not do the work. Every such error must surface as an error.
+  throwIfStreamError(parsed);
 
   // The trailing usage chunk has an empty `choices` array — capture its usage
   // even though there's no delta to forward.

--- a/packages/core/src/loop/model-call.ts
+++ b/packages/core/src/loop/model-call.ts
@@ -7,7 +7,14 @@ import { READ_ONLY_TOOL_NAMES, TOOL_NAME } from "../agent";
 
 /** The minimal shape shared by advertised tools and MCP tool schemas. */
 interface INamedTool {
-  readonly function: { readonly name: string };
+  readonly function: { readonly name: string; readonly description?: string };
+}
+
+/** One harness-overlay edit to how an EXISTING tool is offered. */
+interface IToolWiring {
+  readonly id: string;
+  readonly description?: string;
+  readonly enabled?: boolean;
 }
 
 /**
@@ -47,7 +54,8 @@ export function selectThinking(opts: {
 export function offeredToolsFor<T extends INamedTool, U extends INamedTool>(
   tools: readonly T[],
   planMode: boolean,
-  mcpSchemas: readonly U[]
+  mcpSchemas: readonly U[],
+  wiring: readonly IToolWiring[] = []
 ): (T | U)[] {
   const base = planMode
     ? tools.filter(
@@ -57,5 +65,52 @@ export function offeredToolsFor<T extends INamedTool, U extends INamedTool>(
       )
     : [...tools];
 
-  return mcpSchemas.length > 0 ? [...base, ...mcpSchemas] : base;
+  const offered = mcpSchemas.length > 0 ? [...base, ...mcpSchemas] : base;
+
+  return wiring.length > 0 ? applyToolWiring(offered, wiring) : offered;
+}
+
+/**
+ * Apply the overlay's tool edits to the offered set.
+ *
+ * The paper puts `tools` in the editable harness file while holding the TOOL
+ * SET itself constant across variants, and that asymmetry is the whole safety
+ * story here: this can hide a tool or reword how one is described, never
+ * introduce one. An id that names no offered tool does nothing — there is no
+ * path by which a name grants capability.
+ *
+ * Hiding a tool the model needs is allowed and self-correcting: the pass rate
+ * falls, the acceptance rule rejects the edit. That is the loop working, not a
+ * hole in it.
+ */
+function applyToolWiring<T extends INamedTool>(
+  offered: readonly T[],
+  wiring: readonly IToolWiring[]
+): T[] {
+  const byId = new Map(wiring.map((w) => [w.id, w]));
+  const result: T[] = [];
+
+  for (const tool of offered) {
+    const edit = byId.get(tool.function.name);
+
+    if (edit === undefined) {
+      result.push(tool);
+      continue;
+    }
+
+    if (edit.enabled === false) {
+      continue;
+    }
+
+    result.push(
+      edit.description === undefined
+        ? tool
+        : {
+            ...tool,
+            function: { ...tool.function, description: edit.description },
+          }
+    );
+  }
+
+  return result;
 }

--- a/packages/core/src/loop/session.ts
+++ b/packages/core/src/loop/session.ts
@@ -60,6 +60,7 @@ import type { TtsrManager } from "./ttsr";
 import { initTtsrManager, applyTtsrInterrupt } from "./ttsr-init";
 import { assistantMessage } from "./assistant-message";
 import { selectThinking, offeredToolsFor } from "./model-call";
+import { activeOverlay } from "../self-harness/overlay";
 import {
   mineLessons,
   consolidate as consolidateMemory,
@@ -1642,7 +1643,8 @@ export class Session {
     const offeredTools = offeredToolsFor(
       this.tools,
       this.planMode,
-      this.ctx.tool.mcpRegistry?.toolSchemas() ?? []
+      this.ctx.tool.mcpRegistry?.toolSchemas() ?? [],
+      activeOverlay()?.toolOverrides ?? []
     );
     const callStart = performance.now();
     let firstTokenAt = 0;

--- a/packages/core/src/self-harness/build-evidence.ts
+++ b/packages/core/src/self-harness/build-evidence.ts
@@ -1,0 +1,207 @@
+import { readdir } from "node:fs/promises";
+import { basename, join } from "node:path";
+import type { ILoopEvent } from "../loop";
+import { isRecord } from "../lib/guards";
+import type { IMinedRun } from "./mine";
+
+/**
+ * Turn REAL build logs into mining evidence.
+ *
+ * The acceptance rule needs repeatable tasks — you cannot measure a delta
+ * against a build that happens once — so the fixed corpus stays the measuring
+ * instrument. But nothing says the EVIDENCE has to come from the same place.
+ * A corpus that the model passes 8/8 has nothing left to teach it, while the
+ * real work it does every day is full of failures worth mining.
+ *
+ * So: real builds say what is going wrong, the corpus decides whether a
+ * proposed fix actually helps. The paper's rigor is in the second half, and
+ * this leaves it untouched.
+ */
+
+/** A build's slow-green threshold. Real builds run far longer than corpus
+ *  tasks, so a green one is only worth mining when it took much longer than a
+ *  build of that kind should. */
+export const BUILD_SLOW_THRESHOLD = 40;
+
+/**
+ * Parse one JSONL run log into the events mining reads.
+ *
+ * Two writers produce these logs: a flat one (`{kind, message, …}`) and the
+ * typed ledger, which nests the real fields under `payload` and names the
+ * discriminant `type`. Reading only the flat shape would silently mine nothing
+ * from half the logs — the same class of quiet-wrong-answer this whole session
+ * has been about.
+ *
+ * The event is rebuilt field by field rather than asserted, so what mining sees
+ * is only what was actually present. Malformed lines are skipped: a log
+ * truncated by a crash is still evidence, and the crash is often the thing
+ * worth mining.
+ */
+export function parseEventLog(text: string): ILoopEvent[] {
+  const events: ILoopEvent[] = [];
+
+  for (const line of text.split("\n")) {
+    if (line.trim().length === 0) {
+      continue;
+    }
+
+    const event = parseEventLine(line);
+
+    if (event !== null) {
+      events.push(event);
+    }
+  }
+
+  return events;
+}
+
+function parseEventLine(line: string): ILoopEvent | null {
+  let parsed: unknown;
+
+  try {
+    parsed = JSON.parse(line);
+  } catch {
+    return null;
+  }
+
+  if (!isRecord(parsed)) {
+    return null;
+  }
+
+  // The typed ledger writes `{type, payload:{…}}`; payload wins, since it holds
+  // the event's real fields.
+  const rec: Record<string, unknown> = isRecord(parsed.payload)
+    ? { ...parsed, ...parsed.payload }
+    : parsed;
+  const kind = typeof rec.kind === "string" ? rec.kind : rec.type;
+
+  if (typeof kind !== "string" || !isEventKind(kind)) {
+    return null;
+  }
+
+  return {
+    kind,
+    task: typeof rec.task === "string" ? rec.task : "session",
+    message: typeof rec.message === "string" ? rec.message : "",
+    ...(typeof rec.passed === "boolean" ? { passed: rec.passed } : {}),
+    ...(isStringArray(rec.rules) ? { rules: rec.rules } : {}),
+  };
+}
+
+/** The event kinds mining and the pass check actually read. Anything else is a
+ *  token/timing/usage line that classification ignores, so dropping it costs
+ *  nothing and keeps the reconstruction honest about what it knows. */
+const MINED_KINDS = new Set([
+  "cycle",
+  "validated",
+  "tool",
+  "repair",
+  "stuck",
+  "done",
+  "fix",
+  "reverted",
+  "edit",
+  "create",
+]);
+
+function isEventKind(kind: string): kind is ILoopEvent["kind"] {
+  return MINED_KINDS.has(kind);
+}
+
+function isStringArray(value: unknown): value is string[] {
+  return Array.isArray(value) && value.every((v) => typeof v === "string");
+}
+
+/**
+ * Did this run end green?
+ *
+ * The LAST terminal event decides. A multi-task build emits `done` per task, so
+ * counting `done` events would call a run green that finished its first task
+ * and then got stuck on the second — exactly the run most worth mining.
+ */
+export function runPassed(events: readonly ILoopEvent[]): boolean {
+  for (let i = events.length - 1; i >= 0; i -= 1) {
+    const kind = events[i]?.kind;
+
+    if (kind === "done") {
+      return true;
+    }
+
+    if (kind === "stuck") {
+      return false;
+    }
+  }
+
+  return false;
+}
+
+/** A log with no model turns never got started — an endpoint that was down, or
+ *  a run killed on launch. Mining it would manufacture a failure pattern out of
+ *  an infrastructure problem, which is the one thing the campaign's guards
+ *  exist to prevent. */
+function hasRealWork(events: readonly ILoopEvent[]): boolean {
+  return events.some((e) => e.kind === "cycle");
+}
+
+export interface IBuildEvidenceOptions {
+  /** Ignore logs older than this (ms since epoch). A campaign should mine what
+   *  the CURRENT harness did, not what a harness three overlays ago did. */
+  readonly since?: number;
+  /** Cap on how many logs to read, newest first. */
+  readonly limit?: number;
+  readonly slowThreshold?: number;
+}
+
+/**
+ * Read a directory of `*.jsonl` run logs as mining evidence, newest first.
+ *
+ * The task id is the log's filename, which is what the report will show as the
+ * source of a mined pattern — so a human reading `report.md` can open the exact
+ * run the proposer was reacting to.
+ */
+export async function buildEvidenceFrom(
+  logsDir: string,
+  opts: IBuildEvidenceOptions = {}
+): Promise<IMinedRun[]> {
+  let names: string[];
+
+  try {
+    names = (await readdir(logsDir)).filter((n) => n.endsWith(".jsonl"));
+  } catch {
+    return [];
+  }
+
+  // Filenames are timestamp-prefixed, so a lexical sort is newest-last.
+  names.sort();
+  names.reverse();
+
+  const runs: IMinedRun[] = [];
+
+  for (const name of names) {
+    if (opts.limit !== undefined && runs.length >= opts.limit) {
+      break;
+    }
+
+    const path = join(logsDir, name);
+    const file = Bun.file(path);
+
+    if (opts.since !== undefined && file.lastModified < opts.since) {
+      continue;
+    }
+
+    const events = parseEventLog(await file.text());
+
+    if (!hasRealWork(events)) {
+      continue;
+    }
+
+    runs.push({
+      taskId: basename(name, ".jsonl"),
+      passed: runPassed(events),
+      events,
+      slowThreshold: opts.slowThreshold ?? BUILD_SLOW_THRESHOLD,
+    });
+  }
+
+  return runs;
+}

--- a/packages/core/src/self-harness/index.ts
+++ b/packages/core/src/self-harness/index.ts
@@ -39,3 +39,10 @@ export {
   revertOverlay,
   previousPath,
 } from "./promote";
+export {
+  buildEvidenceFrom,
+  parseEventLog,
+  runPassed,
+  BUILD_SLOW_THRESHOLD,
+  type IBuildEvidenceOptions,
+} from "./build-evidence";

--- a/packages/core/src/self-harness/index.ts
+++ b/packages/core/src/self-harness/index.ts
@@ -32,3 +32,10 @@ export {
 } from "./validate";
 export { runSelfHarness, type ISelfHarnessOptions } from "./loop";
 export { emitReport, type IReport } from "./report";
+export {
+  promotionVerdict,
+  regressed,
+  installOverlay,
+  revertOverlay,
+  previousPath,
+} from "./promote";

--- a/packages/core/src/self-harness/loop.ts
+++ b/packages/core/src/self-harness/loop.ts
@@ -11,7 +11,7 @@
  * automatic.
  */
 import { emptyOverlay, isEmptyPatch, mergeOverlay } from "./overlay";
-import { mineWeaknesses } from "./mine";
+import { mineWeaknesses, type IMinedRun } from "./mine";
 import { propose } from "./propose";
 import { validateCandidate, type HarnessEvaluator } from "./validate";
 import type { IProvider } from "../inference";
@@ -36,6 +36,19 @@ export interface ISelfHarnessOptions {
   readonly evaluator: HarnessEvaluator;
   /** Start from an already-promoted overlay to continue a lineage. */
   readonly initialOverlay?: IHarnessOverlay;
+  /**
+   * Extra mining evidence from REAL runs — the model's own build logs, rather
+   * than corpus tasks.
+   *
+   * A corpus the model passes 8/8 has nothing left to teach it, while the work
+   * it does every day is full of failures worth mining. This only widens what
+   * the proposer SEES; the corpus splits still decide accept/reject, because a
+   * one-off build cannot measure a delta.
+   *
+   * Re-read each round: a long campaign should mine what the current harness
+   * is doing now, not a snapshot from before its first accepted edit.
+   */
+  readonly extraEvidence?: () => Promise<readonly IMinedRun[]>;
   /** Await endpoint recovery before retrying an errored baseline — without
    *  this the retry fires straight into the same outage and the session
    *  aborts for weather it could have waited out. */
@@ -53,6 +66,27 @@ function attemptSummary(result: IValidationResult): string {
   const { candidate } = result;
 
   return `${candidate.id} (${result.accepted ? "ACCEPTED" : "rejected"}): targets ${candidate.audit.targetPattern} via ${candidate.audit.surface} — ${candidate.audit.expectedEffect} [Δin=${String(result.deltaIn)}, Δho=${String(result.deltaOut)}: ${result.reason}]`;
+}
+
+/** Pull in the model's own build logs as extra mining evidence, announcing what
+ *  arrived so a report reader can tell corpus-mined patterns from build-mined
+ *  ones. */
+async function realBuildEvidence(
+  opts: ISelfHarnessOptions,
+  round: number,
+  log: (line: string) => void
+): Promise<readonly IMinedRun[]> {
+  const runs = (await opts.extraEvidence?.()) ?? [];
+
+  if (runs.length > 0) {
+    const failed = runs.filter((r) => !r.passed).length;
+
+    log(
+      `round ${String(round)}: ${String(runs.length)} real build run(s) as evidence (${String(failed)} failed)`
+    );
+  }
+
+  return runs;
 }
 
 export async function runSelfHarness(
@@ -102,11 +136,14 @@ export async function runSelfHarness(
       `round ${String(t)}: baseline pass held-in ${String(base.evaluation.heldIn.passed)}/${String(base.evaluation.heldIn.runs)}, held-out ${String(base.evaluation.heldOut.passed)}/${String(base.evaluation.heldOut.runs)}`
     );
 
-    const evidence = mineWeaknesses(base.heldInRuns);
+    const evidence = mineWeaknesses([
+      ...base.heldInRuns,
+      ...(await realBuildEvidence(opts, t, log)),
+    ]);
 
     if (evidence.patterns.length === 0) {
       notes.push(
-        `round ${String(t)}: no held-in failures to mine — loop stops early`
+        `round ${String(t)}: no failures to mine (held-in green, no build evidence) — loop stops early`
       );
       rounds.push({
         round: t,

--- a/packages/core/src/self-harness/overlay.ts
+++ b/packages/core/src/self-harness/overlay.ts
@@ -23,6 +23,7 @@ import {
   type IHarnessOverlay,
   type IOverlayPatch,
   type IProcedureCardEdit,
+  type IToolOverride,
   type IPromptBlockEdit,
   type PromptBlockName,
 } from "./self-harness.types";
@@ -34,7 +35,30 @@ export function emptyOverlay(): IHarnessOverlay {
     agentSpecOverrides: [],
     promptBlocks: {},
     procedureCards: {},
+    toolOverrides: [],
   };
+}
+
+/** A tool edit is only meaningful with an id; everything else is optional, and
+ *  a stray field is dropped rather than carried into the live harness. */
+function parseToolOverride(value: unknown): IToolOverride | null {
+  if (!isRecord(value) || typeof value.id !== "string" || value.id === "") {
+    return null;
+  }
+
+  const override: { id: string; description?: string; enabled?: boolean } = {
+    id: value.id,
+  };
+
+  if (typeof value.description === "string") {
+    override.description = value.description;
+  }
+
+  if (typeof value.enabled === "boolean") {
+    override.enabled = value.enabled;
+  }
+
+  return override;
 }
 
 function parseAgentOverride(value: unknown): IAgentSpecOverride | null {
@@ -172,6 +196,11 @@ export function parseOverlay(value: unknown): IHarnessOverlay | null {
       : [],
     promptBlocks: parsePromptBlocks(value.promptBlocks),
     procedureCards: parseProcedureCards(value.procedureCards),
+    toolOverrides: Array.isArray(value.toolOverrides)
+      ? value.toolOverrides
+          .map(parseToolOverride)
+          .filter((o): o is IToolOverride => o !== null)
+      : [],
   };
 }
 
@@ -222,12 +251,19 @@ export function mergeOverlay(
     procedureCards[rule] = { ...procedureCards[rule], ...card };
   }
 
+  const toolsById = new Map(base.toolOverrides.map((o) => [o.id, o]));
+
+  for (const o of patch.toolOverrides ?? []) {
+    toolsById.set(o.id, { ...toolsById.get(o.id), ...o });
+  }
+
   return {
     version: 1,
     ttsrRules,
     agentSpecOverrides: [...overridesById.values()],
     promptBlocks,
     procedureCards,
+    toolOverrides: [...toolsById.values()],
   };
 }
 
@@ -239,7 +275,8 @@ export function isEmptyPatch(patch: IOverlayPatch): boolean {
     (patch.ttsrRules ?? []).length === 0 &&
     (patch.agentSpecOverrides ?? []).length === 0 &&
     Object.keys(patch.promptBlocks ?? {}).length === 0 &&
-    Object.keys(patch.procedureCards ?? {}).length === 0
+    Object.keys(patch.procedureCards ?? {}).length === 0 &&
+    (patch.toolOverrides ?? []).length === 0
   );
 }
 

--- a/packages/core/src/self-harness/promote.ts
+++ b/packages/core/src/self-harness/promote.ts
@@ -1,0 +1,148 @@
+import { existsSync } from "node:fs";
+import { mkdir, rename, rm } from "node:fs/promises";
+import { dirname } from "node:path";
+import type { ISweepReport } from "../eval";
+import { overlayPathFor } from "./overlay";
+import type { IHarnessOverlay } from "./self-harness.types";
+
+/**
+ * Whether a measured overlay is allowed into LIVE use — the campaign's only
+ * write outside its own directory.
+ *
+ * This is a different instrument from the per-round acceptance rule, on
+ * purpose. Acceptance asks "did this edit avoid regressing the splits the
+ * proposer mined?", which is a low bar to clear by chance across many rounds on
+ * a handful of tasks. Promotion asks the stricter question, on a split that is
+ * never mined and measured at repeats=2: is this overlay's pass rate
+ * distinguishable from the frozen baseline's?
+ *
+ * The paper stops at h_t and leaves deployment alone; this is the step that
+ * decides whether h_t becomes the harness a human's own sessions run under.
+ */
+
+/** A candidate's own uncertainty must clear the baseline, not merely differ
+ *  from it. The z-test alone accepts a tiny delta that is significant at large
+ *  n; the interval alone accepts a wide, noisy one. Requiring both means the
+ *  improvement survives its own error bars. */
+export function promotionVerdict(report: ISweepReport): {
+  promote: boolean;
+  reason: string;
+} {
+  const baseline = report.variants.find((v) => v.label === report.baseline);
+  const candidate = report.variants.find((v) => v.label !== report.baseline);
+
+  if (baseline === undefined || candidate?.vsBaseline === undefined) {
+    return { promote: false, reason: "proof produced no comparable pair" };
+  }
+
+  const { deltaPassRate, z, significant } = candidate.vsBaseline;
+  const stats = describe(deltaPassRate, z, candidate.passRateCI);
+
+  if (deltaPassRate <= 0) {
+    return {
+      promote: false,
+      reason: `no uplift on the proof split (${stats})`,
+    };
+  }
+
+  if (!significant) {
+    return { promote: false, reason: `uplift not significant (${stats})` };
+  }
+
+  if (candidate.passRateCI[0] <= baseline.passRate) {
+    return {
+      promote: false,
+      reason: `uplift does not survive its own interval (${stats}, baseline ${pct(baseline.passRate)})`,
+    };
+  }
+
+  return { promote: true, reason: `significant uplift (${stats})` };
+}
+
+/**
+ * Whether an already-installed overlay has become measurably WORSE than the
+ * frozen baseline.
+ *
+ * Deliberately asymmetric with promotion: getting in requires surviving the
+ * interval check, getting thrown out only requires a significant negative
+ * delta. An unattended loop should be quicker to undo its own work than to
+ * trust it.
+ */
+export function regressed(report: ISweepReport): {
+  yes: boolean;
+  reason: string;
+} {
+  const candidate = report.variants.find((v) => v.label !== report.baseline);
+
+  if (candidate?.vsBaseline === undefined) {
+    return { yes: false, reason: "" };
+  }
+
+  const { deltaPassRate, z, significant } = candidate.vsBaseline;
+
+  return significant && deltaPassRate < 0
+    ? { yes: true, reason: describe(deltaPassRate, z, candidate.passRateCI) }
+    : { yes: false, reason: "" };
+}
+
+function pct(rate: number): string {
+  return (rate * 100).toFixed(1);
+}
+
+function describe(
+  delta: number,
+  z: number,
+  ci: readonly [number, number]
+): string {
+  return `Δ=${pct(delta)}pp z=${z.toFixed(2)} CI=[${pct(ci[0])}, ${pct(ci[1])}]`;
+}
+
+/**
+ * Install an overlay for live use, keeping the displaced one as the rollback
+ * point. Written to a temp file and renamed, so a session starting mid-write
+ * can never read half an overlay — `activeOverlay()` reads this path
+ * synchronously on a hot path with no locking.
+ */
+export async function installOverlay(
+  modelId: string,
+  overlay: IHarnessOverlay
+): Promise<void> {
+  const live = overlayPathFor(modelId);
+
+  await mkdir(dirname(live), { recursive: true });
+
+  if (existsSync(live)) {
+    await Bun.write(previousPath(live), await Bun.file(live).text());
+  }
+
+  const tmp = `${live}.tmp`;
+
+  await Bun.write(tmp, JSON.stringify(overlay, null, 2));
+  await rename(tmp, live);
+}
+
+/**
+ * Undo the last install. Returns false when there was no previous overlay to
+ * restore, in which case the live one is removed outright — the base harness is
+ * always a safe resting state, so a rollback never leaves a known-bad overlay
+ * in place for want of something to replace it with.
+ */
+export async function revertOverlay(modelId: string): Promise<boolean> {
+  const live = overlayPathFor(modelId);
+  const prev = previousPath(live);
+
+  if (existsSync(prev)) {
+    await Bun.write(live, await Bun.file(prev).text());
+    await rm(prev, { force: true });
+
+    return true;
+  }
+
+  await rm(live, { force: true });
+
+  return false;
+}
+
+export function previousPath(livePath: string): string {
+  return `${livePath}.prev`;
+}

--- a/packages/core/src/self-harness/proposal-schema.ts
+++ b/packages/core/src/self-harness/proposal-schema.ts
@@ -1,0 +1,122 @@
+import { PROMPT_BLOCK_NAMES } from "./self-harness.types";
+
+/**
+ * JSON Schema for one proposer response, so a runtime that supports guided
+ * decoding (vLLM, SGLang, OpenAI) constrains generation to this shape.
+ *
+ * WHY THIS EXISTS: asking DeepSeek for "only a JSON object" lost four of six
+ * candidates to `unparseable proposer response` in a single session — the
+ * paper's proposal width K silently collapsed from 3 to 1, and no round ever
+ * had enough candidates for one to clear the acceptance rule. Constraining the
+ * decode makes the reply parse by construction instead of by luck.
+ *
+ * This schema is a MIRROR of `IOverlayPatch`, not the authority on it:
+ * `parseOverlay` still validates every response, so a drift between the two
+ * costs a wasted proposal, never an invalid edit. Keep it in step anyway.
+ *
+ * Deliberately NOT emitted as OpenAI `strict` mode: that subset demands every
+ * property appear in `required`, which would force each candidate to touch all
+ * four surfaces at once and destroy the minimality the paper requires.
+ */
+
+const TTSR_RULE = {
+  type: "object",
+  properties: {
+    name: { type: "string" },
+    condition: { type: "array", items: { type: "string" } },
+    scope: { type: "string", enum: ["content", "tool-args", "both"] },
+    fileGlobs: { type: "array", items: { type: "string" } },
+    guidance: { type: "string" },
+    repeatMode: { type: "string", enum: ["once", "cooldown"] },
+    repeatGap: { type: "integer" },
+  },
+  required: ["name", "condition", "scope", "guidance", "repeatMode"],
+} as const;
+
+const AGENT_SPEC_OVERRIDE = {
+  type: "object",
+  properties: {
+    id: { type: "string" },
+    systemPrompt: { type: "string" },
+    task: { type: "string" },
+    maxTurns: { type: "integer" },
+  },
+  required: ["id"],
+} as const;
+
+const PROMPT_BLOCK_EDIT = {
+  type: "object",
+  properties: {
+    mode: { type: "string", enum: ["append", "replace"] },
+    text: { type: "string" },
+  },
+  required: ["mode", "text"],
+} as const;
+
+const PROCEDURE_CARD_EDIT = {
+  type: "object",
+  properties: {
+    what: { type: "string" },
+    bad: { type: "string" },
+    good: { type: "string" },
+    procedure: { type: "string" },
+  },
+} as const;
+
+const TOOL_OVERRIDE = {
+  type: "object",
+  properties: {
+    id: { type: "string" },
+    description: { type: "string" },
+    enabled: { type: "boolean" },
+  },
+  required: ["id"],
+} as const;
+
+/** The patch object — every surface optional, because a candidate must touch
+ *  as few as possible. */
+const OVERLAY_PATCH = {
+  type: "object",
+  properties: {
+    toolOverrides: { type: "array", items: TOOL_OVERRIDE },
+    ttsrRules: { type: "array", items: TTSR_RULE },
+    agentSpecOverrides: { type: "array", items: AGENT_SPEC_OVERRIDE },
+    promptBlocks: {
+      type: "object",
+      properties: Object.fromEntries(
+        PROMPT_BLOCK_NAMES.map((name) => [name, PROMPT_BLOCK_EDIT])
+      ),
+      additionalProperties: false,
+    },
+    // Keyed by gate rule id (`TS2307`, `no-non-null-assertion`, …), which is an
+    // open set — so the keys are unconstrained and only the values are shaped.
+    procedureCards: {
+      type: "object",
+      additionalProperties: PROCEDURE_CARD_EDIT,
+    },
+  },
+} as const;
+
+/** The full response: the audit record the paper requires, plus the patch. */
+export const PROPOSAL_SCHEMA = {
+  type: "object",
+  properties: {
+    targetPattern: { type: "string" },
+    surface: {
+      type: "string",
+      enum: [
+        "ttsrRules",
+        "promptBlocks",
+        "procedureCards",
+        "agentSpecOverrides",
+        "toolOverrides",
+      ],
+    },
+    expectedEffect: { type: "string" },
+    risks: { type: "string" },
+    patch: OVERLAY_PATCH,
+  },
+  required: ["targetPattern", "surface", "expectedEffect", "risks", "patch"],
+} as const;
+
+export const PROPOSAL_SCHEMA_NAME = "harness_proposal";

--- a/packages/core/src/self-harness/propose.ts
+++ b/packages/core/src/self-harness/propose.ts
@@ -9,6 +9,7 @@
  */
 import type { IProvider } from "../inference";
 import { extractJson } from "../lib/json";
+import { PROPOSAL_SCHEMA, PROPOSAL_SCHEMA_NAME } from "./proposal-schema";
 import { isRecord } from "../lib/guards";
 import { isEmptyPatch, parseOverlay } from "./overlay";
 import type {
@@ -35,10 +36,13 @@ const SURFACE_CATALOG = `You may edit ONLY these declared harness surfaces, expr
 3. "procedureCards": per-gate-rule repair guidance shown when that rule fails, keyed by the exact rule id (e.g. "TS2307", "no-as").
    Shape: {"<ruleId>": {"what": "...", "bad": "...", "good": "...", "procedure": "step-by-step fix workflow"}}
 
-4. "agentSpecOverrides": bounded overrides of existing subagents (explore, research, verify, review-lens). Only systemPrompt, task, and maxTurns — tools and model are NOT editable.
+4. "agentSpecOverrides": bounded overrides of existing subagents (explore, research, verify, review-lens). Only systemPrompt, task, and maxTurns — model is NOT editable.
    Shape: [{"id": "explore", "systemPrompt": "..."?, "task": "..."?, "maxTurns": number?}]
 
-NOT editable (do not attempt): the gate/verifier, its strictness or rules, tool availability, model routing, the control loop.`;
+5. "toolOverrides": how an EXISTING tool is offered — reword its description so its purpose or its failure modes are clearer, or stop offering one that the traces show being misused. You cannot ADD a tool: an id naming a tool the harness does not already offer has no effect. Withdrawing a tool the task needs will show up as a lower pass rate and be rejected.
+   Shape: [{"id": "<advertised tool name>", "description": "..."?, "enabled": false?}]
+
+NOT editable (do not attempt): the gate/verifier, its strictness or rules, WHICH tools exist, model routing, the control loop.`;
 
 const PROPOSER_SYSTEM = `You are the harness-improvement proposer inside tsforge (Self-Harness loop). A fixed model — you — runs coding tasks under a harness; the harness is the object of improvement, not the model or the verifier.
 
@@ -113,6 +117,7 @@ function editCount(patch: IOverlayPatch): number {
   return (
     (patch.ttsrRules?.length ?? 0) +
     (patch.agentSpecOverrides?.length ?? 0) +
+    (patch.toolOverrides?.length ?? 0) +
     Object.keys(patch.promptBlocks ?? {}).length +
     Object.keys(patch.procedureCards ?? {}).length
   );
@@ -238,9 +243,18 @@ export async function propose(
             ),
           },
         ],
-        // Mild temperature: K identical greedy calls would defeat the
-        // parallel-proposal diversity the paper relies on.
-        { temperature: 0.7 }
+        {
+          // Mild temperature: K identical greedy calls would defeat the
+          // parallel-proposal diversity the paper relies on.
+          temperature: 0.7,
+          // Shape the decode. An endpoint without guided decoding ignores this
+          // and the salvage re-ask below still covers it.
+          responseFormat: {
+            type: "json_schema",
+            name: PROPOSAL_SCHEMA_NAME,
+            schema: PROPOSAL_SCHEMA,
+          },
+        }
       );
 
       content = res.content;
@@ -278,7 +292,14 @@ export async function propose(
               content: `Your response was unusable: ${reason ?? "invalid"}. Reply again with ONLY the corrected JSON object — same schema, no prose, no code fences.`,
             },
           ],
-          { temperature: 0 }
+          {
+            temperature: 0,
+            responseFormat: {
+              type: "json_schema",
+              name: PROPOSAL_SCHEMA_NAME,
+              schema: PROPOSAL_SCHEMA,
+            },
+          }
         );
 
         ({ candidate, reason } = parseCandidate(retry.content, id));

--- a/packages/core/src/self-harness/self-harness.types.ts
+++ b/packages/core/src/self-harness/self-harness.types.ts
@@ -39,6 +39,25 @@ export interface IAgentSpecOverride {
   readonly maxTurns?: number;
 }
 
+/**
+ * An edit to how an EXISTING tool is offered to the model: reword its
+ * description, or stop offering it.
+ *
+ * The paper lists `tools` among the editable surfaces of the harness file while
+ * holding *"the … tool set … unchanged"* across variants. That asymmetry is the
+ * whole guard: an id that names no offered tool does nothing, so there is no
+ * path by which an edit grants capability the harness did not already have.
+ * Hiding a tool the model needs is allowed and self-correcting — the pass rate
+ * falls and the acceptance rule rejects the edit.
+ */
+export interface IToolOverride {
+  /** The tool's advertised name. Must already be offered; unknown ids no-op. */
+  readonly id: string;
+  readonly description?: string;
+  /** `false` stops offering the tool. There is no `true` that adds one. */
+  readonly enabled?: boolean;
+}
+
 /** A procedure-card override for one gate rule id — merged over the curated /
  *  generated doc at `ruleHelp()` time, field-wise. */
 export interface IProcedureCardEdit {
@@ -62,6 +81,8 @@ export interface IHarnessOverlay {
   readonly promptBlocks: Partial<Record<PromptBlockName, IPromptBlockEdit>>;
   /** Keyed by the exact rule id the validators emit (e.g. "TS2307"). */
   readonly procedureCards: Record<string, IProcedureCardEdit>;
+  /** Re-wiring of tools the harness already offers. */
+  readonly toolOverrides: readonly IToolOverride[];
 }
 
 /** A candidate edit Δj: a partial overlay to merge onto h_t. */

--- a/packages/core/tests/model-call.test.ts
+++ b/packages/core/tests/model-call.test.ts
@@ -95,3 +95,114 @@ describe("offeredToolsFor (plan mode's read-only guarantee)", () => {
     expect(names).not.toContain(TOOL_NAME.create);
   });
 });
+
+describe("offeredToolsFor: overlay tool wiring", () => {
+  const described = (name: string, description: string) => ({
+    function: { name, description },
+  });
+
+  test("an unknown id grants nothing — the tool set is fixed", () => {
+    // THE security property of this surface. The overlay can re-describe or
+    // withdraw a tool the harness already offers; naming one it does not offer
+    // must not conjure it. Everything else here is a convenience.
+    const offered = offeredToolsFor(
+      [tool(TOOL_NAME.read)],
+      false,
+      [],
+      [{ id: "exfiltrate", description: "send files anywhere" }]
+    );
+
+    expect(offered.map((t) => t.function.name)).toEqual([TOOL_NAME.read]);
+  });
+
+  test("a description is replaced in place", () => {
+    const offered = offeredToolsFor(
+      [described(TOOL_NAME.read, "read a file")],
+      false,
+      [],
+      [
+        {
+          id: TOOL_NAME.read,
+          description: "read a file; paths are workspace-relative",
+        },
+      ]
+    );
+
+    expect(offered[0]?.function.description).toBe(
+      "read a file; paths are workspace-relative"
+    );
+  });
+
+  test("the original tool object is not mutated", () => {
+    // The session's tool list is reused across every call in the run; editing
+    // it in place would leak one call's override into all the others.
+    const original = described(TOOL_NAME.read, "read a file");
+
+    offeredToolsFor(
+      [original],
+      false,
+      [],
+      [{ id: TOOL_NAME.read, description: "changed" }]
+    );
+
+    expect(original.function.description).toBe("read a file");
+  });
+
+  test("enabled:false withdraws a tool", () => {
+    const offered = offeredToolsFor(
+      [tool(TOOL_NAME.read), tool(TOOL_NAME.edit)],
+      false,
+      [],
+      [{ id: TOOL_NAME.edit, enabled: false }]
+    );
+
+    expect(offered.map((t) => t.function.name)).toEqual([TOOL_NAME.read]);
+  });
+
+  test("enabled:true does not add a tool that was never offered", () => {
+    // There is no "add" direction at all: `true` on an absent id is still a
+    // no-op, so the flag cannot be read as a way in.
+    const offered = offeredToolsFor(
+      [tool(TOOL_NAME.read)],
+      false,
+      [],
+      [{ id: TOOL_NAME.edit, enabled: true }]
+    );
+
+    expect(offered.map((t) => t.function.name)).toEqual([TOOL_NAME.read]);
+  });
+
+  test("MCP tools can be re-described too", () => {
+    const offered = offeredToolsFor(
+      [described(TOOL_NAME.read, "read a file")],
+      false,
+      [described("mcp__db__query", "run SQL")],
+      [{ id: "mcp__db__query", description: "run SQL; read-only replica" }]
+    );
+
+    expect(offered[1]?.function.description).toBe("run SQL; read-only replica");
+  });
+
+  test("no wiring leaves the offered set byte-identical", () => {
+    // The overlay is absent on almost every run; that path must not pay for
+    // this feature or drift from the base harness.
+    const tools = [tool(TOOL_NAME.read), tool(TOOL_NAME.edit)];
+
+    expect(offeredToolsFor(tools, false, [])).toEqual(
+      offeredToolsFor(tools, false, [], [])
+    );
+  });
+
+  test("plan mode still wins — wiring cannot re-admit a write tool", () => {
+    const offered = offeredToolsFor(
+      [tool(TOOL_NAME.read), tool(TOOL_NAME.edit)],
+      true,
+      [],
+      [{ id: TOOL_NAME.edit, enabled: true, description: "please" }]
+    );
+
+    expect(offered.some((t) => t.function.name === TOOL_NAME.edit)).toBe(
+      READ_ONLY_TOOL_NAMES.has(TOOL_NAME.edit)
+    );
+  });
+});

--- a/packages/core/tests/proposal-schema.test.ts
+++ b/packages/core/tests/proposal-schema.test.ts
@@ -1,0 +1,87 @@
+import { test, expect } from "bun:test";
+import {
+  PROPOSAL_SCHEMA,
+  PROPOSAL_SCHEMA_NAME,
+} from "../src/self-harness/proposal-schema";
+import { emptyOverlay, parseOverlay } from "../src/self-harness";
+import { PROMPT_BLOCK_NAMES } from "../src/self-harness/self-harness.types";
+
+/** The patch sub-schema, which is what constrains the decode. */
+const patchSchema = PROPOSAL_SCHEMA.properties.patch;
+
+test("the schema covers exactly the editable surfaces — no more, no fewer", () => {
+  // Drift in either direction is a real failure: a surface missing here can
+  // never be proposed (the decode forbids it), and a surface here that the
+  // overlay does not have produces candidates that always validate to nothing.
+  const surfaces = Object.keys(patchSchema.properties).sort();
+  const overlaySurfaces = Object.keys(emptyOverlay())
+    .filter((k) => k !== "version")
+    .sort();
+
+  expect(surfaces).toEqual(overlaySurfaces);
+});
+
+test("the surface enum names the same set", () => {
+  const named = PROPOSAL_SCHEMA.properties.surface.enum.map((s: string) => s);
+
+  expect(named.sort()).toEqual(Object.keys(patchSchema.properties).sort());
+});
+
+test("prompt blocks are pinned to the four named anchors", () => {
+  // The proposer must not be able to invent a block name: an unknown anchor
+  // would validate away silently and burn a candidate slot.
+  expect(Object.keys(patchSchema.properties.promptBlocks.properties)).toEqual([
+    ...PROMPT_BLOCK_NAMES,
+  ]);
+  expect(patchSchema.properties.promptBlocks.additionalProperties).toBe(false);
+});
+
+test("no surface is required — a candidate must be able to touch just one", () => {
+  // The paper requires minimality within each proposal. A `required` list here
+  // would force every candidate to edit all four surfaces at once.
+  expect(patchSchema).not.toHaveProperty("required");
+});
+
+test("the audit record the paper requires is mandatory", () => {
+  expect([...PROPOSAL_SCHEMA.required].sort()).toEqual([
+    "expectedEffect",
+    "patch",
+    "risks",
+    "surface",
+    "targetPattern",
+  ]);
+});
+
+test("a patch shaped by the schema survives the real overlay validator", () => {
+  // The schema only shapes the decode; parseOverlay remains the authority. A
+  // response that satisfies the schema must not then be thrown away.
+  const shaped = {
+    ttsrRules: [
+      {
+        name: "test-sibling-first",
+        condition: ["export function"],
+        scope: "tool-args",
+        guidance: "Create the test sibling before editing the source again.",
+        repeatMode: "cooldown",
+        repeatGap: 3,
+      },
+    ],
+    promptBlocks: { execution: { mode: "append", text: "Check the gate." } },
+    procedureCards: { TS2307: { procedure: "Add the missing import." } },
+    agentSpecOverrides: [{ id: "expert", maxTurns: 12 }],
+  };
+
+  const parsed = parseOverlay(shaped);
+
+  expect(parsed).not.toBeNull();
+  expect(parsed?.ttsrRules).toHaveLength(1);
+  expect(parsed?.promptBlocks.execution?.text).toBe("Check the gate.");
+  expect(parsed?.procedureCards.TS2307?.procedure).toBe(
+    "Add the missing import."
+  );
+  expect(parsed?.agentSpecOverrides[0]?.id).toBe("expert");
+});
+
+test("the schema is named, so a server can report which one it enforced", () => {
+  expect(PROPOSAL_SCHEMA_NAME).toBe("harness_proposal");
+});

--- a/packages/core/tests/request-builder.test.ts
+++ b/packages/core/tests/request-builder.test.ts
@@ -919,3 +919,75 @@ describe("preset name and preset object are behavioural aliases", () => {
     expect(Object.isFrozen(p.thinking?.onValue)).toBe(true);
   });
 });
+
+describe("response format", () => {
+  test("omitted by default — an endpoint that never asked for it sees no field", () => {
+    expect(buildRequestBody(cfg(), MSGS, {}, false)).not.toHaveProperty(
+      "response_format"
+    );
+  });
+
+  test("json_object passes through", () => {
+    const body = buildRequestBody(
+      cfg(),
+      MSGS,
+      { responseFormat: { type: "json_object" } },
+      false
+    );
+
+    expect(body.response_format).toEqual({ type: "json_object" });
+  });
+
+  test("json_schema is nested under json_schema, as the wire expects", () => {
+    // The schema does NOT sit at response_format.schema — a flat shape is
+    // accepted by some servers and silently ignored by others, which would
+    // leave the decode unconstrained while looking configured.
+    const schema = { type: "object", properties: { a: { type: "string" } } };
+    const body = buildRequestBody(
+      cfg(),
+      MSGS,
+      {
+        responseFormat: { type: "json_schema", name: "patch", schema },
+      },
+      false
+    );
+
+    expect(body.response_format).toEqual({
+      type: "json_schema",
+      json_schema: { name: "patch", schema },
+    });
+  });
+
+  test("strict is forwarded only when set", () => {
+    const body = buildRequestBody(
+      cfg(),
+      MSGS,
+      {
+        responseFormat: {
+          type: "json_schema",
+          name: "patch",
+          schema: {},
+          strict: true,
+        },
+      },
+      false
+    );
+
+    expect(body.response_format).toMatchObject({
+      json_schema: { strict: true },
+    });
+  });
+
+  test("a per-model extraBody still wins, for an endpoint with its own spelling", () => {
+    // vLLM also accepts `guided_json`; a model entry must be able to override
+    // the default spelling without a code change.
+    const body = buildRequestBody(
+      cfg({ extraBody: { response_format: { type: "text" } } }),
+      MSGS,
+      { responseFormat: { type: "json_object" } },
+      false
+    );
+
+    expect(body.response_format).toEqual({ type: "text" });
+  });
+});

--- a/packages/core/tests/self-harness-build-evidence.test.ts
+++ b/packages/core/tests/self-harness-build-evidence.test.ts
@@ -1,0 +1,222 @@
+import { test, expect, describe } from "bun:test";
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  buildEvidenceFrom,
+  parseEventLog,
+  runPassed,
+  mineWeaknesses,
+} from "../src/self-harness";
+
+/**
+ * Real build logs as mining evidence. The corpus stays the measuring
+ * instrument — a one-off build cannot show a delta — but a corpus the model
+ * passes 8/8 has nothing left to teach it, while its everyday work is full of
+ * failures worth mining.
+ */
+
+function line(event: Record<string, unknown>): string {
+  return `${JSON.stringify(event)}\n`;
+}
+
+describe("parseEventLog", () => {
+  test("reads the flat writer's events", () => {
+    const events = parseEventLog(
+      line({ kind: "cycle", task: "t", message: "turn 1" }) +
+        line({ kind: "done", task: "t", message: "done in 1" })
+    );
+
+    expect(events.map((e) => e.kind)).toEqual(["cycle", "done"]);
+  });
+
+  test("reads the typed ledger's nested shape too", () => {
+    // The ledger writes {type, payload:{…}}. Reading only the flat shape mined
+    // NOTHING from half the logs on disk — 27 runs became 39 once this landed.
+    const events = parseEventLog(
+      line({ type: "cycle", payload: { task: "t", message: "turn 1" } }) +
+        line({ type: "stuck", payload: { task: "t", message: "parked" } })
+    );
+
+    expect(events.map((e) => e.kind)).toEqual(["cycle", "stuck"]);
+    expect(events[1]?.message).toBe("parked");
+  });
+
+  test("carries the fields classification reads", () => {
+    const events = parseEventLog(
+      line({
+        kind: "validated",
+        task: "t",
+        message: "gate red",
+        passed: false,
+        rules: ["TS2307", "no-explicit-any"],
+      })
+    );
+
+    expect(events[0]?.passed).toBe(false);
+    expect(events[0]?.rules).toEqual(["TS2307", "no-explicit-any"]);
+  });
+
+  test("survives a truncated log", () => {
+    // A crash mid-write is exactly the run worth mining; a parse error must not
+    // discard the events that did land.
+    const events = parseEventLog(
+      line({ kind: "cycle", task: "t", message: "turn 1" }) +
+        '{"kind":"done","task":"t","mess'
+    );
+
+    expect(events).toHaveLength(1);
+  });
+
+  test("drops noise rather than inventing events", () => {
+    const events = parseEventLog(
+      line({ kind: "token", task: "t", message: "…" }) +
+        line({ nokind: true }) +
+        "not json at all\n"
+    );
+
+    expect(events).toHaveLength(0);
+  });
+});
+
+describe("runPassed", () => {
+  test("the LAST terminal event decides", () => {
+    // A multi-task build emits `done` per task. Counting them would call a run
+    // green that finished task 1 and then got stuck on task 2 — the run most
+    // worth mining.
+    const events = parseEventLog(
+      line({ kind: "done", task: "1", message: "task 1 done" }) +
+        line({ kind: "stuck", task: "2", message: "parked" })
+    );
+
+    expect(runPassed(events)).toBe(false);
+  });
+
+  test("green when the run ends done", () => {
+    const events = parseEventLog(
+      line({ kind: "stuck", task: "1", message: "retrying" }) +
+        line({ kind: "done", task: "1", message: "done" })
+    );
+
+    expect(runPassed(events)).toBe(true);
+  });
+
+  test("a run that never terminated is not a pass", () => {
+    const events = parseEventLog(
+      line({ kind: "cycle", task: "t", message: "" })
+    );
+
+    expect(runPassed(events)).toBe(false);
+  });
+});
+
+describe("buildEvidenceFrom", () => {
+  async function logsDir(files: Record<string, string>): Promise<string> {
+    const dir = await mkdtemp(join(tmpdir(), "tsforge-buildlogs-"));
+
+    for (const [name, body] of Object.entries(files)) {
+      await writeFile(join(dir, name), body);
+    }
+
+    return dir;
+  }
+
+  test("reads each log as one run, newest first", async () => {
+    const dir = await logsDir({
+      "2026-01-01-a.jsonl":
+        line({ kind: "cycle", task: "t", message: "" }) +
+        line({ kind: "done", task: "t", message: "" }),
+      "2026-02-01-b.jsonl":
+        line({ kind: "cycle", task: "t", message: "" }) +
+        line({ kind: "stuck", task: "t", message: "" }),
+    });
+
+    try {
+      const runs = await buildEvidenceFrom(dir);
+
+      expect(runs.map((r) => r.taskId)).toEqual([
+        "2026-02-01-b",
+        "2026-01-01-a",
+      ]);
+      expect(runs[0]?.passed).toBe(false);
+      expect(runs[1]?.passed).toBe(true);
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  test("skips a log with no model turns", async () => {
+    // An endpoint that was down produces a log with a start line and nothing
+    // else. Mining it would manufacture a failure pattern out of an outage —
+    // precisely what the campaign's infra guards exist to prevent.
+    const dir = await logsDir({
+      "2026-01-01-dead.jsonl": line({
+        kind: "start",
+        task: "t",
+        message: "model x",
+      }),
+    });
+
+    try {
+      expect(await buildEvidenceFrom(dir)).toHaveLength(0);
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  test("honours the newest-N limit", async () => {
+    const body =
+      line({ kind: "cycle", task: "t", message: "" }) +
+      line({ kind: "done", task: "t", message: "" });
+    const dir = await logsDir({
+      "2026-01-01-a.jsonl": body,
+      "2026-02-01-b.jsonl": body,
+      "2026-03-01-c.jsonl": body,
+    });
+
+    try {
+      const runs = await buildEvidenceFrom(dir, { limit: 2 });
+
+      expect(runs.map((r) => r.taskId)).toEqual([
+        "2026-03-01-c",
+        "2026-02-01-b",
+      ]);
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  test("a missing directory is empty evidence, not a crash", async () => {
+    // The campaign passes --build-logs unconditionally; a machine with no logs
+    // yet must run a corpus-only session rather than abort.
+    expect(await buildEvidenceFrom("/nonexistent/logs")).toEqual([]);
+  });
+
+  test("the runs it produces actually mine into patterns", async () => {
+    // End to end: the shape this module emits is the shape mineWeaknesses eats.
+    const dir = await logsDir({
+      "2026-01-01-x.jsonl":
+        line({ kind: "cycle", task: "t", message: "turn 1" }) +
+        line({ kind: "tool", task: "t", message: "edit rejected: no match" }) +
+        line({ kind: "tool", task: "t", message: "edit rejected: no match" }) +
+        line({
+          kind: "validated",
+          task: "t",
+          message: "gate red",
+          passed: false,
+          rules: ["TS2307"],
+        }) +
+        line({ kind: "stuck", task: "t", message: "parked" }),
+    });
+
+    try {
+      const bundle = mineWeaknesses(await buildEvidenceFrom(dir));
+
+      expect(bundle.failedRuns).toBe(1);
+      expect(bundle.patterns.length).toBeGreaterThan(0);
+      expect(bundle.patterns[0]?.taskIds).toContain("2026-01-01-x");
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+});

--- a/packages/core/tests/self-harness-loop.test.ts
+++ b/packages/core/tests/self-harness-loop.test.ts
@@ -429,7 +429,7 @@ describe("runSelfHarness — Algorithm 1 end-to-end (deterministic)", () => {
     // Round 1: h_1 is fully green held-in → early stop (not 3 full rounds).
     expect(lineage.rounds).toHaveLength(2);
     expect(lineage.rounds[1]?.candidates).toEqual([]);
-    expect(lineage.notes.some((n) => n.includes("no held-in failures"))).toBe(
+    expect(lineage.notes.some((n) => n.includes("no failures to mine"))).toBe(
       true
     );
   });

--- a/packages/core/tests/self-harness-overlay.test.ts
+++ b/packages/core/tests/self-harness-overlay.test.ts
@@ -301,3 +301,75 @@ describe("merge patch typing", () => {
     expect(Object.keys(merged.procedureCards)).toEqual(["no-as"]);
   });
 });
+
+describe("tool overrides", () => {
+  afterEach(() => {
+    restoreEnv();
+    resetOverlayCache();
+  });
+
+  test("an installed overlay's tool edits reach the runtime", async () => {
+    // The whole path: a file on disk → activeOverlay() → the value the session
+    // hands to offeredToolsFor. Unit tests cover the filter itself; this pins
+    // that a promoted overlay actually carries tool edits to the model call.
+    const dir = await mkdtemp(join(tmpdir(), "tsforge-tool-overlay-"));
+    const path = join(dir, "overlay.json");
+
+    try {
+      await writeFile(
+        path,
+        JSON.stringify({
+          version: 1,
+          toolOverrides: [
+            { id: "read", description: "read a file; paths are relative" },
+            { id: "run", enabled: false },
+          ],
+        })
+      );
+      process.env.TSFORGE_SELF_HARNESS_OVERLAY = path;
+      resetOverlayCache();
+
+      const overrides = activeOverlay()?.toolOverrides ?? [];
+
+      expect(overrides).toHaveLength(2);
+      expect(overrides[0]).toEqual({
+        id: "read",
+        description: "read a file; paths are relative",
+      });
+      expect(overrides[1]).toEqual({ id: "run", enabled: false });
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  test("a tool edit without an id is dropped, not carried half-formed", () => {
+    const parsed = parseOverlay({
+      version: 1,
+      toolOverrides: [{ description: "no id here" }, { id: "read" }],
+    });
+
+    expect(parsed?.toolOverrides).toEqual([{ id: "read" }]);
+  });
+
+  test("a patch that only edits tools is not an empty patch", () => {
+    // isEmptyPatch decides whether a candidate is rejected outright. Missing
+    // the new surface here would silently discard every tool proposal.
+    const patch: IOverlayPatch = { toolOverrides: [{ id: "read" }] };
+
+    expect(isEmptyPatch(patch)).toBe(false);
+  });
+
+  test("tool edits merge by id, field-wise", () => {
+    const base = mergeOverlay(emptyOverlay(), {
+      toolOverrides: [{ id: "read", description: "first" }],
+    });
+    const merged = mergeOverlay(base, {
+      toolOverrides: [{ id: "read", enabled: false }, { id: "edit" }],
+    });
+
+    expect(merged.toolOverrides).toEqual([
+      { id: "read", description: "first", enabled: false },
+      { id: "edit" },
+    ]);
+  });
+});

--- a/packages/core/tests/self-harness-promote.test.ts
+++ b/packages/core/tests/self-harness-promote.test.ts
@@ -1,0 +1,290 @@
+import { test, expect, describe, afterEach } from "bun:test";
+import { mkdtemp, rm, mkdir, writeFile, readFile } from "node:fs/promises";
+import { existsSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import {
+  promotionVerdict,
+  regressed,
+  installOverlay,
+  revertOverlay,
+  previousPath,
+  emptyOverlay,
+  overlayPathFor,
+} from "../src/self-harness";
+import type { ISweepReport } from "../src/eval";
+
+/**
+ * The promotion gate is the only thing standing between an unattended loop and
+ * the harness a human's own sessions run under. Its failure mode is silent: a
+ * wrong verdict installs a worse harness and nobody is watching.
+ */
+
+const SAVED_HOME = process.env.TSFORGE_HOME;
+
+function restoreHome(): void {
+  if (SAVED_HOME === undefined) {
+    delete process.env.TSFORGE_HOME;
+  } else {
+    process.env.TSFORGE_HOME = SAVED_HOME;
+  }
+}
+
+/** A two-variant proof report. `ci` is the candidate's Wilson interval. */
+function report(opts: {
+  baselineRate: number;
+  delta: number;
+  significant: boolean;
+  ci: [number, number];
+}): ISweepReport {
+  return {
+    baseline: "baseline",
+    variants: [
+      {
+        label: "baseline",
+        passRate: opts.baselineRate,
+        passRateCI: [0, 1],
+      },
+      {
+        label: "self-harness",
+        passRate: opts.baselineRate + opts.delta,
+        passRateCI: opts.ci,
+        vsBaseline: {
+          deltaPassRate: opts.delta,
+          z: opts.significant ? 2.4 : 0.8,
+          significant: opts.significant,
+        },
+      },
+    ],
+  } as unknown as ISweepReport;
+}
+
+describe("promotionVerdict", () => {
+  test("promotes a significant uplift that clears its own interval", () => {
+    const v = promotionVerdict(
+      report({
+        baselineRate: 0.5,
+        delta: 0.25,
+        significant: true,
+        ci: [0.6, 0.9],
+      })
+    );
+
+    expect(v.promote).toBe(true);
+    expect(v.reason).toContain("significant uplift");
+  });
+
+  test("refuses a positive but non-significant delta", () => {
+    // The common case in a small proof split: real-looking movement that is
+    // indistinguishable from noise. Installing on this is how a loop drifts.
+    const v = promotionVerdict(
+      report({
+        baselineRate: 0.5,
+        delta: 0.1,
+        significant: false,
+        ci: [0.45, 0.75],
+      })
+    );
+
+    expect(v.promote).toBe(false);
+    expect(v.reason).toContain("not significant");
+  });
+
+  test("refuses an uplift whose lower bound does not clear the baseline", () => {
+    // Significant by the z-test, but the candidate's own interval still
+    // contains the baseline's rate — the improvement does not survive its
+    // error bars.
+    const v = promotionVerdict(
+      report({
+        baselineRate: 0.5,
+        delta: 0.08,
+        significant: true,
+        ci: [0.42, 0.74],
+      })
+    );
+
+    expect(v.promote).toBe(false);
+    expect(v.reason).toContain("does not survive its own interval");
+  });
+
+  test("refuses a regression outright", () => {
+    const v = promotionVerdict(
+      report({
+        baselineRate: 0.6,
+        delta: -0.2,
+        significant: true,
+        ci: [0.2, 0.6],
+      })
+    );
+
+    expect(v.promote).toBe(false);
+    expect(v.reason).toContain("no uplift");
+  });
+
+  test("refuses when the proof produced no comparison", () => {
+    // A measurement that never ran must never read as approval.
+    const empty = { baseline: "baseline", variants: [] } as ISweepReport;
+
+    expect(promotionVerdict(empty).promote).toBe(false);
+  });
+});
+
+describe("regressed", () => {
+  test("fires on a significant negative delta", () => {
+    const r = regressed(
+      report({
+        baselineRate: 0.7,
+        delta: -0.3,
+        significant: true,
+        ci: [0.2, 0.6],
+      })
+    );
+
+    expect(r.yes).toBe(true);
+  });
+
+  test("does not fire on noise", () => {
+    expect(
+      regressed(
+        report({
+          baselineRate: 0.7,
+          delta: -0.05,
+          significant: false,
+          ci: [0.5, 0.8],
+        })
+      ).yes
+    ).toBe(false);
+  });
+
+  test("is easier to trip than promotion — rollback needs no interval check", () => {
+    // Asymmetric on purpose: an unattended loop should undo its own work more
+    // readily than it trusts it. This delta is significant and negative but its
+    // interval is wide; promotion would refuse the mirror case.
+    const r = report({
+      baselineRate: 0.7,
+      delta: -0.15,
+      significant: true,
+      ci: [0.3, 0.8],
+    });
+
+    expect(regressed(r).yes).toBe(true);
+    expect(promotionVerdict(r).promote).toBe(false);
+  });
+});
+
+describe("install and rollback", () => {
+  afterEach(restoreHome);
+
+  async function home(): Promise<string> {
+    const dir = await mkdtemp(join(tmpdir(), "tsforge-promote-"));
+
+    process.env.TSFORGE_HOME = dir;
+
+    return dir;
+  }
+
+  test("install writes the overlay where the runtime looks for it", async () => {
+    const dir = await home();
+
+    try {
+      const overlay = {
+        ...emptyOverlay(),
+        promptBlocks: { extra: { mode: "append" as const, text: "hello" } },
+      };
+
+      await installOverlay("deepseek/flash", overlay);
+
+      const live = overlayPathFor("deepseek/flash");
+
+      expect(existsSync(live)).toBe(true);
+      expect(JSON.parse(await readFile(live, "utf8"))).toEqual(overlay);
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  test("install keeps the displaced overlay as the rollback point", async () => {
+    const dir = await home();
+
+    try {
+      const first = {
+        ...emptyOverlay(),
+        promptBlocks: { extra: { mode: "append" as const, text: "first" } },
+      };
+
+      await installOverlay("m", first);
+      await installOverlay("m", emptyOverlay());
+
+      expect(
+        JSON.parse(await readFile(previousPath(overlayPathFor("m")), "utf8"))
+      ).toEqual(first);
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  test("rollback restores the previous overlay", async () => {
+    const dir = await home();
+
+    try {
+      const first = {
+        ...emptyOverlay(),
+        promptBlocks: { extra: { mode: "append" as const, text: "first" } },
+      };
+
+      await installOverlay("m", first);
+      await installOverlay("m", emptyOverlay());
+
+      expect(await revertOverlay("m")).toBe(true);
+      expect(JSON.parse(await readFile(overlayPathFor("m"), "utf8"))).toEqual(
+        first
+      );
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  test("rollback with nothing to restore removes the overlay entirely", async () => {
+    // The base harness is always a safe resting state. A rollback must never
+    // leave a known-bad overlay installed for want of a replacement.
+    const dir = await home();
+
+    try {
+      await installOverlay("m", emptyOverlay());
+
+      expect(await revertOverlay("m")).toBe(false);
+      expect(existsSync(overlayPathFor("m"))).toBe(false);
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  test("no partial overlay is ever visible at the live path", async () => {
+    // activeOverlay() reads this path synchronously on a hot path with no
+    // locking, so the write has to be atomic. A session starting mid-install
+    // must see either the old overlay or the new one.
+    const dir = await home();
+
+    try {
+      const live = overlayPathFor("m");
+
+      await mkdir(dirname(live), { recursive: true });
+      await writeFile(live, JSON.stringify(emptyOverlay()));
+
+      const big = {
+        ...emptyOverlay(),
+        promptBlocks: {
+          extra: { mode: "append" as const, text: "x".repeat(200_000) },
+        },
+      };
+
+      await installOverlay("m", big);
+
+      // Whatever is there parses — never a truncated prefix.
+      expect(JSON.parse(await readFile(live, "utf8"))).toEqual(big);
+      expect(existsSync(`${live}.tmp`)).toBe(false);
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+});

--- a/packages/core/tests/streaming.test.ts
+++ b/packages/core/tests/streaming.test.ts
@@ -145,3 +145,87 @@ test("streams a final SSE line even when it has no trailing newline", async () =
 
   expect(r.content).toBe("tail");
 });
+
+test("an error carried INSIDE a 200 stream is raised, not read as silence", async () => {
+  // vLLM answers a rejected parameter with HTTP 200 and an error object in the
+  // SSE body. Ignoring it produced an empty completion that read as "the model
+  // chose to say nothing" — so the loop retried the same doomed request for its
+  // whole turn budget and the task failed as if the model could not do the work.
+  const chunks = [
+    `data: {"error": {"message": "thinking_token_budget is not yet supported by the V2 model runner.", "type": "BadRequestError", "code": 400}}\n`,
+    `data: [DONE]\n`,
+  ];
+  const p = new OpenAICompatibleProvider({
+    baseUrl: "http://x/v1",
+    model: "m",
+    fetch: (async () => sseResponse(chunks)) as unknown as typeof fetch,
+  });
+
+  expect(
+    p.complete([{ role: "user", content: "hi" }], { onToken: () => undefined })
+  ).rejects.toThrow(/thinking_token_budget/u);
+});
+
+test("a rejected optional field is dropped and the call retried once", async () => {
+  // Self-healing across runtime versions: the same harness has to work against
+  // a vLLM that supports thinking_token_budget and one that does not.
+  const bodies: string[] = [];
+  const fakeFetch = (async (_url: string, init: { body: string }) => {
+    bodies.push(init.body);
+
+    return bodies.length === 1
+      ? sseResponse([
+          `data: {"error": {"message": "thinking_token_budget is not yet supported by the V2 model runner.", "code": 400}}\n`,
+          `data: [DONE]\n`,
+        ])
+      : sseResponse([
+          `data: {"choices":[{"delta":{"content":"ok"}}]}\n`,
+          `data: [DONE]\n`,
+        ]);
+  }) as unknown as typeof fetch;
+
+  const p = new OpenAICompatibleProvider({
+    baseUrl: "http://x/v1",
+    model: "m",
+    fetch: fakeFetch,
+    reasoning: "deepseek-local",
+  });
+
+  const r = await p.complete([{ role: "user", content: "hi" }], {
+    onToken: () => undefined,
+    thinkingTokenBudget: 2048,
+  });
+
+  expect(r.content).toBe("ok");
+  expect(bodies).toHaveLength(2);
+  expect(bodies[0]).toContain("thinking_token_budget");
+  expect(bodies[1]).not.toContain("thinking_token_budget");
+});
+
+test("a rejection that names nothing we sent is not retried", async () => {
+  // Blind retry would hide real request errors. Only a 4xx naming an optional
+  // field we actually sent earns a second attempt.
+  let calls = 0;
+  const fakeFetch = (async () => {
+    calls += 1;
+
+    return sseResponse([
+      `data: {"error": {"message": "context length exceeded", "code": 400}}\n`,
+      `data: [DONE]\n`,
+    ]);
+  }) as unknown as typeof fetch;
+
+  const p = new OpenAICompatibleProvider({
+    baseUrl: "http://x/v1",
+    model: "m",
+    fetch: fakeFetch,
+  });
+
+  expect(
+    p.complete([{ role: "user", content: "hi" }], {
+      onToken: () => undefined,
+      thinkingTokenBudget: 2048,
+    })
+  ).rejects.toThrow(/context length/u);
+  expect(calls).toBe(1);
+});


### PR DESCRIPTION
## Why

tsforge already implements arXiv 2606.09498 faithfully. **It has never accepted a single edit** — across every session in July plus the campaign. Not a design problem; the loop was being starved.

From the archived lineages:

```
propose r0-c1: dropped — unparseable proposer response
propose r0-c2: dropped — unparseable proposer response
propose r1-c1: dropped — unparseable proposer response
propose r1-c2: dropped — unparseable proposer response
```

Four of six candidates died at `JSON.parse`. The paper's proposal width K silently collapsed from 3 to 1, the survivor scored Δ=0 on a 4-task split, and the round ended with almost nothing measured.

## What changed

**Proposals are valid by construction.** `ICompleteOptions` learns `responseFormat`; the proposer sends the patch shape as a JSON schema so a runtime with guided decoding cannot emit anything else. Measured live against the endpoint on a real mined pattern: **3/3 candidates, zero dropped**, spread across three different surfaces. The salvage re-ask stays for endpoints that ignore the field.

**Repeats default to 2** — the paper's *"two repeated attempts for each harness candidate"*. The campaign now passes it explicitly, so a mining verdict and the proof split are measured on the same footing. At one attempt, a flaky task and a real gain are the same integer.

**Tool wiring becomes an editable surface**, closing the last divergence from the paper. The paper puts `tools` in the editable harness file while holding *"the … tool set … unchanged"* across variants. So an overlay may reword how a tool is described, or stop offering one — and **an id naming a tool the harness does not already offer does nothing**. There is no add direction. Plan mode's read-only filter still wins.

Withdrawing a tool the work needs is allowed and self-correcting: the pass rate falls and the acceptance rule rejects the edit. That is the loop working.

## What did not change

The verifier. The paper holds *"the benchmark environment, and evaluator … unchanged"*, and this stays enforced. It is not caution — a harness that can edit its own gate can pass by lowering the bar, and every delta it measures stops meaning anything.

## Tests

23 new: wire mapping (including that a per-model `extraBody` still overrides), schema↔overlay drift in both directions, the unknown-id no-op, no mutation of the session's shared tool list, and the overlay-file→runtime path.

`bun run validate` green at 4,266.