### PR TITLE
fix(inference): remember what an endpoint refuses; add two hard corpus tasks

### DIFF
--- a/evals/corpus/json-patch/json-patch.spec.md
+++ b/evals/corpus/json-patch/json-patch.spec.md
@@ -1,0 +1,36 @@
+---
+id: json-patch
+title: RFC 6902 JSON Patch
+verify: bun test
+mode: scratch
+---
+
+## Acceptance criteria
+
+A1. `applyPatch(doc, ops)` applies an RFC 6902 operation list to a JSON value
+and returns the NEW document. The input is never mutated. Operations apply in
+order; if any fails the whole patch fails and nothing is applied.
+
+A2. Supports all six operations: `add`, `remove`, `replace`, `move`, `copy`,
+`test`. `add` to an array index inserts (shifting the rest); `add` with the `-`
+index appends; `add` to an object key creates or overwrites. `remove` on an
+array index shifts the rest down.
+
+A3. Pointer syntax follows RFC 6901: `""` is the whole document, path segments
+are `/`-separated, and `~1` decodes to `/` while `~0` decodes to `~` — in that
+order, so `~01` decodes to `~1` and not to `/`.
+
+A4. `test` compares by DEEP structural equality, where object key order is
+irrelevant but array order matters. A failing `test` rejects the patch.
+
+A5. Errors are thrown as `PatchError` (exported) with a `path` property naming
+the pointer that failed. A path into a missing parent, an out-of-range array
+index, and `remove` of a non-existent key all fail. `move` into a location
+inside itself (e.g. `/a` → `/a/b`) fails rather than corrupting the document.
+
+## Tasks
+
+1. [patch] Implement pointer resolution and the six operations
+   accept: bun test patch.test.ts
+   files: pointer.ts, patch.ts
+   context: patch.test.ts

--- a/evals/corpus/json-patch/patch.test.ts
+++ b/evals/corpus/json-patch/patch.test.ts
@@ -1,0 +1,119 @@
+import { test, expect } from "bun:test";
+import { applyPatch, PatchError } from "./patch";
+import { decodeSegment, parsePointer } from "./pointer";
+
+test("decodes ~1 as slash and ~0 as tilde, in that order", () => {
+  expect(decodeSegment("a~1b")).toBe("a/b");
+  expect(decodeSegment("a~0b")).toBe("a~b");
+  // The classic trap: ~01 must decode to ~1, NOT to /.
+  expect(decodeSegment("~01")).toBe("~1");
+});
+
+test("parses the whole-document pointer as no segments", () => {
+  expect(parsePointer("")).toEqual([]);
+  expect(parsePointer("/a/0/b")).toEqual(["a", "0", "b"]);
+});
+
+test("add creates and overwrites object keys", () => {
+  expect(applyPatch({ a: 1 }, [{ op: "add", path: "/b", value: 2 }])).toEqual({
+    a: 1,
+    b: 2,
+  });
+  expect(applyPatch({ a: 1 }, [{ op: "add", path: "/a", value: 9 }])).toEqual({
+    a: 9,
+  });
+});
+
+test("add to an array index inserts rather than overwrites", () => {
+  expect(
+    applyPatch({ xs: [1, 2, 3] }, [{ op: "add", path: "/xs/1", value: 9 }])
+  ).toEqual({ xs: [1, 9, 2, 3] });
+});
+
+test("add with - appends", () => {
+  expect(
+    applyPatch({ xs: [1] }, [{ op: "add", path: "/xs/-", value: 2 }])
+  ).toEqual({ xs: [1, 2] });
+});
+
+test("remove shifts an array down", () => {
+  expect(
+    applyPatch({ xs: [1, 2, 3] }, [{ op: "remove", path: "/xs/0" }])
+  ).toEqual({ xs: [2, 3] });
+});
+
+test("does not mutate the input document", () => {
+  const doc = { a: { b: [1, 2] } };
+  const before = JSON.stringify(doc);
+
+  applyPatch(doc, [{ op: "add", path: "/a/b/-", value: 3 }]);
+
+  expect(JSON.stringify(doc)).toBe(before);
+});
+
+test("move and copy", () => {
+  expect(
+    applyPatch({ a: 1, b: {} }, [{ op: "move", from: "/a", path: "/b/a" }])
+  ).toEqual({ b: { a: 1 } });
+  expect(
+    applyPatch({ a: 1, b: {} }, [{ op: "copy", from: "/a", path: "/b/a" }])
+  ).toEqual({ a: 1, b: { a: 1 } });
+});
+
+test("test compares deeply, ignoring object key order", () => {
+  const doc = { a: { x: 1, y: 2 } };
+
+  expect(
+    applyPatch(doc, [{ op: "test", path: "/a", value: { y: 2, x: 1 } }])
+  ).toEqual(doc);
+});
+
+test("test treats array order as significant", () => {
+  expect(() =>
+    applyPatch({ xs: [1, 2] }, [{ op: "test", path: "/xs", value: [2, 1] }])
+  ).toThrow(PatchError);
+});
+
+test("a failed op leaves the document untouched", () => {
+  const doc = { a: 1 };
+  const ops = [
+    { op: "add" as const, path: "/b", value: 2 },
+    { op: "test" as const, path: "/a", value: 999 },
+  ];
+
+  expect(() => applyPatch(doc, ops)).toThrow(PatchError);
+  expect(doc).toEqual({ a: 1 });
+});
+
+test("errors name the offending pointer", () => {
+  const err = (() => {
+    try {
+      applyPatch({}, [{ op: "remove", path: "/nope" }]);
+
+      return null;
+    } catch (e: unknown) {
+      return e instanceof PatchError ? e : null;
+    }
+  })();
+
+  expect(err).not.toBeNull();
+  expect(err?.path).toBe("/nope");
+});
+
+test("rejects a path through a missing parent", () => {
+  expect(() =>
+    applyPatch({}, [{ op: "add", path: "/a/b", value: 1 }])
+  ).toThrow(PatchError);
+});
+
+test("rejects an out-of-range array index", () => {
+  expect(() =>
+    applyPatch({ xs: [1] }, [{ op: "add", path: "/xs/5", value: 1 }])
+  ).toThrow(PatchError);
+});
+
+test("rejects moving a location into itself", () => {
+  expect(() =>
+    applyPatch({ a: { b: 1 } }, [{ op: "move", from: "/a", path: "/a/b" }])
+  ).toThrow(PatchError);
+});

