### PR TITLE
fix: don't cache a verdict no reviewer produced

### DIFF
--- a/packages/core/src/cli/harness-review-mode.ts
+++ b/packages/core/src/cli/harness-review-mode.ts
@@ -219,8 +219,9 @@ async function readCachedVerdict(
       return null;
     }
 
-    // honorCachedVerdict drops any cached pre-review gate block (defense in depth
-    // beside the CACHE_VERSION bump) so a transient precondition never re-serves.
+    // honorCachedVerdict drops any cached pre-review gate block OR no-quorum
+    // block (defense in depth beside the CACHE_VERSION bump) so neither a
+    // transient precondition nor an endpoint outage ever re-serves.
     return honorCachedVerdict(parseVerdict(parsed.verdict));
   } catch {
     return null;

--- a/packages/core/src/reviewers/aggregate.ts
+++ b/packages/core/src/reviewers/aggregate.ts
@@ -23,6 +23,15 @@ export interface IVerdict {
    *  be cached: a flaky validate under load would otherwise poison the tree-hash
    *  and block every future push until the cache is hand-purged. */
   preReview?: boolean;
+  /** True when the panel RAN but too few reviewers came back to reach the
+   *  quorum — every one of them errored, or enough did. Same category as
+   *  `preReview` and cached under the same rule: an endpoint that was down is
+   *  not a judgment about the code. Without this, one outage writes a BLOCK
+   *  against the tree hash and re-serves it for that exact tree forever, so the
+   *  only ways past it are to touch a file or vary the intent string (which
+   *  feeds the cache key). Observed live on 2026-08-05: `ok: 0, errored: 4`
+   *  cached, then replayed as `cache hit, reusing verdict`. */
+  noQuorum?: boolean;
 }
 
 const SECURITY_CODES: readonly FindingCode[] = ["security", "supply-chain"];
@@ -177,6 +186,7 @@ export function aggregate(
     ranked,
     perReviewer: reviews,
     identity: opts.identity,
+    ...(reviews.length < opts.minReviewers ? { noQuorum: true } : {}),
   };
 }
 
@@ -257,5 +267,6 @@ export function parseVerdict(raw: unknown): IVerdict | null {
     perReviewer: parsedReviews,
     identity,
     ...(raw.preReview === true ? { preReview: true } : {}),
+    ...(raw.noQuorum === true ? { noQuorum: true } : {}),
   };
 }

