### PR TITLE
feat(evals): aim the campaign at tasks with headroom; a corpus task that checks itself

### DIFF
--- a/evals/corpus/extract-dup/extract-dup.spec.md
+++ b/evals/corpus/extract-dup/extract-dup.spec.md
@@ -1,0 +1,28 @@
+---
+id: extract-dup
+title: De-duplicate a rounding helper across a codebase
+verify: bun test
+mode: existing
+---
+
+## Acceptance criteria
+
+A1. `src/shared/money.ts` exports `roundHalfUp(cents: number, factor: number)`
+implementing HALF-UP rounding away from zero: `roundHalfUp(-125, 1)` is `-13`
+tenths-of-a-cent → i.e. ties round away from zero, not toward positive infinity.
+
+A2. Every module that currently inlines that same half-up rounding imports it
+from `src/shared/money.ts` instead. No module may keep its own copy.
+
+A3. `src/reporting/forecast.ts` looks similar but is NOT the same function — it
+rounds HALF-EVEN (banker's rounding). It must keep its own behaviour and must
+NOT be rewired to the shared helper.
+
+A4. All existing behaviour is preserved exactly; `bun test` passes.
+
+## Tasks
+
+1. [extract] Extract the shared rounding helper and rewire its call sites
+   accept: bun test
+   files: src/shared/money.ts, src/billing/invoice.ts, src/orders/total.ts, src/shipping/quote.ts, src/reporting/forecast.ts
+   context: src/shared/structure.test.ts, src/billing/invoice.test.ts, src/orders/total.test.ts, src/shipping/quote.test.ts, src/reporting/forecast.test.ts, src/shared/money.test.ts

--- a/evals/corpus/extract-dup/src/billing/invoice.test.ts
+++ b/evals/corpus/extract-dup/src/billing/invoice.test.ts
@@ -1,0 +1,7 @@
+import { test, expect } from "bun:test";
+import { invoiceTotal } from "./invoice";
+
+test("invoiceTotal sums then rounds half-up", () => {
+  expect(invoiceTotal([120, 5], 10)).toBe(13);
+  expect(invoiceTotal([-120, -5], 10)).toBe(-13);
+});

--- a/evals/corpus/extract-dup/src/billing/invoice.ts
+++ b/evals/corpus/extract-dup/src/billing/invoice.ts
@@ -1,0 +1,12 @@
+/** Half-up rounding, away from zero. */
+function round(cents: number, factor: number): number {
+  const scaled = cents / factor;
+
+  return scaled < 0 ? -Math.floor(-scaled + 0.5) : Math.floor(scaled + 0.5);
+}
+
+export function invoiceTotal(lines: readonly number[], factor: number): number {
+  const sum = lines.reduce((acc, n) => acc + n, 0);
+
+  return round(sum, factor);
+}

--- a/evals/corpus/extract-dup/src/orders/total.test.ts
+++ b/evals/corpus/extract-dup/src/orders/total.test.ts
@@ -1,0 +1,7 @@
+import { test, expect } from "bun:test";
+import { orderTotal } from "./total";
+
+test("orderTotal sums then rounds half-up", () => {
+  expect(orderTotal([120, 5], 10)).toBe(13);
+  expect(orderTotal([-120, -5], 10)).toBe(-13);
+});

--- a/evals/corpus/extract-dup/src/orders/total.ts
+++ b/evals/corpus/extract-dup/src/orders/total.ts
@@ -1,0 +1,12 @@
+/** Half-up rounding, away from zero. */
+function round(cents: number, factor: number): number {
+  const scaled = cents / factor;
+
+  return scaled < 0 ? -Math.floor(-scaled + 0.5) : Math.floor(scaled + 0.5);
+}
+
+export function orderTotal(items: readonly number[], factor: number): number {
+  const sum = items.reduce((acc, n) => acc + n, 0);
+
+  return round(sum, factor);
+}

--- a/evals/corpus/extract-dup/src/reporting/forecast.test.ts
+++ b/evals/corpus/extract-dup/src/reporting/forecast.test.ts
@@ -1,0 +1,9 @@
+import { test, expect } from "bun:test";
+import { forecastTotal } from "./forecast";
+
+test("forecast keeps BANKER'S rounding — ties go to even", () => {
+  // 12.5 → 12 (even), not 13. Rewiring this to the shared half-up helper
+  // breaks it, which is the point: the two look alike and are not the same.
+  expect(forecastTotal([120, 5], 10)).toBe(12);
+  expect(forecastTotal([130, 5], 10)).toBe(14);
+});

--- a/evals/corpus/extract-dup/src/reporting/forecast.ts
+++ b/evals/corpus/extract-dup/src/reporting/forecast.ts
@@ -1,0 +1,26 @@
+/** Half-EVEN (banker's) rounding — deliberately NOT the same as the half-up
+ *  helper the other modules share. Ties go to the nearest even value. */
+function roundHalfEven(cents: number, factor: number): number {
+  const scaled = cents / factor;
+  const floor = Math.floor(scaled);
+  const diff = scaled - floor;
+
+  if (diff > 0.5) {
+    return floor + 1;
+  }
+
+  if (diff < 0.5) {
+    return floor;
+  }
+
+  return floor % 2 === 0 ? floor : floor + 1;
+}
+
+export function forecastTotal(
+  samples: readonly number[],
+  factor: number
+): number {
+  const sum = samples.reduce((acc, n) => acc + n, 0);
+
+  return roundHalfEven(sum, factor);
+}

--- a/evals/corpus/extract-dup/src/shared/money.test.ts
+++ b/evals/corpus/extract-dup/src/shared/money.test.ts
@@ -1,0 +1,14 @@
+import { test, expect } from "bun:test";
+import { roundHalfUp } from "./money";
+
+test("rounds halves away from zero, in both directions", () => {
+  expect(roundHalfUp(125, 10)).toBe(13);
+  // The trap: -12.5 must go to -13, not -12. Math.round would give -12.
+  expect(roundHalfUp(-125, 10)).toBe(-13);
+});
+
+test("leaves non-ties alone", () => {
+  expect(roundHalfUp(124, 10)).toBe(12);
+  expect(roundHalfUp(126, 10)).toBe(13);
+  expect(roundHalfUp(-124, 10)).toBe(-12);
+});

--- a/evals/corpus/extract-dup/src/shared/money.ts
+++ b/evals/corpus/extract-dup/src/shared/money.ts
@@ -1,0 +1,2 @@
+/** Shared money helpers. */
+export const CURRENCY = "EUR";

--- a/evals/corpus/extract-dup/src/shared/structure.test.ts
+++ b/evals/corpus/extract-dup/src/shared/structure.test.ts
@@ -1,0 +1,43 @@
+import { test, expect } from "bun:test";
+import { join } from "node:path";
+
+/**
+ * The requirement here is STRUCTURAL — "no module keeps its own copy" — so
+ * behaviour tests cannot see it. Without this, the task passes by adding the
+ * shared helper and changing nothing else, which is exactly what happened the
+ * first time it was run.
+ */
+
+const SHARERS = [
+  ["billing", "invoice.ts"],
+  ["orders", "total.ts"],
+  ["shipping", "quote.ts"],
+] as const;
+
+async function sourceOf(dir: string, file: string): Promise<string> {
+  return Bun.file(join(import.meta.dir, "..", dir, file)).text();
+}
+
+for (const [dir, file] of SHARERS) {
+  test(`${dir}/${file} uses the shared helper`, async () => {
+    const src = await sourceOf(dir, file);
+
+    expect(src).toContain("roundHalfUp");
+    expect(src).toMatch(/from\s+"\.\.\/shared\/money"/u);
+  });
+
+  test(`${dir}/${file} keeps no rounding of its own`, async () => {
+    const src = await sourceOf(dir, file);
+
+    // Any local function declaration in these modules is the duplicate: each
+    // one should be left with a single exported total.
+    expect(src).not.toMatch(/^function /mu);
+    expect(src).not.toContain("Math.floor");
+  });
+}
+
+test("forecast is NOT rewired — it rounds half-even", async () => {
+  const src = await sourceOf("reporting", "forecast.ts");
+
+  expect(src).not.toContain("roundHalfUp");
+});

--- a/evals/corpus/extract-dup/src/shipping/quote.test.ts
+++ b/evals/corpus/extract-dup/src/shipping/quote.test.ts
@@ -1,0 +1,7 @@
+import { test, expect } from "bun:test";
+import { shippingQuote } from "./quote";
+
+test("shippingQuote sums then rounds half-up", () => {
+  expect(shippingQuote([120, 5], 10)).toBe(13);
+  expect(shippingQuote([-120, -5], 10)).toBe(-13);
+});

--- a/evals/corpus/extract-dup/src/shipping/quote.ts
+++ b/evals/corpus/extract-dup/src/shipping/quote.ts
@@ -1,0 +1,12 @@
+/** Half-up rounding, away from zero. */
+function round(cents: number, factor: number): number {
+  const scaled = cents / factor;
+
+  return scaled < 0 ? -Math.floor(-scaled + 0.5) : Math.floor(scaled + 0.5);
+}
+
+export function shippingQuote(legs: readonly number[], factor: number): number {
+  const sum = legs.reduce((acc, n) => acc + n, 0);
+
+  return round(sum, factor);
+}

--- a/packages/core/scripts/self-harness-campaign.ts
+++ b/packages/core/scripts/self-harness-campaign.ts
@@ -56,12 +56,16 @@ const PROOF_SPLIT = ["auth", "fix-regression"] as const;
  *  Alternate per session. (Also succeeded by a BoringStack corpus in future.) */
 const ROTATIONS = [
   {
-    heldIn: "checkout,debounce,validators,handlers",
-    heldOut: "query,rate-limit",
+    // task-pool sits in held-in on BOTH rotations on purpose: measured at 7-10
+    // cycles against a corpus that otherwise greens in 1-2, it is the only task
+    // with room left to improve. The pass bit cannot see that, but the
+    // efficiency dimension of the acceptance rule can (≥2 cycles and ≥20%).
+    heldIn: "task-pool,query,checkout,validators",
+    heldOut: "json-patch,handlers",
   },
   {
-    heldIn: "slugify,math,fixtures,migrate",
-    heldOut: "query,rate-limit",
+    heldIn: "task-pool,json-patch,migrate,fixtures",
+    heldOut: "extract-dup,debounce",
   },
 ] as const;
 


### PR DESCRIPTION
## What the measurements say

Three new tasks, measured against DeepSeek-V4-Flash-0731 tonight. It passes all of them:

| task | result |
|---|---|
| `json-patch` (RFC 6902, pointer escaping, deep test) | 2/2 green, 1–3 cycles |
| `extract-dup` (brownfield multi-file refactor + trap) | 3/3 green, 1–2 cycles |
| `task-pool` (bounded concurrency, abort, AggregateError) | 2/2 green, 7–10 cycles |

Writing harder single-file specs does not produce failures. The difficulty this model actually hits lives in **scale** — which is what the real build logs show (58–71 cycles, `build-fail`) and what a five-file corpus task cannot reproduce.

## So the rotations aim at what can move

`task-pool` is in held-in on **both** rotations. Against a corpus that greens in 1–2 cycles it runs 7–10, which is over the slow-green threshold of 8 — so it's the only task generating efficiency evidence, and the acceptance rule's efficiency dimension can act on it (≥2 cycles and ≥20%, held-out not regressing).

The pass bit can't see that kind of improvement. Right now it's the only place a measurable win is available.

## A task that checks itself

`extract-dup`'s first version was a fake. The spec said *"no module may keep its own copy"*, only behaviour was tested, and the model passed by adding the shared helper and changing nothing else — three greens that meant nothing.

A structural test now reads each module's source and asserts it imports the helper and keeps no rounding of its own. Reference refactor: 13/13. The shortcut: fails 7.

That's the **third** check tonight that passed without checking — the eval corpus looked healthy while every task died on a swallowed 400, and the rule-doc verifier certified evasions by asking whether the rule stayed quiet. All three cost more than the bugs they hid.

`bun run validate` green at 4,297.