### PR TITLE
fix: stop sending a field the vLLM V2 runner rejects

### DIFF
--- a/packages/core/src/inference/reasoning-profile.ts
+++ b/packages/core/src/inference/reasoning-profile.ts
@@ -97,10 +97,11 @@ export const REASONING_PRESETS: Readonly<
    *  its `budget`; that path is served by runtimes that accept the field.
    *
    *  This is the default for the common case, not a claim that no DeepSeek
-   *  server accepts the field. A deployment running V1 (`VLLM_USE_V2_MODEL_
-   *  RUNNER=0`) can have it back by setting `reasoning` to a full profile
-   *  rather than this preset name — the learner can only remove a field, never
-   *  restore one, so the preset is the only place to put it back. */
+   *  server accepts the field. A deployment running the V1 runner
+   *  (`VLLM_USE_V2_MODEL_RUNNER=0`) can have it back by setting `reasoning` to
+   *  a full profile rather than this preset name — the learner can only remove
+   *  a field, never restore one, so the preset is the only place to put it
+   *  back. */
   "deepseek-local": {
     thinking: { path: "chat_template_kwargs.thinking" },
     effort: "chat_template_kwargs.reasoning_effort",

--- a/packages/core/src/inference/reasoning-profile.ts
+++ b/packages/core/src/inference/reasoning-profile.ts
@@ -94,7 +94,13 @@ export const REASONING_PRESETS: Readonly<
    *  is the default. The field survived here because the unsupported-field
    *  learner retries without it, so every turn worked — at the cost of a wasted
    *  round trip per process and a 400 in the server log each time. Qwen keeps
-   *  its `budget`; that path is served by runtimes that accept the field. */
+   *  its `budget`; that path is served by runtimes that accept the field.
+   *
+   *  This is the default for the common case, not a claim that no DeepSeek
+   *  server accepts the field. A deployment running V1 (`VLLM_USE_V2_MODEL_
+   *  RUNNER=0`) can have it back by setting `reasoning` to a full profile
+   *  rather than this preset name — the learner can only remove a field, never
+   *  restore one, so the preset is the only place to put it back. */
   "deepseek-local": {
     thinking: { path: "chat_template_kwargs.thinking" },
     effort: "chat_template_kwargs.reasoning_effort",

--- a/packages/core/src/inference/reasoning-profile.ts
+++ b/packages/core/src/inference/reasoning-profile.ts
@@ -87,11 +87,17 @@ export const REASONING_PRESETS: Readonly<
   /** A DeepSeek checkpoint served by a template-driven runtime (vLLM, SGLang).
    *  `thinking` here is a kwarg of the DeepSeek-V4 CHAT TEMPLATE, which the
    *  runtime merely forwards — it is not a vLLM-wide field, which is why this
-   *  is keyed to the model family and not to the server. */
+   *  is keyed to the model family and not to the server.
+   *
+   *  No `budget`: vLLM's V2 model runner answers `thinking_token_budget` with a
+   *  400 ("not yet supported ... run with VLLM_USE_V2_MODEL_RUNNER=0"), and V2
+   *  is the default. The field survived here because the unsupported-field
+   *  learner retries without it, so every turn worked — at the cost of a wasted
+   *  round trip per process and a 400 in the server log each time. Qwen keeps
+   *  its `budget`; that path is served by runtimes that accept the field. */
   "deepseek-local": {
     thinking: { path: "chat_template_kwargs.thinking" },
     effort: "chat_template_kwargs.reasoning_effort",
-    budget: "thinking_token_budget",
   },
 
   /** OpenAI o-series: effort only, renamed token cap, no temperature. */

--- a/packages/core/tests/request-builder.test.ts
+++ b/packages/core/tests/request-builder.test.ts
@@ -129,13 +129,19 @@ describe("buildRequestBody: reasoning styles", () => {
     expect(b.chat_template_kwargs).toBeUndefined();
   });
 
-  test("deepseek-local forwards thinking_token_budget (a vLLM param, like qwen)", () => {
+  test("deepseek-local omits thinking_token_budget — the V2 runner 400s on it", () => {
     const b = body(
       { reasoning: "deepseek-local" },
       { enableThinking: true, thinkingTokenBudget: 2048 }
     );
 
-    expect(b.thinking_token_budget).toBe(2048);
+    // The budget is dropped, not relocated: nothing anywhere in the body
+    // carries 2048, so this fails if a later edit reintroduces the field under
+    // any path.
+    expect(b.thinking_token_budget).toBeUndefined();
+    expect(JSON.stringify(b)).not.toContain("2048");
+    // The controls the runner DOES accept still go out.
+    expect(b.chat_template_kwargs).toEqual({ thinking: true });
   });
 
   test.each([

--- a/packages/core/tests/request-builder.test.ts
+++ b/packages/core/tests/request-builder.test.ts
@@ -135,11 +135,14 @@ describe("buildRequestBody: reasoning styles", () => {
       { enableThinking: true, thinkingTokenBudget: 2048 }
     );
 
-    // The budget is dropped, not relocated: nothing anywhere in the body
-    // carries 2048, so this fails if a later edit reintroduces the field under
-    // any path.
     expect(b.thinking_token_budget).toBeUndefined();
-    expect(JSON.stringify(b)).not.toContain("2048");
+    // Dropped, not relocated: asking for a budget changes NOTHING about the
+    // body, so this fails if a later edit reintroduces the field under any
+    // path. Comparing two bodies rather than grepping for 2048 keeps the test
+    // independent of the default token cap and the model id.
+    expect(b).toEqual(body({ reasoning: "deepseek-local" }, {
+      enableThinking: true,
+    }));
     // The controls the runner DOES accept still go out.
     expect(b.chat_template_kwargs).toEqual({ thinking: true });
   });

--- a/packages/core/tests/request-builder.test.ts
+++ b/packages/core/tests/request-builder.test.ts
@@ -140,9 +140,14 @@ describe("buildRequestBody: reasoning styles", () => {
     // body, so this fails if a later edit reintroduces the field under any
     // path. Comparing two bodies rather than grepping for 2048 keeps the test
     // independent of the default token cap and the model id.
-    expect(b).toEqual(body({ reasoning: "deepseek-local" }, {
-      enableThinking: true,
-    }));
+    expect(b).toEqual(
+      body(
+        { reasoning: "deepseek-local" },
+        {
+          enableThinking: true,
+        }
+      )
+    );
     // The controls the runner DOES accept still go out.
     expect(b.chat_template_kwargs).toEqual({ thinking: true });
   });

--- a/packages/core/tests/streaming.test.ts
+++ b/packages/core/tests/streaming.test.ts
@@ -169,6 +169,10 @@ test("an error carried INSIDE a 200 stream is raised, not read as silence", asyn
 test("a rejected optional field is dropped and the call retried once", async () => {
   // Self-healing across runtime versions: the same harness has to work against
   // a vLLM that supports thinking_token_budget and one that does not.
+  //
+  // `qwen` is the fixture because it is the preset that still declares that
+  // budget. deepseek-local dropped it — its endpoint refuses the field, so the
+  // learner would have had nothing to drop and this would test nothing.
   const bodies: string[] = [];
   const fakeFetch = (async (_url: string, init: { body: string }) => {
     bodies.push(init.body);
@@ -188,7 +192,7 @@ test("a rejected optional field is dropped and the call retried once", async () 
     baseUrl: "http://x/v1",
     model: "m",
     fetch: fakeFetch,
-    reasoning: "deepseek-local",
+    reasoning: "qwen",
   });
 
   const r = await p.complete([{ role: "user", content: "hi" }], {
@@ -253,7 +257,7 @@ test("an endpoint's rejection is remembered — the next call does not ask again
     baseUrl: "http://x/v1",
     model: "m",
     fetch: fakeFetch,
-    reasoning: "deepseek-local",
+    reasoning: "qwen",
   });
   const call = async (): Promise<string> =>
     (
@@ -296,7 +300,7 @@ test("switching endpoints forgets what the old one refused", async () => {
     baseUrl: "http://x/v1",
     model: "m",
     fetch: fakeFetch,
-    reasoning: "deepseek-local" as const,
+    reasoning: "qwen" as const,
   };
   const p = new OpenAICompatibleProvider(cfg);
   const opts = { onToken: () => undefined, thinkingTokenBudget: 2048 };


### PR DESCRIPTION
## What

Removes `budget: "thinking_token_budget"` from the `deepseek-local` reasoning preset.

## Why

vLLM's V2 model runner answers that field with a 400, and V2 is the default. Verified live against the endpoint this repo actually targets:

```
$ curl .../v1/chat/completions -d '{... "thinking_token_budget": 256}'
{"error":{"message":"thinking_token_budget is not yet supported by the V2 model
runner. Run vLLM with VLLM_USE_V2_MODEL_RUNNER=0 to use thinking_token_budget.",
"type":"BadRequestError","code":400}}
```

The same call without the field returns a normal completion.

Nothing was broken, which is why it lasted: the unsupported-field learner records the rejection and retries without it. The cost was a wasted round trip per process and 877 400s in the server log.

`qwen` keeps its `budget` — that preset is served by runtimes that accept the field.

## Tests

- The test asserting `deepseek-local` *forwards* the budget is inverted. It now builds the body with and without the option and asserts they are identical, so the field cannot be reintroduced under any path. Confirmed red with the field restored before landing.
- Three unsupported-field-learner tests used `deepseek-local` as their vehicle for sending the budget and correctly went red. They test the learner, not the preset, so they move to `qwen` — with a comment saying why, because pointing them back is the obvious future edit.

## Verification

- `bun run validate`: green, 4506 tests across 306 files
- `harness-review`: PASS, 3 reviewers, 0 errored (two rounds)