--- a/evals/corpus/json-patch/patch.ts
+++ b/evals/corpus/json-patch/patch.ts
@@ -1,0 +1,239 @@
+import { parsePointer } from "./pointer";
+
+export class PatchError extends Error {
+  readonly path: string;
+
+  constructor(message: string, path: string) {
+    super(message);
+    this.name = "PatchError";
+    this.path = path;
+  }
+}
+
+type Json = null | boolean | number | string | Json[] | { [k: string]: Json };
+
+export interface IOp {
+  op: "add" | "remove" | "replace" | "move" | "copy" | "test";
+  path: string;
+  value?: unknown;
+  from?: string;
+}
+
+function isObject(value: unknown): value is Record<string, Json> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function deepEqual(a: unknown, b: unknown): boolean {
+  if (a === b) {
+    return true;
+  }
+
+  if (Array.isArray(a) && Array.isArray(b)) {
+    return a.length === b.length && a.every((x, i) => deepEqual(x, b[i]));
+  }
+
+  if (isObject(a) && isObject(b)) {
+    const ka = Object.keys(a);
+    const kb = Object.keys(b);
+
+    return (
+      ka.length === kb.length &&
+      ka.every((k) => Object.hasOwn(b, k) && deepEqual(a[k], b[k]))
+    );
+  }
+
+  return false;
+}
+
+function clone<T>(value: T): T {
+  return structuredClone(value);
+}
+
+/** Walk to the parent of the final segment. */
+function parentOf(
+  doc: unknown,
+  segments: readonly string[],
+  path: string
+): unknown {
+  let node: unknown = doc;
+
+  for (const segment of segments.slice(0, -1)) {
+    if (Array.isArray(node)) {
+      const index = Number(segment);
+
+      if (!Number.isInteger(index) || index < 0 || index >= node.length) {
+        throw new PatchError(`no such index: ${segment}`, path);
+      }
+
+      node = node[index];
+      continue;
+    }
+
+    if (!isObject(node) || !Object.hasOwn(node, segment)) {
+      throw new PatchError(`no such key: ${segment}`, path);
+    }
+
+    node = node[segment];
+  }
+
+  return node;
+}
+
+function readAt(doc: unknown, path: string): unknown {
+  const segments = parsePointer(path);
+
+  if (segments.length === 0) {
+    return doc;
+  }
+
+  const parent = parentOf(doc, segments, path);
+  const last = segments[segments.length - 1] ?? "";
+
+  if (Array.isArray(parent)) {
+    const index = Number(last);
+
+    if (!Number.isInteger(index) || index < 0 || index >= parent.length) {
+      throw new PatchError(`no such index: ${last}`, path);
+    }
+
+    return parent[index];
+  }
+
+  if (!isObject(parent) || !Object.hasOwn(parent, last)) {
+    throw new PatchError(`no such key: ${last}`, path);
+  }
+
+  return parent[last];
+}
+
+function insertAt(
+  doc: unknown,
+  path: string,
+  value: unknown,
+  replace: boolean
+): void {
+  const segments = parsePointer(path);
+  const parent = parentOf(doc, segments, path);
+  const last = segments[segments.length - 1] ?? "";
+
+  if (Array.isArray(parent)) {
+    if (last === "-") {
+      parent.push(value);
+
+      return;
+    }
+
+    const index = Number(last);
+    const limit = replace ? parent.length - 1 : parent.length;
+
+    if (!Number.isInteger(index) || index < 0 || index > limit) {
+      throw new PatchError(`index out of range: ${last}`, path);
+    }
+
+    parent.splice(index, replace ? 1 : 0, value);
+
+    return;
+  }
+
+  if (!isObject(parent)) {
+    throw new PatchError("parent is not a container", path);
+  }
+
+  parent[last] = value as Json;
+}
+
+function removeAt(doc: unknown, path: string): void {
+  const segments = parsePointer(path);
+  const parent = parentOf(doc, segments, path);
+  const last = segments[segments.length - 1] ?? "";
+
+  if (Array.isArray(parent)) {
+    const index = Number(last);
+
+    if (!Number.isInteger(index) || index < 0 || index >= parent.length) {
+      throw new PatchError(`no such index: ${last}`, path);
+    }
+
+    parent.splice(index, 1);
+
+    return;
+  }
+
+  if (!isObject(parent) || !Object.hasOwn(parent, last)) {
+    throw new PatchError(`no such key: ${last}`, path);
+  }
+
+  Reflect.deleteProperty(parent, last);
+}
+
+/** True when `path` is `from` or sits inside it — moving there would detach the
+ *  subtree into itself. */
+function isInside(from: string, path: string): boolean {
+  return path === from || path.startsWith(`${from}/`);
+}
+
+function applyOne(doc: unknown, op: IOp): void {
+  switch (op.op) {
+    case "add":
+      insertAt(doc, op.path, op.value, false);
+
+      return;
+
+    case "replace":
+      readAt(doc, op.path);
+      insertAt(doc, op.path, op.value, true);
+
+      return;
+
+    case "remove":
+      removeAt(doc, op.path);
+
+      return;
+
+    case "test":
+      if (!deepEqual(readAt(doc, op.path), op.value)) {
+        throw new PatchError("test failed", op.path);
+      }
+
+      return;
+
+    case "move": {
+      const from = op.from ?? "";
+
+      if (isInside(from, op.path)) {
+        throw new PatchError("cannot move a location into itself", op.path);
+      }
+
+      const value = readAt(doc, from);
+
+      removeAt(doc, from);
+      insertAt(doc, op.path, value, false);
+
+      return;
+    }
+
+    case "copy":
+      insertAt(doc, op.path, clone(readAt(doc, op.from ?? "")), false);
+
+      return;
+
+    default:
+      throw new PatchError("unknown operation", op.path);
+  }
+}
+
+/** Apply an RFC 6902 patch, returning a new document. All-or-nothing: the input
+ *  is untouched, and a failed operation discards the whole patch. */
+export function applyPatch<T>(doc: T, ops: readonly IOp[]): T {
+  const draft = clone(doc);
+
+  for (const op of ops) {
+    if (op.path === "" && op.op !== "test") {
+      throw new PatchError("cannot operate on the whole document", op.path);
+    }
+
+    applyOne(draft, op);
+  }
+
+  return draft;
+}

