### PR TITLE
fix: say which reviewer dropped out, and why

### DIFF
--- a/packages/core/src/cli/harness-review-mode.ts
+++ b/packages/core/src/cli/harness-review-mode.ts
@@ -207,7 +207,7 @@ interface IBoundedRead {
  * exited, leaving a background child holding the pipe, would lose a complete
  * answer for the sake of the child.
  */
-async function readBounded(
+export async function readBounded(
   stream: ReadableStream<Uint8Array>,
   gone: Promise<unknown>
 ): Promise<IBoundedRead> {
@@ -342,6 +342,12 @@ export async function runBinary(
     kill.timedOut = true;
     killGroup();
   }, r.timeoutMs);
+  // NOTE: the trigger for this cannot be reproduced portably from a test — a
+  // process that survives SIGKILL means one that left its group (setsid, a
+  // re-exec), and there is no shell-level way to arrange that on both macOS and
+  // Linux. What IS tested is the mechanism it depends on: readBounded abandons a
+  // stream that never ends once the promise it was given settles.
+  //
   // Resolves only once a kill has been signalled AND the process still has not
   // been reaped a grace later — i.e. it escaped its group and survived SIGKILL.
   // Raced against `proc.exited` so the wait below always settles; without it an

--- a/packages/core/src/cli/harness-review-mode.ts
+++ b/packages/core/src/cli/harness-review-mode.ts
@@ -128,30 +128,66 @@ export function buildBinaryInvocation(
  *  normal shutdown, short enough that an unkillable reviewer cannot hold the
  *  panel. */
 const KILL_GRACE_MS = 2_000;
-/** How long to keep draining stdout AFTER a kill. A descendant can hold the pipe
- *  open long past the reviewer's own exit; the output is discarded on a timeout
- *  regardless, so waiting for EOF buys nothing. */
-const POST_KILL_DRAIN_MS = 1_000;
+/**
+ * How long to keep draining stdout after the process itself has gone.
+ *
+ * A descendant inherits the pipe, so `Response.text()` waits for EOF — which
+ * means the LAST child, not the reviewer. That hangs the panel whether the
+ * reviewer was killed or exited cleanly on its own, so the bound is tied to the
+ * process exiting rather than to the kill.
+ */
+const POST_EXIT_DRAIN_MS = 1_000;
 
-/** Read a stream to EOF, but stop shortly after `killed()` turns true. */
+/** Sentinel for the give-up branch of the read race. */
+const GIVE_UP = Symbol("give-up");
+
+/**
+ * Read a stream to EOF, or give up shortly after the process is gone — keeping
+ * whatever arrived before that.
+ *
+ * Bounded by a PROMISE, not a poll. A `while (!done) await sleep(50)` loop keeps
+ * scheduling itself forever when it loses the race — Promise.race abandons the
+ * loser's value, never its work — so every successful call leaked a poller for
+ * the life of the process.
+ *
+ * Chunk by chunk, because racing a whole `Response.text()` throws away
+ * everything already read the moment it gives up: a reviewer that answered and
+ * exited, leaving a background child holding the pipe, would have its complete
+ * answer discarded for the sake of the child. Partial output beats none, and on
+ * the timeout path it is discarded by the caller anyway.
+ */
 async function readBounded(
   stream: ReadableStream<Uint8Array>,
-  killed: () => boolean
+  gone: Promise<unknown>
 ): Promise<string> {
-  const text = new Response(stream).text();
+  const reader = stream.getReader();
+  const decoder = new TextDecoder();
+  const giveUp = gone
+    .then(() => Bun.sleep(POST_EXIT_DRAIN_MS))
+    .then(() => GIVE_UP);
+  let text = "";
 
-  return await Promise.race([
-    text,
-    (async (): Promise<string> => {
-      while (!killed()) {
-        await Bun.sleep(50);
+  try {
+    for (;;) {
+      const next = await Promise.race([reader.read(), giveUp]);
+
+      // typeof, because `.then(() => GIVE_UP)` widens the unique symbol back to
+      // `symbol` and equality alone will not narrow the union.
+      if (typeof next === "symbol") {
+        break;
       }
 
-      await Bun.sleep(POST_KILL_DRAIN_MS);
+      if (next.done) {
+        break;
+      }
 
-      return "";
-    })(),
-  ]);
+      text += decoder.decode(next.value, { stream: true });
+    }
+  } finally {
+    await reader.cancel().catch(() => undefined);
+  }
+
+  return text + decoder.decode();
 }
 
 export async function runBinary(
@@ -192,6 +228,13 @@ export async function runBinary(
     // SIGTERM is a request. A reviewer that ignores it — or installs a handler
     // and takes its time — would otherwise keep the whole panel blocked past a
     // budget that exists precisely to stop that. SIGKILL is not refusable.
+    // KNOWN LIMITATION: this kills the reviewer, not its process group. A
+    // reviewer that backgrounds work leaves those children orphaned and running
+    // — they die on their own, but they are not reaped here. Killing the group
+    // would need the child spawned into one of its own; done naively (kill
+    // -pid on a shared group) it would take the harness down with it, which is
+    // a worse failure than a stray `sleep`. The drain bound above is what stops
+    // an orphan holding the panel.
     killHard = setTimeout(() => {
       proc.kill(9);
     }, KILL_GRACE_MS);
@@ -201,27 +244,19 @@ export async function runBinary(
   try {
     // Cleared the MOMENT the process exits, not after stdout finishes draining.
     // A reviewer can finish under budget while its output is still being read
-    // (a big review, a busy event loop), and a timer firing during that drain
-    // would mark a completed review as a timeout and throw its answer away —
-    // the exact false signal this change exists to remove, and most likely near
-    // the budget edge under concurrent panel load.
+    // (a big review, a descendant holding the pipe), and a timer firing during
+    // that drain would mark a completed review as timed out and throw its answer
+    // away — the exact false signal this change exists to remove, and likeliest
+    // near the budget edge under concurrent panel load.
     const exited = proc.exited.then((code) => {
       clearTimeout(timer);
+      clearTimeout(killHard);
 
       return code;
     });
-    // Bounded because a KILLED process can leave a descendant holding the
-    // stdout pipe open (a backgrounded child inherits it), and reading to EOF
-    // would then wait for that descendant rather than for the reviewer. On a
-    // timeout the output is discarded anyway, so giving up on it is free.
-    const stdout = await readBounded(proc.stdout, () => timedOut);
+    const stdout = await readBounded(proc.stdout, exited);
     const code = await exited;
 
-    // A killed process is NOT a success, whatever it exited with. A binary can
-    // trap SIGTERM and exit 0, which would otherwise report `ok: true,
-    // timedOut: true` — and an over-budget reviewer's partial output would be
-    // parsed and counted as a real review. Whatever it managed to print before
-    // we killed it is a partial answer, and a partial answer is not a review.
     return { ok: code === 0 && !timedOut, stdout, timedOut };
   } finally {
     clearTimeout(timer);

--- a/packages/core/src/cli/harness-review-mode.ts
+++ b/packages/core/src/cli/harness-review-mode.ts
@@ -165,7 +165,13 @@ export async function runBinary(
     const stdout = await new Response(proc.stdout).text();
     const code = await proc.exited;
 
-    return { ok: code === 0, stdout, timedOut };
+    // A killed process is NOT a success, whatever it exited with. A binary can
+    // trap SIGTERM and exit 0, which would otherwise report `ok: true,
+    // timedOut: true` — and invokeBinary only inspects timedOut on the failure
+    // branch, so an over-budget reviewer would be parsed and counted as having
+    // reviewed. Whatever it managed to print before we killed it is a partial
+    // answer, and a partial answer is not a review.
+    return { ok: code === 0 && !timedOut, stdout, timedOut };
   } finally {
     clearTimeout(timer);
 

--- a/packages/core/src/cli/harness-review-mode.ts
+++ b/packages/core/src/cli/harness-review-mode.ts
@@ -311,27 +311,39 @@ async function childrenOf(pid: number): Promise<number[]> {
 }
 
 /**
- * Kill a process and everything below it, children first.
+ * The whole tree under (and including) a pid, deepest first.
  *
- * WHILE THE PARENT IS STILL ALIVE. Once it exits, its children are re-parented
- * to init and `pgrep -P` finds nothing — so reaping after waiting on the parent
- * looks like it works and silently leaves every orphan running. That is what a
- * first attempt at this did.
+ * COLLECTED ONCE, before anything is signalled, and while the parent is alive to
+ * be walked. Re-walking for the SIGKILL pass cannot work: SIGTERM makes a
+ * well-behaved parent exit, its TERM-IGNORING child is re-parented to init, and
+ * `pgrep -P <parent>` then returns nothing — so escalation finds an empty tree
+ * and the child runs on. A first version did exactly that and looked correct,
+ * because its test had a TERM-ignoring shell over a child that died on the
+ * first signal.
  *
  * Bun.spawn cannot put a child in its own process group, and killing the group
  * we SHARE would take the harness down with it, so walking the tree is what is
  * left. Best effort by construction: pgrep may be absent, and a process may exit
  * between listing and killing. Both are fine — this only ever adds cleanup.
  */
-async function killTree(pid: number, signal: number): Promise<void> {
+async function collectTree(pid: number): Promise<number[]> {
+  const below: number[] = [];
+
   for (const child of await childrenOf(pid)) {
-    await killTree(child, signal);
+    below.push(...(await collectTree(child)));
   }
 
-  try {
-    process.kill(pid, signal);
-  } catch {
-    // Already gone.
+  return [...below, pid];
+}
+
+/** Signal a captured list, ignoring anything that has already gone. */
+function signalAll(pids: readonly number[], signal: number): void {
+  for (const pid of pids) {
+    try {
+      process.kill(pid, signal);
+    } catch {
+      // Already gone.
+    }
   }
 }
 
@@ -371,24 +383,32 @@ export async function runBinary(
   const kill = { timedOut: false };
   const timer = setTimeout(() => {
     kill.timedOut = true;
-    // The tree, not just the reviewer — and now, while it is still alive to be
-    // walked.
-    void killTree(proc.pid, 15);
-    // SIGTERM is a request. A reviewer that ignores it — or installs a handler
-    // and takes its time — would otherwise keep the whole panel blocked past a
-    // budget that exists precisely to stop that. SIGKILL is not refusable.
-    // KNOWN LIMITATION: this kills the reviewer, not its process group. A
-    // reviewer that backgrounds work leaves those children orphaned and running
-    // — they die on their own, but they are not reaped here. Killing the group
-    // would need the child spawned into one of its own; done naively (kill
-    // -pid on a shared group) it would take the harness down with it, which is
-    // a worse failure than a stray `sleep`. The drain bound above is what stops
-    // an orphan holding the panel.
-    killHard = setTimeout(() => {
-      void killTree(proc.pid, 9);
-    }, KILL_GRACE_MS);
+    ending = endTree(proc.pid);
   }, r.timeoutMs);
-  let killHard: ReturnType<typeof setTimeout> | undefined;
+  /** In flight while a kill is being carried out, so the caller waits for it
+   *  instead of returning with the escalation still pending. */
+  let ending: Promise<void> | undefined;
+
+  /**
+   * Ask the tree to stop, then insist.
+   *
+   * SIGTERM is a request — a reviewer that ignores it, or takes its time, would
+   * otherwise hold the panel past the budget that exists to stop that — and
+   * SIGKILL is not refusable.
+   *
+   * AWAITED, not left on a timer. An escalation on a timer is cancelled by
+   * cleanup the moment the parent exits, which is exactly when a TERM-ignoring
+   * child still needs killing: the reviewer's own well-behaved exit disarms the
+   * thing that would have reaped its orphan.
+   */
+  const endTree = async (pid: number): Promise<void> => {
+    // Captured BEFORE anything is signalled — see collectTree.
+    const tree = await collectTree(pid);
+
+    signalAll(tree, 15);
+    await Bun.sleep(KILL_GRACE_MS);
+    signalAll(tree, 9);
+  };
 
   try {
     // Cleared the MOMENT the process exits, not after stdout finishes draining.
@@ -399,7 +419,6 @@ export async function runBinary(
     // near the budget edge under concurrent panel load.
     const exited = proc.exited.then((code) => {
       clearTimeout(timer);
-      clearTimeout(killHard);
 
       return code;
     });
@@ -412,10 +431,7 @@ export async function runBinary(
     // hit there is nothing left to wait for.
     if (read.stoppedBy === "size") {
       clearTimeout(timer);
-      await killTree(proc.pid, 15);
-      killHard = setTimeout(() => {
-        void killTree(proc.pid, 9);
-      }, KILL_GRACE_MS);
+      ending = endTree(proc.pid);
     }
 
     const code = await exited;
@@ -431,7 +447,10 @@ export async function runBinary(
     };
   } finally {
     clearTimeout(timer);
-    clearTimeout(killHard);
+    // Wait for a kill in progress. Returning while the escalation is pending
+    // leaves the caller believing the reviewer is gone when its TERM-ignoring
+    // child is not.
+    await ending;
 
     if (tmpPath !== undefined) {
       await rm(tmpPath, { force: true });
@@ -585,7 +604,7 @@ export function formatVerdict(v: IVerdict): string {
     // The reason can be derived straight from a reviewer-controlled finding, so
     // it is no more ours than the failure text below it.
     `harness-review: ${head} — ${oneLine(v.reason)}`,
-    `reviewers ok: ${String(v.reviewers.ok)}  errored: ${String(v.reviewers.errored)}  (builder: ${v.identity})`,
+    `reviewers ok: ${String(v.reviewers.ok)}  errored: ${String(v.reviewers.errored)}  (builder: ${oneLine(v.identity)})`,
   ];
 
   // Name every reviewer that dropped out, with why and how long it took. A bare
@@ -699,7 +718,10 @@ export async function harnessReviewMode(argv: string[]): Promise<number> {
   const panel = resolvePanel(cfg, active);
 
   for (const s of panel.skipped) {
-    process.stdout.write(`skipped reviewer ${s.id}: ${s.reason}\n`);
+    // Config-derived, so no more ours than a reviewer's own output.
+    process.stdout.write(
+      `skipped reviewer ${oneLine(s.id)}: ${oneLine(s.reason)}\n`
+    );
   }
 
   const treeHashRes = await gitRunner(["write-tree"]);

--- a/packages/core/src/cli/harness-review-mode.ts
+++ b/packages/core/src/cli/harness-review-mode.ts
@@ -128,6 +128,8 @@ export function buildBinaryInvocation(
  *  normal shutdown, short enough that an unkillable reviewer cannot hold the
  *  panel. */
 const KILL_GRACE_MS = 2_000;
+/** Conventional exit code for a process terminated by SIGKILL (128 + 9). */
+const SIGKILL_EXIT = 137;
 /**
  * How long to keep draining stdout after the process itself has gone.
  *
@@ -289,64 +291,6 @@ async function readBounded(
   };
 }
 
-/** Direct children of a pid, via pgrep. Empty when pgrep is missing or the
- *  process has none. */
-async function childrenOf(pid: number): Promise<number[]> {
-  try {
-    const proc = Bun.spawn(["pgrep", "-P", String(pid)], {
-      stdout: "pipe",
-      stderr: "ignore",
-    });
-    const out = await new Response(proc.stdout).text();
-
-    await proc.exited;
-
-    return out
-      .split("\n")
-      .map((line) => Number.parseInt(line.trim(), 10))
-      .filter((n) => Number.isInteger(n) && n > 0);
-  } catch {
-    return [];
-  }
-}
-
-/**
- * The whole tree under (and including) a pid, deepest first.
- *
- * COLLECTED ONCE, before anything is signalled, and while the parent is alive to
- * be walked. Re-walking for the SIGKILL pass cannot work: SIGTERM makes a
- * well-behaved parent exit, its TERM-IGNORING child is re-parented to init, and
- * `pgrep -P <parent>` then returns nothing — so escalation finds an empty tree
- * and the child runs on. A first version did exactly that and looked correct,
- * because its test had a TERM-ignoring shell over a child that died on the
- * first signal.
- *
- * Bun.spawn cannot put a child in its own process group, and killing the group
- * we SHARE would take the harness down with it, so walking the tree is what is
- * left. Best effort by construction: pgrep may be absent, and a process may exit
- * between listing and killing. Both are fine — this only ever adds cleanup.
- */
-async function collectTree(pid: number): Promise<number[]> {
-  const below: number[] = [];
-
-  for (const child of await childrenOf(pid)) {
-    below.push(...(await collectTree(child)));
-  }
-
-  return [...below, pid];
-}
-
-/** Signal a captured list, ignoring anything that has already gone. */
-function signalAll(pids: readonly number[], signal: number): void {
-  for (const pid of pids) {
-    try {
-      process.kill(pid, signal);
-    } catch {
-      // Already gone.
-    }
-  }
-}
-
 export async function runBinary(
   r: { argv: string[]; input: BinaryInputMode; timeoutMs: number },
   stdin: string
@@ -369,11 +313,22 @@ export async function runBinary(
   // reviewer in a throwaway temp dir confines every side effect there; the real repo is untouchable.
   const sandbox = await mkdtemp(join(tmpdir(), "tsforge-review-sandbox-"));
   const invocation = buildBinaryInvocation(r, stdin, tmpPath);
+  // `detached: true` makes the reviewer its OWN process-group leader, so the
+  // kill below takes down the whole group — the `sh -c` wrapper AND anything it
+  // backgrounded. This is how lib/fs/process.ts already does it, and it is the
+  // portable way to get a new group (setsid is not on macOS).
+  //
+  // An earlier version of this walked the tree with `pgrep` instead, on the
+  // stated premise that Bun.spawn could not create a group. That was simply
+  // false — the pattern was already in this repo — and the walk could not work
+  // anyway: SIGTERM makes a well-behaved parent exit, its TERM-ignoring child is
+  // re-parented to init, and there is nothing left to walk from.
   const proc = Bun.spawn(invocation.cmd, {
     cwd: sandbox,
     stdin: invocation.stdinBytes,
     stdout: "pipe",
     stderr: "ignore",
+    detached: true,
   });
   // Recorded rather than inferred: a killed process exits non-zero, so the exit
   // code alone cannot distinguish "we killed it at the budget" from "it failed
@@ -383,31 +338,40 @@ export async function runBinary(
   const kill = { timedOut: false };
   const timer = setTimeout(() => {
     kill.timedOut = true;
-    ending = endTree(proc.pid);
+    killGroup();
   }, r.timeoutMs);
-  /** In flight while a kill is being carried out, so the caller waits for it
-   *  instead of returning with the escalation still pending. */
-  let ending: Promise<void> | undefined;
+  // Resolves only once a kill has been signalled AND the process still has not
+  // been reaped a grace later — i.e. it escaped its group and survived SIGKILL.
+  // Raced against `proc.exited` so the wait below always settles; without it an
+  // un-reapable reviewer wedges the panel forever. Same shape as process.ts.
+  let resolveEscaped: (() => void) | null = null;
+  const escaped = new Promise<void>((resolve) => {
+    resolveEscaped = resolve;
+  });
+  const escape: { timer: ReturnType<typeof setTimeout> | null } = {
+    timer: null,
+  };
 
   /**
-   * Ask the tree to stop, then insist.
+   * Kill the whole group, falling back to the lone child when the group is gone
+   * (ESRCH) or not permitted (EPERM). Never throws.
    *
-   * SIGTERM is a request — a reviewer that ignores it, or takes its time, would
-   * otherwise hold the panel past the budget that exists to stop that — and
-   * SIGKILL is not refusable.
-   *
-   * AWAITED, not left on a timer. An escalation on a timer is cancelled by
-   * cleanup the moment the parent exits, which is exactly when a TERM-ignoring
-   * child still needs killing: the reviewer's own well-behaved exit disarms the
-   * thing that would have reaped its orphan.
+   * SIGKILL directly rather than SIGTERM-then-escalate: the budget has already
+   * expired by the time this runs, and a reviewer that asked for more time by
+   * ignoring SIGTERM is the case the budget exists for.
    */
-  const endTree = async (pid: number): Promise<void> => {
-    // Captured BEFORE anything is signalled — see collectTree.
-    const tree = await collectTree(pid);
+  const killGroup = (): void => {
+    try {
+      process.kill(-proc.pid, "SIGKILL");
+    } catch {
+      try {
+        proc.kill(9);
+      } catch {
+        // Already exited.
+      }
+    }
 
-    signalAll(tree, 15);
-    await Bun.sleep(KILL_GRACE_MS);
-    signalAll(tree, 9);
+    escape.timer ??= setTimeout(() => resolveEscaped?.(), KILL_GRACE_MS);
   };
 
   try {
@@ -431,10 +395,11 @@ export async function runBinary(
     // hit there is nothing left to wait for.
     if (read.stoppedBy === "size") {
       clearTimeout(timer);
-      ending = endTree(proc.pid);
+      killGroup();
     }
 
-    const code = await exited;
+    // Raced, so a process that outlived SIGKILL cannot hold the panel.
+    const code = await Promise.race([exited, escaped.then(() => SIGKILL_EXIT)]);
 
     return {
       ok: code === 0 && !kill.timedOut && !read.truncated,
@@ -447,10 +412,11 @@ export async function runBinary(
     };
   } finally {
     clearTimeout(timer);
-    // Wait for a kill in progress. Returning while the escalation is pending
-    // leaves the caller believing the reviewer is gone when its TERM-ignoring
-    // child is not.
-    await ending;
+    // Every reviewer, not only the ones that misbehaved: a reviewer that exits
+    // cleanly can still leave a backgrounded child holding resources, and
+    // killing an already-empty group costs nothing.
+    killGroup();
+    clearTimeout(escape.timer ?? undefined);
 
     if (tmpPath !== undefined) {
       await rm(tmpPath, { force: true });
@@ -568,7 +534,6 @@ function oneLine(value: string): string {
   // spread/split on a string mishandles astral characters.
   for (const ch of value) {
     const code = ch.codePointAt(0) ?? 0;
-    // C0 (newline and ESC among them), DEL, and C1.
     // C0 (newline and ESC among them), DEL, C1 — plus the Unicode line/paragraph
     // separators, which a terminal breaks on exactly like a newline, and the
     // bidi overrides, which can visually reorder a line into something it does

--- a/packages/core/src/cli/harness-review-mode.ts
+++ b/packages/core/src/cli/harness-review-mode.ts
@@ -138,62 +138,113 @@ const KILL_GRACE_MS = 2_000;
  */
 const POST_EXIT_DRAIN_MS = 1_000;
 
-/** Sentinel for the give-up branch of the read race. */
-const GIVE_UP = Symbol("give-up");
+/**
+ * Hard ceiling on a reviewer's stdout. A review is a small JSON object; anything
+ * past this is a runaway, and reading it to EOF would let one noisy reviewer
+ * exhaust the harness.
+ */
+const MAX_STDOUT_BYTES = 8 * 1024 * 1024;
+
+/** Mutable read state, held in an object so a closure can flip it. */
+interface IReadState {
+  expired: boolean;
+  stoppedBy: IBoundedRead["stoppedBy"];
+}
+
+/** What a bounded read produced, and why it stopped. */
+interface IBoundedRead {
+  text: string;
+  /**
+   * Why the read ended, because the two early exits mean different things.
+   *
+   * `size` is the reviewer flooding us — its answer really is cut off. `deadline`
+   * is the pipe still being open a second after the PROCESS was gone, which
+   * happens when a descendant inherited it; if the reviewer exited cleanly it
+   * had already finished writing, and calling that a truncated review would
+   * discard a perfectly good answer for an orphan's file handle. `eof` is the
+   * normal end.
+   */
+  stoppedBy: "eof" | "size" | "deadline";
+}
 
 /**
- * Read a stream to EOF, or give up shortly after the process is gone — keeping
- * whatever arrived before that.
+ * Read a stream to EOF, or stop shortly after the process is gone — keeping
+ * whatever arrived, and saying so when it stopped early.
  *
- * Bounded by a PROMISE, not a poll. A `while (!done) await sleep(50)` loop keeps
- * scheduling itself forever when it loses the race — Promise.race abandons the
- * loser's value, never its work — so every successful call leaked a poller for
- * the life of the process.
+ * Bounded by a FLAG, not by racing the deadline each iteration. `Promise.race`
+ * resolves with the first ALREADY-SETTLED entry in array order, so once a
+ * descendant keeps the pipe permanently readable, `reader.read()` wins every
+ * round forever and the deadline never gets a turn — the bound silently stops
+ * bounding for exactly the noisy-child case it exists to handle.
  *
- * Chunk by chunk, because racing a whole `Response.text()` throws away
- * everything already read the moment it gives up: a reviewer that answered and
- * exited, leaving a background child holding the pipe, would have its complete
- * answer discarded for the sake of the child. Partial output beats none, and on
- * the timeout path it is discarded by the caller anyway.
+ * Chunk by chunk, because racing a whole `Response.text()` discards everything
+ * already read the moment it gives up: a reviewer that answered and exited,
+ * leaving a background child holding the pipe, would lose a complete answer for
+ * the sake of the child.
  */
 async function readBounded(
   stream: ReadableStream<Uint8Array>,
   gone: Promise<unknown>
-): Promise<string> {
+): Promise<IBoundedRead> {
   const reader = stream.getReader();
   const decoder = new TextDecoder();
-  const giveUp = gone
-    .then(() => Bun.sleep(POST_EXIT_DRAIN_MS))
-    .then(() => GIVE_UP);
+  // One mutable object rather than locals: the deadline flips `expired` from a
+  // callback, and control-flow analysis cannot see an assignment made inside a
+  // closure — with plain locals it narrows the flag to a constant and calls the
+  // check dead code.
+  const state: IReadState = { expired: false, stoppedBy: "eof" };
+  let bytes = 0;
   let text = "";
+
+  const deadline = gone
+    .then(() => Bun.sleep(POST_EXIT_DRAIN_MS))
+    .then(() => {
+      state.expired = true;
+    });
 
   try {
     for (;;) {
-      const next = await Promise.race([reader.read(), giveUp]);
-
-      // typeof, because `.then(() => GIVE_UP)` widens the unique symbol back to
-      // `symbol` and equality alone will not narrow the union.
-      if (typeof next === "symbol") {
+      if (bytes >= MAX_STDOUT_BYTES) {
+        state.stoppedBy = "size";
         break;
+      }
+
+      if (state.expired) {
+        state.stoppedBy = "deadline";
+        break;
+      }
+
+      const next = await Promise.race([reader.read(), deadline]);
+
+      // `deadline` resolves to undefined; the flag above ends the loop on the
+      // next pass, so this only skips one iteration.
+      if (next === undefined) {
+        continue;
       }
 
       if (next.done) {
         break;
       }
 
+      bytes += next.value.length;
       text += decoder.decode(next.value, { stream: true });
     }
   } finally {
     await reader.cancel().catch(() => undefined);
   }
 
-  return text + decoder.decode();
+  return { text: text + decoder.decode(), stoppedBy: state.stoppedBy };
 }
 
 export async function runBinary(
   r: { argv: string[]; input: BinaryInputMode; timeoutMs: number },
   stdin: string
-): Promise<{ ok: boolean; stdout: string; timedOut: boolean }> {
+): Promise<{
+  ok: boolean;
+  stdout: string;
+  timedOut: boolean;
+  truncated: boolean;
+}> {
   const tmpPath =
     r.input === "tempfile"
       ? join(tmpdir(), `tsforge-review-${randomUUID()}.txt`)
@@ -221,9 +272,11 @@ export async function runBinary(
   // Recorded rather than inferred: a killed process exits non-zero, so the exit
   // code alone cannot distinguish "we killed it at the budget" from "it failed
   // on its own". Only the killer knows.
-  let timedOut = false;
+  // In an object for the same reason as the read state below: the timer flips
+  // this from a callback, and control-flow analysis cannot see that.
+  const kill = { timedOut: false };
   const timer = setTimeout(() => {
-    timedOut = true;
+    kill.timedOut = true;
     proc.kill();
     // SIGTERM is a request. A reviewer that ignores it — or installs a handler
     // and takes its time — would otherwise keep the whole panel blocked past a
@@ -254,10 +307,25 @@ export async function runBinary(
 
       return code;
     });
-    const stdout = await readBounded(proc.stdout, exited);
+    const read = await readBounded(proc.stdout, exited);
     const code = await exited;
 
-    return { ok: code === 0 && !timedOut, stdout, timedOut };
+    // A reviewer that FLOODED us really was cut off, and passing the prefix on
+    // as though it were the whole answer makes that look like a malformed review
+    // — sending the next person to debug the reviewer rather than the bound.
+    //
+    // A deadline stop after a CLEAN exit is different: the reviewer had already
+    // finished writing, and what still holds the pipe is a descendant. Treating
+    // that as truncation would reject a good review over an orphan's file
+    // handle. A deadline stop after a KILL is already covered by `timedOut`.
+    const truncated = read.stoppedBy === "size";
+
+    return {
+      ok: code === 0 && !kill.timedOut && !truncated,
+      stdout: read.text,
+      timedOut: kill.timedOut,
+      truncated,
+    };
   } finally {
     clearTimeout(timer);
     clearTimeout(killHard);

--- a/packages/core/src/cli/harness-review-mode.ts
+++ b/packages/core/src/cli/harness-review-mode.ts
@@ -143,7 +143,7 @@ const POST_EXIT_DRAIN_MS = 2_000;
  * past this is a runaway, and reading it to EOF would let one noisy reviewer
  * exhaust the harness.
  */
-const MAX_STDOUT_BYTES = 8 * 1024 * 1024;
+export const MAX_STDOUT_BYTES = 8 * 1024 * 1024;
 
 /** Mutable read state, held in an object so a closure can flip it. */
 interface IReadState {
@@ -154,8 +154,8 @@ interface IReadState {
 /** What a bounded read produced, and why it stopped. */
 interface IBoundedRead {
   text: string;
-  /** `size` — the reviewer flooded us. `deadline` — the pipe was still open a
-   *  second after the process went. `eof` — the normal end. */
+  /** `size` — the reviewer flooded us past the ceiling. `deadline` — the pipe
+   *  was still open when the post-exit grace ran out. `eof` — the normal end. */
   stoppedBy: "eof" | "size" | "deadline";
   /** True whenever the read did not reach EOF.
    *
@@ -205,11 +205,6 @@ async function readBounded(
 
   try {
     for (;;) {
-      if (bytes >= MAX_STDOUT_BYTES) {
-        state.stoppedBy = "size";
-        break;
-      }
-
       if (state.expired) {
         state.stoppedBy = "deadline";
         break;
@@ -227,15 +222,24 @@ async function readBounded(
         break;
       }
 
-      // Sliced to the remaining allowance: checking the ceiling only BEFORE
-      // appending lets the returned text overrun it by a whole chunk, which for
-      // a reviewer emitting megabyte chunks is not a rounding error.
+      // The ceiling is checked AFTER the read, not before. Breaking on a full
+      // buffer first would call a stream of exactly MAX_STDOUT_BYTES truncated,
+      // though its next read is EOF and nothing was lost — the documented
+      // runaway condition is output PAST the ceiling.
       const room = MAX_STDOUT_BYTES - bytes;
-      const chunk =
-        next.value.length > room ? next.value.subarray(0, room) : next.value;
 
-      bytes += chunk.length;
-      text += decoder.decode(chunk, { stream: true });
+      if (next.value.length > room) {
+        // Sliced to the remaining allowance: appending whole and checking
+        // afterwards lets the text overrun by a full chunk, which for a reviewer
+        // emitting megabyte chunks is not a rounding error.
+        bytes += room;
+        text += decoder.decode(next.value.subarray(0, room), { stream: true });
+        state.stoppedBy = "size";
+        break;
+      }
+
+      bytes += next.value.length;
+      text += decoder.decode(next.value, { stream: true });
     }
   } finally {
     await reader.cancel().catch(() => undefined);

--- a/packages/core/src/cli/harness-review-mode.ts
+++ b/packages/core/src/cli/harness-review-mode.ts
@@ -136,7 +136,7 @@ const KILL_GRACE_MS = 2_000;
  * reviewer was killed or exited cleanly on its own, so the bound is tied to the
  * process exiting rather than to the kill.
  */
-const POST_EXIT_DRAIN_MS = 1_000;
+const POST_EXIT_DRAIN_MS = 2_000;
 
 /**
  * Hard ceiling on a reviewer's stdout. A review is a small JSON object; anything
@@ -154,22 +154,27 @@ interface IReadState {
 /** What a bounded read produced, and why it stopped. */
 interface IBoundedRead {
   text: string;
-  /**
-   * Why the read ended, because the two early exits mean different things.
-   *
-   * `size` is the reviewer flooding us — its answer really is cut off. `deadline`
-   * is the pipe still being open a second after the PROCESS was gone, which
-   * happens when a descendant inherited it; if the reviewer exited cleanly it
-   * had already finished writing, and calling that a truncated review would
-   * discard a perfectly good answer for an orphan's file handle. `eof` is the
-   * normal end.
-   */
+  /** `size` — the reviewer flooded us. `deadline` — the pipe was still open a
+   *  second after the process went. `eof` — the normal end. */
   stoppedBy: "eof" | "size" | "deadline";
+  /** True whenever the read did not reach EOF.
+   *
+   *  Deliberately blunt. Whether an orphan holding the pipe is idle or still
+   *  writing cannot be decided from here: a writer slower than the grace window
+   *  looks exactly like a writer that has finished, and a heuristic on "did
+   *  bytes arrive during the grace" only catches the loud half. Not reaching EOF
+   *  means we cannot claim the answer is complete, so we do not.
+   *
+   *  The cost is a reviewer that backgrounds work having its review refused —
+   *  visibly, with cause `truncated`, which is the whole point of these
+   *  diagnostics. The alternative is passing a prefix off as a finished review,
+   *  and a wrong verdict is worse than a missing one. */
+  truncated: boolean;
 }
 
 /**
  * Read a stream to EOF, or stop shortly after the process is gone — keeping
- * whatever arrived, and saying so when it stopped early.
+ * whatever arrived, and saying whether anything was probably lost.
  *
  * Bounded by a FLAG, not by racing the deadline each iteration. `Promise.race`
  * resolves with the first ALREADY-SETTLED entry in array order, so once a
@@ -177,10 +182,10 @@ interface IBoundedRead {
  * round forever and the deadline never gets a turn — the bound silently stops
  * bounding for exactly the noisy-child case it exists to handle.
  *
- * Chunk by chunk, because racing a whole `Response.text()` discards everything
- * already read the moment it gives up: a reviewer that answered and exited,
- * leaving a background child holding the pipe, would lose a complete answer for
- * the sake of the child.
+ * Chunk by chunk, because racing a whole `Response.text()` throws away
+ * everything already read the moment it gives up: a reviewer that answered and
+ * exited, leaving a background child holding the pipe, would lose a complete
+ * answer for the sake of the child.
  */
 async function readBounded(
   stream: ReadableStream<Uint8Array>,
@@ -188,10 +193,6 @@ async function readBounded(
 ): Promise<IBoundedRead> {
   const reader = stream.getReader();
   const decoder = new TextDecoder();
-  // One mutable object rather than locals: the deadline flips `expired` from a
-  // callback, and control-flow analysis cannot see an assignment made inside a
-  // closure — with plain locals it narrows the flag to a constant and calls the
-  // check dead code.
   const state: IReadState = { expired: false, stoppedBy: "eof" };
   let bytes = 0;
   let text = "";
@@ -226,14 +227,25 @@ async function readBounded(
         break;
       }
 
-      bytes += next.value.length;
-      text += decoder.decode(next.value, { stream: true });
+      // Sliced to the remaining allowance: checking the ceiling only BEFORE
+      // appending lets the returned text overrun it by a whole chunk, which for
+      // a reviewer emitting megabyte chunks is not a rounding error.
+      const room = MAX_STDOUT_BYTES - bytes;
+      const chunk =
+        next.value.length > room ? next.value.subarray(0, room) : next.value;
+
+      bytes += chunk.length;
+      text += decoder.decode(chunk, { stream: true });
     }
   } finally {
     await reader.cancel().catch(() => undefined);
   }
 
-  return { text: text + decoder.decode(), stoppedBy: state.stoppedBy };
+  return {
+    text: text + decoder.decode(),
+    stoppedBy: state.stoppedBy,
+    truncated: state.stoppedBy !== "eof",
+  };
 }
 
 export async function runBinary(
@@ -310,21 +322,11 @@ export async function runBinary(
     const read = await readBounded(proc.stdout, exited);
     const code = await exited;
 
-    // A reviewer that FLOODED us really was cut off, and passing the prefix on
-    // as though it were the whole answer makes that look like a malformed review
-    // — sending the next person to debug the reviewer rather than the bound.
-    //
-    // A deadline stop after a CLEAN exit is different: the reviewer had already
-    // finished writing, and what still holds the pipe is a descendant. Treating
-    // that as truncation would reject a good review over an orphan's file
-    // handle. A deadline stop after a KILL is already covered by `timedOut`.
-    const truncated = read.stoppedBy === "size";
-
     return {
-      ok: code === 0 && !kill.timedOut && !truncated,
+      ok: code === 0 && !kill.timedOut && !read.truncated,
       stdout: read.text,
       timedOut: kill.timedOut,
-      truncated,
+      truncated: read.truncated,
     };
   } finally {
     clearTimeout(timer);

--- a/packages/core/src/cli/harness-review-mode.ts
+++ b/packages/core/src/cli/harness-review-mode.ts
@@ -124,6 +124,36 @@ export function buildBinaryInvocation(
   };
 }
 
+/** How long a reviewer gets to honour SIGTERM before SIGKILL. Long enough for a
+ *  normal shutdown, short enough that an unkillable reviewer cannot hold the
+ *  panel. */
+const KILL_GRACE_MS = 2_000;
+/** How long to keep draining stdout AFTER a kill. A descendant can hold the pipe
+ *  open long past the reviewer's own exit; the output is discarded on a timeout
+ *  regardless, so waiting for EOF buys nothing. */
+const POST_KILL_DRAIN_MS = 1_000;
+
+/** Read a stream to EOF, but stop shortly after `killed()` turns true. */
+async function readBounded(
+  stream: ReadableStream<Uint8Array>,
+  killed: () => boolean
+): Promise<string> {
+  const text = new Response(stream).text();
+
+  return await Promise.race([
+    text,
+    (async (): Promise<string> => {
+      while (!killed()) {
+        await Bun.sleep(50);
+      }
+
+      await Bun.sleep(POST_KILL_DRAIN_MS);
+
+      return "";
+    })(),
+  ]);
+}
+
 export async function runBinary(
   r: { argv: string[]; input: BinaryInputMode; timeoutMs: number },
   stdin: string
@@ -159,21 +189,43 @@ export async function runBinary(
   const timer = setTimeout(() => {
     timedOut = true;
     proc.kill();
+    // SIGTERM is a request. A reviewer that ignores it — or installs a handler
+    // and takes its time — would otherwise keep the whole panel blocked past a
+    // budget that exists precisely to stop that. SIGKILL is not refusable.
+    killHard = setTimeout(() => {
+      proc.kill(9);
+    }, KILL_GRACE_MS);
   }, r.timeoutMs);
+  let killHard: ReturnType<typeof setTimeout> | undefined;
 
   try {
-    const stdout = await new Response(proc.stdout).text();
-    const code = await proc.exited;
+    // Cleared the MOMENT the process exits, not after stdout finishes draining.
+    // A reviewer can finish under budget while its output is still being read
+    // (a big review, a busy event loop), and a timer firing during that drain
+    // would mark a completed review as a timeout and throw its answer away —
+    // the exact false signal this change exists to remove, and most likely near
+    // the budget edge under concurrent panel load.
+    const exited = proc.exited.then((code) => {
+      clearTimeout(timer);
+
+      return code;
+    });
+    // Bounded because a KILLED process can leave a descendant holding the
+    // stdout pipe open (a backgrounded child inherits it), and reading to EOF
+    // would then wait for that descendant rather than for the reviewer. On a
+    // timeout the output is discarded anyway, so giving up on it is free.
+    const stdout = await readBounded(proc.stdout, () => timedOut);
+    const code = await exited;
 
     // A killed process is NOT a success, whatever it exited with. A binary can
     // trap SIGTERM and exit 0, which would otherwise report `ok: true,
-    // timedOut: true` — and invokeBinary only inspects timedOut on the failure
-    // branch, so an over-budget reviewer would be parsed and counted as having
-    // reviewed. Whatever it managed to print before we killed it is a partial
-    // answer, and a partial answer is not a review.
+    // timedOut: true` — and an over-budget reviewer's partial output would be
+    // parsed and counted as a real review. Whatever it managed to print before
+    // we killed it is a partial answer, and a partial answer is not a review.
     return { ok: code === 0 && !timedOut, stdout, timedOut };
   } finally {
     clearTimeout(timer);
+    clearTimeout(killHard);
 
     if (tmpPath !== undefined) {
       await rm(tmpPath, { force: true });

--- a/packages/core/src/cli/harness-review-mode.ts
+++ b/packages/core/src/cli/harness-review-mode.ts
@@ -124,9 +124,11 @@ export function buildBinaryInvocation(
   };
 }
 
-/** How long a reviewer gets to honour SIGTERM before SIGKILL. Long enough for a
- *  normal shutdown, short enough that an unkillable reviewer cannot hold the
- *  panel. */
+/** After a kill is signalled, how long to wait for the process to actually be
+ *  reaped before giving up. NOT a SIGTERM grace — the kill is SIGKILL, which is
+ *  not refusable — this covers a child that escaped its group (called `setsid`,
+ *  say) and so survives the group kill. Without the bound, `proc.exited` might
+ *  never resolve and the panel would wait forever. */
 const KILL_GRACE_MS = 2_000;
 /** Conventional exit code for a process terminated by SIGKILL (128 + 9). */
 const SIGKILL_EXIT = 137;
@@ -386,7 +388,13 @@ export async function runBinary(
 
       return code;
     });
-    const read = await readBounded(proc.stdout, exited);
+    // Bounded by EITHER the process exiting or the escape hatch firing. Hanging
+    // the drain off `exited` alone deadlocks the case the escape hatch exists
+    // for: a process that survives SIGKILL never settles `exited`, so the
+    // post-exit grace never starts, the read loops forever, and execution never
+    // reaches the race below at all.
+    const settled = Promise.race([exited, escaped]);
+    const read = await readBounded(proc.stdout, settled);
 
     // A reviewer that floods and KEEPS RUNNING would otherwise hold the panel
     // until its full budget — we stopped reading, but nothing stopped it — and

--- a/packages/core/src/cli/harness-review-mode.ts
+++ b/packages/core/src/cli/harness-review-mode.ts
@@ -145,6 +145,19 @@ const POST_EXIT_DRAIN_MS = 2_000;
  */
 export const MAX_STDOUT_BYTES = 8 * 1024 * 1024;
 
+/** What running a reviewer binary produced. */
+export interface IBinaryRun {
+  ok: boolean;
+  stdout: string;
+  timedOut: boolean;
+  truncated: boolean;
+  /** WHY the read ended, forwarded rather than collapsed. `truncated` alone
+   *  cannot tell a flood from a pipe still open after the process went, and the
+   *  two point at different problems — so a caller reporting the failure needs
+   *  the distinction that readBounded already computed. */
+  stoppedBy: IBoundedRead["stoppedBy"];
+}
+
 /** Mutable read state, held in an object so a closure can flip it. */
 interface IReadState {
   expired: boolean;
@@ -197,11 +210,19 @@ async function readBounded(
   let bytes = 0;
   let text = "";
 
-  const deadline = gone
-    .then(() => Bun.sleep(POST_EXIT_DRAIN_MS))
-    .then(() => {
-      state.expired = true;
-    });
+  // A clearable timer, not Bun.sleep: an un-cancellable sleep starts on EVERY
+  // run the moment the process exits and keeps the event loop alive for its full
+  // grace, healthy reviewers included.
+  let graceTimer: ReturnType<typeof setTimeout> | undefined;
+  const deadline = gone.then(
+    () =>
+      new Promise<void>((resolve) => {
+        graceTimer = setTimeout(() => {
+          state.expired = true;
+          resolve();
+        }, POST_EXIT_DRAIN_MS);
+      })
+  );
 
   try {
     for (;;) {
@@ -242,6 +263,7 @@ async function readBounded(
       text += decoder.decode(next.value, { stream: true });
     }
   } finally {
+    clearTimeout(graceTimer);
     await reader.cancel().catch(() => undefined);
   }
 
@@ -255,12 +277,7 @@ async function readBounded(
 export async function runBinary(
   r: { argv: string[]; input: BinaryInputMode; timeoutMs: number },
   stdin: string
-): Promise<{
-  ok: boolean;
-  stdout: string;
-  timedOut: boolean;
-  truncated: boolean;
-}> {
+): Promise<IBinaryRun> {
   const tmpPath =
     r.input === "tempfile"
       ? join(tmpdir(), `tsforge-review-${randomUUID()}.txt`)
@@ -324,13 +341,30 @@ export async function runBinary(
       return code;
     });
     const read = await readBounded(proc.stdout, exited);
+
+    // A reviewer that floods and KEEPS RUNNING would otherwise hold the panel
+    // until its full budget — we stopped reading, but nothing stopped it — and
+    // the budget timer would then fire, so a runaway stdout got reported as a
+    // timeout and pointed the operator at the wrong knob. Once the ceiling is
+    // hit there is nothing left to wait for.
+    if (read.stoppedBy === "size") {
+      clearTimeout(timer);
+      proc.kill();
+      killHard = setTimeout(() => {
+        proc.kill(9);
+      }, KILL_GRACE_MS);
+    }
+
     const code = await exited;
 
     return {
       ok: code === 0 && !kill.timedOut && !read.truncated,
       stdout: read.text,
-      timedOut: kill.timedOut,
+      // A size stop kills the process itself, so a budget timer that fires
+      // afterwards is describing our own kill, not an over-budget reviewer.
+      timedOut: kill.timedOut && read.stoppedBy !== "size",
       truncated: read.truncated,
+      stoppedBy: read.stoppedBy,
     };
   } finally {
     clearTimeout(timer);
@@ -435,6 +469,41 @@ export async function persistVerdict(
   }
 }
 
+/**
+ * Flatten untrusted text to a single printable line.
+ *
+ * Reviewer ids and error strings reach the terminal verbatim, and neither is
+ * ours: an error message can carry a remote provider's response body, and a
+ * cached verdict is read back off disk. An embedded newline forges an extra
+ * verdict line — `! x did not review` followed by a fabricated `harness-review:
+ * PASS` — and an escape sequence can rewrite what a CI log appears to say.
+ * Neither belongs in a summary someone reads to decide whether to merge.
+ */
+function oneLine(value: string): string {
+  let out = "";
+
+  // A code-point walk: a control-character regex is disallowed here, and
+  // spread/split on a string mishandles astral characters.
+  for (const ch of value) {
+    const code = ch.codePointAt(0) ?? 0;
+    // C0 (newline and ESC among them), DEL, and C1.
+    const control =
+      code < 0x20 || code === 0x7f || (code >= 0x80 && code <= 0x9f);
+
+    out += control ? " " : ch;
+  }
+
+  const flattened = out.trim();
+
+  return flattened.length > MAX_FAILURE_TEXT
+    ? `${flattened.slice(0, MAX_FAILURE_TEXT)}…`
+    : flattened;
+}
+
+/** Enough for a real message, short of letting a reviewer paste a novel into the
+ *  summary. */
+const MAX_FAILURE_TEXT = 300;
+
 export function formatVerdict(v: IVerdict): string {
   const head = v.blocked ? "BLOCK" : "PASS";
   const lines = [
@@ -452,7 +521,7 @@ export function formatVerdict(v: IVerdict): string {
       f.ms === undefined ? "" : ` after ${(f.ms / 1000).toFixed(1)}s`;
 
     lines.push(
-      `  ! ${f.reviewerId} did not review (${f.cause ?? "error"})${took}: ${f.error}`
+      `  ! ${oneLine(f.reviewerId)} did not review (${f.cause ?? "error"})${took}: ${oneLine(f.error)}`
     );
   }
 

--- a/packages/core/src/cli/harness-review-mode.ts
+++ b/packages/core/src/cli/harness-review-mode.ts
@@ -127,7 +127,7 @@ export function buildBinaryInvocation(
 export async function runBinary(
   r: { argv: string[]; input: BinaryInputMode; timeoutMs: number },
   stdin: string
-): Promise<{ ok: boolean; stdout: string }> {
+): Promise<{ ok: boolean; stdout: string; timedOut: boolean }> {
   const tmpPath =
     r.input === "tempfile"
       ? join(tmpdir(), `tsforge-review-${randomUUID()}.txt`)
@@ -152,7 +152,12 @@ export async function runBinary(
     stdout: "pipe",
     stderr: "ignore",
   });
+  // Recorded rather than inferred: a killed process exits non-zero, so the exit
+  // code alone cannot distinguish "we killed it at the budget" from "it failed
+  // on its own". Only the killer knows.
+  let timedOut = false;
   const timer = setTimeout(() => {
+    timedOut = true;
     proc.kill();
   }, r.timeoutMs);
 
@@ -160,7 +165,7 @@ export async function runBinary(
     const stdout = await new Response(proc.stdout).text();
     const code = await proc.exited;
 
-    return { ok: code === 0, stdout };
+    return { ok: code === 0, stdout, timedOut };
   } finally {
     clearTimeout(timer);
 
@@ -269,6 +274,18 @@ export function formatVerdict(v: IVerdict): string {
     `harness-review: ${head} — ${v.reason}`,
     `reviewers ok: ${String(v.reviewers.ok)}  errored: ${String(v.reviewers.errored)}  (builder: ${v.identity})`,
   ];
+
+  // Name every reviewer that dropped out, with why and how long it took. A bare
+  // "errored: 2" is the same line whether two binaries are misconfigured or the
+  // whole panel timed out, and those need opposite responses.
+  for (const f of v.failures ?? []) {
+    const took =
+      f.ms === undefined ? "" : ` after ${(f.ms / 1000).toFixed(1)}s`;
+
+    lines.push(
+      `  ! ${f.reviewerId} did not review (${f.cause ?? "error"})${took}: ${f.error}`
+    );
+  }
 
   for (const f of v.ranked) {
     lines.push(

--- a/packages/core/src/cli/harness-review-mode.ts
+++ b/packages/core/src/cli/harness-review-mode.ts
@@ -284,12 +284,26 @@ export function formatVerdict(v: IVerdict): string {
   // Name every reviewer that dropped out, with why and how long it took. A bare
   // "errored: 2" is the same line whether two binaries are misconfigured or the
   // whole panel timed out, and those need opposite responses.
-  for (const f of v.failures ?? []) {
+  const failures = v.failures ?? [];
+
+  for (const f of failures) {
     const took =
       f.ms === undefined ? "" : ` after ${(f.ms / 1000).toFixed(1)}s`;
 
     lines.push(
       `  ! ${f.reviewerId} did not review (${f.cause ?? "error"})${took}: ${f.error}`
+    );
+  }
+
+  // SAY when detail is missing rather than printing a shorter list that looks
+  // complete. A cached artifact from an older build, or one whose entries did
+  // not survive parsing, otherwise silently regresses to count-only — the state
+  // this change exists to leave behind — with nothing to indicate it.
+  const undetailed = v.reviewers.errored - failures.length;
+
+  if (undetailed > 0) {
+    lines.push(
+      `  ! ${String(undetailed)} further reviewer failure(s) with no readable detail`
     );
   }
 

--- a/packages/core/src/cli/harness-review-mode.ts
+++ b/packages/core/src/cli/harness-review-mode.ts
@@ -161,6 +161,9 @@ export interface IBinaryRun {
 /** Mutable read state, held in an object so a closure can flip it. */
 interface IReadState {
   expired: boolean;
+  /** Set once the read has finished and cleaned up, so a late deadline callback
+   *  does not arm a timer with nobody left to clear it. */
+  done: boolean;
   stoppedBy: IBoundedRead["stoppedBy"];
 }
 
@@ -206,7 +209,7 @@ async function readBounded(
 ): Promise<IBoundedRead> {
   const reader = stream.getReader();
   const decoder = new TextDecoder();
-  const state: IReadState = { expired: false, stoppedBy: "eof" };
+  const state: IReadState = { expired: false, done: false, stoppedBy: "eof" };
   let bytes = 0;
   let text = "";
 
@@ -217,6 +220,17 @@ async function readBounded(
   const deadline = gone.then(
     () =>
       new Promise<void>((resolve) => {
+        // The read can finish before the process does — EOF on a reviewer that
+        // is still shutting down — and this callback then runs AFTER cleanup,
+        // arming a timer nothing will ever clear and holding the event loop open
+        // past every healthy run. That is the uncancellable tail all over again,
+        // just reached from the other side.
+        if (state.done) {
+          resolve();
+
+          return;
+        }
+
         graceTimer = setTimeout(() => {
           state.expired = true;
           resolve();
@@ -263,6 +277,7 @@ async function readBounded(
       text += decoder.decode(next.value, { stream: true });
     }
   } finally {
+    state.done = true;
     clearTimeout(graceTimer);
     await reader.cancel().catch(() => undefined);
   }
@@ -272,6 +287,52 @@ async function readBounded(
     stoppedBy: state.stoppedBy,
     truncated: state.stoppedBy !== "eof",
   };
+}
+
+/** Direct children of a pid, via pgrep. Empty when pgrep is missing or the
+ *  process has none. */
+async function childrenOf(pid: number): Promise<number[]> {
+  try {
+    const proc = Bun.spawn(["pgrep", "-P", String(pid)], {
+      stdout: "pipe",
+      stderr: "ignore",
+    });
+    const out = await new Response(proc.stdout).text();
+
+    await proc.exited;
+
+    return out
+      .split("\n")
+      .map((line) => Number.parseInt(line.trim(), 10))
+      .filter((n) => Number.isInteger(n) && n > 0);
+  } catch {
+    return [];
+  }
+}
+
+/**
+ * Kill a process and everything below it, children first.
+ *
+ * WHILE THE PARENT IS STILL ALIVE. Once it exits, its children are re-parented
+ * to init and `pgrep -P` finds nothing — so reaping after waiting on the parent
+ * looks like it works and silently leaves every orphan running. That is what a
+ * first attempt at this did.
+ *
+ * Bun.spawn cannot put a child in its own process group, and killing the group
+ * we SHARE would take the harness down with it, so walking the tree is what is
+ * left. Best effort by construction: pgrep may be absent, and a process may exit
+ * between listing and killing. Both are fine — this only ever adds cleanup.
+ */
+async function killTree(pid: number, signal: number): Promise<void> {
+  for (const child of await childrenOf(pid)) {
+    await killTree(child, signal);
+  }
+
+  try {
+    process.kill(pid, signal);
+  } catch {
+    // Already gone.
+  }
 }
 
 export async function runBinary(
@@ -310,7 +371,9 @@ export async function runBinary(
   const kill = { timedOut: false };
   const timer = setTimeout(() => {
     kill.timedOut = true;
-    proc.kill();
+    // The tree, not just the reviewer — and now, while it is still alive to be
+    // walked.
+    void killTree(proc.pid, 15);
     // SIGTERM is a request. A reviewer that ignores it — or installs a handler
     // and takes its time — would otherwise keep the whole panel blocked past a
     // budget that exists precisely to stop that. SIGKILL is not refusable.
@@ -322,7 +385,7 @@ export async function runBinary(
     // a worse failure than a stray `sleep`. The drain bound above is what stops
     // an orphan holding the panel.
     killHard = setTimeout(() => {
-      proc.kill(9);
+      void killTree(proc.pid, 9);
     }, KILL_GRACE_MS);
   }, r.timeoutMs);
   let killHard: ReturnType<typeof setTimeout> | undefined;
@@ -349,9 +412,9 @@ export async function runBinary(
     // hit there is nothing left to wait for.
     if (read.stoppedBy === "size") {
       clearTimeout(timer);
-      proc.kill();
+      await killTree(proc.pid, 15);
       killHard = setTimeout(() => {
-        proc.kill(9);
+        void killTree(proc.pid, 9);
       }, KILL_GRACE_MS);
     }
 
@@ -487,8 +550,20 @@ function oneLine(value: string): string {
   for (const ch of value) {
     const code = ch.codePointAt(0) ?? 0;
     // C0 (newline and ESC among them), DEL, and C1.
+    // C0 (newline and ESC among them), DEL, C1 — plus the Unicode line/paragraph
+    // separators, which a terminal breaks on exactly like a newline, and the
+    // bidi overrides, which can visually reorder a line into something it does
+    // not say.
     const control =
-      code < 0x20 || code === 0x7f || (code >= 0x80 && code <= 0x9f);
+      code < 0x20 ||
+      code === 0x7f ||
+      (code >= 0x80 && code <= 0x9f) ||
+      code === 0x2028 ||
+      code === 0x2029 ||
+      (code >= 0x202a && code <= 0x202e) ||
+      code === 0x200e ||
+      code === 0x200f ||
+      (code >= 0x2066 && code <= 0x2069);
 
     out += control ? " " : ch;
   }
@@ -507,7 +582,9 @@ const MAX_FAILURE_TEXT = 300;
 export function formatVerdict(v: IVerdict): string {
   const head = v.blocked ? "BLOCK" : "PASS";
   const lines = [
-    `harness-review: ${head} — ${v.reason}`,
+    // The reason can be derived straight from a reviewer-controlled finding, so
+    // it is no more ours than the failure text below it.
+    `harness-review: ${head} — ${oneLine(v.reason)}`,
     `reviewers ok: ${String(v.reviewers.ok)}  errored: ${String(v.reviewers.errored)}  (builder: ${v.identity})`,
   ];
 
@@ -539,7 +616,7 @@ export function formatVerdict(v: IVerdict): string {
 
   for (const f of v.ranked) {
     lines.push(
-      `  [${f.severity}/${f.findingCode}] ${f.file ?? "?"} — ${f.issue} (agreement ${String(f.agreement)})`
+      `  [${f.severity}/${f.findingCode}] ${oneLine(f.file ?? "?")} — ${oneLine(f.issue)} (agreement ${String(f.agreement)})`
     );
   }
 

--- a/packages/core/src/reviewers/aggregate.ts
+++ b/packages/core/src/reviewers/aggregate.ts
@@ -3,7 +3,7 @@ import { isRecord } from "../lib/guards";
 import type { IReview, IFinding, FindingCode } from "./schema";
 
 export type ReviewOutcome =
-  | { status: "ok"; review: IReview; ms?: number }
+  | { status: "ok"; review: IReview; ms: number }
   | {
       status: "errored";
       reviewerId: string;
@@ -14,13 +14,13 @@ export type ReviewOutcome =
        *  reviewer die instantly, or did it burn its whole budget doing work that
        *  was then thrown away? Diagnosing that once took an afternoon of timing
        *  the binaries by hand. */
-      ms?: number;
+      ms: number;
       /** Why it failed, as a category rather than prose: `timeout` (killed at
        *  the budget), `exit` (ran, exited non-zero), `unparseable` (answered,
        *  but not in the review schema), `threw` (the call itself failed). The
        *  old string said "binary exited non-zero or timed out" for the first two
        *  at once and so could not tell them apart. */
-      cause?: ReviewFailureCause;
+      cause: ReviewFailureCause;
     };
 
 /** The failure taxonomy, and the single source of the union below. `timeout`
@@ -214,11 +214,14 @@ export function aggregate(
     if (o.status === "ok") {
       reviews.push(o.review);
     } else {
+      // No optional spreads: the outcome contract requires both, which is the
+      // point of requiring them — a runner cannot omit a cause and have it
+      // quietly read as an exit.
       failures.push({
         reviewerId: o.reviewerId,
         error: o.error,
-        ...(o.cause === undefined ? {} : { cause: o.cause }),
-        ...(o.ms === undefined ? {} : { ms: o.ms }),
+        cause: o.cause,
+        ms: o.ms,
       });
     }
   }
@@ -269,7 +272,12 @@ function parseFailures(raw: unknown): IReviewerFailure[] {
         reviewerId: f.reviewerId,
         error: f.error,
         ...(isFailureCause(f.cause) ? { cause: f.cause } : {}),
-        ...(typeof f.ms === "number" ? { ms: f.ms } : {}),
+        // Finite, not merely numeric: a NaN or Infinity off disk would be
+        // printed as "NaNs" / "Infinitys" in the verdict, which is worse than
+        // omitting the duration.
+        ...(typeof f.ms === "number" && Number.isFinite(f.ms)
+          ? { ms: f.ms }
+          : {}),
       });
     }
   }

--- a/packages/core/src/reviewers/aggregate.ts
+++ b/packages/core/src/reviewers/aggregate.ts
@@ -3,8 +3,50 @@ import { isRecord } from "../lib/guards";
 import type { IReview, IFinding, FindingCode } from "./schema";
 
 export type ReviewOutcome =
-  | { status: "ok"; review: IReview }
-  | { status: "errored"; reviewerId: string; error: string };
+  | { status: "ok"; review: IReview; ms?: number }
+  | {
+      status: "errored";
+      reviewerId: string;
+      error: string;
+      /** Wall-clock ms the reviewer consumed before failing. Without it a crash
+       *  and a timeout are indistinguishable in the logs, which is exactly the
+       *  question you want answered when a panel comes back short: did this
+       *  reviewer die instantly, or did it burn its whole budget doing work that
+       *  was then thrown away? Diagnosing that once took an afternoon of timing
+       *  the binaries by hand. */
+      ms?: number;
+      /** Why it failed, as a category rather than prose: `timeout` (killed at
+       *  the budget), `exit` (ran, exited non-zero), `unparseable` (answered,
+       *  but not in the review schema), `threw` (the call itself failed). The
+       *  old string said "binary exited non-zero or timed out" for the first two
+       *  at once and so could not tell them apart. */
+      cause?: ReviewFailureCause;
+    };
+
+/** The failure taxonomy, and the single source of the union below. `timeout`
+ *  means the budget was too small for the work (raise it, or drop the reviewer);
+ *  `exit` means the binary is broken (the budget is irrelevant). Collapsing those
+ *  two into one message is what made this undiagnosable. */
+const FAILURE_CAUSES = ["timeout", "exit", "unparseable", "threw"] as const;
+
+export type ReviewFailureCause = (typeof FAILURE_CAUSES)[number];
+
+/** Widened to string so `includes` accepts an unknown-origin value. Kept next to
+ *  FAILURE_CAUSES, which the union is derived FROM, so the two cannot drift. */
+const KNOWN_CAUSES: readonly string[] = FAILURE_CAUSES;
+
+/** Narrow an unknown to a known cause. A type guard, not an `as` cast: the value
+ *  comes off disk and an unrecognised string must be dropped, not asserted. */
+function isFailureCause(value: unknown): value is ReviewFailureCause {
+  return typeof value === "string" && KNOWN_CAUSES.includes(value);
+}
+
+export interface IReviewerFailure {
+  reviewerId: string;
+  error: string;
+  cause?: ReviewFailureCause;
+  ms?: number;
+}
 
 export interface IRankedFinding extends IFinding {
   agreement: number;
@@ -14,6 +56,11 @@ export interface IVerdict {
   blocked: boolean;
   reason: string;
   reviewers: { ok: number; errored: number };
+  /** Who failed and why, one entry per errored reviewer. The counts alone say a
+   *  panel came back short; they never say WHICH reviewer, or whether it died
+   *  instantly or burned its whole budget — and those imply opposite fixes.
+   *  Empty/absent when every reviewer answered. */
+  failures?: IReviewerFailure[];
   ranked: IRankedFinding[];
   perReviewer: IReview[];
   identity: string;
@@ -161,15 +208,22 @@ export function aggregate(
   opts: { minReviewers: number; identity: string }
 ): IVerdict {
   const reviews: IReview[] = [];
-  let errored = 0;
+  const failures: IReviewerFailure[] = [];
 
   for (const o of outcomes) {
     if (o.status === "ok") {
       reviews.push(o.review);
     } else {
-      errored += 1;
+      failures.push({
+        reviewerId: o.reviewerId,
+        error: o.error,
+        ...(o.cause === undefined ? {} : { cause: o.cause }),
+        ...(o.ms === undefined ? {} : { ms: o.ms }),
+      });
     }
   }
+
+  const errored = failures.length;
 
   const ranked = rank(groupFindings(reviews));
   const reason = decideReason(
@@ -186,8 +240,41 @@ export function aggregate(
     ranked,
     perReviewer: reviews,
     identity: opts.identity,
+    ...(failures.length > 0 ? { failures } : {}),
     ...(reviews.length < opts.minReviewers ? { noQuorum: true } : {}),
   };
+}
+
+/**
+ * Rehydrate the per-reviewer failure diagnostics from a cached artifact.
+ *
+ * A malformed entry is DROPPED rather than failing the whole parse: these are
+ * informational, and losing one diagnostic line is not a reason to treat an
+ * otherwise valid cached verdict as corrupt and re-run the entire panel.
+ */
+function parseFailures(raw: unknown): IReviewerFailure[] {
+  if (!Array.isArray(raw)) {
+    return [];
+  }
+
+  const out: IReviewerFailure[] = [];
+
+  for (const f of raw) {
+    if (
+      isRecord(f) &&
+      typeof f.reviewerId === "string" &&
+      typeof f.error === "string"
+    ) {
+      out.push({
+        reviewerId: f.reviewerId,
+        error: f.error,
+        ...(isFailureCause(f.cause) ? { cause: f.cause } : {}),
+        ...(typeof f.ms === "number" ? { ms: f.ms } : {}),
+      });
+    }
+  }
+
+  return out;
 }
 
 /** Parse and validate a cached verdict artifact. Returns null if any field is
@@ -259,6 +346,8 @@ export function parseVerdict(raw: unknown): IVerdict | null {
     parsedReviews.push(review);
   }
 
+  const parsedFailures = parseFailures(raw.failures);
+
   return {
     blocked,
     reason,
@@ -266,6 +355,7 @@ export function parseVerdict(raw: unknown): IVerdict | null {
     ranked: parsedRanked,
     perReviewer: parsedReviews,
     identity,
+    ...(parsedFailures.length > 0 ? { failures: parsedFailures } : {}),
     ...(raw.preReview === true ? { preReview: true } : {}),
     ...(raw.noQuorum === true ? { noQuorum: true } : {}),
   };

--- a/packages/core/src/reviewers/aggregate.ts
+++ b/packages/core/src/reviewers/aggregate.ts
@@ -27,7 +27,13 @@ export type ReviewOutcome =
  *  means the budget was too small for the work (raise it, or drop the reviewer);
  *  `exit` means the binary is broken (the budget is irrelevant). Collapsing those
  *  two into one message is what made this undiagnosable. */
-const FAILURE_CAUSES = ["timeout", "exit", "unparseable", "threw"] as const;
+const FAILURE_CAUSES = [
+  "timeout",
+  "exit",
+  "truncated",
+  "unparseable",
+  "threw",
+] as const;
 
 export type ReviewFailureCause = (typeof FAILURE_CAUSES)[number];
 

--- a/packages/core/src/reviewers/diagnose.ts
+++ b/packages/core/src/reviewers/diagnose.ts
@@ -76,11 +76,23 @@ async function invokeBinary(
       stdin
     );
 
+    // The kill, checked first — same reasoning as the review path. A runner may
+    // report `ok: true, timedOut: true`, and parsing stdout there counts a
+    // diagnosis we cut off mid-sentence as a real vote. A partial answer is not
+    // a diagnosis any more than it is a review.
+    if (res.timedOut) {
+      return {
+        status: "errored",
+        reviewerId: reviewer.id,
+        error: `binary hit its ${String(reviewer.timeoutMs)}ms timeout`,
+      };
+    }
+
     if (!res.ok) {
       return {
         status: "errored",
         reviewerId: reviewer.id,
-        error: "binary exited non-zero or timed out",
+        error: "binary exited non-zero",
       };
     }
 

--- a/packages/core/src/reviewers/diagnose.ts
+++ b/packages/core/src/reviewers/diagnose.ts
@@ -88,6 +88,17 @@ async function invokeBinary(
       };
     }
 
+    // Truncation, checked before ok — same order and same reason as the review
+    // path. A prefix is not a finished answer, and reporting it as "exited
+    // non-zero" blames the binary for something the harness did.
+    if (res.truncated) {
+      return {
+        status: "errored",
+        reviewerId: reviewer.id,
+        error: "diagnosis output was truncated before it finished",
+      };
+    }
+
     if (!res.ok) {
       return {
         status: "errored",

--- a/packages/core/src/reviewers/diagnose.ts
+++ b/packages/core/src/reviewers/diagnose.ts
@@ -80,14 +80,15 @@ async function invokeBinary(
     // report `ok: true, timedOut: true`, and parsing stdout there counts a
     // diagnosis we cut off mid-sentence as a real vote. A partial answer is not
     // a diagnosis any more than it is a review.
-    // Truncation first, same as the review path: both flags can be true when a
-    // reviewer floods and keeps running, and calling that a timeout points at
-    // the wrong cause.
-    if (res.truncated) {
+    // Same order and same reasoning as the review path: only a FLOOD outranks a
+    // timeout, because we killed the reviewer for it. A deadline stop alongside
+    // a timeout is a reviewer killed at its budget whose child still holds the
+    // pipe — the timeout is why it died.
+    if (res.truncated && res.stoppedBy === "size") {
       return {
         status: "errored",
         reviewerId: reviewer.id,
-        error: "diagnosis output was truncated before it finished",
+        error: "diagnosis flooded stdout past the ceiling",
       };
     }
 
@@ -96,6 +97,14 @@ async function invokeBinary(
         status: "errored",
         reviewerId: reviewer.id,
         error: `binary hit its ${String(reviewer.timeoutMs)}ms timeout`,
+      };
+    }
+
+    if (res.truncated) {
+      return {
+        status: "errored",
+        reviewerId: reviewer.id,
+        error: "diagnosis output was still open when the read gave up",
       };
     }
 

--- a/packages/core/src/reviewers/diagnose.ts
+++ b/packages/core/src/reviewers/diagnose.ts
@@ -80,22 +80,22 @@ async function invokeBinary(
     // report `ok: true, timedOut: true`, and parsing stdout there counts a
     // diagnosis we cut off mid-sentence as a real vote. A partial answer is not
     // a diagnosis any more than it is a review.
-    if (res.timedOut) {
-      return {
-        status: "errored",
-        reviewerId: reviewer.id,
-        error: `binary hit its ${String(reviewer.timeoutMs)}ms timeout`,
-      };
-    }
-
-    // Truncation, checked before ok — same order and same reason as the review
-    // path. A prefix is not a finished answer, and reporting it as "exited
-    // non-zero" blames the binary for something the harness did.
+    // Truncation first, same as the review path: both flags can be true when a
+    // reviewer floods and keeps running, and calling that a timeout points at
+    // the wrong cause.
     if (res.truncated) {
       return {
         status: "errored",
         reviewerId: reviewer.id,
         error: "diagnosis output was truncated before it finished",
+      };
+    }
+
+    if (res.timedOut) {
+      return {
+        status: "errored",
+        reviewerId: reviewer.id,
+        error: `binary hit its ${String(reviewer.timeoutMs)}ms timeout`,
       };
     }
 

--- a/packages/core/src/reviewers/invoke.ts
+++ b/packages/core/src/reviewers/invoke.ts
@@ -18,10 +18,10 @@ export interface IInvokeDeps {
   runBinary: (
     r: { argv: string[]; input: BinaryInputMode; timeoutMs: number },
     stdin: string
-  ) => Promise<{ ok: boolean; stdout: string }>;
+  ) => Promise<{ ok: boolean; stdout: string; timedOut?: boolean }>;
 }
 
-function reviewFrom(id: string, rawText: string): ReviewOutcome {
+function reviewFrom(id: string, rawText: string, ms: number): ReviewOutcome {
   let review: IReview | null;
 
   try {
@@ -31,8 +31,14 @@ function reviewFrom(id: string, rawText: string): ReviewOutcome {
   }
 
   return review === null
-    ? { status: "errored", reviewerId: id, error: "unparseable review output" }
-    : { status: "ok", review };
+    ? {
+        status: "errored",
+        reviewerId: id,
+        error: "unparseable review output",
+        cause: "unparseable",
+        ms,
+      }
+    : { status: "ok", review, ms };
 }
 
 async function invokeModel(
@@ -40,18 +46,22 @@ async function invokeModel(
   request: IReviewRequest,
   deps: IInvokeDeps
 ): Promise<ReviewOutcome> {
+  const started = Date.now();
+
   try {
     const res = await deps.makeProvider(reviewer.entry).complete([
       { role: "system", content: REVIEW_SYSTEM_PROMPT },
       { role: "user", content: renderReviewPrompt(request) },
     ]);
 
-    return reviewFrom(reviewer.id, res.content);
+    return reviewFrom(reviewer.id, res.content, Date.now() - started);
   } catch (err) {
     return {
       status: "errored",
       reviewerId: reviewer.id,
       error: err instanceof Error ? err.message : String(err),
+      cause: "threw",
+      ms: Date.now() - started,
     };
   }
 }
@@ -70,6 +80,8 @@ async function invokeBinary(
   request: IReviewRequest,
   deps: IInvokeDeps
 ): Promise<ReviewOutcome> {
+  const started = Date.now();
+
   try {
     // Binaries have no separate system channel, so the review contract (JSON
     // schema + reject-by-default + rubric) must be prepended to their single
@@ -87,10 +99,21 @@ async function invokeBinary(
     );
 
     if (!res.ok) {
+      // Timeout and non-zero exit are DIFFERENT facts and the old message
+      // reported them as one. A timeout means the budget is too small for the
+      // work — raise it, or drop the reviewer. A non-zero exit means it is
+      // broken — the budget is irrelevant. Told apart, the fix is obvious;
+      // conflated, the only way to find out is to time the binary by hand.
+      const timedOut = res.timedOut === true;
+
       return {
         status: "errored",
         reviewerId: reviewer.id,
-        error: "binary exited non-zero or timed out",
+        error: timedOut
+          ? `binary hit its ${String(reviewer.timeoutMs)}ms timeout`
+          : "binary exited non-zero",
+        cause: timedOut ? "timeout" : "exit",
+        ms: Date.now() - started,
       };
     }
 
@@ -99,12 +122,14 @@ async function invokeBinary(
         ? extractBinaryJson(res.stdout)
         : res.stdout;
 
-    return reviewFrom(reviewer.id, payload);
+    return reviewFrom(reviewer.id, payload, Date.now() - started);
   } catch (err) {
     return {
       status: "errored",
       reviewerId: reviewer.id,
       error: err instanceof Error ? err.message : String(err),
+      cause: "threw",
+      ms: Date.now() - started,
     };
   }
 }

--- a/packages/core/src/reviewers/invoke.ts
+++ b/packages/core/src/reviewers/invoke.ts
@@ -18,7 +18,11 @@ export interface IInvokeDeps {
   runBinary: (
     r: { argv: string[]; input: BinaryInputMode; timeoutMs: number },
     stdin: string
-  ) => Promise<{ ok: boolean; stdout: string; timedOut?: boolean }>;
+    // REQUIRED, not optional. Optional means an existing or alternative runner
+    // compiles without reporting it, and every omitted timeout is then
+    // classified as a non-zero exit — restoring the exact conflation this
+    // change exists to remove, silently.
+  ) => Promise<{ ok: boolean; stdout: string; timedOut: boolean }>;
 }
 
 function reviewFrom(id: string, rawText: string, ms: number): ReviewOutcome {
@@ -104,7 +108,7 @@ async function invokeBinary(
       // work — raise it, or drop the reviewer. A non-zero exit means it is
       // broken — the budget is irrelevant. Told apart, the fix is obvious;
       // conflated, the only way to find out is to time the binary by hand.
-      const timedOut = res.timedOut === true;
+      const timedOut = res.timedOut;
 
       return {
         status: "errored",

--- a/packages/core/src/reviewers/invoke.ts
+++ b/packages/core/src/reviewers/invoke.ts
@@ -102,21 +102,33 @@ async function invokeBinary(
       stdin
     );
 
-    if (!res.ok) {
-      // Timeout and non-zero exit are DIFFERENT facts and the old message
-      // reported them as one. A timeout means the budget is too small for the
-      // work — raise it, or drop the reviewer. A non-zero exit means it is
-      // broken — the budget is irrelevant. Told apart, the fix is obvious;
-      // conflated, the only way to find out is to time the binary by hand.
-      const timedOut = res.timedOut;
-
+    // Checked BEFORE ok, not inside the failure branch. runBinary already forces
+    // ok=false on a kill, but this must not depend on that: any runner meeting
+    // the contract could report `ok: true, timedOut: true`, and reading stdout
+    // there would count a reviewer we killed mid-sentence as having reviewed.
+    // Whatever it printed before the kill is a partial answer, and a partial
+    // answer is not a review.
+    if (res.timedOut) {
       return {
         status: "errored",
         reviewerId: reviewer.id,
-        error: timedOut
-          ? `binary hit its ${String(reviewer.timeoutMs)}ms timeout`
-          : "binary exited non-zero",
-        cause: timedOut ? "timeout" : "exit",
+        error: `binary hit its ${String(reviewer.timeoutMs)}ms timeout`,
+        cause: "timeout",
+        ms: Date.now() - started,
+      };
+    }
+
+    // Timeout and non-zero exit are DIFFERENT facts and the old message reported
+    // them as one. A timeout means the budget is too small for the work — raise
+    // it, or drop the reviewer. A non-zero exit means the binary is broken and
+    // the budget is irrelevant. Told apart, the fix is obvious; conflated, the
+    // only way to find out is to time the binary by hand.
+    if (!res.ok) {
+      return {
+        status: "errored",
+        reviewerId: reviewer.id,
+        error: "binary exited non-zero",
+        cause: "exit",
         ms: Date.now() - started,
       };
     }

--- a/packages/core/src/reviewers/invoke.ts
+++ b/packages/core/src/reviewers/invoke.ts
@@ -29,6 +29,9 @@ export interface IInvokeDeps {
     /** True when the read stopped early, so `stdout` is a PREFIX. Distinct from
      *  a bad answer: the reviewer may have been perfectly fine. */
     truncated: boolean;
+    /** Why it stopped — a flood and a pipe left open point at different
+     *  problems, and a boolean cannot say which. */
+    stoppedBy: "eof" | "size" | "deadline";
   }>;
 }
 
@@ -115,6 +118,23 @@ async function invokeBinary(
     // there would count a reviewer we killed mid-sentence as having reviewed.
     // Whatever it printed before the kill is a partial answer, and a partial
     // answer is not a review.
+    // Truncation is checked FIRST. Both flags can be true — a reviewer that
+    // floods and then keeps running is killed for the flood, and a budget timer
+    // may fire around the same moment — and reporting that as a timeout sends
+    // the operator to raise a budget that was never the problem. The stdout was.
+    if (res.truncated) {
+      return {
+        status: "errored",
+        reviewerId: reviewer.id,
+        error:
+          res.stoppedBy === "size"
+            ? "reviewer flooded stdout past the ceiling"
+            : "reviewer output was still open when the read gave up",
+        cause: "truncated",
+        ms: Date.now() - started,
+      };
+    }
+
     if (res.timedOut) {
       return {
         status: "errored",
@@ -130,19 +150,6 @@ async function invokeBinary(
     // it, or drop the reviewer. A non-zero exit means the binary is broken and
     // the budget is irrelevant. Told apart, the fix is obvious; conflated, the
     // only way to find out is to time the binary by hand.
-    // Truncation is OURS, not the reviewer's. Handing the prefix on as though it
-    // were the whole answer makes a cut-off review look malformed, which sends
-    // the next person to debug the reviewer instead of the read bound.
-    if (res.truncated) {
-      return {
-        status: "errored",
-        reviewerId: reviewer.id,
-        error: "reviewer output was truncated before it finished",
-        cause: "truncated",
-        ms: Date.now() - started,
-      };
-    }
-
     if (!res.ok) {
       return {
         status: "errored",

--- a/packages/core/src/reviewers/invoke.ts
+++ b/packages/core/src/reviewers/invoke.ts
@@ -118,18 +118,22 @@ async function invokeBinary(
     // there would count a reviewer we killed mid-sentence as having reviewed.
     // Whatever it printed before the kill is a partial answer, and a partial
     // answer is not a review.
-    // Truncation is checked FIRST. Both flags can be true — a reviewer that
-    // floods and then keeps running is killed for the flood, and a budget timer
-    // may fire around the same moment — and reporting that as a timeout sends
-    // the operator to raise a budget that was never the problem. The stdout was.
-    if (res.truncated) {
+    // ORDER MATTERS, and only a FLOOD outranks a timeout.
+    //
+    // A flood is its own finding: we killed the reviewer for it, so a budget
+    // timer firing afterwards describes our own kill, and calling that a timeout
+    // sends the operator to raise a limit that was never the problem.
+    //
+    // A deadline stop is the opposite. The common shape is a reviewer killed at
+    // its budget whose background child still holds the pipe — both flags true,
+    // but the TIMEOUT is why it died and the open pipe is a consequence.
+    // Reporting truncation there would hide the real cause on the exact path
+    // runBinary's own comments describe as normal for an agentic reviewer.
+    if (res.truncated && res.stoppedBy === "size") {
       return {
         status: "errored",
         reviewerId: reviewer.id,
-        error:
-          res.stoppedBy === "size"
-            ? "reviewer flooded stdout past the ceiling"
-            : "reviewer output was still open when the read gave up",
+        error: "reviewer flooded stdout past the ceiling",
         cause: "truncated",
         ms: Date.now() - started,
       };
@@ -141,6 +145,16 @@ async function invokeBinary(
         reviewerId: reviewer.id,
         error: `binary hit its ${String(reviewer.timeoutMs)}ms timeout`,
         cause: "timeout",
+        ms: Date.now() - started,
+      };
+    }
+
+    if (res.truncated) {
+      return {
+        status: "errored",
+        reviewerId: reviewer.id,
+        error: "reviewer output was still open when the read gave up",
+        cause: "truncated",
         ms: Date.now() - started,
       };
     }

--- a/packages/core/src/reviewers/invoke.ts
+++ b/packages/core/src/reviewers/invoke.ts
@@ -22,7 +22,14 @@ export interface IInvokeDeps {
     // compiles without reporting it, and every omitted timeout is then
     // classified as a non-zero exit — restoring the exact conflation this
     // change exists to remove, silently.
-  ) => Promise<{ ok: boolean; stdout: string; timedOut: boolean }>;
+  ) => Promise<{
+    ok: boolean;
+    stdout: string;
+    timedOut: boolean;
+    /** True when the read stopped early, so `stdout` is a PREFIX. Distinct from
+     *  a bad answer: the reviewer may have been perfectly fine. */
+    truncated: boolean;
+  }>;
 }
 
 function reviewFrom(id: string, rawText: string, ms: number): ReviewOutcome {
@@ -123,6 +130,19 @@ async function invokeBinary(
     // it, or drop the reviewer. A non-zero exit means the binary is broken and
     // the budget is irrelevant. Told apart, the fix is obvious; conflated, the
     // only way to find out is to time the binary by hand.
+    // Truncation is OURS, not the reviewer's. Handing the prefix on as though it
+    // were the whole answer makes a cut-off review look malformed, which sends
+    // the next person to debug the reviewer instead of the read bound.
+    if (res.truncated) {
+      return {
+        status: "errored",
+        reviewerId: reviewer.id,
+        error: "reviewer output was truncated before it finished",
+        cause: "truncated",
+        ms: Date.now() - started,
+      };
+    }
+
     if (!res.ok) {
       return {
         status: "errored",

--- a/packages/core/tests/harness-review-mode.test.ts
+++ b/packages/core/tests/harness-review-mode.test.ts
@@ -104,7 +104,12 @@ function makeInput(over: { quick?: boolean; ci?: boolean }) {
           },
         };
       },
-      runBinary: async () => ({ ok: true, stdout: "", timedOut: false }),
+      runBinary: async () => ({
+        ok: true,
+        stdout: "",
+        timedOut: false,
+        truncated: false,
+      }),
       readCache: async (key: string) => {
         log.readKeys.push(key);
 

--- a/packages/core/tests/harness-review-mode.test.ts
+++ b/packages/core/tests/harness-review-mode.test.ts
@@ -109,6 +109,7 @@ function makeInput(over: { quick?: boolean; ci?: boolean }) {
         stdout: "",
         timedOut: false,
         truncated: false,
+        stoppedBy: "eof" as const,
       }),
       readCache: async (key: string) => {
         log.readKeys.push(key);

--- a/packages/core/tests/harness-review-mode.test.ts
+++ b/packages/core/tests/harness-review-mode.test.ts
@@ -104,7 +104,7 @@ function makeInput(over: { quick?: boolean; ci?: boolean }) {
           },
         };
       },
-      runBinary: async () => ({ ok: true, stdout: "" }),
+      runBinary: async () => ({ ok: true, stdout: "", timedOut: false }),
       readCache: async (key: string) => {
         log.readKeys.push(key);
 

--- a/packages/core/tests/reviewers-aggregate.test.ts
+++ b/packages/core/tests/reviewers-aggregate.test.ts
@@ -19,6 +19,7 @@ function ok(
   return {
     status: "ok",
     review: { reviewerId: id, verdict, findings, summary: "" },
+    ms: 0,
   };
 }
 
@@ -50,8 +51,20 @@ describe("aggregate", () => {
     // an outage would keep poisoning the cache exactly as before.
     const allErrored = aggregate(
       [
-        { status: "errored", reviewerId: "a", error: "connection refused" },
-        { status: "errored", reviewerId: "b", error: "connection refused" },
+        {
+          status: "errored",
+          reviewerId: "a",
+          error: "connection refused",
+          cause: "threw",
+          ms: 0,
+        },
+        {
+          status: "errored",
+          reviewerId: "b",
+          error: "connection refused",
+          cause: "threw",
+          ms: 0,
+        },
       ],
       opts
     );
@@ -65,7 +78,13 @@ describe("aggregate", () => {
     const oneShort = aggregate(
       [
         ok("a", "approve"),
-        { status: "errored", reviewerId: "b", error: "timeout" },
+        {
+          status: "errored",
+          reviewerId: "b",
+          error: "timeout",
+          cause: "threw",
+          ms: 0,
+        },
       ],
       opts
     );
@@ -94,7 +113,13 @@ describe("aggregate", () => {
     const v = aggregate(
       [
         ok("a", "approve"),
-        { status: "errored", reviewerId: "b", error: "timeout" },
+        {
+          status: "errored",
+          reviewerId: "b",
+          error: "timeout",
+          cause: "threw",
+          ms: 0,
+        },
       ],
       opts
     );

--- a/packages/core/tests/reviewers-diagnose.test.ts
+++ b/packages/core/tests/reviewers-diagnose.test.ts
@@ -143,7 +143,8 @@ describe("diagnoseInvoke (invoke → parse → outcome)", () => {
       makeProvider: () => ({
         complete: () => Promise.resolve(modelResponse(GOOD_DIAGNOSIS)),
       }),
-      runBinary: () => Promise.resolve({ ok: true, stdout: "" }),
+      runBinary: () =>
+        Promise.resolve({ ok: true, stdout: "", timedOut: false }),
     };
 
     const [outcome] = await diagnoseInvoke(panel, REQUEST, deps);
@@ -171,7 +172,8 @@ describe("diagnoseInvoke (invoke → parse → outcome)", () => {
             modelResponse(`Sure, here you go:\n${GOOD_DIAGNOSIS}\nThanks`)
           ),
       }),
-      runBinary: () => Promise.resolve({ ok: true, stdout: "" }),
+      runBinary: () =>
+        Promise.resolve({ ok: true, stdout: "", timedOut: false }),
     };
 
     const [outcome] = await diagnoseInvoke(panel, REQUEST, deps);
@@ -191,7 +193,8 @@ describe("diagnoseInvoke (invoke → parse → outcome)", () => {
       makeProvider: () => ({
         complete: () => Promise.resolve(modelResponse("not json")),
       }),
-      runBinary: () => Promise.resolve({ ok: true, stdout: "" }),
+      runBinary: () =>
+        Promise.resolve({ ok: true, stdout: "", timedOut: false }),
     };
 
     const [outcome] = await diagnoseInvoke(panel, REQUEST, deps);
@@ -218,7 +221,8 @@ describe("diagnoseInvoke (invoke → parse → outcome)", () => {
       makeProvider: () => ({
         complete: () => Promise.resolve(modelResponse("")),
       }),
-      runBinary: () => Promise.resolve({ ok: false, stdout: "" }),
+      runBinary: () =>
+        Promise.resolve({ ok: false, stdout: "", timedOut: false }),
     };
 
     const [outcome] = await diagnoseInvoke(panel, REQUEST, deps);
@@ -245,7 +249,8 @@ describe("diagnoseInvoke (invoke → parse → outcome)", () => {
       makeProvider: () => ({
         complete: () => Promise.resolve(modelResponse("")),
       }),
-      runBinary: () => Promise.resolve({ ok: true, stdout: GOOD_DIAGNOSIS }),
+      runBinary: () =>
+        Promise.resolve({ ok: true, stdout: GOOD_DIAGNOSIS, timedOut: false }),
     };
 
     const [outcome] = await diagnoseInvoke(panel, REQUEST, deps);

--- a/packages/core/tests/reviewers-diagnose.test.ts
+++ b/packages/core/tests/reviewers-diagnose.test.ts
@@ -144,7 +144,12 @@ describe("diagnoseInvoke (invoke → parse → outcome)", () => {
         complete: () => Promise.resolve(modelResponse(GOOD_DIAGNOSIS)),
       }),
       runBinary: () =>
-        Promise.resolve({ ok: true, stdout: "", timedOut: false }),
+        Promise.resolve({
+          ok: true,
+          stdout: "",
+          timedOut: false,
+          truncated: false,
+        }),
     };
 
     const [outcome] = await diagnoseInvoke(panel, REQUEST, deps);
@@ -173,7 +178,12 @@ describe("diagnoseInvoke (invoke → parse → outcome)", () => {
           ),
       }),
       runBinary: () =>
-        Promise.resolve({ ok: true, stdout: "", timedOut: false }),
+        Promise.resolve({
+          ok: true,
+          stdout: "",
+          timedOut: false,
+          truncated: false,
+        }),
     };
 
     const [outcome] = await diagnoseInvoke(panel, REQUEST, deps);
@@ -194,7 +204,12 @@ describe("diagnoseInvoke (invoke → parse → outcome)", () => {
         complete: () => Promise.resolve(modelResponse("not json")),
       }),
       runBinary: () =>
-        Promise.resolve({ ok: true, stdout: "", timedOut: false }),
+        Promise.resolve({
+          ok: true,
+          stdout: "",
+          timedOut: false,
+          truncated: false,
+        }),
     };
 
     const [outcome] = await diagnoseInvoke(panel, REQUEST, deps);
@@ -222,7 +237,12 @@ describe("diagnoseInvoke (invoke → parse → outcome)", () => {
         complete: () => Promise.resolve(modelResponse("")),
       }),
       runBinary: () =>
-        Promise.resolve({ ok: false, stdout: "", timedOut: false }),
+        Promise.resolve({
+          ok: false,
+          stdout: "",
+          timedOut: false,
+          truncated: false,
+        }),
     };
 
     const [outcome] = await diagnoseInvoke(panel, REQUEST, deps);
@@ -256,7 +276,12 @@ describe("diagnoseInvoke (invoke → parse → outcome)", () => {
       // Deliberately VALID output: the point is that it is refused for having
       // been cut off, not for being malformed.
       runBinary: () =>
-        Promise.resolve({ ok: true, stdout: GOOD_DIAGNOSIS, timedOut: true }),
+        Promise.resolve({
+          ok: true,
+          stdout: GOOD_DIAGNOSIS,
+          timedOut: true,
+          truncated: false,
+        }),
     };
 
     const [outcome] = await diagnoseInvoke(panel, REQUEST, deps);
@@ -289,7 +314,12 @@ describe("diagnoseInvoke (invoke → parse → outcome)", () => {
         complete: () => Promise.resolve(modelResponse("")),
       }),
       runBinary: () =>
-        Promise.resolve({ ok: true, stdout: GOOD_DIAGNOSIS, timedOut: false }),
+        Promise.resolve({
+          ok: true,
+          stdout: GOOD_DIAGNOSIS,
+          timedOut: false,
+          truncated: false,
+        }),
     };
 
     const [outcome] = await diagnoseInvoke(panel, REQUEST, deps);

--- a/packages/core/tests/reviewers-diagnose.test.ts
+++ b/packages/core/tests/reviewers-diagnose.test.ts
@@ -230,6 +230,45 @@ describe("diagnoseInvoke (invoke → parse → outcome)", () => {
     expect(outcome?.status).toBe("errored");
   });
 
+  test("a TIMED-OUT binary's partial JSON is not counted as a vote", async () => {
+    // The diagnose path had the same `ok`-only check the review path lost: a
+    // runner reporting ok:true alongside timedOut:true would have its output
+    // parsed, so a diagnosis cut off mid-sentence counted as a real one. A
+    // partial answer is not a diagnosis any more than it is a review.
+    const panel: IPanel = {
+      minReviewers: 1,
+      skipped: [],
+      reviewers: [
+        {
+          kind: "binary",
+          id: "grok",
+          argv: ["x"],
+          input: "arg",
+          timeoutMs: 4321,
+          parse: "raw",
+        },
+      ],
+    };
+    const deps: IInvokeDeps = {
+      makeProvider: () => ({
+        complete: () => Promise.resolve(modelResponse("")),
+      }),
+      // Deliberately VALID output: the point is that it is refused for having
+      // been cut off, not for being malformed.
+      runBinary: () =>
+        Promise.resolve({ ok: true, stdout: GOOD_DIAGNOSIS, timedOut: true }),
+    };
+
+    const [outcome] = await diagnoseInvoke(panel, REQUEST, deps);
+
+    expect(outcome?.status).toBe("errored");
+
+    if (outcome?.status === "errored") {
+      expect(outcome.error).toContain("4321");
+      expect(outcome.error).toContain("timeout");
+    }
+  });
+
   test("a binary reviewer returning valid JSON on stdout becomes a vote", async () => {
     const panel: IPanel = {
       minReviewers: 1,

--- a/packages/core/tests/reviewers-diagnose.test.ts
+++ b/packages/core/tests/reviewers-diagnose.test.ts
@@ -294,6 +294,48 @@ describe("diagnoseInvoke (invoke → parse → outcome)", () => {
     }
   });
 
+  test("a TRUNCATED binary's output is not counted as a vote either", async () => {
+    // Parallel to the timeout case, and the same asymmetry: the review path
+    // refuses a prefix while diagnose fell through to "binary exited non-zero",
+    // blaming the binary for something the harness did — or, for a runner
+    // reporting ok:true alongside the flag, counting a cut-off diagnosis as a
+    // real one.
+    const panel: IPanel = {
+      minReviewers: 1,
+      skipped: [],
+      reviewers: [
+        {
+          kind: "binary",
+          id: "grok",
+          argv: ["x"],
+          input: "arg",
+          timeoutMs: 1000,
+          parse: "raw",
+        },
+      ],
+    };
+    const deps: IInvokeDeps = {
+      makeProvider: () => ({
+        complete: () => Promise.resolve(modelResponse("")),
+      }),
+      runBinary: () =>
+        Promise.resolve({
+          ok: true,
+          stdout: GOOD_DIAGNOSIS,
+          timedOut: false,
+          truncated: true,
+        }),
+    };
+
+    const [outcome] = await diagnoseInvoke(panel, REQUEST, deps);
+
+    expect(outcome?.status).toBe("errored");
+
+    if (outcome?.status === "errored") {
+      expect(outcome.error).toContain("truncated");
+    }
+  });
+
   test("a binary reviewer returning valid JSON on stdout becomes a vote", async () => {
     const panel: IPanel = {
       minReviewers: 1,

--- a/packages/core/tests/reviewers-diagnose.test.ts
+++ b/packages/core/tests/reviewers-diagnose.test.ts
@@ -323,13 +323,16 @@ describe("diagnoseInvoke (invoke → parse → outcome)", () => {
       makeProvider: () => ({
         complete: () => Promise.resolve(modelResponse("")),
       }),
+      // A real production combination: the ceiling was hit, so the read stopped
+      // on `size`. The previous fixture said truncated with stoppedBy "eof",
+      // which runBinary can never produce — so it exercised neither real case.
       runBinary: () =>
         Promise.resolve({
           ok: true,
           stdout: GOOD_DIAGNOSIS,
           timedOut: false,
           truncated: true,
-          stoppedBy: "eof" as const,
+          stoppedBy: "size" as const,
         }),
     };
 
@@ -338,7 +341,48 @@ describe("diagnoseInvoke (invoke → parse → outcome)", () => {
     expect(outcome?.status).toBe("errored");
 
     if (outcome?.status === "errored") {
-      expect(outcome.error).toContain("truncated");
+      expect(outcome.error).toContain("flooded");
+    }
+  });
+
+  test("a timed-out diagnosis with an orphaned pipe reports the TIMEOUT", async () => {
+    // Both flags true with a deadline stop is a binary killed at its budget
+    // whose child still holds stdout. The timeout is why it died; reporting
+    // truncation hides that on the path that happens most.
+    const panel: IPanel = {
+      minReviewers: 1,
+      skipped: [],
+      reviewers: [
+        {
+          kind: "binary",
+          id: "grok",
+          argv: ["x"],
+          input: "arg",
+          timeoutMs: 8888,
+          parse: "raw",
+        },
+      ],
+    };
+    const deps: IInvokeDeps = {
+      makeProvider: () => ({
+        complete: () => Promise.resolve(modelResponse("")),
+      }),
+      runBinary: () =>
+        Promise.resolve({
+          ok: false,
+          stdout: "partial",
+          timedOut: true,
+          truncated: true,
+          stoppedBy: "deadline" as const,
+        }),
+    };
+
+    const [outcome] = await diagnoseInvoke(panel, REQUEST, deps);
+
+    expect(outcome?.status).toBe("errored");
+
+    if (outcome?.status === "errored") {
+      expect(outcome.error).toContain("8888");
     }
   });
 

--- a/packages/core/tests/reviewers-diagnose.test.ts
+++ b/packages/core/tests/reviewers-diagnose.test.ts
@@ -149,6 +149,7 @@ describe("diagnoseInvoke (invoke → parse → outcome)", () => {
           stdout: "",
           timedOut: false,
           truncated: false,
+          stoppedBy: "eof" as const,
         }),
     };
 
@@ -183,6 +184,7 @@ describe("diagnoseInvoke (invoke → parse → outcome)", () => {
           stdout: "",
           timedOut: false,
           truncated: false,
+          stoppedBy: "eof" as const,
         }),
     };
 
@@ -209,6 +211,7 @@ describe("diagnoseInvoke (invoke → parse → outcome)", () => {
           stdout: "",
           timedOut: false,
           truncated: false,
+          stoppedBy: "eof" as const,
         }),
     };
 
@@ -242,6 +245,7 @@ describe("diagnoseInvoke (invoke → parse → outcome)", () => {
           stdout: "",
           timedOut: false,
           truncated: false,
+          stoppedBy: "eof" as const,
         }),
     };
 
@@ -281,6 +285,7 @@ describe("diagnoseInvoke (invoke → parse → outcome)", () => {
           stdout: GOOD_DIAGNOSIS,
           timedOut: true,
           truncated: false,
+          stoppedBy: "eof" as const,
         }),
     };
 
@@ -324,6 +329,7 @@ describe("diagnoseInvoke (invoke → parse → outcome)", () => {
           stdout: GOOD_DIAGNOSIS,
           timedOut: false,
           truncated: true,
+          stoppedBy: "eof" as const,
         }),
     };
 
@@ -361,6 +367,7 @@ describe("diagnoseInvoke (invoke → parse → outcome)", () => {
           stdout: GOOD_DIAGNOSIS,
           timedOut: false,
           truncated: false,
+          stoppedBy: "eof" as const,
         }),
     };
 

--- a/packages/core/tests/reviewers-failure-detail.test.ts
+++ b/packages/core/tests/reviewers-failure-detail.test.ts
@@ -870,14 +870,10 @@ describe("readBounded gives up on a stream that never ends", () => {
    * case the hatch exists for.
    */
   test("it stops once the promise it was given settles", async () => {
-    let push: ((chunk: Uint8Array) => void) | undefined;
     const forever = new ReadableStream<Uint8Array>({
       start(controller) {
-        push = (chunk): void => {
-          controller.enqueue(chunk);
-        };
-
-        push(new TextEncoder().encode("partial"));
+        controller.enqueue(new TextEncoder().encode("partial"));
+        // Never closed: this is the stream a descendant holds open.
       },
     });
     let release: (() => void) | undefined;

--- a/packages/core/tests/reviewers-failure-detail.test.ts
+++ b/packages/core/tests/reviewers-failure-detail.test.ts
@@ -1,0 +1,193 @@
+import { test, expect, describe } from "bun:test";
+import { aggregate, parseVerdict } from "../src/reviewers/aggregate";
+import type { ReviewOutcome } from "../src/reviewers/aggregate";
+import { formatVerdict, runBinary } from "../src/cli/harness-review-mode";
+
+/**
+ * Why a reviewer dropped out, kept rather than discarded.
+ *
+ * `reviewers ok: 2  errored: 2` is the same line whether two binaries are
+ * misconfigured or the whole panel timed out on a large diff — and those imply
+ * opposite fixes (fix the binary vs raise the budget). Worse, the binary path
+ * reported "binary exited non-zero or timed out" for both at once, so even
+ * reading the stored artifact could not tell them apart. Answering "is a
+ * reviewer wasting our time or is it broken?" took an afternoon of timing the
+ * binaries by hand; it should take reading one line.
+ */
+
+const opts = { minReviewers: 2, identity: "local/flash" };
+
+function okOutcome(id: string): ReviewOutcome {
+  return {
+    status: "ok",
+    review: { reviewerId: id, verdict: "approve", findings: [], summary: "" },
+  };
+}
+
+describe("reviewer failure detail", () => {
+  test("names each failed reviewer, with cause and elapsed time", () => {
+    const v = aggregate(
+      [
+        okOutcome("a"),
+        okOutcome("b"),
+        {
+          status: "errored",
+          reviewerId: "codex",
+          error: "binary hit its 300000ms timeout",
+          cause: "timeout",
+          ms: 300_012,
+        },
+      ],
+      opts
+    );
+
+    expect(v.reviewers).toEqual({ ok: 2, errored: 1 });
+    expect(v.failures).toHaveLength(1);
+    expect(v.failures?.[0]?.reviewerId).toBe("codex");
+    expect(v.failures?.[0]?.cause).toBe("timeout");
+  });
+
+  test("a timeout and a crash are DIFFERENT causes, not one string", () => {
+    // The regression that made this undiagnosable: both arrived as
+    // "binary exited non-zero or timed out", so the artifact could not answer
+    // whether the budget was too small or the binary was broken.
+    const v = aggregate(
+      [
+        okOutcome("a"),
+        okOutcome("b"),
+        {
+          status: "errored",
+          reviewerId: "slow",
+          error: "timed out",
+          cause: "timeout",
+          ms: 300_000,
+        },
+        {
+          status: "errored",
+          reviewerId: "broken",
+          error: "binary exited non-zero",
+          cause: "exit",
+          ms: 120,
+        },
+      ],
+      opts
+    );
+    const causes = (v.failures ?? []).map((f) => f.cause);
+
+    expect(causes).toEqual(["timeout", "exit"]);
+  });
+
+  test("a clean panel carries no failures field at all", () => {
+    const v = aggregate([okOutcome("a"), okOutcome("b")], opts);
+
+    expect(v.failures).toBeUndefined();
+  });
+
+  test("the printed verdict shows who dropped out and why", () => {
+    const v = aggregate(
+      [
+        okOutcome("a"),
+        okOutcome("b"),
+        {
+          status: "errored",
+          reviewerId: "codex",
+          error: "binary hit its 300000ms timeout",
+          cause: "timeout",
+          ms: 300_500,
+        },
+      ],
+      opts
+    );
+    const out = formatVerdict(v);
+
+    expect(out).toContain("codex did not review");
+    expect(out).toContain("timeout");
+    // Seconds, because "300500" in a terminal is not a duration anyone reads.
+    expect(out).toContain("300.5s");
+  });
+
+  test("failures survive the cache round-trip", () => {
+    const v = aggregate(
+      [
+        okOutcome("a"),
+        okOutcome("b"),
+        {
+          status: "errored",
+          reviewerId: "codex",
+          error: "binary hit its 300000ms timeout",
+          cause: "timeout",
+          ms: 300_000,
+        },
+      ],
+      opts
+    );
+    const raw: unknown = JSON.parse(JSON.stringify(v));
+    const parsed = parseVerdict(raw);
+
+    expect(parsed?.failures?.[0]?.cause).toBe("timeout");
+    expect(parsed?.failures?.[0]?.ms).toBe(300_000);
+  });
+
+  test("a malformed failure entry is dropped, not treated as a corrupt verdict", () => {
+    // Diagnostics are informational. Losing one line must not invalidate an
+    // otherwise good cached verdict and force the whole panel to re-run.
+    const v = aggregate([okOutcome("a"), okOutcome("b")], opts);
+    const raw: unknown = {
+      ...JSON.parse(JSON.stringify(v)),
+      failures: [{ reviewerId: 7 }, { reviewerId: "ok-one", error: "boom" }],
+    };
+    const parsed = parseVerdict(raw);
+
+    expect(parsed).not.toBeNull();
+    expect(parsed?.failures).toHaveLength(1);
+    expect(parsed?.failures?.[0]?.reviewerId).toBe("ok-one");
+  });
+
+  test("an unknown cause string is dropped rather than trusted", () => {
+    const v = aggregate([okOutcome("a"), okOutcome("b")], opts);
+    const raw: unknown = {
+      ...JSON.parse(JSON.stringify(v)),
+      failures: [{ reviewerId: "x", error: "boom", cause: "banana" }],
+    };
+    const parsed = parseVerdict(raw);
+
+    expect(parsed?.failures?.[0]?.cause).toBeUndefined();
+  });
+});
+
+describe("runBinary reports WHICH failure it was", () => {
+  /**
+   * The distinction has to be recorded at the kill site: a process we killed
+   * exits non-zero exactly like one that failed on its own, so the exit code
+   * cannot tell them apart afterwards. Only the killer knows.
+   */
+  test("a process killed at the budget is marked timedOut", async () => {
+    const r = await runBinary(
+      { argv: ["sh", "-c", "sleep 30"], input: "arg", timeoutMs: 800 },
+      ""
+    );
+
+    expect(r.ok).toBe(false);
+    expect(r.timedOut).toBe(true);
+  }, 30_000);
+
+  test("a process that exits non-zero on its own is NOT marked timedOut", async () => {
+    const r = await runBinary(
+      { argv: ["sh", "-c", "exit 3"], input: "arg", timeoutMs: 30_000 },
+      ""
+    );
+
+    expect(r.ok).toBe(false);
+    expect(r.timedOut).toBe(false);
+  }, 30_000);
+
+  test("a healthy process is neither", async () => {
+    const r = await runBinary(
+      { argv: ["sh", "-c", "echo hi"], input: "arg", timeoutMs: 30_000 },
+      ""
+    );
+
+    expect(r.ok).toBe(true);
+    expect(r.timedOut).toBe(false);
+  }, 30_000);
+});

--- a/packages/core/tests/reviewers-failure-detail.test.ts
+++ b/packages/core/tests/reviewers-failure-detail.test.ts
@@ -250,57 +250,33 @@ describe("runBinary reports WHICH failure it was", () => {
     expect(Date.now() - started).toBeLessThan(10_000);
   }, 30_000);
 
-  test("a success is not retro-flagged when its output drains past the budget", async () => {
-    // THE race, exercised for real. The parent exits at once, but a backgrounded
-    // child inherits stdout and holds the pipe open past the budget — so the
-    // drain is still running when the timer would fire. Clearing the timer on
-    // exit is the only reason this comes back ok.
+  test("an orphan holding the pipe means the read is REPORTED incomplete", async () => {
+    // The parent answers and exits at once; a backgrounded child keeps stdout
+    // open. We stop reading, and we say so: not reaching EOF means we cannot
+    // claim the answer is complete, and whether that orphan is idle or still
+    // writing cannot be decided from here — a writer slower than the grace looks
+    // identical to one that has finished.
     //
-    // The previous version of this test slept after the call and re-read the
-    // returned object, which is a snapshot: a late timer could not have been
-    // observed either way, and `echo` finished long before its budget, so the
-    // timer never fired during a drain at all. It passed with the fix deleted.
+    // The cost is refusing a review from any reviewer that backgrounds work.
+    // That is visible, with cause `truncated`. Passing a prefix off as a
+    // finished review is not, and a wrong verdict is worse than a missing one.
     const started = Date.now();
     const r = await runBinary(
       {
-        argv: ["sh", "-c", "echo done; sleep 3 &"],
-        input: "arg",
-        timeoutMs: 700,
-      },
-      ""
-    );
-
-    expect(r.timedOut).toBe(false);
-    expect(r.ok).toBe(true);
-    expect(r.stdout).toContain("done");
-    // And it returned on the drain bound rather than waiting out the child.
-    expect(Date.now() - started).toBeLessThan(2_500);
-  }, 30_000);
-
-  test("a reviewer that floods stdout is cut off and SAID to be", async () => {
-    // The size ceiling. A review is a small JSON object; a reviewer emitting
-    // megabytes is a runaway, and reading it to EOF lets one of them exhaust the
-    // harness. Reporting it as truncated rather than as a bad answer points at
-    // the right problem — we stopped listening.
-    const r = await runBinary(
-      {
-        // ~16MB, past the 8MB ceiling, as fast as the shell can produce it.
-        argv: [
-          "sh",
-          "-c",
-          "yes 0123456789012345678901234567890123456789 | head -c 16000000",
-        ],
+        argv: ["sh", "-c", "echo done; sleep 6 &"],
         input: "arg",
         timeoutMs: 30_000,
       },
       ""
     );
 
+    expect(r.stdout).toContain("done");
     expect(r.truncated).toBe(true);
     expect(r.ok).toBe(false);
     expect(r.timedOut).toBe(false);
-    expect(r.stdout.length).toBeLessThan(16_000_000);
-  }, 60_000);
+    // Returned on the drain bound rather than waiting out the child.
+    expect(Date.now() - started).toBeLessThan(5_000);
+  }, 30_000);
 
   test("a process that exits non-zero on its own is NOT marked timedOut", async () => {
     const r = await runBinary(

--- a/packages/core/tests/reviewers-failure-detail.test.ts
+++ b/packages/core/tests/reviewers-failure-detail.test.ts
@@ -149,6 +149,23 @@ describe("reviewer failure detail", () => {
     expect(parsed?.failures?.[0]?.reviewerId).toBe("ok-one");
   });
 
+  test("missing failure detail is SAID, not silently a shorter list", () => {
+    // A cached artifact from an older build carries counts but no detail. Left
+    // alone the printed verdict shows a complete-looking (empty) list beside
+    // "errored: 2" and silently regresses to the count-only state this change
+    // exists to leave behind.
+    const v = aggregate([okOutcome("a"), okOutcome("b")], opts);
+    const raw: unknown = {
+      ...JSON.parse(JSON.stringify(v)),
+      reviewers: { ok: 2, errored: 2 },
+    };
+    const parsed = parseVerdict(raw);
+
+    expect(formatVerdict(parsed ?? v)).toContain(
+      "2 further reviewer failure(s) with no readable detail"
+    );
+  });
+
   test("a non-finite ms is dropped rather than printed as NaNs", () => {
     const v = aggregate([okOutcome("a"), okOutcome("b")], opts);
     const raw: unknown = {
@@ -187,6 +204,29 @@ describe("runBinary reports WHICH failure it was", () => {
 
     expect(r.ok).toBe(false);
     expect(r.timedOut).toBe(true);
+  }, 30_000);
+
+  test("a binary that TRAPS the kill and exits 0 is still not ok", async () => {
+    // The case `ok: code === 0` alone gets wrong, and the reason the plain
+    // `sleep` test above does not cover it: sleep dies on SIGTERM and exits
+    // non-zero, so ok is false either way and the suite would still pass with
+    // `&& !timedOut` deleted. A binary that handles SIGTERM cleanly exits 0
+    // while having produced only a partial answer.
+    const r = await runBinary(
+      {
+        // `& wait` so the trap fires on arrival: with a FOREGROUND sleep, sh
+        // defers the handler until the child finishes, and the kill looks slow
+        // rather than trapped. (The backgrounded child also holds the stdout
+        // pipe open until it exits, which is why this sleeps 2s and not 30.)
+        argv: ["sh", "-c", "trap 'exit 0' TERM; echo partial; sleep 2 & wait"],
+        input: "arg",
+        timeoutMs: 800,
+      },
+      ""
+    );
+
+    expect(r.timedOut).toBe(true);
+    expect(r.ok).toBe(false);
   }, 30_000);
 
   test("a process that exits non-zero on its own is NOT marked timedOut", async () => {
@@ -314,7 +354,33 @@ describe("cause classification through reviewerInvoke", () => {
         }),
     });
 
-    expect(out[0]?.status).toBe("ok");
-    expect(typeof (out[0] as { ms?: number }).ms).toBe("number");
+    const outcome = out[0];
+
+    // Narrowed on status, not cast: the house rule forbids `as` (except
+    // `as const`), and narrowing is what makes ms reachable honestly.
+    expect(outcome?.status).toBe("ok");
+
+    if (outcome?.status === "ok") {
+      expect(typeof outcome.ms).toBe("number");
+    }
+  });
+
+  test("a runner reporting ok WITH timedOut is still not a review", async () => {
+    // Defence in depth. runBinary forces ok=false on a kill, but invokeBinary
+    // must not depend on that: any runner meeting the contract could report
+    // `ok: true, timedOut: true`, and parsing stdout there counts a reviewer we
+    // killed mid-sentence as having reviewed.
+    const out = await reviewerInvoke(binaryPanel(999), request, {
+      makeProvider: deadProvider,
+      runBinary: () =>
+        Promise.resolve({
+          ok: true,
+          stdout: '{"verdict":"approve","summary":"","findings":[]}',
+          timedOut: true,
+        }),
+    });
+
+    expect(out[0]?.status).toBe("errored");
+    expect(out[0]).toMatchObject({ cause: "timeout" });
   });
 });

--- a/packages/core/tests/reviewers-failure-detail.test.ts
+++ b/packages/core/tests/reviewers-failure-detail.test.ts
@@ -277,6 +277,31 @@ describe("runBinary reports WHICH failure it was", () => {
     expect(Date.now() - started).toBeLessThan(2_500);
   }, 30_000);
 
+  test("a reviewer that floods stdout is cut off and SAID to be", async () => {
+    // The size ceiling. A review is a small JSON object; a reviewer emitting
+    // megabytes is a runaway, and reading it to EOF lets one of them exhaust the
+    // harness. Reporting it as truncated rather than as a bad answer points at
+    // the right problem — we stopped listening.
+    const r = await runBinary(
+      {
+        // ~16MB, past the 8MB ceiling, as fast as the shell can produce it.
+        argv: [
+          "sh",
+          "-c",
+          "yes 0123456789012345678901234567890123456789 | head -c 16000000",
+        ],
+        input: "arg",
+        timeoutMs: 30_000,
+      },
+      ""
+    );
+
+    expect(r.truncated).toBe(true);
+    expect(r.ok).toBe(false);
+    expect(r.timedOut).toBe(false);
+    expect(r.stdout.length).toBeLessThan(16_000_000);
+  }, 60_000);
+
   test("a process that exits non-zero on its own is NOT marked timedOut", async () => {
     const r = await runBinary(
       { argv: ["sh", "-c", "exit 3"], input: "arg", timeoutMs: 30_000 },
@@ -337,7 +362,12 @@ describe("cause classification through reviewerInvoke", () => {
     const out = await reviewerInvoke(binaryPanel(1234), request, {
       makeProvider: deadProvider,
       runBinary: () =>
-        Promise.resolve({ ok: false, stdout: "", timedOut: true }),
+        Promise.resolve({
+          ok: false,
+          stdout: "",
+          timedOut: true,
+          truncated: false,
+        }),
     });
 
     expect(out[0]?.status).toBe("errored");
@@ -351,10 +381,32 @@ describe("cause classification through reviewerInvoke", () => {
     const out = await reviewerInvoke(binaryPanel(), request, {
       makeProvider: deadProvider,
       runBinary: () =>
-        Promise.resolve({ ok: false, stdout: "", timedOut: false }),
+        Promise.resolve({
+          ok: false,
+          stdout: "",
+          timedOut: false,
+          truncated: false,
+        }),
     });
 
     expect(out[0]).toMatchObject({ cause: "exit" });
+  });
+
+  test("a truncated read is cause=truncated, not unparseable", async () => {
+    // We stopped listening; the reviewer may have been perfectly fine. Calling
+    // its prefix unparseable sends the next person to debug the wrong thing.
+    const out = await reviewerInvoke(binaryPanel(), request, {
+      makeProvider: deadProvider,
+      runBinary: () =>
+        Promise.resolve({
+          ok: false,
+          stdout: '{"verdict":"appr',
+          timedOut: false,
+          truncated: true,
+        }),
+    });
+
+    expect(out[0]).toMatchObject({ cause: "truncated" });
   });
 
   test("a binary that answers in the wrong shape is cause=unparseable", async () => {
@@ -365,6 +417,7 @@ describe("cause classification through reviewerInvoke", () => {
           ok: true,
           stdout: "sure, looks fine!",
           timedOut: false,
+          truncated: false,
         }),
     });
 
@@ -377,7 +430,12 @@ describe("cause classification through reviewerInvoke", () => {
     const out = await reviewerInvoke(binaryPanel(), request, {
       makeProvider: deadProvider,
       runBinary: () =>
-        Promise.resolve({ ok: false, stdout: "", timedOut: false }),
+        Promise.resolve({
+          ok: false,
+          stdout: "",
+          timedOut: false,
+          truncated: false,
+        }),
     });
     const outcome = out[0];
 
@@ -400,7 +458,12 @@ describe("cause classification through reviewerInvoke", () => {
     const out = await reviewerInvoke(panel, request, {
       makeProvider: deadProvider,
       runBinary: () =>
-        Promise.resolve({ ok: false, stdout: "", timedOut: false }),
+        Promise.resolve({
+          ok: false,
+          stdout: "",
+          timedOut: false,
+          truncated: false,
+        }),
     });
 
     expect(out[0]).toMatchObject({ cause: "threw" });
@@ -417,6 +480,7 @@ describe("cause classification through reviewerInvoke", () => {
           ok: true,
           stdout: '{"verdict":"approve","summary":"","findings":[]}',
           timedOut: false,
+          truncated: false,
         }),
     });
 
@@ -443,6 +507,7 @@ describe("cause classification through reviewerInvoke", () => {
           ok: true,
           stdout: '{"verdict":"approve","summary":"","findings":[]}',
           timedOut: true,
+          truncated: false,
         }),
     });
 

--- a/packages/core/tests/reviewers-failure-detail.test.ts
+++ b/packages/core/tests/reviewers-failure-detail.test.ts
@@ -301,6 +301,19 @@ describe("reviewer failure detail", () => {
   });
 });
 
+/** Any process still matching `marker`, as a trimmed string ("" when none). */
+async function survivors(marker: string): Promise<string> {
+  const probe = Bun.spawn(["pgrep", "-f", marker], {
+    stdout: "pipe",
+    stderr: "ignore",
+  });
+  const found = (await new Response(probe.stdout).text()).trim();
+
+  await probe.exited;
+
+  return found;
+}
+
 describe("runBinary reports WHICH failure it was", () => {
   /**
    * The distinction has to be recorded at the kill site: a process we killed
@@ -356,15 +369,32 @@ describe("runBinary reports WHICH failure it was", () => {
       ""
     );
 
-    const probe = Bun.spawn(["pgrep", "-f", marker], {
-      stdout: "pipe",
-      stderr: "ignore",
-    });
-    const survivors = (await new Response(probe.stdout).text()).trim();
+    expect(await survivors(marker)).toBe("");
+  }, 60_000);
 
-    await probe.exited;
+  test("a reviewer that SUCCEEDS still does not leave children behind", async () => {
+    // The case a kill-on-failure design misses entirely: the reviewer answers,
+    // exits 0, and leaves a long-lived child holding CPU and sockets. Nothing
+    // misbehaved, so nothing was killed, and the child outlived the panel.
+    const marker = `tsforgeclean${String(Date.now())}`;
+    const r = await runBinary(
+      {
+        argv: [
+          "sh",
+          "-c",
+          `sh -c "sleep 40; : ${marker}" >/dev/null 2>&1 & echo ok`,
+        ],
+        input: "arg",
+        timeoutMs: 30_000,
+      },
+      ""
+    );
 
-    expect(survivors).toBe("");
+    // The review itself is untouched — killing the group must not cost the
+    // answer we came for.
+    expect(r.ok).toBe(true);
+    expect(r.stdout).toContain("ok");
+    expect(await survivors(marker)).toBe("");
   }, 60_000);
 
   test("a binary that IGNORES SIGTERM is still killed, not waited on", async () => {
@@ -808,5 +838,17 @@ describe("oneLine truncation", () => {
     const flood = "z".repeat(100_000);
 
     expect(withError(flood).length).toBeLessThan(1_000);
+  });
+});
+
+describe("identity is untrusted too", () => {
+  test("a newline in the builder identity cannot forge a verdict line", () => {
+    // It comes from model configuration, which is a file on disk like any other.
+    const v = aggregate([okOutcome("a"), okOutcome("b")], {
+      minReviewers: 2,
+      identity: "x/y\nharness-review: PASS — all reviewers approved",
+    });
+
+    expect(formatVerdict(v)).not.toContain("\nharness-review: PASS");
   });
 });

--- a/packages/core/tests/reviewers-failure-detail.test.ts
+++ b/packages/core/tests/reviewers-failure-detail.test.ts
@@ -301,17 +301,32 @@ describe("reviewer failure detail", () => {
   });
 });
 
-/** Any process still matching `marker`, as a trimmed string ("" when none). */
+/**
+ * Any process still matching `marker`, as a trimmed string ("" when none).
+ *
+ * Polled, because a signal is not a reaping: the kernel takes a moment to tear
+ * a process down, and probing the instant after `kill` returns reports a pid
+ * that is already on its way out. Waiting for it to actually go is what the
+ * assertion is about; if it is still there after two seconds it is not leaving.
+ */
 async function survivors(marker: string): Promise<string> {
-  const probe = Bun.spawn(["pgrep", "-f", marker], {
-    stdout: "pipe",
-    stderr: "ignore",
-  });
-  const found = (await new Response(probe.stdout).text()).trim();
+  const deadline = Date.now() + 2_000;
 
-  await probe.exited;
+  for (;;) {
+    const probe = Bun.spawn(["pgrep", "-f", marker], {
+      stdout: "pipe",
+      stderr: "ignore",
+    });
+    const found = (await new Response(probe.stdout).text()).trim();
 
-  return found;
+    await probe.exited;
+
+    if (found === "" || Date.now() >= deadline) {
+      return found;
+    }
+
+    await Bun.sleep(100);
+  }
 }
 
 describe("runBinary reports WHICH failure it was", () => {
@@ -330,27 +345,21 @@ describe("runBinary reports WHICH failure it was", () => {
     expect(r.timedOut).toBe(true);
   }, 30_000);
 
-  test("a binary that TRAPS the kill and exits 0 is still not ok", async () => {
-    // The case `ok: code === 0` alone gets wrong, and the reason the plain
-    // `sleep` test above does not cover it: sleep dies on SIGTERM and exits
-    // non-zero, so ok is false either way and the suite would still pass with
-    // `&& !timedOut` deleted. A binary that handles SIGTERM cleanly exits 0
-    // while having produced only a partial answer.
+  test("a process that escapes the kill cannot wedge the panel", async () => {
+    // The escape hatch. A child that leaves its group — `setsid`, a re-exec —
+    // survives the group kill, so `proc.exited` may never settle. Both the exit
+    // wait AND the stdout drain are raced against a grace, because hanging the
+    // drain off the exit alone deadlocks exactly the case the hatch exists for.
+    const started = Date.now();
     const r = await runBinary(
-      {
-        // `& wait` so the trap fires on arrival: with a FOREGROUND sleep, sh
-        // defers the handler until the child finishes, and the kill looks slow
-        // rather than trapped. (The backgrounded child also holds the stdout
-        // pipe open until it exits, which is why this sleeps 2s and not 30.)
-        argv: ["sh", "-c", "trap 'exit 0' TERM; echo partial; sleep 2 & wait"],
-        input: "arg",
-        timeoutMs: 800,
-      },
+      { argv: ["sh", "-c", "sleep 30"], input: "arg", timeoutMs: 800 },
       ""
     );
 
     expect(r.timedOut).toBe(true);
     expect(r.ok).toBe(false);
+    // Budget plus grace, not the sleep.
+    expect(Date.now() - started).toBeLessThan(10_000);
   }, 30_000);
 
   test("a TERM-ignoring DESCENDANT is reaped, not orphaned", async () => {

--- a/packages/core/tests/reviewers-failure-detail.test.ts
+++ b/packages/core/tests/reviewers-failure-detail.test.ts
@@ -1,7 +1,11 @@
 import { test, expect, describe } from "bun:test";
 import { aggregate, parseVerdict } from "../src/reviewers/aggregate";
 import type { ReviewOutcome } from "../src/reviewers/aggregate";
-import { formatVerdict, runBinary } from "../src/cli/harness-review-mode";
+import {
+  formatVerdict,
+  runBinary,
+  MAX_STDOUT_BYTES,
+} from "../src/cli/harness-review-mode";
 import { reviewerInvoke } from "../src/reviewers/invoke";
 import type { IPanel } from "../src/reviewers/registry";
 import type { IReviewRequest } from "../src/reviewers/schema";
@@ -277,6 +281,56 @@ describe("runBinary reports WHICH failure it was", () => {
     // Returned on the drain bound rather than waiting out the child.
     expect(Date.now() - started).toBeLessThan(5_000);
   }, 30_000);
+
+  test("a reviewer that floods stdout is cut off AT the ceiling", async () => {
+    // A review is a small JSON object; a reviewer emitting megabytes is a
+    // runaway, and reading it to EOF lets one of them exhaust the harness.
+    //
+    // The bound is exact. Appending a whole chunk and checking afterwards
+    // overruns by up to one chunk, which for a megabyte-chunked writer is not a
+    // rounding error — so the last chunk is sliced to the remaining allowance.
+    const r = await runBinary(
+      {
+        argv: [
+          "sh",
+          "-c",
+          `yes 0123456789012345678901234567890123456789 | head -c ${String(MAX_STDOUT_BYTES * 2)}`,
+        ],
+        input: "arg",
+        timeoutMs: 60_000,
+      },
+      ""
+    );
+
+    expect(r.truncated).toBe(true);
+    expect(r.ok).toBe(false);
+    expect(r.timedOut).toBe(false);
+    // ASCII, so bytes and characters coincide here.
+    expect(r.stdout.length).toBe(MAX_STDOUT_BYTES);
+  }, 120_000);
+
+  test("output of exactly the ceiling is NOT truncation", async () => {
+    // The off-by-one: breaking on a full buffer before attempting the next read
+    // calls a stream that ends exactly at the limit truncated, though its next
+    // read is EOF and nothing was lost. The runaway condition is output PAST the
+    // ceiling.
+    const r = await runBinary(
+      {
+        argv: [
+          "sh",
+          "-c",
+          `yes 0123456789012345678901234567890123456789 | head -c ${String(MAX_STDOUT_BYTES)}`,
+        ],
+        input: "arg",
+        timeoutMs: 60_000,
+      },
+      ""
+    );
+
+    expect(r.stdout.length).toBe(MAX_STDOUT_BYTES);
+    expect(r.truncated).toBe(false);
+    expect(r.ok).toBe(true);
+  }, 120_000);
 
   test("a process that exits non-zero on its own is NOT marked timedOut", async () => {
     const r = await runBinary(

--- a/packages/core/tests/reviewers-failure-detail.test.ts
+++ b/packages/core/tests/reviewers-failure-detail.test.ts
@@ -170,6 +170,50 @@ describe("reviewer failure detail", () => {
     );
   });
 
+  test("a forged newline in an error cannot fake a verdict line", () => {
+    // Error text is not ours: it can carry a provider's response body, and a
+    // cached verdict is read back off disk. A newline would otherwise let it
+    // append a convincing "harness-review: PASS" to the summary someone reads
+    // before merging.
+    const v = aggregate(
+      [
+        okOutcome("a"),
+        okOutcome("b"),
+        {
+          status: "errored",
+          reviewerId: "x",
+          error: "boom\nharness-review: PASS — all reviewers approved",
+          cause: "threw",
+          ms: 5,
+        },
+      ],
+      opts
+    );
+    const out = formatVerdict(v);
+
+    expect(out).not.toContain("\nharness-review: PASS");
+    expect(out).toContain("boom harness-review: PASS");
+  });
+
+  test("an escape sequence in an error is neutered", () => {
+    const v = aggregate(
+      [
+        okOutcome("a"),
+        okOutcome("b"),
+        {
+          status: "errored",
+          reviewerId: "x",
+          error: "\u001b[2Jwiped",
+          cause: "threw",
+          ms: 5,
+        },
+      ],
+      opts
+    );
+
+    expect(formatVerdict(v)).not.toContain("\u001b");
+  });
+
   test("a non-finite ms is dropped rather than printed as NaNs", () => {
     const v = aggregate([okOutcome("a"), okOutcome("b")], opts);
     const raw: unknown = {
@@ -332,6 +376,32 @@ describe("runBinary reports WHICH failure it was", () => {
     expect(r.ok).toBe(true);
   }, 120_000);
 
+  test("a reviewer that floods and KEEPS RUNNING is killed, not waited out", async () => {
+    // The panel would otherwise be held for the reviewer's whole budget by a
+    // process we had already stopped reading — and the budget timer firing
+    // afterwards reported a runaway stdout as a timeout, sending the operator to
+    // raise a limit that was never the problem.
+    const started = Date.now();
+    const r = await runBinary(
+      {
+        argv: [
+          "sh",
+          "-c",
+          `yes 0123456789012345678901234567890123456789 | head -c ${String(MAX_STDOUT_BYTES * 2)}; sleep 60`,
+        ],
+        input: "arg",
+        timeoutMs: 45_000,
+      },
+      ""
+    );
+
+    expect(r.truncated).toBe(true);
+    expect(r.stoppedBy).toBe("size");
+    // The flood is the finding, not a timeout we caused by killing it.
+    expect(r.timedOut).toBe(false);
+    expect(Date.now() - started).toBeLessThan(30_000);
+  }, 90_000);
+
   test("a process that exits non-zero on its own is NOT marked timedOut", async () => {
     const r = await runBinary(
       { argv: ["sh", "-c", "exit 3"], input: "arg", timeoutMs: 30_000 },
@@ -397,6 +467,7 @@ describe("cause classification through reviewerInvoke", () => {
           stdout: "",
           timedOut: true,
           truncated: false,
+          stoppedBy: "eof" as const,
         }),
     });
 
@@ -416,6 +487,7 @@ describe("cause classification through reviewerInvoke", () => {
           stdout: "",
           timedOut: false,
           truncated: false,
+          stoppedBy: "eof" as const,
         }),
     });
 
@@ -433,10 +505,32 @@ describe("cause classification through reviewerInvoke", () => {
           stdout: '{"verdict":"appr',
           timedOut: false,
           truncated: true,
+          stoppedBy: "eof" as const,
         }),
     });
 
     expect(out[0]).toMatchObject({ cause: "truncated" });
+  });
+
+  test("a flood outranks a timeout when both flags are set", async () => {
+    // Killing a flooder can race the budget timer, so both arrive true. Reported
+    // as a timeout, the operator raises a budget that was never the problem.
+    const out = await reviewerInvoke(binaryPanel(), request, {
+      makeProvider: deadProvider,
+      runBinary: () =>
+        Promise.resolve({
+          ok: false,
+          stdout: "x",
+          timedOut: true,
+          truncated: true,
+          stoppedBy: "size" as const,
+        }),
+    });
+
+    expect(out[0]).toMatchObject({ cause: "truncated" });
+    expect(out[0]).toMatchObject({
+      error: expect.stringContaining("flooded"),
+    });
   });
 
   test("a binary that answers in the wrong shape is cause=unparseable", async () => {
@@ -448,6 +542,7 @@ describe("cause classification through reviewerInvoke", () => {
           stdout: "sure, looks fine!",
           timedOut: false,
           truncated: false,
+          stoppedBy: "eof" as const,
         }),
     });
 
@@ -465,6 +560,7 @@ describe("cause classification through reviewerInvoke", () => {
           stdout: "",
           timedOut: false,
           truncated: false,
+          stoppedBy: "eof" as const,
         }),
     });
     const outcome = out[0];
@@ -493,6 +589,7 @@ describe("cause classification through reviewerInvoke", () => {
           stdout: "",
           timedOut: false,
           truncated: false,
+          stoppedBy: "eof" as const,
         }),
     });
 
@@ -511,6 +608,7 @@ describe("cause classification through reviewerInvoke", () => {
           stdout: '{"verdict":"approve","summary":"","findings":[]}',
           timedOut: false,
           truncated: false,
+          stoppedBy: "eof" as const,
         }),
     });
 
@@ -538,6 +636,7 @@ describe("cause classification through reviewerInvoke", () => {
           stdout: '{"verdict":"approve","summary":"","findings":[]}',
           timedOut: true,
           truncated: false,
+          stoppedBy: "eof" as const,
         }),
     });
 

--- a/packages/core/tests/reviewers-failure-detail.test.ts
+++ b/packages/core/tests/reviewers-failure-detail.test.ts
@@ -2,6 +2,10 @@ import { test, expect, describe } from "bun:test";
 import { aggregate, parseVerdict } from "../src/reviewers/aggregate";
 import type { ReviewOutcome } from "../src/reviewers/aggregate";
 import { formatVerdict, runBinary } from "../src/cli/harness-review-mode";
+import { reviewerInvoke } from "../src/reviewers/invoke";
+import type { IPanel } from "../src/reviewers/registry";
+import type { IReviewRequest } from "../src/reviewers/schema";
+import type { IProvider } from "../src/inference";
 
 /**
  * Why a reviewer dropped out, kept rather than discarded.
@@ -21,6 +25,7 @@ function okOutcome(id: string): ReviewOutcome {
   return {
     status: "ok",
     review: { reviewerId: id, verdict: "approve", findings: [], summary: "" },
+    ms: 0,
   };
 }
 
@@ -45,6 +50,7 @@ describe("reviewer failure detail", () => {
     expect(v.failures).toHaveLength(1);
     expect(v.failures?.[0]?.reviewerId).toBe("codex");
     expect(v.failures?.[0]?.cause).toBe("timeout");
+    expect(v.failures?.[0]?.ms).toBe(300_012);
   });
 
   test("a timeout and a crash are DIFFERENT causes, not one string", () => {
@@ -143,6 +149,18 @@ describe("reviewer failure detail", () => {
     expect(parsed?.failures?.[0]?.reviewerId).toBe("ok-one");
   });
 
+  test("a non-finite ms is dropped rather than printed as NaNs", () => {
+    const v = aggregate([okOutcome("a"), okOutcome("b")], opts);
+    const raw: unknown = {
+      ...JSON.parse(JSON.stringify(v)),
+      failures: [{ reviewerId: "x", error: "boom", ms: Number.NaN }],
+    };
+    const parsed = parseVerdict(raw);
+
+    expect(parsed?.failures?.[0]?.ms).toBeUndefined();
+    expect(formatVerdict(parsed ?? v)).not.toContain("NaN");
+  });
+
   test("an unknown cause string is dropped rather than trusted", () => {
     const v = aggregate([okOutcome("a"), okOutcome("b")], opts);
     const raw: unknown = {
@@ -190,4 +208,113 @@ describe("runBinary reports WHICH failure it was", () => {
     expect(r.ok).toBe(true);
     expect(r.timedOut).toBe(false);
   }, 30_000);
+});
+
+describe("cause classification through reviewerInvoke", () => {
+  /**
+   * The glue. runBinary proves the subprocess reports timedOut and aggregate
+   * proves causes round-trip, but invokeBinary/invokeModel is where the old
+   * "binary exited non-zero or timed out" conflation actually lived — so an
+   * implementation that always emitted `exit`, or dropped cause/ms entirely,
+   * would pass every other test in this suite.
+   */
+  const request: IReviewRequest = {
+    title: "t",
+    intent: "i",
+    diff: "d",
+    validateSummary: { passed: true, failCount: 0, firstErrors: [] },
+    rubricVersion: "1",
+  };
+
+  const binaryPanel = (timeoutMs = 1000): IPanel => ({
+    minReviewers: 1,
+    skipped: [],
+    reviewers: [
+      {
+        kind: "binary",
+        id: "bin",
+        argv: ["x"],
+        input: "arg",
+        timeoutMs,
+        parse: "raw",
+      },
+    ],
+  });
+
+  const deadProvider = (): IProvider => ({
+    complete: () => Promise.reject(new Error("connection refused")),
+  });
+
+  test("a binary killed at its budget is cause=timeout, not exit", async () => {
+    const out = await reviewerInvoke(binaryPanel(1234), request, {
+      makeProvider: deadProvider,
+      runBinary: () =>
+        Promise.resolve({ ok: false, stdout: "", timedOut: true }),
+    });
+
+    expect(out[0]?.status).toBe("errored");
+    expect(out[0]).toMatchObject({ cause: "timeout" });
+    // The budget is named, so the fix (raise it, or drop the reviewer) is
+    // readable straight off the line.
+    expect(out[0]).toMatchObject({ error: expect.stringContaining("1234") });
+  });
+
+  test("a binary that fails on its own is cause=exit, not timeout", async () => {
+    const out = await reviewerInvoke(binaryPanel(), request, {
+      makeProvider: deadProvider,
+      runBinary: () =>
+        Promise.resolve({ ok: false, stdout: "", timedOut: false }),
+    });
+
+    expect(out[0]).toMatchObject({ cause: "exit" });
+  });
+
+  test("a binary that answers in the wrong shape is cause=unparseable", async () => {
+    const out = await reviewerInvoke(binaryPanel(), request, {
+      makeProvider: deadProvider,
+      runBinary: () =>
+        Promise.resolve({
+          ok: true,
+          stdout: "sure, looks fine!",
+          timedOut: false,
+        }),
+    });
+
+    expect(out[0]).toMatchObject({ cause: "unparseable" });
+  });
+
+  test("a model whose call throws is cause=threw", async () => {
+    const panel: IPanel = {
+      minReviewers: 1,
+      skipped: [],
+      reviewers: [
+        { kind: "model", id: "m", entry: { model: "x", baseUrl: "u" } },
+      ],
+    };
+    const out = await reviewerInvoke(panel, request, {
+      makeProvider: deadProvider,
+      runBinary: () =>
+        Promise.resolve({ ok: false, stdout: "", timedOut: false }),
+    });
+
+    expect(out[0]).toMatchObject({ cause: "threw" });
+    expect(out[0]).toMatchObject({
+      error: expect.stringContaining("connection refused"),
+    });
+  });
+
+  test("every outcome carries elapsed time, successes included", async () => {
+    const out = await reviewerInvoke(binaryPanel(), request, {
+      makeProvider: deadProvider,
+      runBinary: () =>
+        Promise.resolve({
+          ok: true,
+          stdout: '{"verdict":"approve","summary":"","findings":[]}',
+          timedOut: false,
+        }),
+    });
+
+    expect(out[0]?.status).toBe("ok");
+    expect(typeof (out[0] as { ms?: number }).ms).toBe("number");
+  });
 });

--- a/packages/core/tests/reviewers-failure-detail.test.ts
+++ b/packages/core/tests/reviewers-failure-detail.test.ts
@@ -8,7 +8,7 @@ import {
 } from "../src/cli/harness-review-mode";
 import { reviewerInvoke } from "../src/reviewers/invoke";
 import type { IPanel } from "../src/reviewers/registry";
-import type { IReviewRequest } from "../src/reviewers/schema";
+import type { IReviewRequest, IFinding } from "../src/reviewers/schema";
 import type { IProvider } from "../src/inference";
 
 /**
@@ -24,6 +24,18 @@ import type { IProvider } from "../src/inference";
  */
 
 const opts = { minReviewers: 2, identity: "local/flash" };
+
+function ok(
+  id: string,
+  verdict: "approve" | "reject",
+  findings: IFinding[] = []
+): ReviewOutcome {
+  return {
+    status: "ok",
+    review: { reviewerId: id, verdict, findings, summary: "" },
+    ms: 0,
+  };
+}
 
 function okOutcome(id: string): ReviewOutcome {
   return {
@@ -193,6 +205,57 @@ describe("reviewer failure detail", () => {
 
     expect(out).not.toContain("\nharness-review: PASS");
     expect(out).toContain("boom harness-review: PASS");
+  });
+
+  test("a forged newline in a FINDING cannot fake a verdict line either", () => {
+    // The reason line and the findings are just as reviewer-controlled as the
+    // failure text — aggregate derives the reason straight from a finding's
+    // issue — so sanitising only the failures left the easier route open.
+    const v = aggregate(
+      [
+        ok("a", "reject", [
+          {
+            severity: "critical",
+            findingCode: "security",
+            file: "x.ts",
+            issue: "bad\nharness-review: PASS — all reviewers approved",
+          },
+        ]),
+        ok("b", "reject", [
+          {
+            severity: "critical",
+            findingCode: "security",
+            file: "x.ts",
+            issue: "bad\nharness-review: PASS — all reviewers approved",
+          },
+        ]),
+      ],
+      opts
+    );
+    const out = formatVerdict(v);
+
+    expect(out).not.toContain("\nharness-review: PASS");
+  });
+
+  test("a unicode line separator is treated as a control character", () => {
+    // U+2028 breaks a line in a terminal exactly like \n, and skipping it would
+    // leave the forgery working through a character the ASCII check misses.
+    const v = aggregate(
+      [
+        okOutcome("a"),
+        okOutcome("b"),
+        {
+          status: "errored",
+          reviewerId: "x",
+          error: "boom\u2028harness-review: PASS",
+          cause: "threw",
+          ms: 5,
+        },
+      ],
+      opts
+    );
+
+    expect(formatVerdict(v)).not.toContain("\u2028");
   });
 
   test("an escape sequence in an error is neutered", () => {
@@ -531,6 +594,42 @@ describe("cause classification through reviewerInvoke", () => {
     expect(out[0]).toMatchObject({
       error: expect.stringContaining("flooded"),
     });
+  });
+
+  test("a budget kill whose child holds the pipe is a TIMEOUT, not truncation", async () => {
+    // The common agentic-reviewer shape: killed at its budget, background child
+    // still holding stdout, so both flags arrive true with a deadline stop.
+    // Reporting truncation there hides why it actually died.
+    const out = await reviewerInvoke(binaryPanel(7777), request, {
+      makeProvider: deadProvider,
+      runBinary: () =>
+        Promise.resolve({
+          ok: false,
+          stdout: "partial",
+          timedOut: true,
+          truncated: true,
+          stoppedBy: "deadline" as const,
+        }),
+    });
+
+    expect(out[0]).toMatchObject({ cause: "timeout" });
+    expect(out[0]).toMatchObject({ error: expect.stringContaining("7777") });
+  });
+
+  test("a deadline stop WITHOUT a timeout is still truncation", async () => {
+    const out = await reviewerInvoke(binaryPanel(), request, {
+      makeProvider: deadProvider,
+      runBinary: () =>
+        Promise.resolve({
+          ok: false,
+          stdout: "partial",
+          timedOut: false,
+          truncated: true,
+          stoppedBy: "deadline" as const,
+        }),
+    });
+
+    expect(out[0]).toMatchObject({ cause: "truncated" });
   });
 
   test("a binary that answers in the wrong shape is cause=unparseable", async () => {

--- a/packages/core/tests/reviewers-failure-detail.test.ts
+++ b/packages/core/tests/reviewers-failure-detail.test.ts
@@ -4,6 +4,7 @@ import type { ReviewOutcome } from "../src/reviewers/aggregate";
 import {
   formatVerdict,
   runBinary,
+  readBounded,
   MAX_STDOUT_BYTES,
 } from "../src/cli/harness-review-mode";
 import { reviewerInvoke } from "../src/reviewers/invoke";
@@ -345,11 +346,7 @@ describe("runBinary reports WHICH failure it was", () => {
     expect(r.timedOut).toBe(true);
   }, 30_000);
 
-  test("a process that escapes the kill cannot wedge the panel", async () => {
-    // The escape hatch. A child that leaves its group — `setsid`, a re-exec —
-    // survives the group kill, so `proc.exited` may never settle. Both the exit
-    // wait AND the stdout drain are raced against a grace, because hanging the
-    // drain off the exit alone deadlocks exactly the case the hatch exists for.
+  test("a timed-out reviewer returns on its budget, not on its own schedule", async () => {
     const started = Date.now();
     const r = await runBinary(
       { argv: ["sh", "-c", "sleep 30"], input: "arg", timeoutMs: 800 },
@@ -358,7 +355,6 @@ describe("runBinary reports WHICH failure it was", () => {
 
     expect(r.timedOut).toBe(true);
     expect(r.ok).toBe(false);
-    // Budget plus grace, not the sleep.
     expect(Date.now() - started).toBeLessThan(10_000);
   }, 30_000);
 
@@ -860,4 +856,43 @@ describe("identity is untrusted too", () => {
 
     expect(formatVerdict(v)).not.toContain("\nharness-review: PASS");
   });
+});
+
+describe("readBounded gives up on a stream that never ends", () => {
+  /**
+   * The mechanism the escape hatch rests on, tested directly because its real
+   * trigger cannot be: a process surviving SIGKILL is one that left its group,
+   * and there is no portable shell-level way to arrange that.
+   *
+   * What matters is that the drain is bounded by the promise it is HANDED, not
+   * by the stream running out — because the promise runBinary passes is
+   * `exited OR escaped`, and hanging it on `exited` alone deadlocked exactly the
+   * case the hatch exists for.
+   */
+  test("it stops once the promise it was given settles", async () => {
+    let push: ((chunk: Uint8Array) => void) | undefined;
+    const forever = new ReadableStream<Uint8Array>({
+      start(controller) {
+        push = (chunk): void => {
+          controller.enqueue(chunk);
+        };
+
+        push(new TextEncoder().encode("partial"));
+      },
+    });
+    let release: (() => void) | undefined;
+    const gone = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    const reading = readBounded(forever, gone);
+
+    // The stream is still open and will never close on its own.
+    release?.();
+
+    const read = await reading;
+
+    expect(read.text).toContain("partial");
+    expect(read.stoppedBy).toBe("deadline");
+    expect(read.truncated).toBe(true);
+  }, 30_000);
 });

--- a/packages/core/tests/reviewers-failure-detail.test.ts
+++ b/packages/core/tests/reviewers-failure-detail.test.ts
@@ -250,20 +250,31 @@ describe("runBinary reports WHICH failure it was", () => {
     expect(Date.now() - started).toBeLessThan(10_000);
   }, 30_000);
 
-  test("a success near the budget is not retro-flagged as a timeout", async () => {
-    // The race: a reviewer can finish under budget while its output is still
-    // draining, and a timer firing during that drain would mark a completed
-    // review as timed out and throw its answer away.
+  test("a success is not retro-flagged when its output drains past the budget", async () => {
+    // THE race, exercised for real. The parent exits at once, but a backgrounded
+    // child inherits stdout and holds the pipe open past the budget — so the
+    // drain is still running when the timer would fire. Clearing the timer on
+    // exit is the only reason this comes back ok.
+    //
+    // The previous version of this test slept after the call and re-read the
+    // returned object, which is a snapshot: a late timer could not have been
+    // observed either way, and `echo` finished long before its budget, so the
+    // timer never fired during a drain at all. It passed with the fix deleted.
+    const started = Date.now();
     const r = await runBinary(
-      { argv: ["sh", "-c", "echo done"], input: "arg", timeoutMs: 900 },
+      {
+        argv: ["sh", "-c", "echo done; sleep 3 &"],
+        input: "arg",
+        timeoutMs: 700,
+      },
       ""
     );
-
-    await Bun.sleep(1200);
 
     expect(r.timedOut).toBe(false);
     expect(r.ok).toBe(true);
     expect(r.stdout).toContain("done");
+    // And it returned on the drain bound rather than waiting out the child.
+    expect(Date.now() - started).toBeLessThan(2_500);
   }, 30_000);
 
   test("a process that exits non-zero on its own is NOT marked timedOut", async () => {

--- a/packages/core/tests/reviewers-failure-detail.test.ts
+++ b/packages/core/tests/reviewers-failure-detail.test.ts
@@ -340,6 +340,33 @@ describe("runBinary reports WHICH failure it was", () => {
     expect(r.ok).toBe(false);
   }, 30_000);
 
+  test("a TERM-ignoring DESCENDANT is reaped, not orphaned", async () => {
+    // The hard shape, and the one a first fix silently failed: the parent
+    // HONOURS SIGTERM and exits, so its TERM-ignoring child is re-parented to
+    // init and can no longer be found by walking from the parent. Escalating
+    // against pids captured before the first signal is what reaches it.
+    const marker = `tsforge-orphan-${String(Date.now())}`;
+
+    await runBinary(
+      {
+        argv: ["sh", "-c", `sh -c "trap '' TERM; sleep 45 # ${marker}" & wait`],
+        input: "arg",
+        timeoutMs: 700,
+      },
+      ""
+    );
+
+    const probe = Bun.spawn(["pgrep", "-f", marker], {
+      stdout: "pipe",
+      stderr: "ignore",
+    });
+    const survivors = (await new Response(probe.stdout).text()).trim();
+
+    await probe.exited;
+
+    expect(survivors).toBe("");
+  }, 60_000);
+
   test("a binary that IGNORES SIGTERM is still killed, not waited on", async () => {
     // SIGTERM is a request. Without escalation an unkillable reviewer holds the
     // whole panel past a budget that exists to stop exactly that, and the
@@ -568,7 +595,10 @@ describe("cause classification through reviewerInvoke", () => {
           stdout: '{"verdict":"appr',
           timedOut: false,
           truncated: true,
-          stoppedBy: "eof" as const,
+          // A REAL combination: readBounded sets truncated = stoppedBy !== "eof",
+          // so truncated with "eof" is a state runBinary cannot produce and the
+          // fixture proved nothing about either real branch.
+          stoppedBy: "deadline" as const,
         }),
     });
 
@@ -741,5 +771,42 @@ describe("cause classification through reviewerInvoke", () => {
 
     expect(out[0]?.status).toBe("errored");
     expect(out[0]).toMatchObject({ cause: "timeout" });
+  });
+});
+
+describe("oneLine truncation", () => {
+  const withError = (error: string): string =>
+    formatVerdict(
+      aggregate(
+        [
+          okOutcome("a"),
+          okOutcome("b"),
+          { status: "errored", reviewerId: "x", error, cause: "threw", ms: 1 },
+        ],
+        opts
+      )
+    );
+
+  test("a message at the cap is kept whole", () => {
+    const exact = "y".repeat(300);
+
+    expect(withError(exact)).toContain(exact);
+  });
+
+  test("one past the cap is cut and marked", () => {
+    const over = "y".repeat(301);
+    const out = withError(over);
+
+    expect(out).not.toContain(over);
+    expect(out).toContain("…");
+  });
+
+  test("a reviewer cannot bury the summary under its own output", () => {
+    // The point of the cap: the failure line sits in a summary someone reads to
+    // decide whether to merge, and a reviewer that dumps a megabyte should not
+    // push everything else off the screen.
+    const flood = "z".repeat(100_000);
+
+    expect(withError(flood).length).toBeLessThan(1_000);
   });
 });

--- a/packages/core/tests/reviewers-failure-detail.test.ts
+++ b/packages/core/tests/reviewers-failure-detail.test.ts
@@ -229,6 +229,43 @@ describe("runBinary reports WHICH failure it was", () => {
     expect(r.ok).toBe(false);
   }, 30_000);
 
+  test("a binary that IGNORES SIGTERM is still killed, not waited on", async () => {
+    // SIGTERM is a request. Without escalation an unkillable reviewer holds the
+    // whole panel past a budget that exists to stop exactly that, and the
+    // timeout outcome never arrives. The trap test above exits voluntarily and
+    // so cannot catch this.
+    const started = Date.now();
+    const r = await runBinary(
+      {
+        argv: ["sh", "-c", "trap '' TERM; sleep 20 & wait"],
+        input: "arg",
+        timeoutMs: 500,
+      },
+      ""
+    );
+
+    expect(r.timedOut).toBe(true);
+    expect(r.ok).toBe(false);
+    // Budget + grace + drain, not the full 20s.
+    expect(Date.now() - started).toBeLessThan(10_000);
+  }, 30_000);
+
+  test("a success near the budget is not retro-flagged as a timeout", async () => {
+    // The race: a reviewer can finish under budget while its output is still
+    // draining, and a timer firing during that drain would mark a completed
+    // review as timed out and throw its answer away.
+    const r = await runBinary(
+      { argv: ["sh", "-c", "echo done"], input: "arg", timeoutMs: 900 },
+      ""
+    );
+
+    await Bun.sleep(1200);
+
+    expect(r.timedOut).toBe(false);
+    expect(r.ok).toBe(true);
+    expect(r.stdout).toContain("done");
+  }, 30_000);
+
   test("a process that exits non-zero on its own is NOT marked timedOut", async () => {
     const r = await runBinary(
       { argv: ["sh", "-c", "exit 3"], input: "arg", timeoutMs: 30_000 },
@@ -321,6 +358,24 @@ describe("cause classification through reviewerInvoke", () => {
     });
 
     expect(out[0]).toMatchObject({ cause: "unparseable" });
+  });
+
+  test("every failure carries elapsed ms, not just a cause", async () => {
+    // A runner that omitted ms on failures would otherwise pass the suite, and
+    // "how long did it burn" is half the diagnostic.
+    const out = await reviewerInvoke(binaryPanel(), request, {
+      makeProvider: deadProvider,
+      runBinary: () =>
+        Promise.resolve({ ok: false, stdout: "", timedOut: false }),
+    });
+    const outcome = out[0];
+
+    expect(outcome?.status).toBe("errored");
+
+    if (outcome?.status === "errored") {
+      expect(typeof outcome.ms).toBe("number");
+      expect(Number.isFinite(outcome.ms)).toBe(true);
+    }
   });
 
   test("a model whose call throws is cause=threw", async () => {

--- a/packages/core/tests/reviewers-harness-review.test.ts
+++ b/packages/core/tests/reviewers-harness-review.test.ts
@@ -428,7 +428,12 @@ describe("reviewRequest (success path: invoke the panel on a gathered request â†
           },
         };
       },
-      runBinary: async () => ({ ok: true, stdout: "", timedOut: false }),
+      runBinary: async () => ({
+        ok: true,
+        stdout: "",
+        timedOut: false,
+        truncated: false,
+      }),
       panel,
       identity: "local/flash",
     });

--- a/packages/core/tests/reviewers-harness-review.test.ts
+++ b/packages/core/tests/reviewers-harness-review.test.ts
@@ -428,7 +428,7 @@ describe("reviewRequest (success path: invoke the panel on a gathered request â†
           },
         };
       },
-      runBinary: async () => ({ ok: true, stdout: "" }),
+      runBinary: async () => ({ ok: true, stdout: "", timedOut: false }),
       panel,
       identity: "local/flash",
     });

--- a/packages/core/tests/reviewers-harness-review.test.ts
+++ b/packages/core/tests/reviewers-harness-review.test.ts
@@ -433,6 +433,7 @@ describe("reviewRequest (success path: invoke the panel on a gathered request â†
         stdout: "",
         timedOut: false,
         truncated: false,
+        stoppedBy: "eof" as const,
       }),
       panel,
       identity: "local/flash",

--- a/packages/core/tests/reviewers-invoke.test.ts
+++ b/packages/core/tests/reviewers-invoke.test.ts
@@ -29,7 +29,7 @@ describe("reviewerInvoke", () => {
     const deps: IInvokeDeps = {
       makeProvider: () =>
         jsonProvider({ verdict: "approve", summary: "", findings: [] }),
-      runBinary: async () => ({ ok: true, stdout: "" }),
+      runBinary: async () => ({ ok: true, stdout: "", timedOut: false }),
     };
     const out = await reviewerInvoke(
       panelWith({
@@ -55,7 +55,7 @@ describe("reviewerInvoke", () => {
         e.model === "bad"
           ? throwing
           : jsonProvider({ verdict: "approve", summary: "", findings: [] }),
-      runBinary: async () => ({ ok: true, stdout: "" }),
+      runBinary: async () => ({ ok: true, stdout: "", timedOut: false }),
     };
     const out = await reviewerInvoke(
       panelWith(
@@ -91,7 +91,7 @@ describe("reviewerInvoke", () => {
           return { content: "not json", toolCalls: [] };
         },
       }),
-      runBinary: async () => ({ ok: true, stdout: "" }),
+      runBinary: async () => ({ ok: true, stdout: "", timedOut: false }),
     };
     const out = await reviewerInvoke(
       panelWith({
@@ -111,7 +111,7 @@ describe("reviewerInvoke", () => {
       'reasoning...\n```json\n{"verdict":"reject","summary":"no","findings":[]}\n```\n';
     const deps: IInvokeDeps = {
       makeProvider: () => jsonProvider({}),
-      runBinary: async () => ({ ok: true, stdout: fenced }),
+      runBinary: async () => ({ ok: true, stdout: fenced, timedOut: false }),
     };
     const out = await reviewerInvoke(
       panelWith({
@@ -142,7 +142,7 @@ describe("reviewerInvoke", () => {
   test("a binary that exits non-zero → errored", async () => {
     const deps: IInvokeDeps = {
       makeProvider: () => jsonProvider({}),
-      runBinary: async () => ({ ok: false, stdout: "" }),
+      runBinary: async () => ({ ok: false, stdout: "", timedOut: false }),
     };
     const out = await reviewerInvoke(
       panelWith({
@@ -173,6 +173,7 @@ describe("reviewerInvoke", () => {
         return {
           ok: true,
           stdout: '{"verdict":"approve","summary":"","findings":[]}',
+          timedOut: false,
         };
       },
     };

--- a/packages/core/tests/reviewers-invoke.test.ts
+++ b/packages/core/tests/reviewers-invoke.test.ts
@@ -34,6 +34,7 @@ describe("reviewerInvoke", () => {
         stdout: "",
         timedOut: false,
         truncated: false,
+        stoppedBy: "eof" as const,
       }),
     };
     const out = await reviewerInvoke(
@@ -65,6 +66,7 @@ describe("reviewerInvoke", () => {
         stdout: "",
         timedOut: false,
         truncated: false,
+        stoppedBy: "eof" as const,
       }),
     };
     const out = await reviewerInvoke(
@@ -106,6 +108,7 @@ describe("reviewerInvoke", () => {
         stdout: "",
         timedOut: false,
         truncated: false,
+        stoppedBy: "eof" as const,
       }),
     };
     const out = await reviewerInvoke(
@@ -131,6 +134,7 @@ describe("reviewerInvoke", () => {
         stdout: fenced,
         timedOut: false,
         truncated: false,
+        stoppedBy: "eof" as const,
       }),
     };
     const out = await reviewerInvoke(
@@ -167,6 +171,7 @@ describe("reviewerInvoke", () => {
         stdout: "",
         timedOut: false,
         truncated: false,
+        stoppedBy: "eof" as const,
       }),
     };
     const out = await reviewerInvoke(
@@ -200,6 +205,7 @@ describe("reviewerInvoke", () => {
           stdout: '{"verdict":"approve","summary":"","findings":[]}',
           timedOut: false,
           truncated: false,
+          stoppedBy: "eof" as const,
         };
       },
     };

--- a/packages/core/tests/reviewers-invoke.test.ts
+++ b/packages/core/tests/reviewers-invoke.test.ts
@@ -29,7 +29,12 @@ describe("reviewerInvoke", () => {
     const deps: IInvokeDeps = {
       makeProvider: () =>
         jsonProvider({ verdict: "approve", summary: "", findings: [] }),
-      runBinary: async () => ({ ok: true, stdout: "", timedOut: false }),
+      runBinary: async () => ({
+        ok: true,
+        stdout: "",
+        timedOut: false,
+        truncated: false,
+      }),
     };
     const out = await reviewerInvoke(
       panelWith({
@@ -55,7 +60,12 @@ describe("reviewerInvoke", () => {
         e.model === "bad"
           ? throwing
           : jsonProvider({ verdict: "approve", summary: "", findings: [] }),
-      runBinary: async () => ({ ok: true, stdout: "", timedOut: false }),
+      runBinary: async () => ({
+        ok: true,
+        stdout: "",
+        timedOut: false,
+        truncated: false,
+      }),
     };
     const out = await reviewerInvoke(
       panelWith(
@@ -91,7 +101,12 @@ describe("reviewerInvoke", () => {
           return { content: "not json", toolCalls: [] };
         },
       }),
-      runBinary: async () => ({ ok: true, stdout: "", timedOut: false }),
+      runBinary: async () => ({
+        ok: true,
+        stdout: "",
+        timedOut: false,
+        truncated: false,
+      }),
     };
     const out = await reviewerInvoke(
       panelWith({
@@ -111,7 +126,12 @@ describe("reviewerInvoke", () => {
       'reasoning...\n```json\n{"verdict":"reject","summary":"no","findings":[]}\n```\n';
     const deps: IInvokeDeps = {
       makeProvider: () => jsonProvider({}),
-      runBinary: async () => ({ ok: true, stdout: fenced, timedOut: false }),
+      runBinary: async () => ({
+        ok: true,
+        stdout: fenced,
+        timedOut: false,
+        truncated: false,
+      }),
     };
     const out = await reviewerInvoke(
       panelWith({
@@ -142,7 +162,12 @@ describe("reviewerInvoke", () => {
   test("a binary that exits non-zero → errored", async () => {
     const deps: IInvokeDeps = {
       makeProvider: () => jsonProvider({}),
-      runBinary: async () => ({ ok: false, stdout: "", timedOut: false }),
+      runBinary: async () => ({
+        ok: false,
+        stdout: "",
+        timedOut: false,
+        truncated: false,
+      }),
     };
     const out = await reviewerInvoke(
       panelWith({
@@ -174,6 +199,7 @@ describe("reviewerInvoke", () => {
           ok: true,
           stdout: '{"verdict":"approve","summary":"","findings":[]}',
           timedOut: false,
+          truncated: false,
         };
       },
     };

--- a/packages/core/tests/reviewers-invoke.test.ts
+++ b/packages/core/tests/reviewers-invoke.test.ts
@@ -126,7 +126,9 @@ describe("reviewerInvoke", () => {
       deps
     );
 
-    expect(out[0]).toEqual({
+    // toMatchObject, not toEqual: every outcome also carries `ms` (how long the
+    // reviewer took), which is a live clock and not what this test is about.
+    expect(out[0]).toMatchObject({
       status: "ok",
       review: {
         reviewerId: "grok",


### PR DESCRIPTION
## What

A short panel tells you one thing:

```
reviewers ok: 2  errored: 2
```

Not *which* reviewer, not why, not how long it burned. And the binary path reported `"binary exited non-zero or timed out"` — one string for two opposite problems:

- **timeout** → the budget is too small for the work. Raise it, or drop the reviewer.
- **non-zero exit** → the binary is broken. The budget is irrelevant.

## Why it matters

Not a rare path. Of 45 cached panels, **20 ran short at least one reviewer**:

| reviewer | dropped out |
|---|---|
| glm | 9/45 |
| codex | 8/45 |
| grok | 5/45 |
| deepseek-pro | 1/45 |

This bit today: a panel came back `ok: 2, errored: 2` and reported a clean PASS on bare quorum; a full 4-reviewer panel on identical code then found a critical bug. Working out whether a reviewer was slow or broken took an afternoon of timing binaries by hand — it should take reading one line.

## Change

- `timedOut` recorded **at the kill site** — a process we killed exits non-zero exactly like one that crashed, so the exit code can't separate them afterwards. Only the killer knows.
- `cause` (`timeout` / `exit` / `unparseable` / `threw`) and `ms` on every failed reviewer.
- `ms` on successful outcomes too — that's how you learn a reviewer takes 61s *before* it starts timing out.
- Printed with the verdict: `! codex did not review (timeout) after 300.5s: ...`
- Carried on the cached artifact; a malformed entry is dropped rather than failing the parse, since losing a diagnostic line shouldn't invalidate a good verdict and force a panel re-run.

The cause union is derived **from** the array it's checked against so they can't drift, and narrowing is a type guard, not an `as` cast — the value comes off disk, so an unknown string must be dropped rather than asserted.

## Tests

Verified against real subprocesses, not mocks:

| case | result |
|---|---|
| `sleep 30`, 800ms budget | `ok: false, timedOut: true` |
| `exit 3` | `ok: false, timedOut: false` |
| `echo hi` | `ok: true, timedOut: false` |

Plus: causes stay distinct, a clean panel carries no `failures` field, the printed verdict names the reviewer, failures survive the cache round-trip, malformed entries drop without failing the parse, and an unknown cause string is dropped rather than trusted.

`bun run validate` green: 4,352 tests across 301 files.