### PR TITLE
fix(self-harness): bound the mining evidence by age, not just by count

### DIFF
--- a/packages/core/scripts/self-harness.ts
+++ b/packages/core/scripts/self-harness.ts
@@ -6,7 +6,7 @@
 //
 // Run:  bun packages/core/scripts/self-harness.ts [--rounds 3] [--width 3]
 //         [--repeats 2] [--held-in a,b,..] [--held-out c,d,..]
-//         [--dry-run] [--no-judge] [--build-logs [dir]] [--build-logs-limit 40]
+//         [--dry-run] [--no-judge] [--build-logs [dir]] [--build-logs-limit 40] [--build-logs-days 7]
 // Judge override (else the active model judges): TSFORGE_JUDGE_URL/MODEL/KEY.
 import { mkdir } from "node:fs/promises";
 import { join } from "node:path";
@@ -77,10 +77,13 @@ const buildLogsRaw = argValue("build-logs");
 const buildLogsDir = hasFlag("build-logs")
   ? (buildLogsRaw ?? join(homedir(), ".tsforge", "logs"))
   : undefined;
-// Newest N logs. This is also what keeps the evidence current: as new builds
-// land they push older ones out, so a campaign that has already fixed something
-// stops mining the failures it fixed.
+// Newest N logs, AND only recent ones. The count alone does not keep evidence
+// current: measured 2026-08-05, the newest 40 logs reached back to 17 July —
+// so the loop was mining failures produced by a harness that no longer exists,
+// including ones fixed hours earlier. A proposal slot spent on a solved problem
+// is a slot not spent on a live one.
 const buildEvidenceLimit = Number(argValue("build-logs-limit") ?? "40");
+const buildEvidenceDays = Number(argValue("build-logs-days") ?? "7");
 
 /** Continue a lineage: start from a previous session's accepted overlay so
  *  improvements COMPOUND across sessions. Fails loudly on a bad path/file —
@@ -397,7 +400,10 @@ const lineage = await runSelfHarness({
     ? {}
     : {
         extraEvidence: () =>
-          buildEvidenceFrom(buildLogsDir, { limit: buildEvidenceLimit }),
+          buildEvidenceFrom(buildLogsDir, {
+            limit: buildEvidenceLimit,
+            since: Date.now() - buildEvidenceDays * 24 * 60 * 60 * 1000,
+          }),
       }),
   waitHealthy,
   log: say,


### PR DESCRIPTION
## The problem

The loop mines the newest 40 build logs. Measured tonight, those reach back to **17 July** — so it's learning from failures produced by a harness that no longer exists, including ones fixed hours earlier in this same session.

It showed up in a real accepted edit: one of tonight's rules targets `Expected blank line` / `padding-line-between-statements`, which was largely a *broken-fixture* problem until #238 made every corpus task satisfy the gate that grades it. The rule is still defensible — the model's own generated code trips that rule too — but the evidence that motivated it was substantially stale.

A proposal slot spent on a solved problem is a slot not spent on a live one, and the loop only gets K per round.

## The fix

Default to the last 7 days, overridable with `--build-logs-days`. The count cap stays: age keeps the evidence relevant, count keeps the prompt bounded.

`bun run validate` green at 4,301.