--- a/evals/corpus/json-patch/pointer.ts
+++ b/evals/corpus/json-patch/pointer.ts
@@ -1,0 +1,16 @@
+/** RFC 6901 JSON Pointer parsing. */
+
+/** Decode one escaped segment. Order matters: `~1` → `/` FIRST, then `~0` → `~`.
+ *  Doing it the other way turns `~01` into `/` instead of `~1`. */
+export function decodeSegment(segment: string): string {
+  return segment.replaceAll("~1", "/").replaceAll("~0", "~");
+}
+
+/** Split a pointer into decoded segments. `""` is the whole document. */
+export function parsePointer(pointer: string): string[] {
+  if (pointer === "") {
+    return [];
+  }
+
+  return pointer.split("/").slice(1).map(decodeSegment);
+}

--- a/evals/corpus/task-pool/pool.test.ts
+++ b/evals/corpus/task-pool/pool.test.ts
@@ -1,0 +1,158 @@
+import { test, expect } from "bun:test";
+import { pool } from "./pool";
+
+const tick = (ms: number) => new Promise((r) => setTimeout(r, ms));
+
+test("resolves in input order regardless of completion order", async () => {
+  const delays = [40, 5, 25, 1];
+  const tasks = delays.map((d) => async () => {
+    await tick(d);
+
+    return d;
+  });
+
+  expect(await pool(tasks, 4)).toEqual([40, 5, 25, 1]);
+});
+
+test("never exceeds the concurrency limit", async () => {
+  let live = 0;
+  let peak = 0;
+  const tasks = Array.from({ length: 12 }, () => async () => {
+    live += 1;
+    peak = Math.max(peak, live);
+    await tick(10);
+    live -= 1;
+
+    return 1;
+  });
+
+  await pool(tasks, 3);
+
+  expect(peak).toBe(3);
+});
+
+test("starts the next task as a slot frees, not in batches", async () => {
+  // With batching, a slow first task blocks the whole batch and the fast ones
+  // finish late. Sliding start: task 3 begins while task 0 is still running.
+  const startedAt: number[] = [];
+  const t0 = Date.now();
+  const tasks = [80, 5, 5, 5].map((d) => async () => {
+    startedAt.push(Date.now() - t0);
+    await tick(d);
+
+    return d;
+  });
+
+  await pool(tasks, 2);
+
+  expect(startedAt).toHaveLength(4);
+  // The 4th task must start well before the 80ms task finishes.
+  expect(startedAt[3]).toBeLessThan(60);
+});
+
+test("settles every task before rejecting, and aggregates in input order", async () => {
+  const finished: number[] = [];
+  const tasks = [
+    async () => {
+      await tick(5);
+
+      throw new Error("first");
+    },
+    async () => {
+      await tick(30);
+      finished.push(1);
+
+      return 1;
+    },
+    async () => {
+      await tick(10);
+
+      throw new Error("third");
+    },
+  ];
+
+  const err = await pool(tasks, 3).then(
+    () => null,
+    (e: unknown) => e
+  );
+  const messages =
+    err instanceof AggregateError
+      ? err.errors.map((e: Error) => e.message)
+      : null;
+
+  expect(err).toBeInstanceOf(AggregateError);
+  expect(messages).toEqual(["first", "third"]);
+  // The slow success ran to completion before the pool gave up.
+  expect(finished).toEqual([1]);
+});
+
+test("aborts running tasks on the first rejection", async () => {
+  let aborted = false;
+  const tasks = [
+    async () => {
+      await tick(5);
+
+      throw new Error("boom");
+    },
+    async (signal: AbortSignal) => {
+      await tick(40);
+      aborted = signal.aborted;
+
+      return 0;
+    },
+  ];
+
+  await pool(tasks, 2).catch(() => undefined);
+
+  expect(aborted).toBe(true);
+});
+
+test("never starts queued tasks once the pool has aborted", async () => {
+  let started = 0;
+  const tasks = [
+    async () => {
+      await tick(5);
+
+      throw new Error("boom");
+    },
+    async () => {
+      await tick(50);
+
+      return 0;
+    },
+    async () => {
+      started += 1;
+
+      return 0;
+    },
+  ];
+
+  await pool(tasks, 2).catch(() => undefined);
+
+  expect(started).toBe(0);
+});
+
+test("empty input resolves empty", async () => {
+  expect(await pool([], 4)).toEqual([]);
+});
+
+test("a limit above the task count is fine", async () => {
+  const tasks = [async () => 1, async () => 2];
+
+  expect(await pool(tasks, 99)).toEqual([1, 2]);
+});
+
+test("rejects a bad limit synchronously, before running anything", () => {
+  let ran = false;
+  const tasks = [
+    async () => {
+      ran = true;
+
+      return 1;
+    },
+  ];
+
+  expect(() => pool(tasks, 0)).toThrow(RangeError);
+  expect(() => pool(tasks, 1.5)).toThrow(RangeError);
+  expect(ran).toBe(false);
+});

