### PR TITLE
Lib hardening: shared-decoder Unicode corruption, isRecord array hole, TRACE=0 footgun, clipboard bound

### DIFF
--- a/0
+++ b/0
@@ -1,0 +1,3 @@
+[t] should not surface
+Error: should not surface
+    at <anonymous> (/agjs/code/tsforge/packages/core/tests/lib-trace.test.ts:37:22)

--- a/FALSE
+++ b/FALSE
@@ -1,0 +1,3 @@
+[t] should not surface
+Error: should not surface
+    at <anonymous> (/agjs/code/tsforge/packages/core/tests/lib-trace.test.ts:37:22)

--- a/Off
+++ b/Off
@@ -1,0 +1,3 @@
+[t] should not surface
+Error: should not surface
+    at <anonymous> (/agjs/code/tsforge/packages/core/tests/lib-trace.test.ts:37:22)

--- a/false
+++ b/false
@@ -1,0 +1,3 @@
+[t] should not surface
+Error: should not surface
+    at <anonymous> (/agjs/code/tsforge/packages/core/tests/lib-trace.test.ts:37:22)

--- a/no
+++ b/no
@@ -1,0 +1,3 @@
+[t] should not surface
+Error: should not surface
+    at <anonymous> (/agjs/code/tsforge/packages/core/tests/lib-trace.test.ts:37:22)

--- a/off
+++ b/off
@@ -1,0 +1,3 @@
+[t] should not surface
+Error: should not surface
+    at <anonymous> (/agjs/code/tsforge/packages/core/tests/lib-trace.test.ts:37:22)

--- a/packages/core/src/lib/clipboard/clipboard-image.ts
+++ b/packages/core/src/lib/clipboard/clipboard-image.ts
@@ -45,6 +45,17 @@ function osascriptArgs(path: string): string[] {
   return ["osascript", ...script.flatMap((line) => ["-e", line])];
 }
 
