### PR TITLE
fix: the graded score never reached the acceptance rule

### DIFF
--- a/packages/core/scripts/self-harness.ts
+++ b/packages/core/scripts/self-harness.ts
@@ -24,11 +24,11 @@ import {
   resolveSplits,
   runSelfHarness,
   emptyOverlay,
+  mergeOutcomes,
   parseOverlay,
   type HarnessEvaluator,
   type IEvaluateOutcome,
   type IHarnessOverlay,
-  type ISplitScore,
   type ISplits,
 } from "../src/self-harness";
 import type { IProvider } from "../src/inference";
@@ -172,44 +172,6 @@ let evaluations = 0;
 /** Per-task attempts before an errored task is given up (its errored count
  *  then propagates so upstream logic reacts honestly). */
 const TASK_ATTEMPTS = 3;
-
-function meanOfSignaled(values: readonly number[]): number {
-  const signaled = values.filter((v) => v > 0);
-
-  return signaled.length === 0
-    ? 0
-    : signaled.reduce((a, b) => a + b, 0) / signaled.length;
-}
-
-/** Merge single-task outcomes into one split outcome. Counts sum; the
- *  quality/concision means recompute over tasks that carry a signal —
- *  identical semantics to evaluateHarness's own aggregation. */
-function mergeOutcomes(
-  outcomes: readonly IEvaluateOutcome[]
-): IEvaluateOutcome {
-  const records = outcomes.flatMap((o) => [...o.records]);
-  const runs = outcomes.flatMap((o) => [...o.runs]);
-  const perTask: ISplitScore["perTask"] = {};
-
-  for (const outcome of outcomes) {
-    for (const [task, summary] of Object.entries(outcome.score.perTask)) {
-      perTask[task] = summary;
-    }
-  }
-
-  return {
-    records,
-    runs,
-    score: {
-      passed: outcomes.reduce((a, o) => a + o.score.passed, 0),
-      runs: outcomes.reduce((a, o) => a + o.score.runs, 0),
-      errored: outcomes.reduce((a, o) => a + o.score.errored, 0),
-      avgQuality: meanOfSignaled(outcomes.map((o) => o.score.avgQuality)),
-      avgLoc: meanOfSignaled(outcomes.map((o) => o.score.avgLoc)),
-      perTask,
-    },
-  };
-}
 
 /** Evaluate one split TASK BY TASK: an errored task (endpoint outage) waits
  *  out the weather and retries, so one flap costs one task's re-run — not the

--- a/packages/core/src/self-harness/evaluate.ts
+++ b/packages/core/src/self-harness/evaluate.ts
@@ -548,7 +548,6 @@ async function withOverlayEnv<T>(
   }
 }
 
-/** Mean over per-task values that carry a real signal (>0), or 0 when none. */
 /**
  * Build a split score from the runs it is a score OF — the ONE place this type
  * is assembled.
@@ -593,6 +592,9 @@ export function splitScore(
   };
 }
 
+/** Mean over per-task values that carry a real signal (>0), or 0 when none —
+ *  quality needs a judge call and loc needs a shipped solution, so a 0 means
+ *  "not measured on this task" rather than "measured as nothing". */
 export function meanOfSignaled(values: readonly number[]): number {
   const signaled = values.filter((v) => v > 0);
 

--- a/packages/core/src/self-harness/evaluate.ts
+++ b/packages/core/src/self-harness/evaluate.ts
@@ -595,7 +595,7 @@ export function splitScore(
 /** Mean over per-task values that carry a real signal (>0), or 0 when none —
  *  quality needs a judge call and loc needs a shipped solution, so a 0 means
  *  "not measured on this task" rather than "measured as nothing". */
-export function meanOfSignaled(values: readonly number[]): number {
+function meanOfSignaled(values: readonly number[]): number {
   const signaled = values.filter((v) => v > 0);
 
   return signaled.length === 0

--- a/packages/core/src/self-harness/evaluate.ts
+++ b/packages/core/src/self-harness/evaluate.ts
@@ -549,7 +549,7 @@ async function withOverlayEnv<T>(
 }
 
 /** Mean over per-task values that carry a real signal (>0), or 0 when none. */
-function meanOfSignaled(values: readonly number[]): number {
+export function meanOfSignaled(values: readonly number[]): number {
   const signaled = values.filter((v) => v > 0);
 
   return signaled.length === 0

--- a/packages/core/src/self-harness/evaluate.ts
+++ b/packages/core/src/self-harness/evaluate.ts
@@ -549,6 +549,50 @@ async function withOverlayEnv<T>(
 }
 
 /** Mean over per-task values that carry a real signal (>0), or 0 when none. */
+/**
+ * Build a split score from the runs it is a score OF — the ONE place this type
+ * is assembled.
+ *
+ * It used to be built twice: here from records, and again in the merge from
+ * per-outcome scores. Two constructions of one type is how a field goes missing,
+ * and one did — `avgProgress` was added here and forgotten there, so the graded
+ * dimension never reached the acceptance rule for a week while every test passed.
+ * Deriving from records in both places closes that, rather than patching the
+ * field that happened to be dropped.
+ *
+ * It also makes duplicate task entries merge instead of overwrite: `summarize`
+ * groups by label, so two outcomes for one task combine into a single summary
+ * with the right run count, where the old merge kept whichever came last beside
+ * a total that counted both.
+ */
+export function splitScore(
+  records: readonly IRunRecord[],
+  errored: number
+): ISplitScore {
+  const summaries = summarize([...records]);
+  const perTask: Record<string, (typeof summaries)[number]> = {};
+
+  for (const summary of summaries) {
+    perTask[summary.label] = summary;
+  }
+
+  return {
+    passed: records.filter((r) => r.passed).length,
+    runs: records.length,
+    errored,
+    avgQuality: meanOfSignaled(summaries.map((s) => s.avgQuality)),
+    avgLoc: meanOfSignaled(summaries.map((s) => s.avgLoc)),
+    // Mean over RUNS, not over tasks: a task measured twice should weigh twice.
+    // A record with NO score is an errored one — it never reached scoring — and
+    // meanProgress skips it, so an outage cannot enter the graded figure as
+    // measured zero progress. Completed runs always carry a number (0 when they
+    // produced no gate readings), so nothing that did run can drop out of the
+    // denominator.
+    avgProgress: meanProgress(records.map((r) => r.progress)),
+    perTask,
+  };
+}
+
 export function meanOfSignaled(values: readonly number[]): number {
   const signaled = values.filter((v) => v > 0);
 
@@ -634,28 +678,7 @@ export async function evaluateHarness(
 
     const { records, runs, erroredCount: errored } = sink;
 
-    const summaries = summarize(records);
-    const perTask: Record<string, (typeof summaries)[number]> = {};
-
-    for (const summary of summaries) {
-      perTask[summary.label] = summary;
-    }
-
-    const score: ISplitScore = {
-      passed: records.filter((r) => r.passed).length,
-      runs: records.length,
-      errored,
-      avgQuality: meanOfSignaled(summaries.map((s) => s.avgQuality)),
-      avgLoc: meanOfSignaled(summaries.map((s) => s.avgLoc)),
-      // Mean over RUNS, not over tasks: a task measured twice should weigh
-      // twice. A record with NO score is an errored one — it never reached
-      // scoring — and meanProgress skips it, so an outage cannot enter the
-      // graded figure as measured zero progress. Completed runs always carry a
-      // number (0 when they produced no gate readings), so nothing that did run
-      // can drop out of the denominator.
-      avgProgress: meanProgress(records.map((r) => r.progress)),
-      perTask,
-    };
+    const score = splitScore(records, errored);
 
     return { score, runs, records };
   });

--- a/packages/core/src/self-harness/index.ts
+++ b/packages/core/src/self-harness/index.ts
@@ -18,7 +18,6 @@ export {
 export { mineWeaknesses, dominantSignal, type IMinedRun } from "./mine";
 export {
   evaluateHarness,
-  splitScore,
   allMustRun,
   solutionFiles,
   guardQuality,

--- a/packages/core/src/self-harness/index.ts
+++ b/packages/core/src/self-harness/index.ts
@@ -18,6 +18,7 @@ export {
 export { mineWeaknesses, dominantSignal, type IMinedRun } from "./mine";
 export {
   evaluateHarness,
+  splitScore,
   allMustRun,
   solutionFiles,
   guardQuality,

--- a/packages/core/src/self-harness/index.ts
+++ b/packages/core/src/self-harness/index.ts
@@ -53,3 +53,4 @@ export {
   type IBuildEvidenceOptions,
 } from "./build-evidence";
 export { runProgress, meanProgress } from "./progress";
+export { mergeOutcomes } from "./merge";

--- a/packages/core/src/self-harness/merge.ts
+++ b/packages/core/src/self-harness/merge.ts
@@ -12,9 +12,26 @@ function meanOfSignaled(values: readonly number[]): number {
     : signaled.reduce((a, b) => a + b, 0) / signaled.length;
 }
 
-/** Merge single-task outcomes into one split outcome. Counts sum; the
- *  quality/concision means recompute over tasks that carry a signal —
- *  identical semantics to evaluateHarness's own aggregation. */
+/**
+ * Merge single-task outcomes into one split outcome. Counts sum.
+ *
+ * The three means are NOT weighted alike, and the difference is deliberate:
+ *
+ *  - `avgProgress` is a mean over RUNS. Every completed run has one, so a task
+ *    measured twice weighs twice — which is what the acceptance rule compares.
+ *  - `avgQuality` and `avgLoc` are means over TASKS that carry a signal. Both
+ *    are measured only on green runs (quality needs a judge call, loc needs a
+ *    shipped solution), so most runs have nothing to contribute and a
+ *    run-weighted mean would be dominated by which tasks happened to pass.
+ *
+ * Matching evaluateHarness's own aggregation, which splits the same way for the
+ * same reason.
+ *
+ * PRECONDITION: one outcome per task. `perTask` is last-write-wins on a key
+ * collision while the counts sum, so passing two outcomes for the same task
+ * gives a coherent count beside a per-task entry from only one of them. The
+ * caller evaluates task by task, which is where that guarantee comes from.
+ */
 export function mergeOutcomes(
   outcomes: readonly IEvaluateOutcome[]
 ): IEvaluateOutcome {

--- a/packages/core/src/self-harness/merge.ts
+++ b/packages/core/src/self-harness/merge.ts
@@ -1,0 +1,54 @@
+import { meanProgress } from "./progress";
+import type { IEvaluateOutcome } from "./evaluate";
+import type { ISplitScore } from "./self-harness.types";
+
+/** Mean over values that carry a signal (> 0); 0 when none do — the same
+ *  convention evaluateHarness uses for quality and concision. */
+function meanOfSignaled(values: readonly number[]): number {
+  const signaled = values.filter((v) => v > 0);
+
+  return signaled.length === 0
+    ? 0
+    : signaled.reduce((a, b) => a + b, 0) / signaled.length;
+}
+
+/** Merge single-task outcomes into one split outcome. Counts sum; the
+ *  quality/concision means recompute over tasks that carry a signal —
+ *  identical semantics to evaluateHarness's own aggregation. */
+export function mergeOutcomes(
+  outcomes: readonly IEvaluateOutcome[]
+): IEvaluateOutcome {
+  const records = outcomes.flatMap((o) => [...o.records]);
+  const runs = outcomes.flatMap((o) => [...o.runs]);
+  const perTask: ISplitScore["perTask"] = {};
+
+  for (const outcome of outcomes) {
+    for (const [task, summary] of Object.entries(outcome.score.perTask)) {
+      perTask[task] = summary;
+    }
+  }
+
+  return {
+    records,
+    runs,
+    score: {
+      passed: outcomes.reduce((a, o) => a + o.score.passed, 0),
+      runs: outcomes.reduce((a, o) => a + o.score.runs, 0),
+      errored: outcomes.reduce((a, o) => a + o.score.errored, 0),
+      avgQuality: meanOfSignaled(outcomes.map((o) => o.score.avgQuality)),
+      avgLoc: meanOfSignaled(outcomes.map((o) => o.score.avgLoc)),
+      // Recomputed over RUNS, not averaged over outcomes: each outcome here is
+      // one task, and a task measured twice must weigh twice — averaging the
+      // per-task means would give a 1-run task the same weight as a 4-run one.
+      //
+      // Omitting this field is what made the graded score inert. Every real
+      // session merges through here (the task-by-task path exists so one
+      // endpoint flap costs one task, not the whole split), so `avgProgress`
+      // was computed per task and then dropped before the acceptance rule saw
+      // it — arriving undefined, failing closed, and rejecting every
+      // equal-pass candidate with "progress was not measured".
+      avgProgress: meanProgress(records.map((r) => r.progress)),
+      perTask,
+    },
+  };
+}

--- a/packages/core/src/self-harness/merge.ts
+++ b/packages/core/src/self-harness/merge.ts
@@ -24,8 +24,10 @@ function meanOfSignaled(values: readonly number[]): number {
  *    shipped solution), so most runs have nothing to contribute and a
  *    run-weighted mean would be dominated by which tasks happened to pass.
  *
- * Matching evaluateHarness's own aggregation, which splits the same way for the
- * same reason.
+ * evaluateHarness splits the same way for the same reason. That is intent, not a
+ * verified invariant — nothing here checks the two stay in step, and the last
+ * comment claiming they were identical went stale without anyone noticing,
+ * which is how this function came to drop a field for a week.
  *
  * PRECONDITION: one outcome per task. `perTask` is last-write-wins on a key
  * collision while the counts sum, so passing two outcomes for the same task

--- a/packages/core/src/self-harness/merge.ts
+++ b/packages/core/src/self-harness/merge.ts
@@ -1,68 +1,32 @@
-import { meanProgress } from "./progress";
-// The SAME helper evaluateHarness uses, not a copy of it. A second
-// implementation of a convention is how the two drift apart, and this docblock
-// already admits nothing keeps them in step — duplicating it would rebuild the
-// exact hazard that let a field go missing for a week.
-import { meanOfSignaled } from "./evaluate";
+import { splitScore } from "./evaluate";
 import type { IEvaluateOutcome } from "./evaluate";
-import type { ISplitScore } from "./self-harness.types";
 
 /**
- * Merge single-task outcomes into one split outcome. Counts sum.
+ * Merge single-task outcomes into one split outcome.
  *
- * The three means are NOT weighted alike, and the difference is deliberate:
+ * Derived from the RECORDS, through the same `splitScore` the evaluator uses —
+ * not rebuilt from the per-outcome scores. That rebuild is the whole reason this
+ * PR exists: it listed the fields by hand, `avgProgress` was added to the
+ * evaluator and forgotten here, and the graded dimension never reached the
+ * acceptance rule for a week while every test passed. Two ways to construct one
+ * type is the defect; patching the field that happened to be dropped would have
+ * left the next one waiting.
  *
- *  - `avgProgress` is a mean over RUNS. Every completed run has one, so a task
- *    measured twice weighs twice — which is what the acceptance rule compares.
- *  - `avgQuality` and `avgLoc` are means over TASKS that carry a signal. Both
- *    are measured only on green runs (quality needs a judge call, loc needs a
- *    shipped solution), so most runs have nothing to contribute and a
- *    run-weighted mean would be dominated by which tasks happened to pass.
+ * Only `errored` still sums across outcomes, because an errored run produces no
+ * record to count — that is what "errored" means.
  *
- * evaluateHarness splits the same way for the same reason. That is intent, not a
- * verified invariant — nothing here checks the two stay in step, and the last
- * comment claiming they were identical went stale without anyone noticing,
- * which is how this function came to drop a field for a week.
- *
- * PRECONDITION: one outcome per task. `perTask` is last-write-wins on a key
- * collision while the counts sum, so passing two outcomes for the same task
- * gives a coherent count beside a per-task entry from only one of them. The
- * caller evaluates task by task, which is where that guarantee comes from.
+ * Duplicate task entries now MERGE rather than overwrite: `summarize` groups by
+ * label, so two outcomes for one task become a single summary with the right run
+ * count. The old merge kept whichever came last beside a total that counted
+ * both, which made `perTask.avgCycles` — read by the acceptance rule's blowup
+ * guard — describe a fraction of the runs it was compared against.
  */
 export function mergeOutcomes(
   outcomes: readonly IEvaluateOutcome[]
 ): IEvaluateOutcome {
   const records = outcomes.flatMap((o) => [...o.records]);
   const runs = outcomes.flatMap((o) => [...o.runs]);
-  const perTask: ISplitScore["perTask"] = {};
+  const errored = outcomes.reduce((a, o) => a + o.score.errored, 0);
 
-  for (const outcome of outcomes) {
-    for (const [task, summary] of Object.entries(outcome.score.perTask)) {
-      perTask[task] = summary;
-    }
-  }
-
-  return {
-    records,
-    runs,
-    score: {
-      passed: outcomes.reduce((a, o) => a + o.score.passed, 0),
-      runs: outcomes.reduce((a, o) => a + o.score.runs, 0),
-      errored: outcomes.reduce((a, o) => a + o.score.errored, 0),
-      avgQuality: meanOfSignaled(outcomes.map((o) => o.score.avgQuality)),
-      avgLoc: meanOfSignaled(outcomes.map((o) => o.score.avgLoc)),
-      // Recomputed over RUNS, not averaged over outcomes: each outcome here is
-      // one task, and a task measured twice must weigh twice — averaging the
-      // per-task means would give a 1-run task the same weight as a 4-run one.
-      //
-      // Omitting this field is what made the graded score inert. Every real
-      // session merges through here (the task-by-task path exists so one
-      // endpoint flap costs one task, not the whole split), so `avgProgress`
-      // was computed per task and then dropped before the acceptance rule saw
-      // it — arriving undefined, failing closed, and rejecting every
-      // equal-pass candidate with "progress was not measured".
-      avgProgress: meanProgress(records.map((r) => r.progress)),
-      perTask,
-    },
-  };
+  return { records, runs, score: splitScore(records, errored) };
 }

--- a/packages/core/src/self-harness/merge.ts
+++ b/packages/core/src/self-harness/merge.ts
@@ -12,8 +12,12 @@ import type { IEvaluateOutcome } from "./evaluate";
  * type is the defect; patching the field that happened to be dropped would have
  * left the next one waiting.
  *
- * Only `errored` still sums across outcomes, because an errored run produces no
- * record to count — that is what "errored" means.
+ * Only `errored` still sums across outcomes, and NOT for the reason I first
+ * wrote here. An errored run does produce a record — `runOneSpec` pushes a
+ * placeholder on its catch path, so it is counted in `runs` like any other. What
+ * that record lacks is any field saying it errored: it looks exactly like a run
+ * that failed honestly. So the count cannot be recovered from the records and
+ * has to be carried alongside them.
  *
  * Duplicate task entries now MERGE rather than overwrite: `summarize` groups by
  * label, so two outcomes for one task become a single summary with the right run

--- a/packages/core/src/self-harness/merge.ts
+++ b/packages/core/src/self-harness/merge.ts
@@ -1,16 +1,11 @@
 import { meanProgress } from "./progress";
+// The SAME helper evaluateHarness uses, not a copy of it. A second
+// implementation of a convention is how the two drift apart, and this docblock
+// already admits nothing keeps them in step — duplicating it would rebuild the
+// exact hazard that let a field go missing for a week.
+import { meanOfSignaled } from "./evaluate";
 import type { IEvaluateOutcome } from "./evaluate";
 import type { ISplitScore } from "./self-harness.types";
-
-/** Mean over values that carry a signal (> 0); 0 when none do — the same
- *  convention evaluateHarness uses for quality and concision. */
-function meanOfSignaled(values: readonly number[]): number {
-  const signaled = values.filter((v) => v > 0);
-
-  return signaled.length === 0
-    ? 0
-    : signaled.reduce((a, b) => a + b, 0) / signaled.length;
-}
 
 /**
  * Merge single-task outcomes into one split outcome. Counts sum.

--- a/packages/core/tests/self-harness-merge.test.ts
+++ b/packages/core/tests/self-harness-merge.test.ts
@@ -144,16 +144,12 @@ describe("the merge cannot silently drop a field", () => {
     // its own assertion.
     const carried = new Map(Object.entries(merged.score));
 
-    // Named, not a silent `typeof !== "object"` skip. Today that only means
-    // perTask, but any future nested field would drop out of coverage with no
-    // signal while the docblock above still advertised the pair as structural.
-    const NESTED = new Set(["perTask"]);
-
+    // No skip list. The previous `typeof !== "object"` guard, and the named set
+    // that replaced it, were both inert: `perTask` is `{}`, which is defined, so
+    // removing either changed nothing about pass or fail. Ceremony that looks
+    // like coverage is worse than none — every key is asserted, and `perTask`
+    // gets a real test of its own below.
     for (const [key, value] of Object.entries(input.score)) {
-      if (NESTED.has(key)) {
-        continue;
-      }
-
       if (value !== undefined) {
         expect(carried.get(key)).toBeDefined();
       }
@@ -211,5 +207,65 @@ describe("meanOfSignaled — the quality and concision means", () => {
 
     expect(merged.score.avgQuality).toBe(0);
     expect(merged.score.avgLoc).toBe(0);
+  });
+});
+
+describe("the collections merge, not just the counts", () => {
+  /**
+   * Untouched by every other test here, because every fixture left `runs` and
+   * `perTask` empty and the structural check only compares keys of `score` —
+   * `records` and `runs` live one level up on IEvaluateOutcome. Replacing either
+   * flatMap with `[]` passed the whole suite.
+   */
+  const withRuns = (
+    task: string,
+    passed: boolean,
+    avgCycles: number
+  ): IEvaluateOutcome => ({
+    records: [run(task, passed, 0.5)],
+    runs: [{ taskId: task, passed, events: [] }],
+    score: {
+      passed: passed ? 1 : 0,
+      runs: 1,
+      errored: 0,
+      avgQuality: 0,
+      avgLoc: 0,
+      perTask: {
+        [task]: {
+          label: task,
+          runs: 1,
+          passed: passed ? 1 : 0,
+          passRate: passed ? 1 : 0,
+          avgCycles,
+          avgTurnsToGreen: null,
+          avgMs: 0,
+          avgQuality: 0,
+          avgLoc: 0,
+          failureClasses: {},
+        },
+      },
+    },
+  });
+
+  test("records and runs are concatenated, not dropped", () => {
+    const merged = mergeOutcomes([
+      withRuns("a", true, 3),
+      withRuns("b", false, 9),
+    ]);
+
+    expect(merged.records).toHaveLength(2);
+    expect(merged.runs.map((r) => r.taskId)).toEqual(["a", "b"]);
+  });
+
+  test("perTask carries every task's summary through", () => {
+    // The acceptance rule's cycle guard reads perTask; an entry lost here is a
+    // task the blowup check silently stops seeing.
+    const merged = mergeOutcomes([
+      withRuns("a", true, 3),
+      withRuns("b", false, 9),
+    ]);
+
+    expect(Object.keys(merged.score.perTask).sort()).toEqual(["a", "b"]);
+    expect(merged.score.perTask.b?.avgCycles).toBe(9);
   });
 });

--- a/packages/core/tests/self-harness-merge.test.ts
+++ b/packages/core/tests/self-harness-merge.test.ts
@@ -172,38 +172,43 @@ describe("an empty merge", () => {
   });
 });
 
-describe("meanOfSignaled — the quality and concision means", () => {
+describe("quality and concision come from the RUNS now", () => {
   /**
-   * This helper came across from an untested script along with the merge, and
-   * nothing asserted what it computes: every fixture set both to 0 and the only
-   * assertion that touched them was `toBeDefined()`, which any number passes.
-   * The convention it encodes is not obvious and is easy to "simplify" away.
+   * These used to be averaged from the per-outcome scores. They are derived from
+   * records through `splitScore`, like everything else — so a test that sets
+   * `score.avgQuality` and no records asserts a substrate the merge no longer
+   * reads, which is exactly what this one did before.
+   *
+   * The convention itself is unchanged and worth pinning: a run with no judged
+   * quality carries none (the judge only scores green runs), and those runs are
+   * skipped rather than counted as zero.
    */
-  const scored = (avgQuality: number, avgLoc: number): IEvaluateOutcome => ({
-    records: [],
-    runs: [],
-    score: {
-      passed: 0,
-      runs: 0,
-      errored: 0,
-      avgQuality,
-      avgLoc,
-      perTask: {},
-    },
+  const judged = (task: string, quality: number, loc: number): IRunRecord => ({
+    label: task,
+    passed: true,
+    cycles: 1,
+    ms: 0,
+    quality,
+    loc,
+    progress: 1,
   });
 
-  test("averages only the outcomes that carry a signal", () => {
-    // 0 means "not measured here" — quality needs a judge call and loc needs a
-    // shipped solution, so most tasks have neither. Counting the zeros would
-    // drag the mean toward however many tasks failed.
-    const merged = mergeOutcomes([scored(4, 100), scored(0, 0), scored(2, 50)]);
+  test("only runs that carry a signal are averaged", () => {
+    const merged = mergeOutcomes([
+      outcome([judged("a", 4, 100)]),
+      outcome([run("b", true, 1)]),
+      outcome([judged("c", 2, 50)]),
+    ]);
 
     expect(merged.score.avgQuality).toBeCloseTo(3, 5);
     expect(merged.score.avgLoc).toBeCloseTo(75, 5);
   });
 
   test("no signal at all stays 0, not NaN", () => {
-    const merged = mergeOutcomes([scored(0, 0), scored(0, 0)]);
+    const merged = mergeOutcomes([
+      outcome([run("a", true, 1)]),
+      outcome([run("b", true, 1)]),
+    ]);
 
     expect(merged.score.avgQuality).toBe(0);
     expect(merged.score.avgLoc).toBe(0);
@@ -212,17 +217,17 @@ describe("meanOfSignaled — the quality and concision means", () => {
 
 describe("the collections merge, not just the counts", () => {
   /**
-   * Untouched by every other test here, because every fixture left `runs` and
-   * `perTask` empty and the structural check only compares keys of `score` —
-   * `records` and `runs` live one level up on IEvaluateOutcome. Replacing either
-   * flatMap with `[]` passed the whole suite.
+   * Untouched by every other test here, because every fixture left `runs` empty
+   * and the structural check only compares keys of `score` — `records` and
+   * `runs` live one level up on IEvaluateOutcome. Replacing either flatMap with
+   * `[]` passed the whole suite.
    */
   const withRuns = (
     task: string,
     passed: boolean,
-    avgCycles: number
+    cycles: number
   ): IEvaluateOutcome => ({
-    records: [run(task, passed, 0.5)],
+    records: [{ label: task, passed, cycles, ms: 0, progress: passed ? 1 : 0 }],
     runs: [{ taskId: task, passed, events: [] }],
     score: {
       passed: passed ? 1 : 0,
@@ -230,20 +235,7 @@ describe("the collections merge, not just the counts", () => {
       errored: 0,
       avgQuality: 0,
       avgLoc: 0,
-      perTask: {
-        [task]: {
-          label: task,
-          runs: 1,
-          passed: passed ? 1 : 0,
-          passRate: passed ? 1 : 0,
-          avgCycles,
-          avgTurnsToGreen: null,
-          avgMs: 0,
-          avgQuality: 0,
-          avgLoc: 0,
-          failureClasses: {},
-        },
-      },
+      perTask: {},
     },
   });
 
@@ -257,9 +249,9 @@ describe("the collections merge, not just the counts", () => {
     expect(merged.runs.map((r) => r.taskId)).toEqual(["a", "b"]);
   });
 
-  test("perTask carries every task's summary through", () => {
-    // The acceptance rule's cycle guard reads perTask; an entry lost here is a
-    // task the blowup check silently stops seeing.
+  test("perTask carries every task through, derived from its runs", () => {
+    // The acceptance rule's cycle guard reads perTask; a task missing here is
+    // one the blowup check silently stops seeing.
     const merged = mergeOutcomes([
       withRuns("a", true, 3),
       withRuns("b", false, 9),
@@ -267,5 +259,43 @@ describe("the collections merge, not just the counts", () => {
 
     expect(Object.keys(merged.score.perTask).sort()).toEqual(["a", "b"]);
     expect(merged.score.perTask.b?.avgCycles).toBe(9);
+  });
+
+  test("two outcomes for ONE task merge instead of overwriting", () => {
+    // The old merge kept whichever entry came last beside a total counting
+    // both, so perTask described a fraction of the runs it was compared
+    // against — and perTask.avgCycles is what the blowup guard reads. Deriving
+    // from records makes summarize group them.
+    const merged = mergeOutcomes([
+      withRuns("a", true, 2),
+      withRuns("a", true, 8),
+    ]);
+
+    expect(merged.score.runs).toBe(2);
+    expect(merged.score.perTask.a?.runs).toBe(2);
+    expect(merged.score.perTask.a?.avgCycles).toBe(5);
+  });
+});
+
+describe("errored is the one count that cannot come from records", () => {
+  test("it sums across outcomes", () => {
+    // An errored run produces no record to count — that is what errored means —
+    // so this is the only field the merge still adds up itself, and the only one
+    // a records-derived score cannot check. Every fixture hardcoded 0, so
+    // replacing the reduce with a literal 0 survived the whole suite.
+    const withErrors = (n: number): IEvaluateOutcome => ({
+      records: [run("t", false, 0.5)],
+      runs: [],
+      score: {
+        passed: 0,
+        runs: 1,
+        errored: n,
+        avgQuality: 0,
+        avgLoc: 0,
+        perTask: {},
+      },
+    });
+
+    expect(mergeOutcomes([withErrors(2), withErrors(3)]).score.errored).toBe(5);
   });
 });

--- a/packages/core/tests/self-harness-merge.test.ts
+++ b/packages/core/tests/self-harness-merge.test.ts
@@ -172,16 +172,19 @@ describe("an empty merge", () => {
   });
 });
 
-describe("quality and concision come from the RUNS now", () => {
+describe("quality and concision are averaged over TASKS, not runs", () => {
   /**
-   * These used to be averaged from the per-outcome scores. They are derived from
-   * records through `splitScore`, like everything else — so a test that sets
-   * `score.avgQuality` and no records asserts a substrate the merge no longer
-   * reads, which is exactly what this one did before.
+   * The SUBSTRATE changed with this PR — they are derived from records through
+   * `splitScore` now rather than averaged from per-outcome scores — but the
+   * weighting did not, and an earlier name for this block ("come from the RUNS
+   * now") got that wrong. `splitScore` computes both as a mean over TASK
+   * summaries, deliberately unlike `avgProgress`, which is a mean over runs.
    *
-   * The convention itself is unchanged and worth pinning: a run with no judged
-   * quality carries none (the judge only scores green runs), and those runs are
-   * skipped rather than counted as zero.
+   * The reason is three lines from each other in that function: every completed
+   * run has a progress score, so a task measured twice should weigh twice; but
+   * quality needs a judge call and loc needs a shipped solution, so most runs
+   * have neither and a run-weighted mean would be decided by which tasks
+   * happened to pass.
    */
   const judged = (task: string, quality: number, loc: number): IRunRecord => ({
     label: task,
@@ -279,23 +282,37 @@ describe("the collections merge, not just the counts", () => {
 
 describe("errored is the one count that cannot come from records", () => {
   test("it sums across outcomes", () => {
-    // An errored run produces no record to count — that is what errored means —
-    // so this is the only field the merge still adds up itself, and the only one
-    // a records-derived score cannot check. Every fixture hardcoded 0, so
-    // replacing the reduce with a literal 0 survived the whole suite.
+    // Not because an errored run leaves no record — it leaves one, a
+    // placeholder pushed on the catch path, counted in `runs` like any other.
+    // What that record lacks is a field marking it errored: it is
+    // indistinguishable from a run that failed honestly. So the count travels
+    // beside the records rather than being derived from them.
+    //
+    // The fixture is shaped like a real outcome for that reason: errored: 2
+    // means two placeholder records, not one.
     const withErrors = (n: number): IEvaluateOutcome => ({
-      records: [run("t", false, 0.5)],
+      records: Array.from({ length: n }, () => ({
+        label: "t",
+        passed: false,
+        cycles: 0,
+        ms: 0,
+      })),
       runs: [],
       score: {
         passed: 0,
-        runs: 1,
+        runs: n,
         errored: n,
         avgQuality: 0,
         avgLoc: 0,
         perTask: {},
       },
     });
+    const merged = mergeOutcomes([withErrors(2), withErrors(3)]);
 
-    expect(mergeOutcomes([withErrors(2), withErrors(3)]).score.errored).toBe(5);
+    expect(merged.score.errored).toBe(5);
+    // And they still count as runs, which is what makes the field necessary.
+    expect(merged.score.runs).toBe(5);
+    // No progress on any of them, so the split stays unmeasured rather than 0.
+    expect(merged.score.avgProgress).toBeUndefined();
   });
 });

--- a/packages/core/tests/self-harness-merge.test.ts
+++ b/packages/core/tests/self-harness-merge.test.ts
@@ -95,3 +95,48 @@ describe("mergeOutcomes carries the graded score across the join", () => {
     expect(merged.score.runs).toBe(3);
   });
 });
+
+describe("the merge cannot silently drop a field", () => {
+  /**
+   * The structural version of this test, and the one that would have caught the
+   * original bug. Asserting `avgProgress` survives only covers the field I
+   * already know about — a hand-written fixture listing every key cannot notice
+   * the merge omitting a key, which is exactly how `avgProgress` was lost for a
+   * week. This compares the merged score's shape against the input's, so the
+   * NEXT field added to ISplitScore is covered without anyone remembering to
+   * add a case.
+   */
+  test("every key of the input score appears on the merged score", () => {
+    const input = outcome([run("a", true, 1)]);
+    const merged = mergeOutcomes([input]);
+
+    expect(Object.keys(merged.score).sort()).toEqual(
+      Object.keys(input.score).sort()
+    );
+  });
+
+  test("and none of them is undefined when the input had a value", () => {
+    // Shape alone is not enough: a merge could carry the key and drop the
+    // value, which is what `avgProgress: undefined` would have looked like.
+    const input: IEvaluateOutcome = {
+      records: [run("a", false, 0.5)],
+      runs: [],
+      score: {
+        passed: 0,
+        runs: 1,
+        errored: 0,
+        avgQuality: 4,
+        avgLoc: 12,
+        avgProgress: 0.5,
+        perTask: {},
+      },
+    };
+    const merged = mergeOutcomes([input]);
+
+    for (const [key, value] of Object.entries(input.score)) {
+      if (value !== undefined && typeof value !== "object") {
+        expect(merged.score[key as keyof typeof merged.score]).toBeDefined();
+      }
+    }
+  });
+});

--- a/packages/core/tests/self-harness-merge.test.ts
+++ b/packages/core/tests/self-harness-merge.test.ts
@@ -144,10 +144,72 @@ describe("the merge cannot silently drop a field", () => {
     // its own assertion.
     const carried = new Map(Object.entries(merged.score));
 
+    // Named, not a silent `typeof !== "object"` skip. Today that only means
+    // perTask, but any future nested field would drop out of coverage with no
+    // signal while the docblock above still advertised the pair as structural.
+    const NESTED = new Set(["perTask"]);
+
     for (const [key, value] of Object.entries(input.score)) {
-      if (value !== undefined && typeof value !== "object") {
+      if (NESTED.has(key)) {
+        continue;
+      }
+
+      if (value !== undefined) {
         expect(carried.get(key)).toBeDefined();
       }
     }
+  });
+});
+
+describe("an empty merge", () => {
+  test("yields nothing measured, not a zero", () => {
+    // Reachable: evaluateSplitResilient pushes no outcome when the task list is
+    // empty, or when every attempt for every task throws. A zero here would be
+    // a measured claim about a split that never ran, and the acceptance rule
+    // reads `undefined` as fail-closed precisely so that cannot happen.
+    const merged = mergeOutcomes([]);
+
+    expect(merged.score.avgProgress).toBeUndefined();
+    expect(merged.score.runs).toBe(0);
+    expect(merged.score.passed).toBe(0);
+    expect(merged.score.errored).toBe(0);
+  });
+});
+
+describe("meanOfSignaled — the quality and concision means", () => {
+  /**
+   * This helper came across from an untested script along with the merge, and
+   * nothing asserted what it computes: every fixture set both to 0 and the only
+   * assertion that touched them was `toBeDefined()`, which any number passes.
+   * The convention it encodes is not obvious and is easy to "simplify" away.
+   */
+  const scored = (avgQuality: number, avgLoc: number): IEvaluateOutcome => ({
+    records: [],
+    runs: [],
+    score: {
+      passed: 0,
+      runs: 0,
+      errored: 0,
+      avgQuality,
+      avgLoc,
+      perTask: {},
+    },
+  });
+
+  test("averages only the outcomes that carry a signal", () => {
+    // 0 means "not measured here" — quality needs a judge call and loc needs a
+    // shipped solution, so most tasks have neither. Counting the zeros would
+    // drag the mean toward however many tasks failed.
+    const merged = mergeOutcomes([scored(4, 100), scored(0, 0), scored(2, 50)]);
+
+    expect(merged.score.avgQuality).toBeCloseTo(3, 5);
+    expect(merged.score.avgLoc).toBeCloseTo(75, 5);
+  });
+
+  test("no signal at all stays 0, not NaN", () => {
+    const merged = mergeOutcomes([scored(0, 0), scored(0, 0)]);
+
+    expect(merged.score.avgQuality).toBe(0);
+    expect(merged.score.avgLoc).toBe(0);
   });
 });

--- a/packages/core/tests/self-harness-merge.test.ts
+++ b/packages/core/tests/self-harness-merge.test.ts
@@ -1,5 +1,5 @@
 import { test, expect, describe } from "bun:test";
-import { mergeOutcomes } from "../src/self-harness";
+import { mergeOutcomes, acceptanceDecision } from "../src/self-harness";
 import type { IEvaluateOutcome } from "../src/self-harness";
 import type { IRunRecord } from "../src/eval";
 
@@ -314,5 +314,65 @@ describe("errored is the one count that cannot come from records", () => {
     expect(merged.score.runs).toBe(5);
     // No progress on any of them, so the split stays unmeasured rather than 0.
     expect(merged.score.avgProgress).toBeUndefined();
+  });
+});
+
+describe("the seam this PR exists to defend", () => {
+  /**
+   * The composition, end to end: records → splitScore → merge → the acceptance
+   * rule's graded dimension.
+   *
+   * Every test that existed when the bug shipped drove `evaluateHarness` or
+   * `acceptanceDecision` DIRECTLY. Nothing ran a score through the join, so a
+   * merge that dropped `avgProgress` left both sides passing while the graded
+   * dimension silently never fired. This is the test that would have caught it,
+   * and it fails if any link in that chain stops carrying the field.
+   *
+   * It deliberately does NOT reach through `evaluateSplitResilient` — that owns
+   * the retry loop and endpoint probing, and faking an endpoint to reach this
+   * assertion would test the mock. What it pins is the data path, which is what
+   * broke.
+   */
+  const evaluation = (
+    heldIn: IEvaluateOutcome,
+    heldOut: IEvaluateOutcome
+  ): {
+    heldIn: IEvaluateOutcome["score"];
+    heldOut: IEvaluateOutcome["score"];
+  } => ({
+    heldIn: mergeOutcomes([heldIn]).score,
+    heldOut: mergeOutcomes([heldOut]).score,
+  });
+
+  test("a merged split drives the graded decision, equal pass counts", () => {
+    // Same passes on both sides, so the pass-count rule is silent and only the
+    // graded dimension can decide. Before the fix this returned "progress was
+    // not measured on both splits" — which is precisely what a live session
+    // reported.
+    const base = evaluation(
+      outcome([run("a", false, 0.3)]),
+      outcome([run("b", false, 0.5)])
+    );
+    const cand = evaluation(
+      outcome([run("a", false, 0.8)]),
+      outcome([run("b", false, 0.5)])
+    );
+    const decision = acceptanceDecision(base, cand);
+
+    expect(decision.accepted).toBe(true);
+    expect(decision.reason).toContain("progress gain");
+  });
+
+  test("and it still refuses a candidate that got LESS far", () => {
+    const base = evaluation(
+      outcome([run("a", false, 0.8)]),
+      outcome([run("b", false, 0.5)])
+    );
+    const cand = evaluation(
+      outcome([run("a", false, 0.2)]),
+      outcome([run("b", false, 0.5)])
+    );
+
+    expect(acceptanceDecision(base, cand).accepted).toBe(false);
   });
 });

--- a/packages/core/tests/self-harness-merge.test.ts
+++ b/packages/core/tests/self-harness-merge.test.ts
@@ -1,0 +1,97 @@
+import { test, expect, describe } from "bun:test";
+import { mergeOutcomes } from "../src/self-harness";
+import type { IEvaluateOutcome } from "../src/self-harness";
+import type { IRunRecord } from "../src/eval";
+
+/**
+ * The seam that made the graded score inert in production.
+ *
+ * Every real session evaluates TASK BY TASK — that is what lets one endpoint
+ * flap cost one task's re-run instead of the whole split — and merges the
+ * per-task outcomes here. The merge rebuilt ISplitScore field by field and
+ * omitted `avgProgress`, so the score was computed correctly per task and
+ * dropped before the acceptance rule saw it: `progressDecision` got undefined,
+ * failed closed, and rejected every equal-pass candidate with "progress was not
+ * measured on both splits".
+ *
+ * It survived 16 review rounds and 4,483 tests because every test drove
+ * `evaluateHarness` or `acceptanceDecision` directly. Nothing crossed the join.
+ */
+
+function outcome(records: IRunRecord[]): IEvaluateOutcome {
+  return {
+    records,
+    runs: [],
+    score: {
+      passed: records.filter((r) => r.passed).length,
+      runs: records.length,
+      errored: 0,
+      avgQuality: 0,
+      avgLoc: 0,
+      avgProgress: undefined,
+      perTask: {},
+    },
+  };
+}
+
+const run = (
+  label: string,
+  passed: boolean,
+  progress?: number
+): IRunRecord => ({
+  label,
+  passed,
+  cycles: 1,
+  ms: 0,
+  ...(progress === undefined ? {} : { progress }),
+});
+
+describe("mergeOutcomes carries the graded score across the join", () => {
+  test("avgProgress survives the merge", () => {
+    const merged = mergeOutcomes([
+      outcome([run("a", false, 0.4)]),
+      outcome([run("b", false, 0.8)]),
+    ]);
+
+    expect(merged.score.avgProgress).toBeCloseTo(0.6, 5);
+  });
+
+  test("it is a mean over RUNS, not over tasks", () => {
+    // A task measured twice weighs twice. Averaging the per-task means would
+    // give a 1-run task the same say as a 3-run one.
+    const merged = mergeOutcomes([
+      outcome([run("a", false, 0), run("a", false, 0), run("a", false, 0)]),
+      outcome([run("b", false, 1)]),
+    ]);
+
+    expect(merged.score.avgProgress).toBeCloseTo(0.25, 5);
+  });
+
+  test("an errored run carries no score and is skipped, not read as zero", () => {
+    // Errored records are pushed without `progress` — an outage is not a run
+    // that made no progress, and counting it as 0 would put weather into the
+    // graded figure.
+    const merged = mergeOutcomes([
+      outcome([run("a", false, 0.5)]),
+      outcome([run("b", false)]),
+    ]);
+
+    expect(merged.score.avgProgress).toBeCloseTo(0.5, 5);
+  });
+
+  test("a split with nothing scored stays unmeasured, not zero", () => {
+    const merged = mergeOutcomes([outcome([run("a", false)])]);
+
+    expect(merged.score.avgProgress).toBeUndefined();
+  });
+
+  test("the counts still sum", () => {
+    const merged = mergeOutcomes([
+      outcome([run("a", true, 1)]),
+      outcome([run("b", false, 0.2), run("b", true, 1)]),
+    ]);
+
+    expect(merged.score.passed).toBe(2);
+    expect(merged.score.runs).toBe(3);
+  });
+});

--- a/packages/core/tests/self-harness-merge.test.ts
+++ b/packages/core/tests/self-harness-merge.test.ts
@@ -102,9 +102,14 @@ describe("the merge cannot silently drop a field", () => {
    * original bug. Asserting `avgProgress` survives only covers the field I
    * already know about — a hand-written fixture listing every key cannot notice
    * the merge omitting a key, which is exactly how `avgProgress` was lost for a
-   * week. This compares the merged score's shape against the input's, so the
-   * NEXT field added to ISplitScore is covered without anyone remembering to
-   * add a case.
+   * week.
+   *
+   * What this buys, precisely: a new OPTIONAL field can be added to the fixture
+   * and dropped by the merge, and these turn red. A new REQUIRED field is a
+   * compile error in the fixture first, so someone edits this file either way —
+   * the value there is that adding it to the fixture is enough, with no separate
+   * assertion to remember. It is not automatic coverage of a field nobody
+   * touches, and claiming that was overselling it.
    */
   test("every key of the input score appears on the merged score", () => {
     const input = outcome([run("a", true, 1)]);
@@ -133,9 +138,15 @@ describe("the merge cannot silently drop a field", () => {
     };
     const merged = mergeOutcomes([input]);
 
+    // A Map off Object.entries, not a dynamic index. Indexing a known-type
+    // object by a runtime string needs an `as` to compile, and the rule against
+    // those exists precisely so a test cannot silence the type system to reach
+    // its own assertion.
+    const carried = new Map(Object.entries(merged.score));
+
     for (const [key, value] of Object.entries(input.score)) {
       if (value !== undefined && typeof value !== "object") {
-        expect(merged.score[key as keyof typeof merged.score]).toBeDefined();
+        expect(carried.get(key)).toBeDefined();
       }
     }
   });

--- a/packages/core/tests/self-harness-split-score.test.ts
+++ b/packages/core/tests/self-harness-split-score.test.ts
@@ -1,0 +1,106 @@
+import { test, expect, describe } from "bun:test";
+import { splitScore } from "../src/self-harness/evaluate";
+import type { IRunRecord } from "../src/eval";
+
+/**
+ * The ONE place ISplitScore is assembled — tested where it lives, not only
+ * through `mergeOutcomes`.
+ *
+ * It used to be built twice, in the evaluator and again in the merge, and that
+ * second construction is what dropped `avgProgress` for a week. Reaching this
+ * function only through the merge would repeat the shape of the original gap in
+ * miniature: a change to its contract that the merge happens to tolerate would
+ * go unnoticed here.
+ */
+
+const run = (
+  label: string,
+  passed: boolean,
+  over: Partial<IRunRecord> = {}
+): IRunRecord => ({
+  label,
+  passed,
+  cycles: 1,
+  ms: 0,
+  progress: passed ? 1 : 0,
+  ...over,
+});
+
+describe("splitScore", () => {
+  test("counts passes and runs from the records themselves", () => {
+    const score = splitScore(
+      [run("a", true), run("b", false), run("c", true)],
+      0
+    );
+
+    expect(score.passed).toBe(2);
+    expect(score.runs).toBe(3);
+  });
+
+  test("errored is carried, not derived", () => {
+    // The placeholder a failed attempt leaves behind is indistinguishable from
+    // an honest failure, so the count has to be passed in.
+    expect(splitScore([run("a", false)], 4).errored).toBe(4);
+  });
+
+  test("avgProgress is a mean over RUNS", () => {
+    const score = splitScore(
+      [
+        run("a", false, { progress: 0 }),
+        run("a", false, { progress: 0 }),
+        run("b", false, { progress: 1 }),
+      ],
+      0
+    );
+
+    // Task-weighted would be 0.5; run-weighted is 1/3, and run-weighted is what
+    // the acceptance rule compares.
+    expect(score.avgProgress).toBeCloseTo(1 / 3, 5);
+  });
+
+  test("a record with no progress is skipped, not counted as zero", () => {
+    const score = splitScore(
+      [
+        run("a", false, { progress: 0.6 }),
+        { label: "b", passed: false, cycles: 0, ms: 0 },
+      ],
+      1
+    );
+
+    expect(score.avgProgress).toBeCloseTo(0.6, 5);
+  });
+
+  test("nothing scored leaves the split unmeasured", () => {
+    const score = splitScore(
+      [{ label: "a", passed: false, cycles: 0, ms: 0 }],
+      1
+    );
+
+    expect(score.avgProgress).toBeUndefined();
+  });
+
+  test("quality and loc are averaged over TASKS that carry a signal", () => {
+    const score = splitScore(
+      [
+        run("a", true, { quality: 4, loc: 100 }),
+        run("b", true),
+        run("c", true, { quality: 2, loc: 50 }),
+      ],
+      0
+    );
+
+    expect(score.avgQuality).toBeCloseTo(3, 5);
+    expect(score.avgLoc).toBeCloseTo(75, 5);
+  });
+
+  test("perTask groups repeats of one task into a single summary", () => {
+    const score = splitScore(
+      [run("a", true, { cycles: 2 }), run("a", true, { cycles: 8 })],
+      0
+    );
+
+    expect(Object.keys(score.perTask)).toEqual(["a"]);
+    expect(score.perTask.a?.runs).toBe(2);
+    expect(score.perTask.a?.avgCycles).toBe(5);
+  });
+});


### PR DESCRIPTION
## Found by a live session, not by tests

`mergeOutcomes` rebuilt `ISplitScore` field by field and **omitted `avgProgress`**:

```ts
score: {
  passed: ..., runs: ..., errored: ...,
  avgQuality: ..., avgLoc: ..., perTask,
  //  avgProgress — absent
}
```

Every real session merges through it: evaluation runs **task by task** so one endpoint flap costs one task's re-run instead of the whole split. So the graded score was computed correctly per run and per task, then dropped before the acceptance rule saw it.

Symptom from tonight's run, with **zero errored runs**:

```
r0-c2 rejected — no strict gain on either split (Δin=0, Δho=0)
                 and progress was not measured on both splits
```

`progressDecision` received `undefined`, failed closed exactly as designed, and rejected the only candidate that reached the graded dimension. #242 exists so an equal-pass candidate is judged on how far its runs got — it has never once influenced a decision.

## Why the tests missed it

Every test drove `evaluateHarness` or `acceptanceDecision` **directly**. Nothing crossed the join between them.

That is the same class of gap the review panel caught twice on that branch — a guard test that bypassed `parseVerdict`, a composed refusal path nobody exercised. Both were fixed. This one was in a CLI script, so it was out of reach of the tests and out of sight of the reviews.

## Change

- `avgProgress` recomputed over **runs** in the merge — a task measured twice weighs twice; averaging per-task means would give a 1-run task the same say as a 3-run one.
- `mergeOutcomes` moved from `scripts/self-harness.ts` into `src/self-harness/merge.ts`. It is real logic on the path every session takes, and it was untestable where it lived.

## Verification

Five tests at the seam: the score survives the merge, it is a mean over runs, an errored run is skipped rather than read as zero, a split with nothing scored stays unmeasured, and the counts still sum.

Mutation-checked — restoring the omission turns **3 of 5** red.

`bun run validate` green: 4,488 tests across 305 files.