### PR TITLE
fix(deps): bump mermaid and js-yaml past six new advisories

### DIFF
--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -23,7 +23,7 @@
     "@tailwindcss/vite": "4.3.3",
     "astro": "7.1.3",
     "astro-mermaid": "2.1.0",
-    "mermaid": "11.16.0",
+    "mermaid": "11.16.1",
     "react": "19.2.8",
     "react-dom": "19.2.8",
     "reading-time": "1.5.0",

--- a/bun.lock
+++ b/bun.lock
@@ -8,7 +8,7 @@
         "@astrojs/starlight": "^0.41.5",
         "@tailwindcss/vite": "^4.3.3",
         "astro": "^7.1.3",
-        "mermaid": "^11.16.0",
+        "mermaid": "^11.16.1",
         "sharp": "^0.35.3",
         "tailwindcss": "^4.3.3",
         "wrangler": "^4.114.0",
@@ -47,7 +47,7 @@
     },
     "apps/docs": {
       "name": "@tsforge/docs",
-      "version": "0.35.0",
+      "version": "0.36.0",
       "dependencies": {
         "@astrojs/react": "6.0.1",
         "@astrojs/sitemap": "3.7.3",
@@ -55,7 +55,7 @@
         "@tailwindcss/vite": "4.3.3",
         "astro": "7.1.3",
         "astro-mermaid": "2.1.0",
-        "mermaid": "11.16.0",
+        "mermaid": "11.16.1",
         "react": "19.2.8",
         "react-dom": "19.2.8",
         "reading-time": "1.5.0",
@@ -69,7 +69,7 @@
     },
     "packages/core": {
       "name": "@agjs/tsforge",
-      "version": "0.35.0",
+      "version": "0.36.0",
       "bin": {
         "tsforge": "./bin/tsforge.js",
       },
@@ -102,7 +102,7 @@
     "brace-expansion": "^5.0.9",
     "dompurify": "^3.4.12",
     "esbuild": "^0.28.1",
-    "js-yaml": "4.3.0",
+    "js-yaml": "4.3.1",
     "postcss": "^8.5.23",
     "sharp": "^0.35.3",
     "svgo": "^4.0.2",
@@ -1504,7 +1504,7 @@
 
     "js-tokens": ["js-tokens@4.0.0", "", {}, "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="],
 
-    "js-yaml": ["js-yaml@4.3.0", "", { "dependencies": { "argparse": "^2.0.1" }, "bin": { "js-yaml": "bin/js-yaml.js" } }, "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q=="],
+    "js-yaml": ["js-yaml@4.3.1", "", { "dependencies": { "argparse": "^2.0.1" }, "bin": { "js-yaml": "bin/js-yaml.js" } }, "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ=="],
 
     "jsdom": ["jsdom@29.1.1", "", { "dependencies": { "@asamuzakjp/css-color": "^5.1.11", "@asamuzakjp/dom-selector": "^7.1.1", "@bramus/specificity": "^2.4.2", "@csstools/css-syntax-patches-for-csstree": "^1.1.3", "@exodus/bytes": "^1.15.0", "css-tree": "^3.2.1", "data-urls": "^7.0.0", "decimal.js": "^10.6.0", "html-encoding-sniffer": "^6.0.0", "is-potential-custom-element-name": "^1.0.1", "lru-cache": "^11.3.5", "parse5": "^8.0.1", "saxes": "^6.0.0", "symbol-tree": "^3.2.4", "tough-cookie": "^6.0.1", "undici": "^7.25.0", "w3c-xmlserializer": "^5.0.0", "webidl-conversions": "^8.0.1", "whatwg-mimetype": "^5.0.0", "whatwg-url": "^16.0.1", "xml-name-validator": "^5.0.0" }, "peerDependencies": { "canvas": "^3.0.0" }, "optionalPeers": ["canvas"] }, "sha512-ECi4Fi2f7BdJtUKTflYRTiaMxIB0O6zfR1fX0GXpUrf6flp8QIYn1UT20YQqdSOfk2dfkCwS8LAFoJDEppNK5Q=="],
 
@@ -1632,7 +1632,7 @@
 
     "mdn-data": ["mdn-data@2.28.1", "", {}, "sha512-U9w+PzSZ00Z5m9rZ5ARVFL5xOfuCHdKYi/1RRwDCJsboFgJDNT3zT6PIPD7mZQYaQLhsZM3GfDRgSMRHhSmVng=="],
 
-    "mermaid": ["mermaid@11.16.0", "", { "dependencies": { "@braintree/sanitize-url": "^7.1.2", "@iconify/utils": "^3.0.2", "@mermaid-js/parser": "^1.2.0", "@types/d3": "^7.4.3", "@upsetjs/venn.js": "^2.0.0", "cytoscape": "^3.33.3", "cytoscape-cose-bilkent": "^4.1.0", "cytoscape-fcose": "^2.2.0", "d3": "^7.9.0", "d3-sankey": "^0.12.3", "dagre-d3-es": "7.0.14", "dayjs": "^1.11.20", "dompurify": "^3.3.3", "es-toolkit": "^1.45.1", "katex": "^0.16.45", "khroma": "^2.1.0", "marked": "^16.3.0", "roughjs": "^4.6.6", "stylis": "^4.3.6", "ts-dedent": "^2.2.0", "uuid": "^11.1.0 || ^12 || ^13 || ^14.0.0" } }, "sha512-Zvm3kbstgdpvIJPPItlL7fppIZ3kibvc1oZIGxdvk9t6UFz6flv+Jw7FtRGKwfcI8OckmH04LqG6LlS6X4B1pA=="],
+    "mermaid": ["mermaid@11.16.1", "", { "dependencies": { "@braintree/sanitize-url": "^7.1.2", "@iconify/utils": "^3.0.2", "@mermaid-js/parser": "^1.2.0", "@types/d3": "^7.4.3", "@upsetjs/venn.js": "^2.0.0", "cytoscape": "^3.33.3", "cytoscape-cose-bilkent": "^4.1.0", "cytoscape-fcose": "^2.2.0", "d3": "^7.9.0", "d3-sankey": "^0.12.3", "dagre-d3-es": "7.0.14", "dayjs": "^1.11.20", "dompurify": "^3.3.3", "es-toolkit": "^1.45.1", "katex": "^0.16.45", "khroma": "^2.1.0", "marked": "^16.3.0", "roughjs": "^4.6.6", "stylis": "^4.3.6", "ts-dedent": "^2.2.0", "uuid": "^11.1.0 || ^12 || ^13 || ^14.0.0" } }, "sha512-TQsq6u22fAn3rek5VOubrhKPo1g5hwC3FXUN9hiyupTckcYiGuuKGkNQrKYwGJkXUxZdojwRG46gsSCFZMDp4g=="],
 
     "micromark": ["micromark@4.0.2", "", { "dependencies": { "@types/debug": "^4.0.0", "debug": "^4.0.0", "decode-named-character-reference": "^1.0.0", "devlop": "^1.0.0", "micromark-core-commonmark": "^2.0.0", "micromark-factory-space": "^2.0.0", "micromark-util-character": "^2.0.0", "micromark-util-chunked": "^2.0.0", "micromark-util-combine-extensions": "^2.0.0", "micromark-util-decode-numeric-character-reference": "^2.0.0", "micromark-util-encode": "^2.0.0", "micromark-util-normalize-identifier": "^2.0.0", "micromark-util-resolve-all": "^2.0.0", "micromark-util-sanitize-uri": "^2.0.0", "micromark-util-subtokenize": "^2.0.0", "micromark-util-symbol": "^2.0.0", "micromark-util-types": "^2.0.0" } }, "sha512-zpe98Q6kvavpCr1NPVSCMebCKfD7CA2NqZ+rykeNhONIJBpc1tFKt9hucLGwha3jNTNI8lHpctWJWoimVF4PfA=="],
 

--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
     "brace-expansion": "^5.0.9",
     "dompurify": "^3.4.12",
     "esbuild": "^0.28.1",
-    "js-yaml": "4.3.0",
+    "js-yaml": "4.3.1",
     "postcss": "^8.5.23",
     "sharp": "^0.35.3",
     "svgo": "^4.0.2",
@@ -81,7 +81,7 @@
     "@astrojs/starlight": "^0.41.5",
     "@tailwindcss/vite": "^4.3.3",
     "astro": "^7.1.3",
-    "mermaid": "^11.16.0",
+    "mermaid": "^11.16.1",
     "sharp": "^0.35.3",
     "tailwindcss": "^4.3.3",
     "wrangler": "^4.114.0"


### PR DESCRIPTION
## Why

The dep scan started failing on every PR without any dependency having changed. OSV's advisory data updates continuously, so a passing scan yesterday says nothing about today — six findings appeared, none of them in `osv-scanner.toml`. This blocks #258 and anything else open.

## What

**js-yaml <4.3.1** — [GHSA-5p4m-2wfm-xmqj](https://github.com/advisories/GHSA-5p4m-2wfm-xmqj), **high**: quadratic CPU consumption resolving `!!omap`. Transitive via astro/starlight; the `overrides` block already pinned 4.3.0, so this is one digit on an existing pin.

**mermaid <11.16.1** — five advisories: prototype pollution via the config APIs ([GHSA-c4c3-pg64-4m4v](https://github.com/advisories/GHSA-c4c3-pg64-4m4v)) and architecture diagrams ([GHSA-3rrr-jr9j-h3q3](https://github.com/advisories/GHSA-3rrr-jr9j-h3q3)), CSS injection into siblings of the diagram ([GHSA-6x64-9x62-f2gx](https://github.com/advisories/GHSA-6x64-9x62-f2gx)), and DoS in XY charts ([GHSA-2v8p-3f2j-5mp7](https://github.com/advisories/GHSA-2v8p-3f2j-5mp7)) and radar diagrams ([GHSA-rhh3-jpg6-66xh](https://github.com/advisories/GHSA-rhh3-jpg6-66xh)).

Mermaid is declared **twice** — in the docs workspace and at the root. Bumping only the workspace left the root resolving 11.16.0 and the scan still red, so both moved.

## Bumped, not allowlisted

Every one of these has a published patch release. Adding `IgnoredVulns` entries would have been recording a reason not to run `bun install`.

## Verification

Both CI steps replicated locally:

- `osv-scanner --config=osv-scanner.toml --lockfile=bun.lock` → **0 unfiltered findings**, which is the count the workflow gates on.
- The workflow's exact `bun audit --audit-level=high --ignore=...` invocation → **exit 0**.

Valibot ([GHSA-5qjj-4xww-7phc](https://github.com/advisories/GHSA-5qjj-4xww-7phc)) remains the only finding and is allowlisted until 2026-09-12 — a dev-only ESLint plugin, unchanged by this PR.

`bun run validate` green (4506 tests, all 8 PTY suites). The docs site builds on the new mermaid — 47 pages plus search index — because a diagram renderer is exactly the sort of bump that passes tests and breaks the site.

Cache-impact: none — dependency versions only, no prompt, tool-schema, or message-assembly change.