### PR TITLE
fix(self-harness): tell the proposer that TTSR conditions are OR-ed

### DIFF
--- a/packages/core/src/self-harness/propose.ts
+++ b/packages/core/src/self-harness/propose.ts
@@ -29,6 +29,7 @@ const SURFACE_CATALOG = `You may edit ONLY these declared harness surfaces, expr
 
 1. "ttsrRules": array of stream-time rules. Each rule aborts generation when a regex matches the live output and injects corrective guidance on retry.
    Shape: {"name": "kebab-case", "condition": ["regex source", ...], "scope": "content"|"tool-args"|"both", "fileGlobs": ["src/**/*.ts"]?, "guidance": "<=300 chars", "repeatMode": "once"|"cooldown", "repeatGap": number?}
+   CONDITIONS ARE OR-ED, NOT AND-ED: the rule fires as soon as ANY one pattern matches. There is no way to require two things at once, so a second pattern always makes a rule fire MORE, never less. Write one pattern that describes the moment you want to interrupt. A broad pattern (e.g. "lint" or "TS\\d{4}") fires on almost every repair turn — that may still help, but say so in "risks" rather than assuming the patterns narrow each other.
 
 2. "promptBlocks": edits to NAMED system-prompt blocks. Names: "bootstrap" (the lead-with-action instruction), "execution" (the gate-feedback-loop instruction), "verification" (the run-your-hypotheses instruction), "extra" (a free block appended after all built-in guidance).
    Shape: {"<name>": {"mode": "append"|"replace", "text": "..."}}


### PR DESCRIPTION
## What happened

The loop accepted a rule tonight whose semantics its author had wrong.

It named the rule `stale-edit-target-after-gate-error` and wrote guidance about *"a gate error [that] referenced a file you may be editing from stale memory"* — plainly meaning gate-error **AND** stale-edit. Its conditions were:

```json
["TS\\d{4}|lint", "tool_input_rejected\\s*:\\s*edit"]
```

TTSR matches with `conditions.some(...)`. So the rule fires the moment the model writes a TS error code or the word "lint" — on almost every repair turn.

## Why the acceptance rule didn't catch it

It measured **−38% cycles** and was accepted honestly. That's plausible: forcing a file re-read evidently helps this model. But the rule is far blunter than its author believed, and the acceptance rule can't see that — it measures outcomes on a short corpus, not whether a rule means what the author thought.

A rule that fires on every turn may help on a five-minute task and hurt on a two-hour build. That gap between "improves the benchmark" and "is a good rule" is worth knowing about.

## The fix

The surface catalog never said which way conditions combine, so the model guessed — and guessed the more useful way. It now says so explicitly, plus the consequence that actually matters:

> a second pattern always makes a rule fire **MORE**, never less — so listing two patterns cannot narrow a trigger, only widen it

Broad patterns stay allowed; the model is asked to declare them in `risks` rather than assume they're being narrowed.

## Deliberately not done

Adding AND semantics to TTSR. That's a runtime change to a matcher the whole loop depends on, and it shouldn't land unattended at 5am on the strength of one observation. Worth discussing — it would let the model express what it actually meant.

`bun run validate` green at 4,301.