### PR TITLE
fix(evals): make every corpus task satisfy the gate that grades it

### DIFF
--- a/evals/corpus/auth/accounts.ts
+++ b/evals/corpus/auth/accounts.ts
@@ -43,6 +43,7 @@ export function signup(
   now: number
 ): SignupResult {
   const validation = validatePassword(password);
+
   if (!validation.ok) {
     return { ok: false, reasons: validation.reasons };
   }
@@ -59,6 +60,7 @@ export function signup(
   };
 
   accounts.set(email, record);
+
   return { ok: true };
 }
 
@@ -105,5 +107,6 @@ export function login(
 
 function hashPassword(password: string): string {
   const buffer = Buffer.from(password);
+
   return buffer.toString("base64");
 }

--- a/evals/corpus/auth/auth.test.ts
+++ b/evals/corpus/auth/auth.test.ts
@@ -13,7 +13,9 @@ beforeEach(() => {
 
 test("password: rejects empty string", () => {
   const result = validatePassword("");
+
   expect(result.ok).toBe(false);
+
   if (!result.ok) {
     expect(result.reasons).toContain("MIN_LENGTH");
   }
@@ -21,7 +23,9 @@ test("password: rejects empty string", () => {
 
 test("password: rejects too short (< 10 chars)", () => {
   const result = validatePassword("Short1!a");
+
   expect(result.ok).toBe(false);
+
   if (!result.ok) {
     expect(result.reasons).toContain("MIN_LENGTH");
   }
@@ -29,7 +33,9 @@ test("password: rejects too short (< 10 chars)", () => {
 
 test("password: rejects missing uppercase", () => {
   const result = validatePassword("password123!");
+
   expect(result.ok).toBe(false);
+
   if (!result.ok) {
     expect(result.reasons).toContain("NEEDS_UPPER");
   }
@@ -37,7 +43,9 @@ test("password: rejects missing uppercase", () => {
 
 test("password: rejects missing lowercase", () => {
   const result = validatePassword("PASSWORD123!");
+
   expect(result.ok).toBe(false);
+
   if (!result.ok) {
     expect(result.reasons).toContain("NEEDS_LOWER");
   }
@@ -45,7 +53,9 @@ test("password: rejects missing lowercase", () => {
 
 test("password: rejects missing digit", () => {
   const result = validatePassword("Password!abc");
+
   expect(result.ok).toBe(false);
+
   if (!result.ok) {
     expect(result.reasons).toContain("NEEDS_DIGIT");
   }
@@ -53,7 +63,9 @@ test("password: rejects missing digit", () => {
 
 test("password: rejects missing symbol", () => {
   const result = validatePassword("Password1abc");
+
   expect(result.ok).toBe(false);
+
   if (!result.ok) {
     expect(result.reasons).toContain("NEEDS_SYMBOL");
   }
@@ -61,11 +73,13 @@ test("password: rejects missing symbol", () => {
 
 test("password: accepts valid password", () => {
   const result = validatePassword("ValidPass123!");
+
   expect(result.ok).toBe(true);
 });
 
 test("password: accepts valid with multiple symbols", () => {
   const result = validatePassword("Complex@Pass#2024");
+
   expect(result.ok).toBe(true);
 });
 
@@ -77,6 +91,7 @@ test("session: issues token with expiry", () => {
   const now = 1000;
   const ttl = 60000;
   const { token, expiry } = issueSession("user123", now, ttl);
+
   expect(typeof token).toBe("string");
   expect(token.length).toBeGreaterThan(0);
   expect(expiry).toBe(now + ttl);
@@ -87,6 +102,7 @@ test("session: validates token before expiry", () => {
   const ttl = 60000;
   const { token, expiry } = issueSession("user123", now, ttl);
   const valid = validateSession(token, expiry - 1);
+
   expect(valid).toBe(true);
 });
 
@@ -95,6 +111,7 @@ test("session: validates token at exactly now", () => {
   const ttl = 60000;
   const { token, expiry } = issueSession("user123", now, ttl);
   const valid = validateSession(token, now);
+
   expect(valid).toBe(true);
 });
 
@@ -103,6 +120,7 @@ test("session: rejects token at exactly expiry", () => {
   const ttl = 60000;
   const { token, expiry } = issueSession("user123", now, ttl);
   const valid = validateSession(token, expiry);
+
   expect(valid).toBe(false);
 });
 
@@ -111,12 +129,14 @@ test("session: rejects token after expiry", () => {
   const ttl = 60000;
   const { token, expiry } = issueSession("user123", now, ttl);
   const valid = validateSession(token, expiry + 1);
+
   expect(valid).toBe(false);
 });
 
 test("session: rejects invalid token", () => {
   const now = 1000;
   const valid = validateSession("invalid.token.here", now);
+
   expect(valid).toBe(false);
 });
 
@@ -125,6 +145,7 @@ test("session: tokens are deterministic (same inputs = same token)", () => {
   const ttl = 3600000;
   const token1 = issueSession("alice", now, ttl).token;
   const token2 = issueSession("alice", now, ttl).token;
+
   expect(token1).toBe(token2);
 });
 
@@ -133,6 +154,7 @@ test("session: different users produce different tokens", () => {
   const ttl = 3600000;
   const token1 = issueSession("alice", now, ttl).token;
   const token2 = issueSession("bob", now, ttl).token;
+
   expect(token1).not.toBe(token2);
 });
 
@@ -143,13 +165,16 @@ test("session: different users produce different tokens", () => {
 test("account: signup creates account", () => {
   const now = 10000;
   const result = signup("user@example.com", "ValidPass123!", now);
+
   expect(result.ok).toBe(true);
 });
 
 test("account: signup rejects invalid password", () => {
   const now = 10000;
   const result = signup("user@example.com", "weak", now);
+
   expect(result.ok).toBe(false);
+
   if (!result.ok) {
     expect(result.reasons).toContain("NEEDS_UPPER");
   }
@@ -159,15 +184,19 @@ test("account: signup rejects duplicate email", () => {
   const now = 10000;
   const signup1 = signup("user@example.com", "ValidPass123!", now);
   const signup2 = signup("user@example.com", "ValidPass456!", now);
+
   expect(signup1.ok).toBe(true);
   expect(signup2.ok).toBe(false);
 });
 
 test("account: login succeeds with correct password", () => {
   const now = 10000;
+
   signup("alice@test.com", "ValidPass123!", now);
   const result = login("alice@test.com", "ValidPass123!", now);
+
   expect(result.ok).toBe(true);
+
   if (result.ok) {
     expect(result.token).toBeDefined();
     expect(result.expiry).toBeDefined();
@@ -176,29 +205,40 @@ test("account: login succeeds with correct password", () => {
 
 test("account: login rejects wrong password", () => {
   const now = 10000;
+
   signup("bob@test.com", "ValidPass123!", now);
   const result = login("bob@test.com", "WrongPass456!", now);
+
   expect(result.ok).toBe(false);
 });
 
 test("account: login locks after 5 consecutive failed attempts", () => {
   const now = 20000;
+
   signup("charlie@test.com", "ValidPass123!", now);
+
   for (let i = 0; i < 5; i++) {
     login("charlie@test.com", "WrongPass456!", now);
   }
+
   const lockedResult = login("charlie@test.com", "ValidPass123!", now);
+
   expect(lockedResult.ok).toBe(false);
 });
 
 test("account: login succeeds on 4 fails then correct password", () => {
   const now = 30000;
+
   signup("dave@test.com", "ValidPass123!", now);
+
   for (let i = 0; i < 4; i++) {
     login("dave@test.com", "WrongPass456!", now);
   }
+
   const successResult = login("dave@test.com", "ValidPass123!", now);
+
   expect(successResult.ok).toBe(true);
+
   if (successResult.ok) {
     expect(successResult.token).toBeDefined();
   }
@@ -206,44 +246,57 @@ test("account: login succeeds on 4 fails then correct password", () => {
 
 test("account: correct password during lockout window rejected", () => {
   const now = 40000;
+
   signup("eve@test.com", "ValidPass123!", now);
+
   for (let i = 0; i < 5; i++) {
     login("eve@test.com", "WrongPass456!", now);
   }
+
   const duringWindowResult = login("eve@test.com", "ValidPass123!", now + 100);
+
   expect(duringWindowResult.ok).toBe(false);
 });
 
 test("account: lockout unlocks after window expires (15 min)", () => {
   const now = 50000;
   const lockoutWindow = 15 * 60 * 1000;
+
   signup("frank@test.com", "ValidPass123!", now);
+
   for (let i = 0; i < 5; i++) {
     login("frank@test.com", "WrongPass456!", now);
   }
+
   const afterWindowResult = login(
     "frank@test.com",
     "ValidPass123!",
     now + lockoutWindow + 1
   );
+
   expect(afterWindowResult.ok).toBe(true);
 });
 
 test("account: successful login resets fail counter", () => {
   const now = 60000;
+
   signup("grace@test.com", "ValidPass123!", now);
   login("grace@test.com", "WrongPass456!", now);
   login("grace@test.com", "WrongPass456!", now + 100);
   const successResult = login("grace@test.com", "ValidPass123!", now + 200);
+
   expect(successResult.ok).toBe(true);
+
   for (let i = 0; i < 4; i++) {
     login("grace@test.com", "WrongPass456!", now + 300 + i * 100);
   }
+
   const stillNotLockedResult = login(
     "grace@test.com",
     "ValidPass123!",
     now + 700
   );
+
   expect(stillNotLockedResult.ok).toBe(true);
 });
 
@@ -253,42 +306,55 @@ test("account: successful login resets fail counter", () => {
 
 test("integration: signup then login produces valid session", () => {
   const now = 70000;
+
   signup("helen@test.com", "SecurePass123!", now);
   const loginResult = login("helen@test.com", "SecurePass123!", now);
+
   expect(loginResult.ok).toBe(true);
+
   if (loginResult.ok) {
     const sessionValid = validateSession(loginResult.token, now);
+
     expect(sessionValid).toBe(true);
   }
 });
 
 test("integration: session expires independent of login", () => {
   const now = 80000;
+
   signup("ivan@test.com", "SecurePass123!", now);
   const loginResult = login("ivan@test.com", "SecurePass123!", now);
+
   expect(loginResult.ok).toBe(true);
+
   if (loginResult.ok) {
     const sessionInvalid = validateSession(
       loginResult.token,
       loginResult.expiry + 1
     );
+
     expect(sessionInvalid).toBe(false);
   }
 });
 
 test("integration: lockout affects only target email", () => {
   const now = 90000;
+
   signup("jack@test.com", "ValidPass123!", now);
   signup("jill@test.com", "ValidPass456!", now);
+
   for (let i = 0; i < 5; i++) {
     login("jack@test.com", "WrongPass999!", now);
   }
+
   const otherUnlocked = login("jill@test.com", "ValidPass456!", now);
+
   expect(otherUnlocked.ok).toBe(true);
 });
 
 test("integration: non-existent email login fails", () => {
   const now = 100000;
   const result = login("nonexistent@test.com", "AnyPass123!", now);
+
   expect(result.ok).toBe(false);
 });

--- a/evals/corpus/auth/sessions.ts
+++ b/evals/corpus/auth/sessions.ts
@@ -10,12 +10,14 @@ export function issueSession(
 ): ISessionToken {
   const expiry = now + ttlMs;
   const token = generateDeterministicToken(userId, now, ttlMs);
+
   return { token, expiry };
 }
 
 export function validateSession(token: string, now: number): boolean {
   try {
     const parts = token.split(".");
+
     if (parts.length !== 3) {
       return false;
     }

--- a/evals/corpus/checkout/checkout.test.ts
+++ b/evals/corpus/checkout/checkout.test.ts
@@ -5,6 +5,7 @@ import type { ILineItem } from "./cart";
 
 test("empty cart", () => {
   const result = checkout([], [], 50000);
+
   expect(result.subtotalCents).toBe(0);
   expect(result.discountCents).toBe(0);
   expect(result.taxCents).toBe(0);
@@ -21,6 +22,7 @@ test("single line item no coupons", () => {
     },
   ];
   const result = checkout(items, [], 50000);
+
   expect(result.subtotalCents).toBe(1000);
   expect(result.discountCents).toBe(0);
   expect(result.taxCents).toBe(50); // 1000 * 50000ppm = 1000 * 0.05 = 50 cents
@@ -33,6 +35,7 @@ test("multiple line items", () => {
     { sku: "B", unitCents: 2000, qty: 1, availableQty: 10 },
   ];
   const result = checkout(items, [], 100000); // 10% tax
+
   expect(result.subtotalCents).toBe(4000);
   expect(result.discountCents).toBe(0);
   expect(result.taxCents).toBe(400); // 4000 * 0.1
@@ -44,6 +47,7 @@ test("qty exceeds available stock is clamped to available", () => {
     { sku: "A", unitCents: 1000, qty: 15, availableQty: 5 },
   ];
   const result = checkout(items, [], 50000);
+
   // Qty is clamped to 5 available, so subtotal = 5 * 1000 = 5000
   expect(result.subtotalCents).toBe(5000);
   expect(result.taxCents).toBe(250);
@@ -56,6 +60,7 @@ test("percent coupon reduces subtotal", () => {
   ];
   const coupons: ICoupon[] = [{ kind: "percent", off: 10 }];
   const result = checkout(items, coupons, 50000);
+
   // 1000 * 0.1 = 100 discount
   expect(result.subtotalCents).toBe(1000);
   expect(result.discountCents).toBe(100);
@@ -69,6 +74,7 @@ test("fixed coupon reduces subtotal", () => {
   ];
   const coupons: ICoupon[] = [{ kind: "fixed", cents: 300 }];
   const result = checkout(items, coupons, 50000);
+
   expect(result.subtotalCents).toBe(2000);
   expect(result.discountCents).toBe(300);
   expect(result.taxCents).toBe(85); // (2000 - 300) * 50000ppm = 1700 * 0.05 = 85
@@ -81,6 +87,7 @@ test("fixed coupon larger than subtotal is clamped", () => {
   ];
   const coupons: ICoupon[] = [{ kind: "fixed", cents: 1000 }];
   const result = checkout(items, coupons, 50000);
+
   // Discount clamped to 500, so after discount subtotal is 0
   expect(result.subtotalCents).toBe(500);
   expect(result.discountCents).toBe(500);
@@ -95,6 +102,7 @@ test("bogo coupon applies to matching sku", () => {
   ];
   const coupons: ICoupon[] = [{ kind: "bogo", sku: "A" }];
   const result = checkout(items, coupons, 50000);
+
   // Subtotal: (2 * 1000) + (1 * 2000) = 4000
   // Discount: 1 * 1000 (one "A" is free)
   expect(result.subtotalCents).toBe(4000);
@@ -109,6 +117,7 @@ test("bogo with qty 1 yields zero discount", () => {
   ];
   const coupons: ICoupon[] = [{ kind: "bogo", sku: "A" }];
   const result = checkout(items, coupons, 50000);
+
   // Only 1 item, so no free item
   expect(result.discountCents).toBe(0);
 });
@@ -122,6 +131,7 @@ test("multiple coupons stack in order: percent then fixed", () => {
     { kind: "fixed", cents: 100 }, // -100
   ];
   const result = checkout(items, coupons, 50000);
+
   // Subtotal: 1000, after percent: 800, after fixed: 700
   expect(result.subtotalCents).toBe(1000);
   expect(result.discountCents).toBe(300);
@@ -138,6 +148,7 @@ test("multiple coupons with bogo stacking", () => {
     { kind: "percent", off: 10 }, // 10% of remaining after bogo
   ];
   const result = checkout(items, coupons, 50000);
+
   // Subtotal: 3000
   // After BOGO: 3000 - 1000 = 2000
   // After percent (10% of 2000): 2000 - 200 = 1800
@@ -152,6 +163,7 @@ test("tax rounding: half-up", () => {
     { sku: "A", unitCents: 333, qty: 1, availableQty: 10 },
   ];
   const result = checkout(items, [], 150000); // 15% tax = 49.95 cents
+
   // 333 * 0.15 = 49.95, rounds half-up to 50
   expect(result.taxCents).toBe(50);
   expect(result.totalCents).toBe(383);
@@ -162,6 +174,7 @@ test("tax rounding: 0.4 rounds down", () => {
     { sku: "A", unitCents: 200, qty: 1, availableQty: 10 },
   ];
   const result = checkout(items, [], 200000); // 20% tax = 40 cents
+
   expect(result.taxCents).toBe(40);
   expect(result.totalCents).toBe(240);
 });
@@ -171,6 +184,7 @@ test("tax rounding: 0.5 rounds up", () => {
     { sku: "A", unitCents: 100, qty: 1, availableQty: 10 },
   ];
   const result = checkout(items, [], 150000); // 15% tax = 15 cents
+
   expect(result.taxCents).toBe(15);
   expect(result.totalCents).toBe(115);
 });
@@ -181,6 +195,7 @@ test("discount then tax with fractional result", () => {
   ];
   const coupons: ICoupon[] = [{ kind: "percent", off: 15 }];
   const result = checkout(items, coupons, 80000); // 8% tax
+
   // Subtotal: 1234
   // Discount: 1234 * 0.15 = 185.1 rounds to 185
   // After discount: 1234 - 185 = 1049
@@ -201,6 +216,7 @@ test("all coupon types in one checkout", () => {
     { kind: "bogo", sku: "A" }, // -2000 (one A is free)
   ];
   const result = checkout(items, coupons, 100000); // 10% tax
+
   // Subtotal: 5000
   // After percent (10%): 5000 - 500 = 4500
   // After fixed: 4500 - 200 = 4300
@@ -217,6 +233,7 @@ test("percent coupon at boundary 0%", () => {
   ];
   const coupons: ICoupon[] = [{ kind: "percent", off: 0 }];
   const result = checkout(items, coupons, 50000);
+
   expect(result.discountCents).toBe(0);
 });
 
@@ -226,6 +243,7 @@ test("percent coupon at boundary 100%", () => {
   ];
   const coupons: ICoupon[] = [{ kind: "percent", off: 100 }];
   const result = checkout(items, coupons, 50000);
+
   expect(result.discountCents).toBe(1000);
   expect(result.totalCents).toBe(0);
 });
@@ -235,6 +253,7 @@ test("zero tax rate", () => {
     { sku: "A", unitCents: 1000, qty: 1, availableQty: 10 },
   ];
   const result = checkout(items, [], 0);
+
   expect(result.taxCents).toBe(0);
   expect(result.totalCents).toBe(1000);
 });
@@ -244,6 +263,7 @@ test("high tax rate", () => {
     { sku: "A", unitCents: 1000, qty: 1, availableQty: 10 },
   ];
   const result = checkout(items, [], 250000); // 25% tax
+
   expect(result.taxCents).toBe(250);
   expect(result.totalCents).toBe(1250);
 });
@@ -253,6 +273,7 @@ test("small amount with rounding", () => {
     { sku: "A", unitCents: 3, qty: 1, availableQty: 10 },
   ];
   const result = checkout(items, [], 333333); // 33.3333% tax
+
   // 3 * 0.333333 = 0.999999 rounds to 1
   expect(result.taxCents).toBe(1);
   expect(result.totalCents).toBe(4);
@@ -264,6 +285,7 @@ test("percent rounding: 1/3 of 100 cents", () => {
   ];
   const coupons: ICoupon[] = [{ kind: "percent", off: 33 }]; // 33% = 33 cents
   const result = checkout(items, coupons, 0);
+
   expect(result.discountCents).toBe(33);
   expect(result.totalCents).toBe(67);
 });
@@ -277,6 +299,7 @@ test("complex stacking: bogo then percent on remainder", () => {
     { kind: "percent", off: 50 }, // 50% of remainder
   ];
   const result = checkout(items, coupons, 100000); // 10% tax
+
   // Subtotal: 4 * 500 = 2000
   // After BOGO: 2000 - 1000 = 1000
   // After 50%: 1000 - 500 = 500
@@ -292,6 +315,7 @@ test("fixed coupon at boundary equal to subtotal", () => {
   ];
   const coupons: ICoupon[] = [{ kind: "fixed", cents: 1000 }];
   const result = checkout(items, coupons, 50000);
+
   expect(result.discountCents).toBe(1000);
   expect(result.totalCents).toBe(0);
 });
@@ -302,6 +326,7 @@ test("negative discount is never allowed", () => {
   ];
   const coupons: ICoupon[] = [{ kind: "fixed", cents: 500 }];
   const result = checkout(items, coupons, 0);
+
   // Discount clamped to 100, total is 0
   expect(result.totalCents).toBeGreaterThanOrEqual(0);
 });
@@ -312,6 +337,7 @@ test("bogo with zero-price item", () => {
   ];
   const coupons: ICoupon[] = [{ kind: "bogo", sku: "A" }];
   const result = checkout(items, coupons, 50000);
+
   expect(result.totalCents).toBe(0);
 });
 
@@ -321,6 +347,7 @@ test("percent coupon with large qty multiplier", () => {
   ];
   const coupons: ICoupon[] = [{ kind: "percent", off: 25 }]; // 25% off
   const result = checkout(items, coupons, 100000); // 10% tax
+
   // Subtotal: 10000
   // Discount: 10000 * 0.25 = 2500
   // After discount: 7500
@@ -336,6 +363,7 @@ test("inventory clamping affects final total", () => {
   ];
   const coupons: ICoupon[] = [{ kind: "percent", off: 20 }];
   const result = checkout(items, coupons, 50000);
+
   // Qty clamped to 5, subtotal: 5000
   // Discount: 5000 * 0.2 = 1000
   // After discount: 4000

--- a/evals/corpus/checkout/coupons.ts
+++ b/evals/corpus/checkout/coupons.ts
@@ -21,21 +21,29 @@ function applySingleCoupon(
       const discountAmount = Math.floor(
         (currentAmount * coupon.off) / 100 + 0.5
       );
+
       return Math.min(discountAmount, currentAmount);
     }
+
     case "fixed": {
       return Math.min(coupon.cents, currentAmount);
     }
+
     case "bogo": {
       const matchingLine = lines.find((line) => line.sku === coupon.sku);
+
       if (!matchingLine || matchingLine.qty < 2) {
         return 0;
       }
+
       const freeQty = Math.floor(matchingLine.qty / 2);
+
       return freeQty * matchingLine.unitCents;
     }
+
     default: {
       const _exhaustive: never = coupon;
+
       return _exhaustive;
     }
   }
@@ -55,6 +63,7 @@ export function applyCoupons(
       coupon,
       lines
     );
+
     totalDiscount += discountForThisCoupon;
     currentAmount -= discountForThisCoupon;
   }

--- a/evals/corpus/checkout/pricing.ts
+++ b/evals/corpus/checkout/pricing.ts
@@ -9,6 +9,7 @@ export function calculateDiscount(
   percentOff: number
 ): number {
   const discountAmount = (subtotalCents * percentOff) / 100;
+
   return roundHalfUp(discountAmount);
 }
 
@@ -21,5 +22,6 @@ export function applyFixedDiscount(
 
 export function calculateTax(amountCents: number, taxRatePpm: number): number {
   const taxAmount = (amountCents * taxRatePpm) / 1000000;
+
   return roundHalfUp(taxAmount);
 }

--- a/evals/corpus/query/executor.ts
+++ b/evals/corpus/query/executor.ts
@@ -16,9 +16,11 @@ export function execute(
   // Apply ORDER BY with stable sort
   if (query.orderBy) {
     const { column, direction } = query.orderBy;
+
     result = stableSort(result, (a, b) => {
       const aVal = a[column];
       const bVal = b[column];
+
       return compareValues(aVal, bVal, direction);
     });
   }
@@ -37,6 +39,7 @@ export function execute(
 function evaluateExpression(expr: IExpression, row: RowType): boolean {
   if (expr.type === "comparison") {
     const val = row[expr.column];
+
     return compareColumn(val, expr.operator, expr.value);
   }
 
@@ -69,9 +72,11 @@ function compareColumn(
     if (operator === "=") {
       return false;
     }
+
     if (operator === "!=") {
       return columnVal !== null; // true if column is not null
     }
+
     // For <, >, <=, >= with null, return false
     return false;
   }
@@ -85,11 +90,13 @@ function compareColumn(
   // Treat numeric strings as numbers if comparing to numbers
   if (typeof columnVal === "string" && typeof compareVal === "number") {
     const numVal = Number(columnVal);
+
     if (!Number.isNaN(numVal)) {
       columnVal = numVal;
     }
   } else if (typeof columnVal === "number" && typeof compareVal === "string") {
     const numVal = Number(compareVal);
+
     if (!Number.isNaN(numVal)) {
       compareVal = numVal;
     }
@@ -122,9 +129,11 @@ function compareValues(
   if (a === null && b === null) {
     return 0;
   }
+
   if (a === null) {
     return 1; // a goes after b (last position)
   }
+
   if (b === null) {
     return -1; // b goes after a (last position)
   }
@@ -135,6 +144,7 @@ function compareValues(
 
   if (!Number.isNaN(aNum) && !Number.isNaN(bNum)) {
     const cmp = aNum - bNum;
+
     return direction === "ASC" ? cmp : -cmp;
   }
 
@@ -142,15 +152,19 @@ function compareValues(
   const aStr = String(a);
   const bStr = String(b);
   const cmp = aStr.localeCompare(bStr);
+
   return direction === "ASC" ? cmp : -cmp;
 }
 
 function stableSort<T>(arr: T[], compareFn: (a: T, b: T) => number): T[] {
   const indexed = arr.map((val, idx) => ({ val, idx }));
+
   indexed.sort((a, b) => {
     const cmp = compareFn(a.val, b.val);
+
     return cmp !== 0 ? cmp : a.idx - b.idx; // Use original index as tiebreaker for stability
   });
+
   return indexed.map((item) => item.val);
 }
 
@@ -162,14 +176,18 @@ function projectColumns(
     if (columns[0] === "*") {
       return { ...row };
     }
+
     const projected: RowType = {};
+
     for (const col of columns) {
       // Validate column exists in row
       if (!(col in row)) {
         throw new Error(`Column ${col} not found in row`);
       }
+
       projected[col] = row[col];
     }
+
     return projected;
   });
 }

--- a/evals/corpus/query/lexer.ts
+++ b/evals/corpus/query/lexer.ts
@@ -85,13 +85,16 @@ export function lex(input: string): Token[] {
     if (input[i] === "'") {
       i += 1;
       let stringValue = "";
+
       while (i < input.length && input[i] !== "'") {
         stringValue += input[i];
         i += 1;
       }
+
       if (i >= input.length) {
         throw new Error("Unterminated string literal");
       }
+
       i += 1; // closing quote
       tokens.push({ type: "string", value: stringValue });
       continue;
@@ -100,16 +103,19 @@ export function lex(input: string): Token[] {
     // Operators (two-char first)
     if (i + 1 < input.length) {
       const twoChar = input.substring(i, i + 2);
+
       if (twoChar === "!=") {
         tokens.push({ type: "operator", value: "!=" });
         i += 2;
         continue;
       }
+
       if (twoChar === "<=") {
         tokens.push({ type: "operator", value: "<=" });
         i += 2;
         continue;
       }
+
       if (twoChar === ">=") {
         tokens.push({ type: "operator", value: ">=" });
         i += 2;
@@ -123,11 +129,13 @@ export function lex(input: string): Token[] {
       i += 1;
       continue;
     }
+
     if (input[i] === "<") {
       tokens.push({ type: "operator", value: "<" });
       i += 1;
       continue;
     }
+
     if (input[i] === ">") {
       tokens.push({ type: "operator", value: ">" });
       i += 1;
@@ -140,16 +148,19 @@ export function lex(input: string): Token[] {
       i += 1;
       continue;
     }
+
     if (input[i] === ")") {
       tokens.push({ type: "delimiter", value: ")" });
       i += 1;
       continue;
     }
+
     if (input[i] === ",") {
       tokens.push({ type: "delimiter", value: "," });
       i += 1;
       continue;
     }
+
     if (input[i] === "*") {
       tokens.push({ type: "delimiter", value: "*" });
       i += 1;
@@ -159,10 +170,12 @@ export function lex(input: string): Token[] {
     // Numbers
     if (/\d/.test(input[i])) {
       let numStr = "";
+
       while (i < input.length && /\d/.test(input[i])) {
         numStr += input[i];
         i += 1;
       }
+
       tokens.push({ type: "number", value: Number(numStr) });
       continue;
     }
@@ -170,12 +183,14 @@ export function lex(input: string): Token[] {
     // Identifiers and keywords
     if (/[a-zA-Z_]/.test(input[i])) {
       let ident = "";
+
       while (i < input.length && /[a-zA-Z0-9_]/.test(input[i])) {
         ident += input[i];
         i += 1;
       }
 
       const upper = ident.toUpperCase();
+
       if (upper === "SELECT") {
         tokens.push({ type: "keyword", value: "SELECT" });
       } else if (upper === "FROM") {
@@ -201,6 +216,7 @@ export function lex(input: string): Token[] {
       } else {
         tokens.push({ type: "identifier", value: ident });
       }
+
       continue;
     }
 

--- a/evals/corpus/query/parser.ts
+++ b/evals/corpus/query/parser.ts
@@ -64,18 +64,23 @@ class Parser {
 
   private expect(type: string, value?: string | number | null): Token {
     const token = this.current();
+
     if (!token || token.type !== type) {
       throw new Error(`Expected ${type}, got ${token?.type}`);
     }
+
     if (value !== undefined && token.value !== value) {
       throw new Error(`Expected value ${value}, got ${token.value}`);
     }
+
     this.advance();
+
     return token;
   }
 
   private isKeyword(value?: string): boolean {
     const token = this.current();
+
     return (
       token?.type === "keyword" &&
       (value === undefined || token.value === value)
@@ -90,6 +95,7 @@ class Parser {
     if (!this.isKeyword("SELECT")) {
       throw new Error("Query must start with SELECT");
     }
+
     this.advance();
 
     const columns = this.parseColumns();
@@ -97,11 +103,13 @@ class Parser {
     if (!this.isKeyword("FROM")) {
       throw new Error("Expected FROM clause");
     }
+
     this.advance();
 
     const table = this.parseIdentifier();
 
     let where: IExpression | undefined;
+
     if (this.isKeyword("WHERE")) {
       this.advance();
       where = this.parseOrExpression();
@@ -110,30 +118,38 @@ class Parser {
     let orderBy:
       | { readonly column: string; readonly direction: "ASC" | "DESC" }
       | undefined;
+
     if (this.isKeyword("ORDER")) {
       this.advance();
+
       if (!this.isKeyword("BY")) {
         throw new Error("Expected BY after ORDER");
       }
+
       this.advance();
       const column = this.parseIdentifier();
       let direction: "ASC" | "DESC" = "ASC";
+
       if (this.isKeyword("ASC")) {
         this.advance();
       } else if (this.isKeyword("DESC")) {
         this.advance();
         direction = "DESC";
       }
+
       orderBy = { column, direction };
     }
 
     let limit: number | undefined;
+
     if (this.isKeyword("LIMIT")) {
       this.advance();
       const token = this.expect("number");
+
       if (typeof token.value !== "number") {
         throw new Error("LIMIT value must be a number");
       }
+
       limit = token.value;
     }
 
@@ -149,6 +165,7 @@ class Parser {
 
     if (this.current()?.type === "delimiter" && this.current()?.value === "*") {
       this.advance();
+
       return ["*"];
     }
 
@@ -167,9 +184,11 @@ class Parser {
 
   private parseIdentifier(): string {
     const token = this.expect("identifier");
+
     if (typeof token.value !== "string") {
       throw new Error("Expected identifier");
     }
+
     return token.value;
   }
 
@@ -179,6 +198,7 @@ class Parser {
     while (this.isKeyword("OR")) {
       this.advance();
       const right = this.parseAndExpression();
+
       left = { type: "or", left, right };
     }
 
@@ -191,6 +211,7 @@ class Parser {
     while (this.isKeyword("AND")) {
       this.advance();
       const right = this.parsePrimaryExpression();
+
       left = { type: "and", left, right };
     }
 
@@ -202,13 +223,16 @@ class Parser {
     if (this.current()?.type === "delimiter" && this.current()?.value === "(") {
       this.advance();
       const expr = this.parseOrExpression();
+
       if (
         this.current()?.type !== "delimiter" ||
         this.current()?.value !== ")"
       ) {
         throw new Error("Expected closing parenthesis");
       }
+
       this.advance();
+
       return expr;
     }
 
@@ -220,12 +244,15 @@ class Parser {
     }
 
     const opToken = this.expect("operator");
+
     if (typeof opToken.value !== "string") {
       throw new Error("Expected operator");
     }
+
     if (!isOperatorValue(opToken.value)) {
       throw new Error("Invalid operator");
     }
+
     const operator = opToken.value;
 
     let value: string | number | null;
@@ -237,15 +264,19 @@ class Parser {
 
     if (token.type === "string") {
       this.advance();
+
       if (typeof token.value !== "string") {
         throw new Error("Expected string value");
       }
+
       value = token.value;
     } else if (token.type === "number") {
       this.advance();
+
       if (typeof token.value !== "number") {
         throw new Error("Expected number value");
       }
+
       value = token.value;
     } else if (token.type === "null") {
       this.advance();

--- a/evals/corpus/query/query.test.ts
+++ b/evals/corpus/query/query.test.ts
@@ -15,6 +15,7 @@ const sampleData = [
 // SELECT * tests
 test("SELECT * returns all columns", () => {
   const result = query("SELECT * FROM users", sampleData);
+
   expect(result).toHaveLength(7);
   expect(result[0]).toHaveProperty("id");
   expect(result[0]).toHaveProperty("name");
@@ -24,12 +25,14 @@ test("SELECT * returns all columns", () => {
 
 test("SELECT * row count matches input", () => {
   const result = query("SELECT * FROM users", sampleData);
+
   expect(result).toHaveLength(7);
 });
 
 // Column projection tests
 test("SELECT specific columns projects subset", () => {
   const result = query("SELECT id, name FROM users", sampleData);
+
   expect(result).toHaveLength(7);
   expect(result[0]).toHaveProperty("id");
   expect(result[0]).toHaveProperty("name");
@@ -39,6 +42,7 @@ test("SELECT specific columns projects subset", () => {
 
 test("SELECT single column", () => {
   const result = query("SELECT name FROM users", sampleData);
+
   expect(result).toHaveLength(7);
   expect(result[0]).toHaveProperty("name");
   expect(result[0]).not.toHaveProperty("id");
@@ -46,6 +50,7 @@ test("SELECT single column", () => {
 
 test("SELECT columns in different order than source", () => {
   const result = query("SELECT name, id FROM users", sampleData);
+
   expect(result[0].name).toBe("Alice");
   expect(result[0].id).toBe(1);
 });
@@ -53,61 +58,72 @@ test("SELECT columns in different order than source", () => {
 // WHERE equality tests
 test("WHERE with = on number column", () => {
   const result = query("SELECT * FROM users WHERE id = 2", sampleData);
+
   expect(result).toHaveLength(1);
   expect(result[0].name).toBe("Bob");
 });
 
 test("WHERE with = on string column", () => {
   const result = query("SELECT * FROM users WHERE region = 'US'", sampleData);
+
   expect(result).toHaveLength(3);
 });
 
 test("WHERE = with no matches returns empty", () => {
   const result = query("SELECT * FROM users WHERE id = 999", sampleData);
+
   expect(result).toHaveLength(0);
 });
 
 // WHERE inequality tests
 test("WHERE with !=", () => {
   const result = query("SELECT * FROM users WHERE region != 'EU'", sampleData);
+
   // US: Alice, Charlie, Eve (3), APAC: Diana (1), null: Frank (0) = 4 rows (Frank's null region doesn't match != 'EU')
   expect(result).toHaveLength(4);
 });
 
 test("WHERE with < comparison", () => {
   const result = query("SELECT * FROM users WHERE score < 90", sampleData);
+
   expect(result).toHaveLength(3); // Bob (87), Diana (88), Grace (85)
 });
 
 test("WHERE with > comparison", () => {
   const result = query("SELECT * FROM users WHERE score > 90", sampleData);
+
   expect(result).toHaveLength(3); // Alice (95), Charlie (92), Frank (95)
 });
 
 test("WHERE with <= comparison", () => {
   const result = query("SELECT * FROM users WHERE score <= 88", sampleData);
+
   expect(result).toHaveLength(3); // Bob (87), Diana (88), Grace (85)
 });
 
 test("WHERE with >= comparison", () => {
   const result = query("SELECT * FROM users WHERE score >= 92", sampleData);
+
   expect(result).toHaveLength(3); // Alice (95), Charlie (92), Frank (95)
 });
 
 // Null handling tests
 test("NULL = NULL is false", () => {
   const result = query("SELECT * FROM users WHERE score = null", sampleData);
+
   expect(result).toHaveLength(0);
 });
 
 test("NULL != x is true for non-null", () => {
   const result = query("SELECT * FROM users WHERE score != null", sampleData);
+
   // score != null returns true only for rows where score is not null
   expect(result).toHaveLength(6); // All non-null scores: Alice, Bob, Charlie, Diana, Frank, Grace
 });
 
 test("NULL in comparisons always fails", () => {
   const result = query("SELECT * FROM users WHERE region = null", sampleData);
+
   expect(result).toHaveLength(0);
 });
 
@@ -117,6 +133,7 @@ test("WHERE with AND", () => {
     "SELECT * FROM users WHERE region = 'US' AND score > 90",
     sampleData
   );
+
   expect(result).toHaveLength(2); // Alice, Charlie
 });
 
@@ -125,6 +142,7 @@ test("WHERE with AND multiple conditions", () => {
     "SELECT * FROM users WHERE id > 2 AND score < 90",
     sampleData
   );
+
   expect(result).toHaveLength(2); // Diana (88), Grace (85)
 });
 
@@ -134,6 +152,7 @@ test("WHERE with OR", () => {
     "SELECT * FROM users WHERE region = 'EU' OR region = 'APAC'",
     sampleData
   );
+
   expect(result).toHaveLength(3); // Bob, Diana, Grace
 });
 
@@ -143,6 +162,7 @@ test("WHERE AND binds tighter than OR", () => {
     "SELECT * FROM users WHERE region = 'US' AND score > 90 OR id = 2",
     sampleData
   );
+
   // (region='US' AND score>90) OR id=2
   // = (Alice, Charlie) OR (Bob) = Alice, Bob, Charlie
   expect(result).toHaveLength(3);
@@ -153,6 +173,7 @@ test("WHERE parentheses override precedence", () => {
     "SELECT * FROM users WHERE region = 'US' OR id = 2 AND score < 88",
     sampleData
   );
+
   // region='US' OR (id=2 AND score<88)
   // region='US': Alice, Charlie, Eve, Frank
   // (id=2 AND score<88): Bob (87<88, id=2)
@@ -166,6 +187,7 @@ test("WHERE parentheses group OR before AND", () => {
     "SELECT * FROM users WHERE (region = 'US' OR region = 'EU') AND score > 85",
     sampleData
   );
+
   // (region='US' OR region='EU') AND score>85
   // US or EU: Alice, Bob, Charlie, Eve, Grace
   // score > 85: Alice(95), Bob(87), Charlie(92), Diana(88), Frank(95), Grace(85)
@@ -176,12 +198,14 @@ test("WHERE parentheses group OR before AND", () => {
 // ORDER BY tests
 test("ORDER BY ASC on number column", () => {
   const result = query("SELECT * FROM users ORDER BY score ASC", sampleData);
+
   expect(result[0].name).toBe("Grace"); // 85
   expect(result[result.length - 1].name).toBe("Eve"); // null goes last
 });
 
 test("ORDER BY DESC on number column", () => {
   const result = query("SELECT * FROM users ORDER BY score DESC", sampleData);
+
   // DESC order: Frank(95), Alice(95), Charlie(92), Diana(88), Bob(87), Grace(85), Eve(null)
   expect(result[0].score).toBe(95);
   expect(result[result.length - 1].name).toBe("Eve"); // null goes last even in DESC
@@ -189,12 +213,14 @@ test("ORDER BY DESC on number column", () => {
 
 test("ORDER BY string column", () => {
   const result = query("SELECT * FROM users ORDER BY name ASC", sampleData);
+
   expect(result[0].name).toBe("Alice");
   expect(result[1].name).toBe("Bob");
 });
 
 test("ORDER BY puts nulls last", () => {
   const result = query("SELECT * FROM users ORDER BY score ASC", sampleData);
+
   // Eve has null score, should be last
   expect(result[result.length - 1].name).toBe("Eve");
 });
@@ -204,22 +230,26 @@ test("ORDER BY stable sort preserves original order for equal values", () => {
   // Alice (95) and Frank (95): Alice appears first in original, Frank second
   const aliceIdx = result.findIndex((r) => r.name === "Alice");
   const frankIdx = result.findIndex((r) => r.name === "Frank");
+
   expect(aliceIdx < frankIdx).toBe(true);
 });
 
 // LIMIT tests
 test("LIMIT truncates results", () => {
   const result = query("SELECT * FROM users LIMIT 3", sampleData);
+
   expect(result).toHaveLength(3);
 });
 
 test("LIMIT 0 returns empty", () => {
   const result = query("SELECT * FROM users LIMIT 0", sampleData);
+
   expect(result).toHaveLength(0);
 });
 
 test("LIMIT greater than result count", () => {
   const result = query("SELECT * FROM users LIMIT 100", sampleData);
+
   expect(result).toHaveLength(7);
 });
 
@@ -229,6 +259,7 @@ test("SELECT, WHERE, ORDER BY together", () => {
     "SELECT id, name FROM users WHERE score > 85 ORDER BY name ASC LIMIT 3",
     sampleData
   );
+
   expect(result).toHaveLength(3);
   expect(result[0].name).toBe("Alice");
 });
@@ -238,6 +269,7 @@ test("Complex query with projection, AND condition, ORDER BY DESC, LIMIT", () =>
     "SELECT name, score FROM users WHERE region = 'US' AND score != null ORDER BY score DESC LIMIT 2",
     sampleData
   );
+
   // Region US: Alice(95), Charlie(92), Eve(null)
   // score != null: Alice(95), Charlie(92) (Eve excluded due to null score)
   expect(result).toHaveLength(2);

--- a/evals/corpus/query/query.ts
+++ b/evals/corpus/query/query.ts
@@ -14,5 +14,6 @@ export function query(
 
   const tokens = lex(queryString);
   const ast = parse(tokens);
+
   return execute(ast, rows);
 }


### PR DESCRIPTION
## `query` was never a hard task — it was an impossible one

July's notes call `query` *"the reliable failure"* and *"the clearest harness-addressable mechanism we have"*. It isn't a mechanism. `query.test.ts` violates the gate's own `padding-line-between-statements` rule, the gate lints the whole task directory, and test files are **read-only to the model** — so the gate can never go green regardless of what it writes.

Caught tonight when a live session burned **92 turns and 26 minutes** on it. The model's diagnosis was exactly right, in its own words:

> *"test.ts is read-only and I can't fix its padding, the gate can't pass"*

It then kept reading files looking for a way out until the no-progress guard stopped it.

## Why this matters more than one broken task

Every failure the loop ever mined from `query` was evidence about a broken fixture, not about the model. That's worse than no signal — the proposer was being asked to change the harness so the model could edit a file it isn't allowed to edit.

## The audit

| task | violations | note |
|---|---|---|
| `query` | 101 | the "reliable failure" |
| `auth` | 73 | **in the proof split** — the thing that decides whether an overlay gets installed |
| `checkout` | 41 | |
| `rate-limit` | 4 | |
| `json-patch` | 2 | added by me yesterday — same mistake |

All clean now, verified by running `strict.eslint.config.mjs` over every task directory.

Only formatting moved; every reference solution still passes its own tests. `rate-limit` still reports 0/3, which is correct — its source is an intentional RED stub that scratch mode deletes before the model starts.

## The rule

A corpus fixture must satisfy the gate it will be graded by, or the task isn't hard, it's impossible. Paid for twice in one session.

`bun run validate` green at 4,301.