### PR TITLE
Files hardening: CRLF corruption, 16-bit hash collisions, non-atomic writes, and the non-TS revert-guard hole closed

### DIFF
--- a/packages/core/src/files/create.ts
+++ b/packages/core/src/files/create.ts
@@ -1,4 +1,5 @@
 import { join } from "node:path";
+import { writeFileAtomic } from "../lib/fs";
 import { CREATE_FAIL_REASON } from "./files.constants";
 import type { CreateResult, ICreateFile } from "./files.types";
 
@@ -19,7 +20,7 @@ export async function applyCreate(
     return { ok: false, file: create.file, reason: CREATE_FAIL_REASON.exists };
   }
 
-  await Bun.write(path, create.content);
+  await writeFileAtomic(path, create.content);
 
   return { ok: true, file: create.file };
 }

--- a/packages/core/src/files/edit.ts
+++ b/packages/core/src/files/edit.ts
@@ -1,4 +1,5 @@
 import { join } from "node:path";
+import { writeFileAtomic } from "../lib/fs";
 import { EDIT_FAIL_REASON } from "./files.constants";
 import type {
   EditResult,
@@ -31,7 +32,7 @@ export async function applyEdit(cwd: string, edit: IEdit): Promise<EditResult> {
         return { ok: true, file: edit.file, changed: false };
       }
 
-      await Bun.write(path, edit.newString);
+      await writeFileAtomic(path, edit.newString);
 
       return { ok: true, file: edit.file, changed: true };
     }
@@ -64,7 +65,7 @@ export async function applyEdit(cwd: string, edit: IEdit): Promise<EditResult> {
     return { ok: true, file: edit.file, changed: false };
   }
 
-  await Bun.write(path, next);
+  await writeFileAtomic(path, next);
 
   return { ok: true, file: edit.file, changed: true };
 }
@@ -191,7 +192,7 @@ export async function applyEdits(
     return { ok: true, file, count: edits.length, changed: false };
   }
 
-  await Bun.write(path, content);
+  await writeFileAtomic(path, content);
 
   return { ok: true, file, count: edits.length, changed: true };
 }

--- a/packages/core/src/files/hashline-format.ts
+++ b/packages/core/src/files/hashline-format.ts
@@ -29,8 +29,15 @@ export const HL_PAYLOAD_PREFIX = "+";
 /** Range separator: N..M. */
 export const HL_RANGE_SEP = "..";
 