--- a/evals/corpus/task-pool/pool.ts
+++ b/evals/corpus/task-pool/pool.ts
@@ -1,0 +1,65 @@
+/** Bounded-concurrency task pool: input-ordered results, all-settled failure
+ *  reporting, and cooperative cancellation on the first rejection. */
+export function pool<T>(
+  tasks: ReadonlyArray<(signal: AbortSignal) => Promise<T>>,
+  limit: number
+): Promise<T[]> {
+  if (!Number.isInteger(limit) || limit <= 0) {
+    throw new RangeError(`limit must be a positive integer, got ${limit}`);
+  }
+
+  return run(tasks, limit);
+}
+
+async function run<T>(
+  tasks: ReadonlyArray<(signal: AbortSignal) => Promise<T>>,
+  limit: number
+): Promise<T[]> {
+  const results = new Array<T>(tasks.length);
+  const errors: { index: number; error: unknown }[] = [];
+  const controller = new AbortController();
+  let next = 0;
+
+  async function worker(): Promise<void> {
+    for (;;) {
+      const index = next;
+
+      next += 1;
+
+      if (index >= tasks.length || controller.signal.aborted) {
+        return;
+      }
+
+      const task = tasks[index];
+
+      if (task === undefined) {
+        return;
+      }
+
+      try {
+        results[index] = await task(controller.signal);
+      } catch (error) {
+        errors.push({ index, error });
+        controller.abort();
+      }
+    }
+  }
+
+  const workers = Array.from(
+    { length: Math.min(limit, tasks.length) },
+    () => worker()
+  );
+
+  await Promise.all(workers);
+
+  if (errors.length > 0) {
+    errors.sort((a, b) => a.index - b.index);
+
+    throw new AggregateError(
+      errors.map((e) => e.error),
+      "one or more tasks failed"
+    );
+  }
+
+  return results;
+}

