### PR TITLE
TTSR: no-as-cast/no-as-any false positives — import renames, prose, and the escaped-newline keyword glue

### DIFF
--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -2,7 +2,7 @@
   "name": "@tsforge/docs",
   "type": "module",
   "private": true,
-  "version": "0.42.0",
+  "version": "0.43.0",
   "description": "tsforge docs — Astro Starlight product site.",
   "scripts": {
     "sync:rules": "bun scripts/sync-rules-catalog.ts",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "tsforge",
   "type": "module",
-  "version": "0.42.0",
+  "version": "0.43.0",
   "license": "MIT",
   "description": "TypeScript coding harness with a deterministic gate, stack-aware guardrails, and stream-level correction.",
   "scripts": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@agjs/tsforge",
   "type": "module",
-  "version": "0.42.0",
+  "version": "0.43.0",
   "license": "MIT",
   "description": "TypeScript coding harness with a deterministic gate, stack-aware guardrails, and stream-level correction.",
   "repository": {

--- a/packages/core/src/loop/ttsr-defaults.ts
+++ b/packages/core/src/loop/ttsr-defaults.ts
@@ -18,8 +18,32 @@ export const DEFAULT_TTSR_RULES: readonly ITtsrRule[] = [
     // `as <type>` — `unknown`/`any`/primitive/PascalType/`{`/`[`/`(`. Excludes the
     // one legal form, `as const` (lowercase, not in the alternation), and prose
     // like "…as the…" (lowercase non-keyword).
+    //
+    // Guards against the false positives that made this rule gaslight the model
+    // (it fired on text that contained no cast at all):
+    //   1. Import/export RENAMES are legal `as` — `import * as React`,
+    //      `import { Foo as Bar }`, `export { a as B }`. Two lookbehinds drop
+    //      anything after `import` up to its terminating `;` (imports can't
+    //      contain casts, and the window crosses JSON-escaped newlines in
+    //      multi-line imports), and after `export {`/`export type {` up to `}`.
+    //      `export const x = y as T` is NOT excluded (no `{` after export).
+    //      No leading \b on import/export: after a JSON-escaped newline the
+    //      text is `\nimport` and the escape's `n` glues onto the keyword
+    //      ("nimport" — no word boundary), which made the lookbehind miss
+    //      every import after the first line. Suffix-matching over-blocks only
+    //      odd identifiers ending in "import", and only until the next `;`.
+    //   2. PROSE — "such as React components", "save this as README.md". A real
+    //      cast's type is followed by a code delimiter (`;` `,` `)` `]` `}` `<`
+    //      `:` `&` `|` `?` `=` or a backslash, which is how a JSON-escaped
+    //      newline/quote appears on this channel — TTSR scans the RAW tool-args
+    //      string); prose is followed by another word. No `$`: at a chunk
+    //      boundary the delimiter simply arrives with the next delta (the
+    //      rolling buffer persists), whereas matching at end-of-buffer would
+    //      fire mid-sentence.
+    //   3. Sentence dots — `[A-Z]\w*(?:\.\w+)*` (not `[\w.]*`) so the `.` ending
+    //      "known as React." can't backtrack into the delimiter lookahead.
     condition: [
-      /\bas\s+(?:unknown|any|string|number|boolean|bigint|symbol|object|never|[A-Z][\w.]*|[[{(])/,
+      /(?<!import\b[^;]{0,300})(?<!export\s+(?:type\s+)?\{[^}]{0,200})\bas\s+(?:(?:unknown|any|string|number|boolean|bigint|symbol|object|never|[A-Z]\w*(?:\.\w+)*)\s{0,3}(?=[;,)\]}<:&|?=\\])|[[{(])/,
     ],
     scope: "tool-args",
     guidance:
@@ -41,7 +65,11 @@ export const DEFAULT_TTSR_RULES: readonly ITtsrRule[] = [
   },
   {
     name: "no-as-any",
-    condition: [/\bas\s+any\b/],
+    // Same delimiter lookahead as no-as-cast: a real `as any` cast is followed
+    // by a code delimiter (or an escaped newline/quote, i.e. a backslash on the
+    // raw tool-args channel); the ENGLISH phrase "as any developer knows" is
+    // followed by a word and must not abort the stream.
+    condition: [/\bas\s+any\b\s{0,3}(?=[;,)\]}<:&|?=\\])/],
     scope: "tool-args",
     guidance:
       "Never use 'as any'. If the type is unknown, use 'unknown' or a proper type. " +

--- a/packages/core/tests/ttsr.test.ts
+++ b/packages/core/tests/ttsr.test.ts
@@ -32,6 +32,61 @@ test("built-in no-as-cast does NOT fire on `as const`", () => {
   expect(hit).toBeNull();
 });
 
+// The gaslighting regression: the rule used to fire on text with NO cast at all
+// (`as` + any capitalized word) — legal import/export renames and plain English
+// prose — and the guidance then scolded the model about `as any` it never wrote.
+test("no-as-cast/no-as-any do NOT fire on import/export renames or prose", () => {
+  const innocents = [
+    'import * as React from "react";\n',
+    'import { Component as Button } from "./b";\n',
+    // A prettier-formatted multi-line import, as it appears on the RAW
+    // tool-args channel (JSON-escaped: newlines are the literal chars \n).
+    'import {\\n  Component as Button,\\n} from "./b";\\n',
+    // A SECOND import after an escaped newline: the escape's `n` glues onto
+    // `import` ("nimport"), which defeated a \b-anchored lookbehind.
+    'import * as React from \\"react\\";\\nimport { Component as Base } from \\"./base\\";',
+    "export { foo as Bar };\n",
+    "export type { Foo as Bar };\n",
+    "// save this as README.md\n",
+    "Render it the same as React components do.\n",
+    "known as Promise chaining.\n",
+    "as many as needed\n",
+    "as any developer knows, this is fine\n",
+  ];
+
+  for (const text of innocents) {
+    const hit = withDefaults().checkDelta(text, {
+      source: "tool-args",
+      currentFile: "apps/ui/src/x.tsx",
+    });
+
+    expect(hit?.name ?? null).toBeNull();
+  }
+});
+
+test("no-as-cast still fires on real casts, incl. escaped-newline endings and post-import code", () => {
+  const casts = [
+    "const x = data as any;\n",
+    // Line ends as a JSON-escaped newline on the raw tool-args channel.
+    "const x = data as any\\nconst y = 1;",
+    "return (x as unknown as T);\n",
+    "foo(bar as string, baz)\n",
+    "const z = v as Array<string>;\n",
+    "export const q = w as any;\n",
+    'import { A } from "./a"; const b = c as Foo;\n',
+    "const t = u as [string, number];\n",
+  ];
+
+  for (const text of casts) {
+    const hit = withDefaults().checkDelta(text, {
+      source: "tool-args",
+      currentFile: "apps/api/src/x.ts",
+    });
+
+    expect(hit?.name).toBe("no-as-cast");
+  }
+});
+
 test("built-in no-eslint-disable fires on an eslint-disable comment", () => {
   const hit = withDefaults().checkDelta(
     "// eslint-disable-next-line @typescript-eslint/no-explicit-any\n",


### PR DESCRIPTION
## The report

> "I'm 110% sure we interrupted the model because of e.g. `as any` and the model would say it didn't even use any."

Confirmed — and the model was right. The trigger wasn't `as any` at all.

## Root causes (three stacked)

1. **`no-as-cast` matched `as` + any capitalized word**, in every file type. That fires on every `import * as React`, every `import { Foo as Bar }` rename, and plain prose ("save this as README.md", "such as React components"). Its guidance text then lectures about `as any`/`as unknown` — hence the model truthfully protesting it never used `any`.
2. **Prose vs cast is distinguishable by what FOLLOWS**: a real cast's type is followed by a code delimiter (`;` `,` `)` `]` `}` `<` …); prose is followed by another word. Neither rule checked.
3. **The escaped-newline keyword glue**: TTSR scans the *raw JSON* tool-args stream, where a newline is the two characters `\n` — so `;\nimport {…` reads as the word "**nimport**" and any `\b`-anchored import guard misses every import after the first line. (This one bit my own first fix attempt; the committed lookbehind is suffix-matched instead.)

## Verified on the real binary (stub-model PTY, A/B vs main)

| arm | model writes an innocent React file (`import * as React` + renames + prose comment) | model writes a real `(globalThis as any).foo` |
| --- | --- | --- |
| **main** | ⚠ `TTSR interrupted: no-as-cast`, **file blocked** — the reported bug, live | fires (correctly) |
| **this branch** | no interrupt, file written | ⚠ fires, file blocked — the rule still bites |

## Tests

19 cases in `ttsr.test.ts` including the raw-escaped-channel shapes (multi-line imports, second-import-after-`\n`, escaped-newline cast endings); the suite is red on the old rules (see-it-fail). Full `typecheck + lint + bun test + arch + rules` green.

## Impact

Every React/TSX write was at risk of a spurious mid-stream abort + corrective retry (wasted turns, confused model). This class of interruption is gone; genuine `as`-cast enforcement is unchanged (and still backstopped by the AST-based gate lint, which was never wrong — only the streaming regex was).