### PR TITLE
fix(inference): raise a body-borne error on the non-streaming path too

### DIFF
--- a/packages/core/src/inference/wire.ts
+++ b/packages/core/src/inference/wire.ts
@@ -4,6 +4,7 @@ import type {
   IToolCall,
   ITokenUsage,
 } from "./inference.types";
+import { ModelRequestError } from "./inference.types";
 import { isArray, isRecord } from "../lib/guards";
 import { TOOL_NAME } from "../agent";
 
@@ -46,12 +47,35 @@ export function toWire(
 }
 
 /** Non-streaming: narrow the response shape with guards — no type assertions. */
+/** Raise a body-borne error, keeping the server's own status when it gives one
+ *  so a permanent rejection stays distinguishable from a blip. */
+function throwIfErrorBody(data: Record<string, unknown>): void {
+  const error = data.error;
+
+  if (!isRecord(error)) {
+    return;
+  }
+
+  const message =
+    typeof error.message === "string" ? error.message : JSON.stringify(error);
+  const status = typeof error.code === "number" ? error.code : 502;
+
+  throw new ModelRequestError(status, message);
+}
+
 export function parseResponse(data: unknown): IModelResponse {
   const empty: IModelResponse = { content: "", toolCalls: [] };
 
   if (!isRecord(data)) {
     return empty;
   }
+
+  // A 200 whose BODY is an error. The streaming path already refuses to read
+  // this as silence; the non-streaming path is what the self-harness proposer,
+  // the judge and the planner use, and there an empty completion is
+  // indistinguishable from the model declining to answer. That is how a dead
+  // endpoint produced months of "unparseable proposer response".
+  throwIfErrorBody(data);
 
   const choices = data.choices;
   const first = isArray(choices) ? choices[0] : undefined;

--- a/packages/core/tests/inference.test.ts
+++ b/packages/core/tests/inference.test.ts
@@ -564,3 +564,38 @@ test("a non-latching profile keeps per-turn thinking control", async () => {
   expect(sent[0]?.chat_template_kwargs).toEqual({ thinking: true });
   expect(sent[1]?.chat_template_kwargs).toEqual({ thinking: false });
 });
+
+test("a non-streaming 200 whose body is an error is raised, not read as silence", () => {
+  // The path the self-harness proposer, the judge and the planner all use.
+  // An empty completion here is indistinguishable from the model declining to
+  // answer — which is how a rejected parameter produced months of
+  // "unparseable proposer response" with nothing pointing at the endpoint.
+  expect(() =>
+    parseResponse({
+      error: {
+        message: "thinking_token_budget is not yet supported",
+        code: 400,
+      },
+    })
+  ).toThrow(/thinking_token_budget/u);
+});
+
+test("an error body with no code is still raised", () => {
+  expect(() => parseResponse({ error: { message: "overloaded" } })).toThrow(
+    /overloaded/u
+  );
+});
+
+test("an ordinary response is untouched by the error check", () => {
+  const res = parseResponse({
+    choices: [{ message: { content: "hello" } }],
+  });
+
+  expect(res.content).toBe("hello");
+});
+
+test("a body with no choices and no error is still an empty response", () => {
+  // Only an `error` object means failure; an unfamiliar-but-benign body must
+  // stay a soft empty, as before.
+  expect(parseResponse({ id: "x" }).content).toBe("");
+});


### PR DESCRIPTION
## The same bug, one path over

The streaming parser learned tonight not to read a server error as silence (#234). The non-streaming parser never did — `parseResponse` returns an empty completion for any body it doesn't recognise, `{"error": {...}}` included. A 200 carrying one is exactly what vLLM sends.

## Why this path matters

Streaming is opt-in via `onToken`. Everything that doesn't stream comes through here:

- the self-harness **proposer**
- the judge
- the planner

An empty completion there is indistinguishable from the model declining to answer. That is how a rejected parameter can produce months of `unparseable proposer response` with nothing pointing at the endpoint — and the loop's own account of why it never improved would have been wrong.

Found by auditing for the pattern after it cost us twice tonight, not by hitting it.

## Scope

Only an `error` object counts as a failure. An unfamiliar-but-benign body stays a soft empty exactly as before, so nothing that works today starts throwing.

4 tests: error body with a code, without a code, an ordinary response, and a merely-unfamiliar body. `bun run validate` green at 4,301.