### PR TITLE
chore: make "I verified it" a command instead of a recollection

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -53,7 +53,8 @@ Remote: https://github.com/agjs/tsforge
   matches nothing fails silently, so `grep` the new text before writing it into
   a commit message. Four commits in one session described fixes that were never
   in the file.
-- **Put logic in `src/`, not `scripts/`.** Tests import from `src/`, so a
-  function parked in a script has no natural place for a test sibling and tends
-  not to get one. The graded score reached the acceptance rule for a week only
-  in theory, because the merge step that dropped it sat in a script.
+- **Scripts orchestrate; `src/` decides.** A file in `scripts/` is an entry
+  point — parse args, call into `src/`, print. Any function it would be a bug to
+  get wrong belongs in `src/`, where a test can import it. The graded score
+  reached the acceptance rule for a week only in theory, because the merge step
+  that dropped it sat in a script.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -45,3 +45,15 @@ Remote: https://github.com/agjs/tsforge
 - Cyclomatic complexity ≤ 20
 - Interfaces prefixed `I`; types live in `*.types.ts`
 - No new logic file without a behavioral test sibling
+- **A test is not coverage until it has failed.** Before claiming a line is
+  tested, break it and watch the test go red. `expect(x).toBeDefined()` passes
+  against `{}` as readily as against the value you meant, so an assertion that
+  cannot fail proves nothing about the line beneath it.
+- **Never describe a change you have not read back.** A scripted edit that
+  matches nothing fails silently, so `grep` the new text before writing it into
+  a commit message. Four commits in one session described fixes that were never
+  in the file.
+- **Put logic in `src/`, not `scripts/`.** Tests import from `src/`, so a
+  function parked in a script has no natural place for a test sibling and tends
+  not to get one. The graded score reached the acceptance rule for a week only
+  in theory, because the merge step that dropped it sat in a script.


### PR DESCRIPTION
## Why

A green suite proves the tests **pass**. It does not prove they would **fail** if the code were wrong. Those are different claims, and the gap between them is where a full day of review rounds went:

| what shipped | how it was caught |
|---|---|
| a guard that did nothing (`perTask` is `{}`, which is defined either way) | by hand |
| a test asserting an outcome both branches produce | by hand |
| four commit messages describing fixes never in the file | by reviewers |
| `avgProgress` dropped by a merge, making #242 inert since it merged | by a live run |

Every one was found the same way — copy the file, delete a line, re-run, restore — roughly **fifteen times by hand** in one session.

## What

```
bun run mutate <file> --changed
```

Comments out one line at a time and reports the ones no test noticed.

- `--changed` mutates only lines the branch touched, so it is fast enough to run before a commit rather than being a ceremony nobody performs.
- Syntax-only lines are skipped — deleting a brace breaks the parse, and a suite that fails to compile "detects" every mutation while proving nothing about coverage.
- The file is restored in a `finally`. A tool built to stop unverified state must not leave any.

Verified both directions on real code: **7 of 7 caught** on `merge.ts`, and a **genuine survivor** found in `evaluate.ts`.

## House rules

Three added, each written from a specific failure rather than from principle:

- **A test is not coverage until it has failed.**
- **Never describe a change you have not read back** — a scripted edit that matches nothing fails silently.
- **Logic in `scripts/` cannot be tested** and will not be reviewed as if it were. The graded score reached the acceptance rule for a week only in theory, because the merge that dropped it lived in a script.

`bun run validate` green: 4,506 tests across 306 files.