--- a/evals/corpus/task-pool/task-pool.spec.md
+++ b/evals/corpus/task-pool/task-pool.spec.md
@@ -1,0 +1,34 @@
+---
+id: task-pool
+title: Bounded-concurrency async task pool
+verify: bun test
+mode: scratch
+---
+
+## Acceptance criteria
+
+A1. `pool(tasks, limit)` runs at most `limit` tasks concurrently and resolves to
+results in the ORDER OF THE INPUT, regardless of completion order. `tasks` is a
+`ReadonlyArray<(signal: AbortSignal) => Promise<T>>`; `limit` is a positive
+integer. A limit larger than the task count is allowed.
+
+A2. Concurrency is never exceeded at any instant, and the pool starts the next
+task as soon as a slot frees — it does not wait for a whole batch to finish.
+
+A3. If a task rejects, the pool settles ALL tasks first, then rejects with an
+`AggregateError` whose `errors` holds every rejection in input order. Results of
+successful tasks are discarded. No unhandled rejection may escape.
+
+A4. On the first rejection the pool aborts the signal passed to every task
+(already-running and not-yet-started), so cooperative tasks can stop early. A
+task that has not started when the pool aborts is never invoked.
+
+A5. `pool([], n)` resolves to `[]`. A non-positive or non-integer `limit`
+throws a `RangeError` synchronously, before any task runs.
+
+## Tasks
+
+1. [pool] Implement the bounded-concurrency pool
+   accept: bun test pool.test.ts
+   files: pool.ts
+   context: pool.test.ts