--- a/packages/core/src/reviewers/harness-review.ts
+++ b/packages/core/src/reviewers/harness-review.ts
@@ -307,8 +307,11 @@ export async function reviewRequest(
 /** Verdict-cache schema version. Bump to invalidate ALL previously written cache
  *  artifacts in one shot. Bumped to "3" when the key changed from a diff-hash to a full
  *  request fingerprint (below): legacy artifacts key on incomparable inputs, so the bump
- *  retires them rather than risk a stale-input collision. */
-export const CACHE_VERSION = "3";
+ *  retires them rather than risk a stale-input collision. Bumped to "4" for the
+ *  no-quorum guard: artifacts written before it carry no `noQuorum` flag, so an
+ *  outage block already on disk would keep being honored by a guard that has
+ *  nothing to test. The bump retires them; the flag stops new ones. */
+export const CACHE_VERSION = "4";
 
 /** Deterministic JSON: recursively sort object keys so equal CONTENT hashes equally
  *  regardless of construction/insertion order. A cache key must not thrash — or, if a
@@ -446,19 +449,33 @@ export async function runReviewFlow(
 }
 
 /** The caching decision, isolated so it is unit-testable without the filesystem.
- *  ONLY a real panel verdict is cached. A pre-review gate/precondition block
- *  (validate failed, empty intent, empty/oversized diff) is transient — caching one
- *  would re-serve as a permanent block for that request, so it is skipped. */
+ *  ONLY a real panel verdict is cached — one where enough reviewers actually
+ *  formed an opinion about the code.
+ *
+ *  Two kinds of block are not that, and neither is cached. A pre-review
+ *  gate/precondition block (validate failed, empty intent, empty/oversized diff)
+ *  never ran the panel at all. A no-quorum block ran it and got too few answers
+ *  back: the reviewers errored, which says something about the endpoint and
+ *  nothing about the diff. Caching either re-serves it as a permanent block for
+ *  that exact tree, escapable only by touching a file or changing the intent
+ *  string. */
 export function shouldCacheVerdict(verdict: IVerdict): boolean {
-  return verdict.preReview !== true;
+  return verdict.preReview !== true && verdict.noQuorum !== true;
 }
 
-/** The read-side guard, isolated for testing: a cached pre-review gate block must
- *  never be honored (defense in depth beside the CACHE_VERSION bump — belt and
- *  suspenders for any pre-review artifact that reaches disk). Returns the verdict
- *  to use, or null to force a fresh live review. */
+/** The read-side guard, isolated for testing: a cached pre-review or no-quorum
+ *  block must never be honored (defense in depth beside the CACHE_VERSION bump —
+ *  belt and suspenders for any such artifact that reaches disk, including one
+ *  written by an older build). Returns the verdict to use, or null to force a
+ *  fresh live review. */
 export function honorCachedVerdict(verdict: IVerdict | null): IVerdict | null {
-  return verdict !== null && verdict.preReview === true ? null : verdict;
+  if (verdict === null) {
+    return null;
+  }
+
+  return verdict.preReview === true || verdict.noQuorum === true
+    ? null
+    : verdict;
 }
 
 export function artifactBody(

--- a/packages/core/tests/harness-review-cache.test.ts
+++ b/packages/core/tests/harness-review-cache.test.ts
@@ -24,6 +24,18 @@ const preReviewBlock: IVerdict = {
   preReview: true,
 };
 
+/** What an endpoint outage actually produces: the panel RAN, and nothing came
+ *  back. `aggregate` sets `noQuorum` and the reason names the shortfall. */
+const noQuorumBlock: IVerdict = {
+  blocked: true,
+  reason: "insufficient reviewers (0 of 2 required)",
+  reviewers: { ok: 0, errored: 4 },
+  ranked: [],
+  perReviewer: [],
+  identity: "local/flash",
+  noQuorum: true,
+};
+
 async function withTempDir(run: (dir: string) => Promise<void>): Promise<void> {
   const dir = await mkdtemp(join(tmpdir(), "hr-cache-"));
 
@@ -42,6 +54,20 @@ describe("persistVerdict (cache-poison guard at the write site)", () => {
       // The exact regression: a transient validate block must never reach disk, or
       // it re-serves as a permanent block for that tree. Prove the file is absent —
       // this catches an omitted/inverted guard the pure predicate test cannot.
+      const files = await readdir(dir).catch(() => []);
+
+      expect(files).toHaveLength(0);
+    });
+  });
+
+  test("a NO-QUORUM block writes NO cache artifact either", async () => {
+    await withTempDir(async (dir) => {
+      await persistVerdict(noQuorumBlock, "key1", "t1", "p1", dir);
+
+      // Observed live on 2026-08-05: every reviewer errored, the resulting BLOCK
+      // was cached against the tree hash, and the next run replayed it as a
+      // cache hit. One endpoint hiccup blocking that exact tree forever, with no
+      // way past but touching a file or changing the intent string.
       const files = await readdir(dir).catch(() => []);
 
       expect(files).toHaveLength(0);

--- a/packages/core/tests/reviewers-aggregate.test.ts
+++ b/packages/core/tests/reviewers-aggregate.test.ts
@@ -6,7 +6,10 @@ import {
   type IVerdict,
 } from "../src/reviewers/aggregate";
 import type { IReview, IFinding } from "../src/reviewers/schema";
-import { shouldCacheVerdict } from "../src/reviewers/harness-review";
+import {
+  shouldCacheVerdict,
+  honorCachedVerdict,
+} from "../src/reviewers/harness-review";
 
 function ok(
   id: string,
@@ -273,6 +276,46 @@ describe("parseVerdict", () => {
     expect(parsed?.ranked).toHaveLength(1);
     expect(parsed?.ranked[0]?.agreement).toBe(2);
     expect(parsed?.perReviewer).toHaveLength(2);
+  });
+
+  test("round-trips the noQuorum flag through the REAL read path", () => {
+    // The production read is readCachedVerdict -> parseVerdict ->
+    // honorCachedVerdict. The honorCachedVerdict unit test hands it an object
+    // directly and so bypasses parseVerdict entirely: if a refactor dropped the
+    // flag on read, that test stays green while the cache-poison bug quietly
+    // returns. This is the only assertion that covers the seam.
+    const raw = JSON.parse(
+      JSON.stringify({
+        blocked: true,
+        reason: "insufficient reviewers (0 of 2 required)",
+        reviewers: { ok: 0, errored: 4 },
+        ranked: [],
+        perReviewer: [],
+        identity: "local/flash",
+        noQuorum: true,
+      })
+    ) as unknown;
+    const parsed = parseVerdict(raw);
+
+    expect(parsed?.noQuorum).toBe(true);
+    expect(honorCachedVerdict(parsed)).toBeNull();
+  });
+
+  test("a verdict without noQuorum parses to undefined (not injected)", () => {
+    // The mirror: injecting the flag where it was absent would make every
+    // cached verdict unusable and silently disable the cache.
+    const v = {
+      blocked: false,
+      reason: "",
+      reviewers: { ok: 4, errored: 0 },
+      ranked: [],
+      perReviewer: [],
+      identity: "local/flash",
+    };
+    const parsed = parseVerdict(v);
+
+    expect(parsed?.noQuorum).toBeUndefined();
+    expect(honorCachedVerdict(parsed)).toBe(parsed);
   });
 
   test("round-trips the preReview flag (cache-poison guard survives serialize→parse)", () => {

--- a/packages/core/tests/reviewers-aggregate.test.ts
+++ b/packages/core/tests/reviewers-aggregate.test.ts
@@ -284,7 +284,7 @@ describe("parseVerdict", () => {
     // directly and so bypasses parseVerdict entirely: if a refactor dropped the
     // flag on read, that test stays green while the cache-poison bug quietly
     // returns. This is the only assertion that covers the seam.
-    const raw = JSON.parse(
+    const raw: unknown = JSON.parse(
       JSON.stringify({
         blocked: true,
         reason: "insufficient reviewers (0 of 2 required)",
@@ -294,7 +294,7 @@ describe("parseVerdict", () => {
         identity: "local/flash",
         noQuorum: true,
       })
-    ) as unknown;
+    );
     const parsed = parseVerdict(raw);
 
     expect(parsed?.noQuorum).toBe(true);

--- a/packages/core/tests/reviewers-aggregate.test.ts
+++ b/packages/core/tests/reviewers-aggregate.test.ts
@@ -6,6 +6,7 @@ import {
   type IVerdict,
 } from "../src/reviewers/aggregate";
 import type { IReview, IFinding } from "../src/reviewers/schema";
+import { shouldCacheVerdict } from "../src/reviewers/harness-review";
 
 function ok(
   id: string,
@@ -38,6 +39,52 @@ describe("aggregate", () => {
     expect(
       aggregate([ok("a", "approve"), ok("b", "reject")], opts).preReview
     ).toBeUndefined();
+  });
+
+  test("a short panel is FLAGGED noQuorum, so its block is never cached", () => {
+    // The production wiring. shouldCacheVerdict and honorCachedVerdict both test
+    // this flag; if aggregate never set it, both guards would be dead code and
+    // an outage would keep poisoning the cache exactly as before.
+    const allErrored = aggregate(
+      [
+        { status: "errored", reviewerId: "a", error: "connection refused" },
+        { status: "errored", reviewerId: "b", error: "connection refused" },
+      ],
+      opts
+    );
+
+    expect(allErrored.reviewers).toEqual({ ok: 0, errored: 2 });
+    expect(allErrored.noQuorum).toBe(true);
+    expect(shouldCacheVerdict(allErrored)).toBe(false);
+
+    // One short of quorum is the same category: not enough opinions to be a
+    // judgment about the code.
+    const oneShort = aggregate(
+      [
+        ok("a", "approve"),
+        { status: "errored", reviewerId: "b", error: "timeout" },
+      ],
+      opts
+    );
+
+    expect(oneShort.noQuorum).toBe(true);
+    expect(shouldCacheVerdict(oneShort)).toBe(false);
+  });
+
+  test("a panel that REACHED quorum is cached, block or pass", () => {
+    // The other half of the invariant: this must not turn into "never cache a
+    // block". A real reject is a judgment about the code and caching it is the
+    // whole point of the cache.
+    const reject = aggregate([ok("a", "approve"), ok("b", "reject")], opts);
+
+    expect(reject.blocked).toBe(true);
+    expect(reject.noQuorum).toBeUndefined();
+    expect(shouldCacheVerdict(reject)).toBe(true);
+
+    const pass = aggregate([ok("a", "approve"), ok("b", "approve")], opts);
+
+    expect(pass.noQuorum).toBeUndefined();
+    expect(shouldCacheVerdict(pass)).toBe(true);
   });
 
   test("insufficient reviewers → block", () => {

--- a/packages/core/tests/reviewers-artifact.test.ts
+++ b/packages/core/tests/reviewers-artifact.test.ts
@@ -111,6 +111,17 @@ describe("reviewRequestKey (cache key = fingerprint of the ACTUAL review request
     );
   });
 
+  test("CACHE_VERSION moved past 3, so pre-noQuorum artifacts are retired", () => {
+    // The bump is load-bearing, not cosmetic. Artifacts written at version 3
+    // predate the noQuorum flag, so a cached outage block from that era carries
+    // nothing for honorCachedVerdict to test and would be honored as a real
+    // verdict — the poison the flag exists to stop, still live on disk.
+    //
+    // Asserting "not 3" rather than "is 4" pins the invalidation this change
+    // required without freezing every future bump.
+    expect(CACHE_VERSION).not.toBe("3");
+  });
+
   test("CACHE_VERSION is mixed into the key — bumping it retires ALL legacy artifacts in one shot", () => {
     // The ONLY lever that invalidates every already-on-disk artifact (e.g. legacy diff-hash
     // keys, or a poisoned pre-review block). If a regression dropped CACHE_VERSION from the

--- a/packages/core/tests/reviewers-artifact.test.ts
+++ b/packages/core/tests/reviewers-artifact.test.ts
@@ -117,9 +117,11 @@ describe("reviewRequestKey (cache key = fingerprint of the ACTUAL review request
     // nothing for honorCachedVerdict to test and would be honored as a real
     // verdict — the poison the flag exists to stop, still live on disk.
     //
-    // Asserting "not 3" rather than "is 4" pins the invalidation this change
-    // required without freezing every future bump.
-    expect(CACHE_VERSION).not.toBe("3");
+    // Asserting "greater than 3" rather than "is 4" pins the invalidation this
+    // change required without freezing every future bump — and unlike "not 3",
+    // it also catches a regression to 1 or 2, which would reactivate an even
+    // older generation of artifacts.
+    expect(Number(CACHE_VERSION)).toBeGreaterThan(3);
   });
 
   test("CACHE_VERSION is mixed into the key — bumping it retires ALL legacy artifacts in one shot", () => {

--- a/packages/core/tests/reviewers-artifact.test.ts
+++ b/packages/core/tests/reviewers-artifact.test.ts
@@ -333,6 +333,21 @@ describe("runReviewFlow (the CLI wiring invariant: gather-before-cache, block-ne
 });
 
 describe("read-side + artifact", () => {
+  test("honorCachedVerdict drops a cached NO-QUORUM block", () => {
+    // Belt and suspenders beside the CACHE_VERSION bump: an outage block written
+    // by an older build carries no flag, and one written by this build must
+    // still never be honored if it somehow reaches disk.
+    expect(
+      honorCachedVerdict({
+        ...v,
+        blocked: true,
+        reason: "insufficient reviewers (0 of 2 required)",
+        reviewers: { ok: 0, errored: 4 },
+        noQuorum: true,
+      })
+    ).toBeNull();
+  });
+
   test("honorCachedVerdict drops a cached pre-review block, passes a real verdict through", () => {
     expect(honorCachedVerdict(null)).toBeNull();
     expect(


### PR DESCRIPTION
## What

An endpoint outage poisons the harness-review cache. When every reviewer errors out, `aggregate` still returns a normal-looking BLOCK — `insufficient reviewers (0 of 2 required)` — which gets cached against the tree hash and re-served indefinitely.

Observed live on 2026-08-05 during the PR #242 review series:

```
harness-review: cache hit, reusing verdict
harness-review: BLOCK — insufficient reviewers (0 of 2 required)
reviewers ok: 0  errored: 4
```

Same code, same tree, permanently blocked by one hiccup. The only escapes were touching a file or varying `--intent` (it feeds the cache key).

## Why the fix is small

The guard already exists and simply didn't cover this case. `IVerdict.preReview` marks pre-review gate blocks (validate failed, empty intent, oversized diff), and its own doc comment states the rationale: transient failures are not reviewer judgments and must never be cached. A panel that *ran* and got too few answers back is the same category.

- `noQuorum` set in `aggregate` when `reviews.length < minReviewers`
- `shouldCacheVerdict` (write side) and `honorCachedVerdict` (read side) both test it, mirroring `preReview`
- `parseVerdict` carries it through
- `CACHE_VERSION` 3 → 4: artifacts already on disk carry no flag, so the guard would have nothing to test on them

## Tests

Each guard was reverted in turn to confirm its test goes red:

| mutation | suite | result |
|---|---|---|
| `aggregate` stops setting the flag | reviewers-aggregate | 1 fail |
| write-side guard reverted | harness-review-cache | 1 fail |
| read-side guard reverted | reviewers-artifact | 1 fail |

The inverse invariant is covered too: a panel that reached quorum is still cached, **including a reject** — caching a real judgment is the point of the cache.

`bun run validate` green: 4,339 tests across 300 files.