+/** Cap on a pasted clipboard image (bytes). Without it a huge paste (a
+ *  multi-hundred-MB screenshot/PSD) was read whole and then base64-encoded
+ *  (~1.33× more) into a string held in the REPL attachment — mirrors the
+ *  MAX_FILE_BYTES bound every workspace read already has. */
+export const MAX_CLIPBOARD_IMAGE_BYTES = 20 * 1024 * 1024;
+
+/** A clipboard image of `size` bytes is readable: non-empty and within the cap. */
+export function clipboardImageSizeOk(size: number): boolean {
+  return size > 0 && size <= MAX_CLIPBOARD_IMAGE_BYTES;
+}
+
 const DEFAULT_DEPS: IClipboardDeps = {
   platform: process.platform,
   run: async (argv) =>
@@ -52,7 +63,7 @@ const DEFAULT_DEPS: IClipboardDeps = {
   readFileBytes: async (path) => {
     const file = Bun.file(path);
 
-    if (!(await file.exists()) || file.size === 0) {
+    if (!(await file.exists()) || !clipboardImageSizeOk(file.size)) {
       return null;
     }
 

--- a/packages/core/src/lib/fs/process.ts
+++ b/packages/core/src/lib/fs/process.ts
@@ -62,6 +62,16 @@ export interface IBoundedCapture {
  *  (trim at 2× the cap back down to the cap) so appending N chars is O(N)
  *  total, not O(N²). The notice reuses the capWithNotice vocabulary
  *  ("output truncated") so downstream message-cap logic recognizes the family. */
+/** A UTF-16 high surrogate (0xD800–0xDBFF) — the first half of an astral pair. */
+function isHighSurrogate(code: number): boolean {
+  return code >= 0xd800 && code <= 0xdbff;
+}
+
+/** A UTF-16 low surrogate (0xDC00–0xDFFF) — the second half of an astral pair. */
+function isLowSurrogate(code: number): boolean {
+  return code >= 0xdc00 && code <= 0xdfff;
+}
+
 export function createBoundedCapture(
   headCap = CAPTURE_HEAD_CAP,
   tailCap = CAPTURE_TAIL_CAP
@@ -72,8 +82,18 @@ export function createBoundedCapture(
 
   const trimTail = (limit: number): void => {
     if (tail.length > limit) {
-      elided += tail.length - tailCap;
-      tail = tail.slice(-tailCap);
+      // Never cut BETWEEN a surrogate pair: if the kept-tail would start on a
+      // low surrogate, drop it into the elided count so the pair isn't split
+      // (harmless in the no-elision join, but the elision notice inserted
+      // between the halves would otherwise strand two replacement chars).
+      let keep = tailCap;
+
+      if (isLowSurrogate(tail.charCodeAt(tail.length - keep))) {
+        keep -= 1;
+      }
+
+      elided += tail.length - keep;
+      tail = tail.slice(-keep);
     }
   };
 
@@ -82,7 +102,13 @@ export function createBoundedCapture(
       let rest = text;
 
       if (head.length < headCap) {
-        const take = Math.min(headCap - head.length, rest.length);
+        let take = Math.min(headCap - head.length, rest.length);
+
+        // Don't end the head on a lone high surrogate (its low half would land
+        // in the tail, across the elision notice).
+        if (take < rest.length && isHighSurrogate(rest.charCodeAt(take - 1))) {
+          take -= 1;
+        }
 
         head += rest.slice(0, take);
         rest = rest.slice(take);
@@ -246,7 +272,6 @@ export async function runArgvCommand(
     }
   }
 
-  const decoder = new TextDecoder();
   const buf: { out: IBoundedCapture; err: IBoundedCapture } = {
     out: createBoundedCapture(),
     err: createBoundedCapture(),
@@ -256,6 +281,15 @@ export async function runArgvCommand(
     stream: ReadableStream<Uint8Array>,
     key: "out" | "err"
   ): Promise<void> => {
+    // Each pump gets its OWN decoder: a single shared TextDecoder retains the
+    // trailing bytes of an incomplete UTF-8 sequence across `decode(…, {stream})`
+    // calls, and the two pumps run concurrently — so a multibyte codepoint split
+    // on a stdout chunk boundary would carry into the NEXT decode, which might be
+    // the stderr pump, corrupting both streams (mojibake / bytes on the wrong
+    // stream). A final flush decode emits any bytes left buffered at EOF (an
+    // incomplete trailing sequence was otherwise silently dropped).
+    const decoder = new TextDecoder();
+
     for await (const bytes of stream) {
       const text = decoder.decode(bytes, { stream: true });
 
@@ -263,6 +297,16 @@ export async function runArgvCommand(
 
       if (onChunk !== undefined) {
         onChunk(text);
+      }
+    }
+
+    const tail = decoder.decode();
+
+    if (tail.length > 0) {
+      buf[key].append(tail);
+
+      if (onChunk !== undefined) {
+        onChunk(tail);
       }
     }
   };

--- a/packages/core/src/lib/guards/guards.ts
+++ b/packages/core/src/lib/guards/guards.ts
@@ -1,6 +1,11 @@
-/** Narrow `unknown` to a record without a type assertion. */
+/** Narrow `unknown` to a record without a type assertion. Excludes arrays:
+ *  `typeof [] === "object"`, so the old check narrowed a JSON array to
+ *  `Record<string, unknown>` — a hole reachable via untrusted model/config
+ *  JSON (e.g. plan.ts narrowed a nested array to an `IStep`, and downstream
+ *  field reads got `undefined` on a value the type system swore was an object).
+ *  Callers wanting either shape have `isArray`. */
 export function isRecord(value: unknown): value is Record<string, unknown> {
-  return typeof value === "object" && value !== null;
+  return typeof value === "object" && value !== null && !Array.isArray(value);
 }
 
 /** Narrow `unknown` to an array of `unknown` (not `any[]`). */

--- a/packages/core/src/lib/trace.ts
+++ b/packages/core/src/lib/trace.ts
@@ -1,18 +1,35 @@
 import { appendFileSync } from "node:fs";
+import { sep } from "node:path";
+
+/** Values that DISABLE tracing (alongside unset/empty) — the natural "off"
+ *  spellings a user would try. Without this, `TSFORGE_TRACE=0` fell through to
+ *  the file branch and created a file literally named `0` in the workspace,
+ *  appending diagnostics (which can carry secrets from failed provider/HTTP
+ *  degrade paths) to it. */
+const TRACE_OFF = new Set(["0", "false", "off", "no"]);
+
+/** Values that route to STDERR rather than a file. */
+const TRACE_STDERR = new Set(["1", "true", "stderr"]);
 
 /**
  * Env-gated diagnostic trace for silent degrade paths. Production stays silent;
  * `TSFORGE_TRACE=1 tsforge …` (or `TSFORGE_DEBUG`) surfaces what quietly degraded.
  *
- * When the env var is set, emit `"[scope] <message>"` (plus the stack for Errors):
- * to a FILE when the value looks like a path, else to stderr (`"1"`/`"true"`/
- * `"stderr"`). Unset ⇒ no-op. Never throws — a failed trace write is not worth
- * crashing a degrade path over, so it falls back to stderr.
+ * `1`/`true`/`stderr` → stderr. Unset/empty or a falsy sentinel
+ * (`0`/`false`/`off`/`no`) → no-op. A value that looks like a PATH (contains a
+ * separator, case-insensitively an absolute path) → appended to that file;
+ * any OTHER bare word is treated as stderr, not a filename, so a typo can't
+ * silently spew diagnostics into a workspace file. Never throws — a failed
+ * trace write falls back to stderr.
  */
 export function trace(scope: string, err: unknown): void {
   const target = process.env.TSFORGE_TRACE ?? process.env.TSFORGE_DEBUG;
 
-  if (target === undefined || target.length === 0) {
+  if (
+    target === undefined ||
+    target.length === 0 ||
+    TRACE_OFF.has(target.toLowerCase())
+  ) {
     return;
   }
 
@@ -21,7 +38,8 @@ export function trace(scope: string, err: unknown): void {
     err instanceof Error && err.stack !== undefined ? `\n${err.stack}` : "";
   const line = `[${scope}] ${message}${stack}\n`;
 
-  if (target === "1" || target === "true" || target === "stderr") {
+  // Only an explicit PATH is a file target; every other bare value → stderr.
+  if (TRACE_STDERR.has(target) || !target.includes(sep)) {
     process.stderr.write(line);
 
     return;

--- a/packages/core/tests/clipboard-image.test.ts
+++ b/packages/core/tests/clipboard-image.test.ts
@@ -3,6 +3,8 @@ import {
   readClipboardImage,
   readClipboardText,
   captureClipboardImageToFile,
+  clipboardImageSizeOk,
+  MAX_CLIPBOARD_IMAGE_BYTES,
   type IClipboardDeps,
 } from "../src/lib/clipboard/clipboard-image";
 
@@ -127,4 +129,14 @@ test("readClipboardText: non-zero exit → empty string", async () => {
   });
 
   expect(text).toBe("");
+});
+
+// ── R1: a clipboard image read is size-bounded ──────────────────────────────
+test("clipboardImageSizeOk bounds the read (empty → false, huge → false)", () => {
+  expect(clipboardImageSizeOk(0)).toBe(false);
+  expect(clipboardImageSizeOk(1)).toBe(true);
+  expect(clipboardImageSizeOk(MAX_CLIPBOARD_IMAGE_BYTES)).toBe(true);
+  expect(clipboardImageSizeOk(MAX_CLIPBOARD_IMAGE_BYTES + 1)).toBe(false);
+  // A multi-hundred-MB paste (the RESOURCE case) is refused before arrayBuffer.
+  expect(clipboardImageSizeOk(500 * 1024 * 1024)).toBe(false);
 });

--- a/packages/core/tests/guards.test.ts
+++ b/packages/core/tests/guards.test.ts
@@ -1,0 +1,44 @@
+import { test, expect, describe } from "bun:test";
+import { isRecord, isArray } from "../src/lib/guards";
+
+describe("isRecord", () => {
+  test("accepts plain objects", () => {
+    expect(isRecord({})).toBe(true);
+    expect(isRecord({ a: 1 })).toBe(true);
+    expect(isRecord(Object.create(null))).toBe(true);
+  });
+
+  test("REJECTS arrays (typeof [] === 'object' — the S1 hole)", () => {
+    expect(isRecord([])).toBe(false);
+    expect(isRecord([1, 2, 3])).toBe(false);
+    expect(isRecord([{ a: 1 }])).toBe(false);
+  });
+
+  test("rejects null, primitives, and functions", () => {
+    expect(isRecord(null)).toBe(false);
+    expect(isRecord(undefined)).toBe(false);
+    expect(isRecord(1)).toBe(false);
+    expect(isRecord("x")).toBe(false);
+    expect(isRecord(true)).toBe(false);
+    expect(isRecord(() => undefined)).toBe(false);
+  });
+
+  test("a nested array in untrusted JSON no longer narrows to a record", () => {
+    // The plan.ts shape: steps: [[1,2],[3,4]] — each nested array must NOT
+    // pass as an IStep-like record.
+    const parsed: unknown = JSON.parse('{"steps":[[1,2],[3,4]]}');
+    const steps = isRecord(parsed) && isArray(parsed.steps) ? parsed.steps : [];
+
+    expect(steps.filter((s) => isRecord(s))).toEqual([]);
+  });
+});
+
+describe("isArray", () => {
+  test("accepts arrays only", () => {
+    expect(isArray([])).toBe(true);
+    expect(isArray([1])).toBe(true);
+    expect(isArray({})).toBe(false);
+    expect(isArray(null)).toBe(false);
+    expect(isArray("x")).toBe(false);
+  });
+});

--- a/packages/core/tests/lib-trace.test.ts
+++ b/packages/core/tests/lib-trace.test.ts
@@ -1,0 +1,101 @@
+import { test, expect, describe, afterEach, spyOn } from "bun:test";
+import { readdirSync, rmSync, existsSync } from "node:fs";
+import { join, sep } from "node:path";
+import { trace } from "../src/lib/trace";
+
+const ENV_KEYS = ["TSFORGE_TRACE", "TSFORGE_DEBUG"] as const;
+const saved = new Map<string, string | undefined>();
+
+function setTrace(value: string | undefined): void {
+  for (const k of ENV_KEYS) {
+    if (!saved.has(k)) {
+      saved.set(k, process.env[k]);
+    }
+
+    if (value === undefined) {
+      process.env[k] = "";
+    } else {
+      process.env[k] = k === "TSFORGE_TRACE" ? value : "";
+    }
+  }
+}
+
+afterEach(() => {
+  for (const [k, v] of saved) {
+    process.env[k] = v ?? "";
+  }
+
+  saved.clear();
+});
+
+describe("trace env handling (F1)", () => {
+  test("falsy sentinels DISABLE tracing — no file, no stderr", () => {
+    const before = new Set(readdirSync(process.cwd()));
+
+    for (const off of ["0", "false", "off", "no", "FALSE", "Off"]) {
+      setTrace(off);
+      const spy = spyOn(process.stderr, "write").mockImplementation(() => true);
+
+      trace("t", new Error("should not surface"));
+
+      expect(spy).not.toHaveBeenCalled();
+      spy.mockRestore();
+    }
+
+    // No stray file named after a sentinel was created in cwd.
+    const after = readdirSync(process.cwd());
+    const created = after.filter((f) => !before.has(f));
+
+    expect(
+      created.filter((f) => ["0", "false", "off", "no"].includes(f))
+    ).toEqual([]);
+  });
+
+  test("a bare word (not a path) routes to stderr, never a file", () => {
+    setTrace("verbose"); // a plausible typo for a level
+    const before = new Set(readdirSync(process.cwd()));
+    const spy = spyOn(process.stderr, "write").mockImplementation(() => true);
+
+    trace("t", new Error("boom"));
+
+    expect(spy).toHaveBeenCalled();
+    spy.mockRestore();
+
+    const created = readdirSync(process.cwd()).filter((f) => !before.has(f));
+
+    expect(created).not.toContain("verbose");
+  });
+
+  test("1/true/stderr route to stderr", () => {
+    for (const on of ["1", "true", "stderr"]) {
+      setTrace(on);
+      const spy = spyOn(process.stderr, "write").mockImplementation(() => true);
+
+      trace("t", new Error("x"));
+
+      expect(spy).toHaveBeenCalled();
+      spy.mockRestore();
+    }
+  });
+
+  test("a value containing a path separator is written to that file", () => {
+    const dir = join(
+      process.env.TMPDIR ?? "/tmp",
+      `tsforge-trace-${String(Date.now())}`
+    );
+    const file = `${dir}${sep}trace.log`;
+
+    try {
+      setTrace(file);
+      // The dir doesn't exist → append fails → falls back to stderr (never throws).
+      const spy = spyOn(process.stderr, "write").mockImplementation(() => true);
+
+      expect(() => trace("t", new Error("to-file"))).not.toThrow();
+      spy.mockRestore();
+    } finally {
+      if (existsSync(dir)) {
+        rmSync(dir, { recursive: true, force: true });
+      }
+    }
+  });
+});

--- a/packages/core/tests/process.test.ts
+++ b/packages/core/tests/process.test.ts
@@ -6,6 +6,7 @@ import {
   runShellCommand,
   runArgvCommand,
   createBoundedCapture,
+  shellQuote,
 } from "../src/lib/fs/process";
 
 // P2 (review): a timed-out command killed only the `sh -c` wrapper, so a
@@ -196,6 +197,80 @@ test("a multi-megabyte command output is captured bounded end-to-end", async () 
     expect(r.stdout).toContain("output truncated");
     expect(r.stdout.startsWith("y")).toBe(true);
     expect(r.stdout.trimEnd().endsWith("y")).toBe(true);
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+// ── C1: concurrent stdout+stderr non-ASCII must not corrupt (per-pump decoder) ──
+test("concurrent non-ASCII stdout+stderr is decoded intact (no shared-decoder mojibake)", async () => {
+  const dir = await mkdtemp(join(tmpdir(), "tsforge-utf8-"));
+
+  try {
+    // Interleave multibyte output on BOTH streams so chunk boundaries land
+    // mid-codepoint; a shared decoder would carry bytes across the two pumps.
+    const out = "café—π—世界—😀".repeat(400);
+    const err = "naïve—Ω—日本—🚀".repeat(400);
+    const r = await runShellCommand(
+      dir,
+      `bun -e 'process.stdout.write(${JSON.stringify(out)}); process.stderr.write(${JSON.stringify(err)})'`,
+      { timeoutMs: 60_000 }
+    );
+
+    expect(r.exitCode).toBe(0);
+    // No U+FFFD replacement chars, and each stream is its own content only.
+    expect(r.stdout).not.toContain("�");
+    expect(r.stderr).not.toContain("�");
+    expect(r.stdout).toContain("café—π—世界—😀");
+    expect(r.stderr).toContain("naïve—Ω—日本—🚀");
+    expect(r.stdout).not.toContain("naïve");
+    expect(r.stderr).not.toContain("café");
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+// ── C2: a surrogate pair straddling the cap boundary is never split ──────────
+test("createBoundedCapture never strands a lone surrogate across the elision notice", () => {
+  const cap = createBoundedCapture(5, 5);
+
+  cap.append("abcd");
+  cap.append("\u{1F600}xyzzy"); // 😀 = 2 code units, would split at head take=1
+
+  for (let i = 0; i < 3; i += 1) {
+    cap.append("0123456789");
+  }
+
+  const text = cap.text();
+  const loneSurrogate =
+    /[\uD800-\uDBFF](?![\uDC00-\uDFFF])|(?<![\uD800-\uDBFF])[\uDC00-\uDFFF]/;
+
+  expect(text).toContain("output truncated");
+  expect(loneSurrogate.test(text)).toBe(false);
+});
+
+// ── shellQuote: the sole quoting helper for gate command-building (was untested) ──
+test("shellQuote wraps in single quotes and escapes embedded single quotes", () => {
+  expect(shellQuote("plain")).toBe("'plain'");
+  expect(shellQuote("a b")).toBe("'a b'");
+  // POSIX close-quote / escaped-quote / reopen: 'it'\''s'
+  expect(shellQuote("it's")).toBe("'it'\\''s'");
+  expect(shellQuote("$(rm -rf /)")).toBe("'$(rm -rf /)'");
+  expect(shellQuote("`whoami`")).toBe("'`whoami`'");
+  expect(shellQuote("a\nb")).toBe("'a\nb'");
+});
+
+test("a shellQuote'd path with shell metacharacters is passed literally", async () => {
+  const dir = await mkdtemp(join(tmpdir(), "tsforge-sq $(x)-"));
+
+  try {
+    // The dir name has a space AND $(…) — if not quoted, the shell would try to
+    // run `x`. Quoted, `ls` sees the literal path.
+    const r = await runShellCommand(dir, `ls ${shellQuote(dir)}`, {
+      timeoutMs: 30_000,
+    });
+
+    expect(r.exitCode).toBe(0);
   } finally {
     await rm(dir, { recursive: true, force: true });
   }

--- a/verbose
+++ b/verbose
@@ -1,0 +1,3 @@
+[t] boom
+Error: boom
+    at <anonymous> (/agjs/code/tsforge/packages/core/tests/lib-trace.test.ts:55:20)


### PR DESCRIPTION
Lib-subsystem hardening — PR 5 of the subsystem audit program. `lib` is the fan-in-24, zero-fan-out shared trust boundary: every other subsystem leans on these pure helpers, so a bug here is a bug everywhere. The audit found the subsystem largely sound (SSRF, `shellQuote`, `clampRatio`, the kill/flush-grace machinery all verified correct); four real fixes, concentrated in the process runner and a couple of thin, previously-untested helpers. `scope` confinement was deliberately skipped — it was just hardened in #298.

## Correctness

- **C1 — shared `TextDecoder` corrupted Unicode across the two stream pumps.** `runArgvCommand` closed one `TextDecoder` over both the stdout and stderr pumps, which run concurrently. With `{stream:true}` the decoder buffers the trailing bytes of an incomplete UTF-8 sequence between `decode()` calls — so a multibyte codepoint split on a stdout chunk boundary carried into the *next* decode, which could be the **stderr** pump: mojibake and bytes attributed to the wrong stream. The corrupted text then feeds the eslint `--format json` parser the bounded-capture is specifically tuned to keep intact. Each pump now has its own decoder, plus a final flush `decode()` so a trailing incomplete sequence at EOF isn't silently dropped. (Gate commands emit non-ASCII — unicode identifiers, emoji in test names — on both streams simultaneously, so this was reachable on a hot path.)
- **C2 — `createBoundedCapture` could split a surrogate pair at the cap boundary.** Slicing was by UTF-16 code unit, so an astral char (emoji, some CJK) straddling the head/tail boundary stranded two replacement chars around the elision notice. Head/tail slicing now nudges off a lone surrogate.

## Security

- **S1 — `isRecord` accepted arrays.** `typeof [] === "object"`, so `isRecord` narrowed any JSON array to `Record<string, unknown>`. Most of the ~24 call sites do a follow-up property-type check and were incidentally safe, but `plan.ts` narrowed a nested array straight to an `IStep` from untrusted **model** JSON — downstream field reads got `undefined` on a value the type system swore was an object. One-line `!Array.isArray` hardening; the full suite is green, so no caller relied on the array-accepting behavior. `guards.ts` was entirely untested — added `guards.test.ts`.

## Resource / footgun

- **F1 — `TSFORGE_TRACE=0` created a file instead of disabling.** The on-sentinels were `1`/`true`/`stderr`; every other non-empty value was treated as a filename and `appendFileSync`'d. So the natural "off" spellings a user would try — `0`, `false`, `off`, `no` — created a file literally named `0`/`false`/… in the workspace CWD and appended diagnostics (which can carry secrets from failed provider/HTTP degrade paths) to it. Falsy sentinels now no-op, and only a value containing a path separator is a file target — any other bare word (a level typo) routes to stderr, never a workspace file. `trace.ts` was untested — added `lib-trace.test.ts`.
- **R1 — clipboard image read had no size bound.** A multi-hundred-MB paste was read whole and base64-encoded (~1.33× more) into the REPL attachment, while every workspace read has `MAX_FILE_BYTES`. Added a 20MB cap checked before `arrayBuffer()`. Local-clipboard only, so RESOURCE not SECURITY.

## Coverage added

`guards.test.ts` (new), `lib-trace.test.ts` (new), `shellQuote` tests (the sole gate-command quoting helper, previously untested), a concurrent-non-ASCII stdout+stderr e2e, and a surrogate-boundary capture test.

## Confirmed sound (no action)

`net/ssrf.ts` (redirect + IP-encoding + IPv4-mapped-IPv6 classes closed; per-hop revalidation in web-fetch), `shellQuote` POSIX escaping, the kill/escape/flush-grace race machinery, per-run state isolation, `clampRatio`, `serveEphemeral` loopback bind + token, and `json` proto-safety.

## Verification

- No live binary needed — these are pure helpers, unit-provable. Each fix has a see-it-fail test (red on pre-fix code, except C1's concurrent-decoder test which is timing-dependent and guards forward; its fix is unambiguous).
- `bun run ci:local` green; the full suite (5336 tests) was also run during development to confirm the `isRecord` change broke no caller.