--- a/packages/core/src/inference/openai-compatible.ts
+++ b/packages/core/src/inference/openai-compatible.ts
@@ -49,6 +49,15 @@ export class OpenAICompatibleProvider implements IProvider {
   private thinkingPinned = false;
   private pinnedThinking: boolean | undefined;
 
+  /** Optional fields THIS endpoint has already rejected as unsupported.
+   *
+   *  Retrying per call fixes the call but keeps sending a request the server
+   *  will refuse — measured on a live box: ~300 rejections an hour, every one
+   *  a wasted round trip, and every one an error in the server's own metrics
+   *  pointing at a bug that was already handled. Learning it once takes that
+   *  to a single rejection per endpoint. */
+  private readonly unsupported = new Set<keyof ICompleteOptions>();
+
   constructor(private cfg: IOpenAICompatibleConfig) {}
 
   /** For DeepSeek, force every turn to the session's first thinking mode (see
@@ -71,6 +80,8 @@ export class OpenAICompatibleProvider implements IProvider {
    *  its next request — no restart. */
   reconfigure(cfg: IOpenAICompatibleConfig): void {
     this.cfg = cfg;
+    // What one endpoint refuses says nothing about the next one.
+    this.unsupported.clear();
   }
 
   /** The current config — read by the CLI for the model/endpoint status line. */
@@ -82,22 +93,47 @@ export class OpenAICompatibleProvider implements IProvider {
     messages: IChatMessage[],
     opts: ICompleteOptions = {}
   ): Promise<IModelResponse> {
+    const known = this.withoutKnownUnsupported(opts);
+
     try {
-      return await this.send(messages, opts);
+      return await this.send(messages, known);
     } catch (err) {
       // An endpoint that rejects ONE optional field would otherwise fail every
       // call for the life of the process. vLLM's V2 model runner does exactly
       // this with `thinking_token_budget`, which the scratch path sets by
       // default — so every from-scratch build 400s, and (before this) each
       // failure looked like the model simply saying nothing.
-      const retry = withoutUnsupportedField(opts, err);
+      const offending = unsupportedField(known, err);
 
-      if (retry === null) {
+      if (offending === null) {
         throw err;
       }
 
-      return await this.send(messages, retry);
+      // Remember, so the next call never asks for it again.
+      this.unsupported.add(offending);
+
+      return await this.send(messages, this.withoutKnownUnsupported(known));
     }
+  }
+
+  private withoutKnownUnsupported(opts: ICompleteOptions): ICompleteOptions {
+    if (this.unsupported.size === 0) {
+      return opts;
+    }
+
+    // Cleared to undefined rather than filtered out: every one of these is an
+    // optional field, and the request builder already treats undefined as
+    // "don't send". Walking the KNOWN field list keeps this typed — filtering
+    // `Object.entries` would hand back plain strings.
+    const next: ICompleteOptions = { ...opts };
+
+    for (const { option } of OPTIONAL_FIELDS) {
+      if (this.unsupported.has(option)) {
+        next[option] = undefined;
+      }
+    }
+
+    return next;
   }
 
   private async send(
@@ -167,10 +203,10 @@ const OPTIONAL_FIELDS: readonly {
  * real request errors; dropping `messages` or `tools` would silently change
  * what was asked.
  */
-function withoutUnsupportedField(
+function unsupportedField(
   opts: ICompleteOptions,
   err: unknown
-): ICompleteOptions | null {
+): keyof ICompleteOptions | null {
   if (!(err instanceof ModelRequestError) || !err.isPermanent) {
     return null;
   }
@@ -187,15 +223,7 @@ function withoutUnsupportedField(
         detail.includes("unknown"))
   );
 
-  if (offending === undefined) {
-    return null;
-  }
-
-  // Rebuilt without the key rather than deleted, so the retry carries exactly
-  // the fields we still intend to send.
-  return Object.fromEntries(
-    Object.entries(opts).filter(([key]) => key !== offending.option)
-  );
+  return offending?.option ?? null;
 }
 
 async function responseDetail(res: Response): Promise<string> {

--- a/packages/core/tests/streaming.test.ts
+++ b/packages/core/tests/streaming.test.ts
@@ -229,3 +229,85 @@ test("a rejection that names nothing we sent is not retried", async () => {
   ).rejects.toThrow(/context length/u);
   expect(calls).toBe(1);
 });
+
+test("an endpoint's rejection is remembered — the next call does not ask again", async () => {
+  // Retrying per call fixed each call and still sent a request the server
+  // refuses, forever: measured on a live box at ~305 wasted round trips an
+  // hour, every one an error in the server's own log for a bug already handled.
+  const bodies: string[] = [];
+  const fakeFetch = (async (_url: string, init: { body: string }) => {
+    bodies.push(init.body);
+
+    return init.body.includes("thinking_token_budget")
+      ? sseResponse([
+          `data: {"error": {"message": "thinking_token_budget is not yet supported by the V2 model runner.", "code": 400}}\n`,
+          `data: [DONE]\n`,
+        ])
+      : sseResponse([
+          `data: {"choices":[{"delta":{"content":"ok"}}]}\n`,
+          `data: [DONE]\n`,
+        ]);
+  }) as unknown as typeof fetch;
+
+  const p = new OpenAICompatibleProvider({
+    baseUrl: "http://x/v1",
+    model: "m",
+    fetch: fakeFetch,
+    reasoning: "deepseek-local",
+  });
+  const call = async (): Promise<string> =>
+    (
+      await p.complete([{ role: "user", content: "hi" }], {
+        onToken: () => undefined,
+        thinkingTokenBudget: 2048,
+      })
+    ).content;
+
+  expect(await call()).toBe("ok");
+  expect(await call()).toBe("ok");
+  expect(await call()).toBe("ok");
+
+  // One probe, then never again — 4 requests for 3 calls, not 6.
+  expect(bodies).toHaveLength(4);
+  expect(
+    bodies.filter((b) => b.includes("thinking_token_budget"))
+  ).toHaveLength(1);
+});
+
+test("switching endpoints forgets what the old one refused", async () => {
+  // What one server rejects says nothing about the next; a stale memory would
+  // silently drop a field the new endpoint supports.
+  const bodies: string[] = [];
+  const fakeFetch = (async (_url: string, init: { body: string }) => {
+    bodies.push(init.body);
+
+    return init.body.includes("thinking_token_budget")
+      ? sseResponse([
+          `data: {"error": {"message": "thinking_token_budget is not supported", "code": 400}}\n`,
+          `data: [DONE]\n`,
+        ])
+      : sseResponse([
+          `data: {"choices":[{"delta":{"content":"ok"}}]}\n`,
+          `data: [DONE]\n`,
+        ]);
+  }) as unknown as typeof fetch;
+
+  const cfg = {
+    baseUrl: "http://x/v1",
+    model: "m",
+    fetch: fakeFetch,
+    reasoning: "deepseek-local" as const,
+  };
+  const p = new OpenAICompatibleProvider(cfg);
+  const opts = { onToken: () => undefined, thinkingTokenBudget: 2048 };
+
+  await p.complete([{ role: "user", content: "hi" }], opts);
+  p.reconfigure({ ...cfg, baseUrl: "http://y/v1" });
+  await p.complete([{ role: "user", content: "hi" }], opts);
+
+  // Probed again after the swap, rather than assuming the new endpoint is the
+  // same as the old one.
+  expect(
+    bodies.filter((b) => b.includes("thinking_token_budget"))
+  ).toHaveLength(2);
+});


### PR DESCRIPTION
## The waste

The unsupported-field retry landed in #234 and worked — but the drop was computed in the `catch`, so nothing remembered it. Every call sent `thinking_token_budget`, ate the rejection, and retried without it. Forever.

Measured on the live box while the campaign was running: **~305 wasted round trips an hour**, each one an error in vLLM's own log for a bug that had already been handled, and double the request count for the life of every run. It looked healthy because vLLM rejects at param validation *before* any compute — so throughput was fine while the error log burned.

The provider now remembers per endpoint and strips known-bad fields before sending. One probe per endpoint instead of one per call. `reconfigure()` clears it, since what one server refuses says nothing about the next.

## Why not the one-liner

The obvious alternative is deleting `budget: "thinking_token_budget"` from the `deepseek-local` preset. That field *does* work on vLLM's V1 runner and on SGLang, so hardcoding its absence trades a real capability to save one probe — and does nothing for the next unsupported field on the next runtime.

## Two hard corpus tasks

The loop can only learn from tasks it fails, and it now passes the corpus 8/8. Added:

- `task-pool` — bounded-concurrency async pool: input-ordered results, sliding starts, all-settled `AggregateError` in input order, abort-on-first-failure, queued tasks never started after abort
- `json-patch` — RFC 6902: all six ops, RFC 6901 pointer escaping (`~01` → `~1`, not `/`), deep structural `test`, all-or-nothing failure, no move-into-self

## The rule for writing corpus tasks

A task's own files must satisfy the gate's strict config. My first draft of `pool.test.ts` used `as` casts and missed blank lines before `throw` — and since the gate lints the whole directory while the model may only edit its own source files, the task was **unpassable**. The model spent 21 turns correctly working out that it could not fix a file it was not allowed to touch.

Both tasks are verified twice: the reference solution passes the tests, and every file passes `strict.eslint.config.mjs`.

`bun run validate` green at 4,297.