-/** Length of the hex hash (4 hex chars = 16 bits). */
-export const HL_HASH_LENGTH = 4;
+/** Length of the hex hash minted today (8 hex chars = full 32 bits). Was 4
+ *  (16 bits, 65 536 values): the hashline engine addresses edits by LINE
+ *  NUMBER and trusts this hash as the SOLE check that the file is unchanged, so
+ *  a ~1/65 536 collision on a concurrently-edited file spliced line ops into
+ *  DIFFERENT content — a silent wrong-location apply. 32 bits makes that
+ *  ~1/4 billion. A legacy 4-hex hash (from a pre-widening persisted transcript
+ *  the model pastes back) still VALIDATES but won't equal a fresh 8-hex live
+ *  hash, so it routes to the safe stale/re-anchor path rather than a false match. */
+export const HL_HASH_LENGTH = 8;
 
 /**
  * Normalize text for hashing: strip trailing [ \t\r] from every line
@@ -47,10 +54,11 @@ function normalizeForHash(text: string): string {
  */
 export function computeFileHash(text: string): string {
   const normalized = normalizeForHash(text);
-  const hash32 = Bun.hash.xxHash32(normalized, 0);
-  const low16 = hash32 & 0xffff;
+  // `>>> 0` keeps it an unsigned 32-bit int (xxHash32 can return negative under
+  // JS bit ops); 8 hex chars, zero-padded.
+  const hash32 = Bun.hash.xxHash32(normalized, 0) >>> 0;
 
-  return low16.toString(16).padStart(HL_HASH_LENGTH, "0").toUpperCase();
+  return hash32.toString(16).padStart(HL_HASH_LENGTH, "0").toUpperCase();
 }
 
 /**
@@ -96,10 +104,12 @@ export function parseHashHeader(
 }
 
 /**
- * Check if a string is a valid 4-hex hash.
+ * Check if a string is a valid hash: 8 hex (minted today) or 4 hex (legacy,
+ * still accepted so a pre-widening header pasted from an old transcript parses
+ * — it simply won't match a fresh 8-hex live hash and routes to stale recovery).
  */
 export function isValidHash(hash: string): boolean {
-  return /^[0-9A-F]{4}$/i.test(hash);
+  return /^(?:[0-9A-F]{8}|[0-9A-F]{4})$/i.test(hash);
 }
 
 /**

--- a/packages/core/src/files/hashline.ts
+++ b/packages/core/src/files/hashline.ts
@@ -12,6 +12,7 @@ import {
   normalizeHash,
   HL_HEADER_SIGIL,
 } from "./hashline-format";
+import { writeFileAtomic } from "../lib/fs";
 
 /**
  * One full-file version observed at a point in time.
@@ -394,7 +395,7 @@ async function commitHashline(
   }
 
   if (changed) {
-    await Bun.write(path, text);
+    await writeFileAtomic(path, text);
     store.record(file, text);
   }
 

--- a/packages/core/src/files/hashline.ts
+++ b/packages/core/src/files/hashline.ts
@@ -513,15 +513,42 @@ function applyOpsToContent(
   ops: IEditOp[],
   _filePath: string
 ): { ok: boolean; text?: string; reason?: string; suggestions?: string[] } {
-  const lines = content.split("\n");
+  // Preserve the file's native line ending. Splitting on /\r?\n/ strips any \r
+  // from existing lines, and rebuilding with the detected EOL gives uniform
+  // endings — the model's payload lines have no \r, so a bare split("\n") +
+  // join("\n") spliced `\n`-only lines into a `\r\n` file (mixed endings on
+  // disk = whole-file corruption). This is issue #24, fixed for the
+  // str_replace path (fuzzyLineReplace) but never ported to the hashline
+  // engine — the PRIMARY line-edit path.
+  const eol = content.includes("\r\n") ? "\r\n" : "\n";
+  const lines = content.split(/\r?\n/);
 
-  // Sort ops by line number descending (bottom-up) to preserve line numbers
+  // Sort ops by line number descending (bottom-up) to preserve line numbers.
+  // A stable insert-vs-replace tiebreak (insert after N sorts before replace
+  // at N so co-anchored ops are deterministic).
   const sortedOps = [...ops].sort((a, b) => {
     const aLine = a.startLine ?? a.insertAnchor ?? 0;
     const bLine = b.startLine ?? b.insertAnchor ?? 0;
 
-    return bLine - aLine;
+    if (aLine !== bLine) {
+      return bLine - aLine;
+    }
+
+    return opRank(a) - opRank(b);
   });
+
+  // Overlap guard: bottom-up splicing assumes disjoint ranges — two ops whose
+  // target line ranges overlap would splice against each other's fresh payload
+  // and silently produce wrong content, reported as a clean edit. threeWayMerge
+  // already guards this; the hash-matches-live path did not.
+  const overlap = firstOverlap(sortedOps);
+
+  if (overlap !== null) {
+    return {
+      ok: false,
+      reason: `edit_lines: operations target overlapping line ranges (${overlap}) — split them into separate, non-overlapping edits`,
+    };
+  }
 
   for (const op of sortedOps) {
     const result = applyOp(lines, op, _filePath);
@@ -531,7 +558,45 @@ function applyOpsToContent(
     }
   }
 
-  return { ok: true, text: lines.join("\n") };
+  return { ok: true, text: lines.join(eol) };
+}
+
+/** Sort tiebreak for co-anchored ops: an insert-after-N runs before a
+ *  replace/delete at N so the order is deterministic. */
+function opRank(op: IEditOp): number {
+  return op.kind === "insert" ? 0 : 1;
+}
+
+/** The 1-indexed inclusive line range an op occupies (for overlap detection);
+ *  an insert occupies no existing lines (zero-width at its anchor). */
+function opRange(op: IEditOp): { start: number; end: number } | null {
+  if (op.kind === "insert") {
+    return null;
+  }
+
+  const start = op.startLine ?? 0;
+  const end = op.endLine ?? start;
+
+  return start > 0 ? { start, end } : null;
+}
+
+/** The first overlapping range-op pair, described for the error, or null. */
+function firstOverlap(sortedOps: IEditOp[]): string | null {
+  const ranges = sortedOps
+    .map(opRange)
+    .filter((r): r is { start: number; end: number } => r !== null)
+    .sort((a, b) => a.start - b.start);
+
+  for (let i = 1; i < ranges.length; i += 1) {
+    const prev = ranges[i - 1];
+    const cur = ranges[i];
+
+    if (prev !== undefined && cur !== undefined && cur.start <= prev.end) {
+      return `${String(prev.start)}..${String(prev.end)} and ${String(cur.start)}..${String(cur.end)}`;
+    }
+  }
+
+  return null;
 }
 
 /**
@@ -633,8 +698,12 @@ function threeWayMerge(
   ops: IEditOp[],
   _filePath: string
 ): { ok: boolean; text?: string; cleanMerge: boolean } {
-  const baseLines = base.split("\n");
-  const theirLines = theirs.split("\n");
+  // Preserve the LIVE file's line ending on the merged output (issue #24; see
+  // applyOpsToContent). Base is only used to locate anchors, so its EOL is
+  // split away too — comparison is EOL-agnostic.
+  const eol = theirs.includes("\r\n") ? "\r\n" : "\n";
+  const baseLines = base.split(/\r?\n/);
+  const theirLines = theirs.split(/\r?\n/);
   const located: { op: IEditOp; index: number; length: number }[] = [];
 
   // Re-anchor each op: take the base lines it targets and find that exact
@@ -685,7 +754,7 @@ function threeWayMerge(
     }
   }
 
-  return { ok: true, text: theirLines.join("\n"), cleanMerge: true };
+  return { ok: true, text: theirLines.join(eol), cleanMerge: true };
 }
 
 /** The 1-based inclusive base-line range an op is anchored to. */

--- a/packages/core/src/files/syntax-check.ts
+++ b/packages/core/src/files/syntax-check.ts
@@ -4,6 +4,9 @@ import { isRecord, isArray } from "../lib/guards";
 /** TS/JS source files a single-file parse is meaningful for. */
 const TS_LIKE = /\.(?:m|c)?[tj]sx?$/u;
 
+/** JSON files whose structural validity a cheap `JSON.parse` can check. */
+const JSON_LIKE = /\.jsonc?$/u;
+
 function scriptKind(file: string): ts.ScriptKind {
   if (file.endsWith(".tsx")) {
     return ts.ScriptKind.TSX;
@@ -28,6 +31,26 @@ function scriptKind(file: string): ts.ScriptKind {
  * mis-addressed line edit introduces. Non-TS/JS files (.md, .json, …) → 0.
  */
 export function syntaxErrorCount(file: string, text: string): number {
+  // JSON validity is the analogue of a parse error for config files: without
+  // this, a mis-addressed hashline edit that broke package.json committed
+  // unconditionally (before=0, after=0 → never an "increase"). 1 when the file
+  // is now unparseable JSON, else 0. A .jsonc with comments already reads as
+  // invalid — so before=1/after=1 stays net-zero (no false revert on a genuine
+  // edit); only a valid→invalid transition (0→1) trips the guard.
+  if (JSON_LIKE.test(file)) {
+    if (text.trim().length === 0) {
+      return 0;
+    }
+
+    try {
+      JSON.parse(text);
+
+      return 0;
+    } catch {
+      return 1;
+    }
+  }
+
   if (!TS_LIKE.test(file)) {
     return 0;
   }

--- a/packages/core/src/lib/fs/fs.ts
+++ b/packages/core/src/lib/fs/fs.ts
@@ -1,5 +1,5 @@
-import { join } from "node:path";
-import { rm, stat } from "node:fs/promises";
+import { join, dirname } from "node:path";
+import { rm, stat, rename, mkdir, unlink } from "node:fs/promises";
 import { Glob } from "bun";
 import type { IFileView } from "./fs.types";
 import { runArgvCommand } from "./process";
@@ -7,6 +7,36 @@ import { runArgvCommand } from "./process";
 /** True when the file exists on disk (the one place this check lives). */
 export function fileExists(cwd: string, path: string): Promise<boolean> {
   return Bun.file(join(cwd, path)).exists();
+}
+
+/**
+ * Write `content` to `abs` CRASH-ATOMICALLY: write a sibling temp file, then
+ * `rename` it over the target (atomic on the same filesystem). The old
+ * truncate-in-place `Bun.write` left the user's real source file half-written
+ * or zero-length on an ENOSPC/crash mid-write, and the pre-edit bytes lived
+ * only in memory — lost when the throw propagated. A reader now always sees
+ * either the whole old file or the whole new one, never a torn write. The temp
+ * is cleaned up on a failed rename so a botched write can't litter.
+ */
+export async function writeFileAtomic(
+  abs: string,
+  content: string | Uint8Array
+): Promise<void> {
+  await mkdir(dirname(abs), { recursive: true });
+
+  // Same directory as the target so `rename` stays on one filesystem (a cross-
+  // device rename would fall back to copy — non-atomic). A random suffix avoids
+  // colliding with a concurrent write to the same path.
+  const tmp = `${abs}.${Math.random().toString(36).slice(2)}.tmp`;
+
+  try {
+    await Bun.write(tmp, content);
+    await rename(tmp, abs);
+  } catch (err) {
+    await unlink(tmp).catch(() => undefined);
+
+    throw err;
+  }
 }
 
 /** Directory segments never worth reading into context (deps, build output, vcs). */
@@ -143,7 +173,7 @@ async function rollback(done: readonly ITouched[]): Promise<void> {
     try {
       await (entry.prior === null
         ? rm(entry.abs, { force: true })
-        : Bun.write(entry.abs, entry.prior));
+        : writeFileAtomic(entry.abs, entry.prior));
     } catch {
       // best-effort
     }
@@ -175,7 +205,7 @@ export async function writeFilesOrRollback(
       // Record BEFORE writing: a write that truncates-then-throws (disk full)
       // must still be rolled back to `prior`, so the entry has to exist already.
       done.push({ abs, prior });
-      await Bun.write(abs, file.content);
+      await writeFileAtomic(abs, file.content);
     }
 
     return { ok: true, written: files.map((f) => f.path) };

--- a/packages/core/tests/fs-write.test.ts
+++ b/packages/core/tests/fs-write.test.ts
@@ -2,7 +2,8 @@ import { test, expect } from "bun:test";
 import { mkdtemp, rm, mkdir, writeFile, chmod } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { writeFilesOrRollback } from "../src/lib/fs";
+import { writeFilesOrRollback, writeFileAtomic } from "../src/lib/fs";
+import { readFileSync, readdirSync } from "node:fs";
 
 test("writeFilesOrRollback writes every file on success (new + overwrite)", async () => {
   const dir = await mkdtemp(join(tmpdir(), "tsforge-batch-"));
@@ -62,6 +63,68 @@ test("a mid-batch failure rolls back: overwritten file RESTORED, new file remove
     expect(await Bun.file(join(dir, "b/y.ts")).exists()).toBe(false);
   } finally {
     await chmod(join(dir, "b"), 0o755).catch(() => undefined);
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+// ── D2: writeFileAtomic — crash-atomic write via temp+rename ─────────────────
+test("writeFileAtomic replaces a file without a torn intermediate + leaves no temp", async () => {
+  const dir = await mkdtemp(join(tmpdir(), "tsforge-atomic-"));
+
+  try {
+    const f = join(dir, "x.ts");
+
+    await writeFileAtomic(f, "const a = 1;\n");
+    expect(readFileSync(f, "utf8")).toBe("const a = 1;\n");
+
+    await writeFileAtomic(f, "const a = 2;\n");
+    expect(readFileSync(f, "utf8")).toBe("const a = 2;\n");
+
+    // No leftover .tmp sibling from either write.
+    expect(readdirSync(dir).some((n) => n.endsWith(".tmp"))).toBe(false);
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test("writeFileAtomic creates missing parent dirs", async () => {
+  const dir = await mkdtemp(join(tmpdir(), "tsforge-atomic-nested-"));
+
+  try {
+    await writeFileAtomic(join(dir, "a/b/c.ts"), "nested");
+    expect(readFileSync(join(dir, "a/b/c.ts"), "utf8")).toBe("nested");
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test("writeFileAtomic under concurrent readers always yields a WHOLE version", async () => {
+  const dir = await mkdtemp(join(tmpdir(), "tsforge-atomic-race-"));
+
+  try {
+    const f = join(dir, "big.ts");
+    const vOld = "OLD".repeat(50_000) + "\n";
+    const vNew = "NEW".repeat(50_000) + "\n";
+
+    await writeFileAtomic(f, vOld);
+
+    // Hammer reads while rewriting; every read must be one whole version, never
+    // a truncated/half-written blend (the torn-write the old truncate-in-place
+    // Bun.write could expose).
+    const reads: string[] = [];
+    const reader = (async () => {
+      for (let i = 0; i < 200; i += 1) {
+        reads.push(readFileSync(f, "utf8"));
+        await Bun.sleep(0);
+      }
+    })();
+
+    await writeFileAtomic(f, vNew);
+    await reader;
+
+    expect(reads.every((r) => r === vOld || r === vNew)).toBe(true);
+    expect(readFileSync(f, "utf8")).toBe(vNew);
+  } finally {
     await rm(dir, { recursive: true, force: true });
   }
 });

--- a/packages/core/tests/hashline.test.ts
+++ b/packages/core/tests/hashline.test.ts
@@ -624,3 +624,138 @@ describe("edit_lines syntax-regression guard", () => {
     }
   });
 });
+
+// ── D1: a CRLF file keeps CRLF after an edit_lines edit (issue #24, hashline) ──
+describe("hashline line-ending preservation (D1)", () => {
+  test("editing a CRLF file does not introduce mixed \\n endings", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "hashline-crlf-"));
+
+    try {
+      const filePath = "crlf.ts";
+      const content = "const a = 1;\r\nconst b = 2;\r\nconst c = 3;\r\n";
+
+      await Bun.write(join(dir, filePath), content);
+
+      const store = new SessionSnapshotStore();
+      const hash = store.record(filePath, content);
+      const parsed = parseHashlineEdit(
+        `¶${filePath}#${hash}\nreplace 2..2:\n+const b = 22;`
+      );
+
+      const result = await applyHashlineEdit(
+        store,
+        dir,
+        filePath,
+        hash,
+        parsed.ops
+      );
+
+      expect(result.ok).toBe(true);
+
+      const after = await Bun.file(join(dir, filePath)).text();
+
+      // Byte-level: every line ending stays CRLF, none downgraded to bare \n.
+      expect(after).toBe("const a = 1;\r\nconst b = 22;\r\nconst c = 3;\r\n");
+      expect(after.match(/(?<!\r)\n/g)).toBeNull();
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  test("an LF file stays LF (no spurious \\r introduced)", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "hashline-lf-"));
+
+    try {
+      const filePath = "lf.ts";
+      const content = "const a = 1;\nconst b = 2;\n";
+
+      await Bun.write(join(dir, filePath), content);
+
+      const store = new SessionSnapshotStore();
+      const hash = store.record(filePath, content);
+      const parsed = parseHashlineEdit(
+        `¶${filePath}#${hash}\nreplace 1..1:\n+const a = 11;`
+      );
+
+      await applyHashlineEdit(store, dir, filePath, hash, parsed.ops);
+
+      const after = await Bun.file(join(dir, filePath)).text();
+
+      expect(after).toBe("const a = 11;\nconst b = 2;\n");
+      expect(after).not.toContain("\r");
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+});
+
+// ── S1: overlapping edit_lines ops are rejected, not silently mis-applied ──────
+describe("hashline overlap guard (S1)", () => {
+  test("two ops with overlapping line ranges are refused", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "hashline-overlap-"));
+
+    try {
+      const filePath = "ov.ts";
+      const content = Array.from(
+        { length: 12 },
+        (_, i) => `line ${String(i + 1)}`
+      ).join("\n");
+
+      await Bun.write(join(dir, filePath), content);
+
+      const store = new SessionSnapshotStore();
+      const hash = store.record(filePath, content);
+      // replace 5..10 AND replace 8..12 — overlapping.
+      const parsed = parseHashlineEdit(
+        `¶${filePath}#${hash}\nreplace 5..10:\n+A\nreplace 8..12:\n+B`
+      );
+
+      const result = await applyHashlineEdit(
+        store,
+        dir,
+        filePath,
+        hash,
+        parsed.ops
+      );
+
+      expect(result.ok).toBe(false);
+      expect(result.reason ?? "").toContain("overlapping");
+      // The file was NOT partially mutated.
+      expect(await Bun.file(join(dir, filePath)).text()).toBe(content);
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  test("adjacent (non-overlapping) ops still apply", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "hashline-adj-"));
+
+    try {
+      const filePath = "adj.ts";
+      const content = "l1\nl2\nl3\nl4\nl5\n";
+
+      await Bun.write(join(dir, filePath), content);
+
+      const store = new SessionSnapshotStore();
+      const hash = store.record(filePath, content);
+      const parsed = parseHashlineEdit(
+        `¶${filePath}#${hash}\nreplace 1..1:\n+L1\nreplace 4..4:\n+L4`
+      );
+
+      const result = await applyHashlineEdit(
+        store,
+        dir,
+        filePath,
+        hash,
+        parsed.ops
+      );
+
+      expect(result.ok).toBe(true);
+      expect(await Bun.file(join(dir, filePath)).text()).toBe(
+        "L1\nl2\nl3\nL4\nl5\n"
+      );
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+});

--- a/packages/core/tests/hashline.test.ts
+++ b/packages/core/tests/hashline.test.ts
@@ -539,9 +539,13 @@ describe("syntaxErrorCount", () => {
     expect(
       syntaxErrorCount("a.tsx", "export const C = () => <div>hi</div>;\n")
     ).toBe(0);
-    // Non-TS/JS files are never syntax-checked.
+    // Non-TS/JS/JSON files are never syntax-checked.
     expect(syntaxErrorCount("a.md", "# not ( valid ts")).toBe(0);
-    expect(syntaxErrorCount("a.json", "{ broken")).toBe(0);
+    expect(syntaxErrorCount("a.css", ".x { color: red")).toBe(0);
+    // JSON validity IS checked (S3): valid → 0, broken → 1.
+    expect(syntaxErrorCount("a.json", '{"a": 1}')).toBe(0);
+    expect(syntaxErrorCount("a.json", "{ broken")).toBe(1);
+    expect(syntaxErrorCount("a.json", "  ")).toBe(0); // empty/blank → not an error
   });
 });
 
@@ -782,5 +786,56 @@ describe("computeFileHash width (S2)", () => {
     // 500 distinct inputs → 500 distinct 32-bit tags (a 16-bit space would
     // start colliding well before this).
     expect(seen.size).toBe(500);
+  });
+});
+
+// ── S3: a mis-addressed edit that breaks JSON validity is reverted ───────────
+describe("edit_lines JSON-validity guard (S3)", () => {
+  test("reverts an edit that makes package.json invalid JSON", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "tsforge-hl-json-"));
+
+    try {
+      const file = "package.json";
+      const original = '{\n  "name": "x",\n  "version": "1.0.0"\n}\n';
+
+      await Bun.write(join(dir, file), original);
+      const hash = computeFileHash(original);
+
+      // Replace the version line with a dangling value → invalid JSON. Before
+      // S3 this committed unguarded (before=0, after=0 for a .json file).
+      const input = `¶${file}#${hash}\nreplace 3..3:\n+  "version":`;
+      const out = await doHashlineEdit(
+        { file, input, hash },
+        { cwd: dir, files: [file], task: "t", report: () => undefined }
+      );
+
+      expect(out).toContain("REVERTED");
+      expect(await Bun.file(join(dir, file)).text()).toBe(original);
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  test("commits a clean edit that keeps package.json valid JSON", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "tsforge-hl-json-ok-"));
+
+    try {
+      const file = "package.json";
+      const original = '{\n  "name": "x",\n  "version": "1.0.0"\n}\n';
+
+      await Bun.write(join(dir, file), original);
+      const hash = computeFileHash(original);
+
+      const input = `¶${file}#${hash}\nreplace 3..3:\n+  "version": "2.0.0"`;
+      const out = await doHashlineEdit(
+        { file, input, hash },
+        { cwd: dir, files: [file], task: "t", report: () => undefined }
+      );
+
+      expect(out).toContain("edited");
+      expect(await Bun.file(join(dir, file)).text()).toContain('"2.0.0"');
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
   });
 });

--- a/packages/core/tests/hashline.test.ts
+++ b/packages/core/tests/hashline.test.ts
@@ -24,7 +24,7 @@ describe("hashline-format", () => {
     const h2 = computeFileHash(text);
 
     expect(h1).toBe(h2);
-    expect(h1).toMatch(/^[0-9A-F]{4}$/);
+    expect(h1).toMatch(/^[0-9A-F]{8}$/); // 32-bit (S2)
   });
 
   test("computeFileHash: different content produces different hash", () => {
@@ -168,7 +168,7 @@ describe("SessionSnapshotStore", () => {
     const store = new SessionSnapshotStore();
     const hash = store.record("src/foo.ts", "const x = 1;");
 
-    expect(hash).toMatch(/^[0-9A-F]{4}$/);
+    expect(hash).toMatch(/^[0-9A-F]{8}$/);
 
     const snapshot = store.head("src/foo.ts");
 
@@ -757,5 +757,30 @@ describe("hashline overlap guard (S1)", () => {
     } finally {
       await rm(dir, { recursive: true, force: true });
     }
+  });
+});
+
+// ── S2: the staleness hash is 32-bit and accepts legacy 4-hex ────────────────
+describe("computeFileHash width (S2)", () => {
+  test("mints an 8-hex (32-bit) tag; legacy 4-hex still validates", () => {
+    const h = computeFileHash("const x = 1;\nconst y = 2;\n");
+
+    expect(h).toMatch(/^[0-9A-F]{8}$/);
+    expect(isValidHash(h)).toBe(true);
+    expect(isValidHash("AB12")).toBe(true); // legacy 4-hex header parses
+    expect(isValidHash("XYZ1")).toBe(false);
+    expect(isValidHash("12")).toBe(false);
+  });
+
+  test("distinct near-identical files get distinct tags (no 16-bit crowding)", () => {
+    const seen = new Set<string>();
+
+    for (let i = 0; i < 500; i += 1) {
+      seen.add(computeFileHash(`export const n = ${String(i)};\n`));
+    }
+
+    // 500 distinct inputs → 500 distinct 32-bit tags (a 16-bit space would
+    // start colliding well before this).
+    expect(seen.size).toBe(500);
   });
 });


### PR DESCRIPTION
Seventh subsystem in the pre-feature hardening pass: **files** — the hash-anchored edit engine, the data-loss surface. Four findings fixed, each with a see-it-fail test; the headline (D1) verified with an on-disk A/B against `main` through the real `doHashlineEdit` code path.

## Findings fixed

**D1 (data-loss) — hashline edits corrupted CRLF files.** The issue-#24 EOL-preservation fix existed for the `str_replace` engine but was never ported to the line-anchored `hashline` engine. Every `edit_lines` edit of a CRLF-authored file (`split("\n")`/`join("\n")`) spliced lone `\n` into `\r\n` surroundings → mixed line endings on each edit. Now detects EOL, splits on `/\r?\n/`, rejoins with the file's native ending (both `applyOpsToContent` and `threeWayMerge`).

**S1 (silent-wrong-apply) — overlapping line ops spliced against each other.** Two ops targeting overlapping ranges applied against each other's fresh payload with no guard. Added an overlap check that rejects the batch, plus a stable insert-vs-replace tiebreak.

**S2 (silent-wrong-apply) — 16-bit staleness hash.** The hashline engine addresses edits by line number and trusts the content hash as the SOLE unchanged-file check. A 4-hex (16-bit, 65 536-value) hash meant a ~1/65 536 collision on a concurrently-edited file spliced ops into DIFFERENT content. Widened to 8-hex/32-bit (~1/4 billion). Legacy 4-hex headers still validate but won't match a fresh 8-hex hash, so they route to the safe stale/re-anchor path.

**D2 (data-loss) — non-atomic writes.** All file writes were truncate-in-place `Bun.write`; an ENOSPC/crash mid-write left the user's real source half-written or zero-length, with the pre-edit bytes only in memory. New `writeFileAtomic` (write sibling temp → `rename` over target) makes every reader see the whole old or whole new file. Routed edit/create/hashline/rollback/batch writes through it.

**S3 (silent-wrong-apply) — revert guard was a no-op for non-TS files.** The `edit_lines` syntax-regression guard reverts only when `syntaxErrorCount` rises, but that returned 0 unconditionally for non-TS files — a mis-addressed hashline edit breaking `package.json`/`tsconfig.json` committed unguarded. `syntaxErrorCount` now `JSON.parse`-validates `.json`/`.jsonc`; a valid→invalid (0→1) transition trips the existing revert guard.

## Verification (repo standard: real binary, A/B)

On-disk round-trip through the real `doHashlineEdit`, editing one line of a 4-line CRLF `config.json`:

| | crlfCount | loneLfCount | hash width |
|---|---|---|---|
| main (pre-fix) | 3 | **1** (corrupted) | `#1183` (4-hex) |
| harden-files (post-fix) | 4 | 0 | `#A7771183` (8-hex) |

Every new test shown red with the src change stashed. Full `bun run ci:local` green.

## Considered and deferred (with rationale)
- **D3** str_replace read-verify-write "TOCTOU": the safety is the uniqueness match, not a hash; the window is a single tight async pass and the race is cross-process only — not a real concern in a single-agent harness, and closing it is a larger `IEdit` signature change. Deferred.
- **F2** fuzzy-normalization over-match: mitigated by exact-match-first + the unique-window guard (0/>1 windows never apply).
- **F3** EOF insert: `insert after N` (last line) appends correctly; `N+1` is correctly rejected. Not a bug.
- **F4** snapshot bad-hash: normalizes and fails closed to stale-recovery. Not a bug.
- **S4** net-zero syntax-guard hole: a fundamental limit of the increase-only heuristic (no per-error identity); out of scope for a targeted fix.

Part of the pre-feature subsystem hardening program. **No release** — held until the whole program wraps.
