### PR TITLE
Browser oracle hardening: blank-screen/script-text/crashed-a11y false-greens closed, launch guarded, mount timeout configurable

### DIFF
--- a/packages/core/ARCHITECTURE.md
+++ b/packages/core/ARCHITECTURE.md
@@ -32,10 +32,10 @@ inventory, see the hand-drawn map on [Internals](/internals/).
 | `files` | Reading, creating, and hash-anchored editing of workspace files | core | 9 | 2k | 5 | 1 |
 | `policy` | Decides which actions are allowed in the current mode before they run | core | 5 | 1k | 5 | 3 |
 | `architecture` ⚠️ | Derives this map from source so the docs cannot drift from the code | optional | 8 | 1k | 0 | 0 |
+| `browser` | Headless Chromium oracle that render-checks a page as a gate stage | optional | 3 | <1k | 1 | 1 |
 | `lsp` | TypeScript language service powering navigation and write-time diagnostics | optional | 3 | <1k | 4 | 0 |
 | `infer-rules` | Scans a repo for its conventions and turns them into rule overrides | core | 7 | <1k | 5 | 2 |
 | `mcp` | Model Context Protocol client that exposes external servers as tools | optional | 8 | <1k | 2 | 1 |
-| `browser` | Headless Chromium oracle that render-checks a page as a gate stage | optional | 3 | <1k | 1 | 1 |
 | `validate` | Runs the gate command and parses tool output into structured errors | core | 7 | <1k | 7 | 2 |
 | `spec` | Task and spec shapes, spec parsing, and test generation from intent | core | 6 | <1k | 6 | 6 |
 | `stack-detection` | Detects the project's stack and picks which rule packs apply | core | 4 | <1k | 8 | 1 |

--- a/packages/core/src/browser/oracle.ts
+++ b/packages/core/src/browser/oracle.ts
@@ -23,18 +23,56 @@ async function loadChromium(): Promise<typeof Chromium | null> {
   }
 }
 
-/** Run axe against a page and return its raw result; null when @axe-core/
- *  playwright isn't installed (a11y is an optional enhancement, like the browser
- *  itself). Kept untyped at the boundary — extractAxeViolations narrows it. */
-async function runAxe(page: Page): Promise<unknown> {
+/** Outcome of an axe run, so the caller can tell three cases apart:
+ *  - `unavailable`: @axe-core/playwright isn't installed → skip (optional dep).
+ *  - `ok`: axe ran → narrow `result` for violations.
+ *  - `error`: axe was PRESENT but `analyze()` threw (CSP blocked the inject,
+ *    version drift, navigation mid-scan). This MUST surface, not be swallowed as
+ *    "clean" — a crashed a11y check reporting zero violations is a false green. */
+type IAxeOutcome =
+  | { kind: "unavailable" }
+  | { kind: "ok"; result: unknown }
+  | { kind: "error"; message: string };
+
+/** Run axe against a page. The dep-absent case (import throws) is a graceful
+ *  skip; a throw from `analyze()` is a real failure the caller reports. */
+async function runAxe(page: Page): Promise<IAxeOutcome> {
+  const mod = await import("@axe-core/playwright").catch(() => null);
+
+  // Import failed → the optional dep isn't installed → skip gracefully.
+  if (mod === null) {
+    return { kind: "unavailable" };
+  }
+
   try {
-    const mod = await import("@axe-core/playwright");
     const builder = new mod.AxeBuilder({ page });
 
-    return await builder.analyze();
-  } catch {
-    return null;
+    return { kind: "ok", result: await builder.analyze() };
+  } catch (error) {
+    return {
+      kind: "error",
+      message: error instanceof Error ? error.message : String(error),
+    };
   }
+}
+
+/** Map an axe outcome + the page location to gate errors. Pure — the a11y
+ *  green/red decision, unit-testable without a browser. `unavailable` → no
+ *  errors (skip); `error` → one "failed to run" error (never silently clean);
+ *  `ok` → the serious/critical violations. */
+export function axeOutcomeToErrors(
+  outcome: IAxeOutcome,
+  where: string
+): string[] {
+  if (outcome.kind === "unavailable") {
+    return [];
+  }
+
+  if (outcome.kind === "error") {
+    return [`a11y check failed to run at ${where}: ${outcome.message}`];
+  }
+
+  return summarizeAxeViolations(extractAxeViolations(outcome.result), where);
 }
 
 /**
@@ -89,6 +127,11 @@ export interface IRenderOptions {
   perfBudget?: IPerfBudget;
   /** Navigation timeout (default 15s). */
   timeoutMs?: number;
+  /** How long the smoke/crawl mount check polls for first paint before declaring
+   *  a page blank (default 5s). A genuinely-blank page ALWAYS costs this full
+   *  budget (the poll can only resolve early on success), so keep it modest;
+   *  tests set it low to stay under the runner timeout. */
+  mountTimeoutMs?: number;
 }
 
 /** Screenshot viewports — a desktop and a mobile pass per page. */
@@ -188,6 +231,58 @@ export function checkPerfBudget(
   return errors;
 }
 
+/** Max time to wait for chromium to launch before treating it as unavailable —
+ *  a hung launch (WSL2 missing libs, zombie process) must not stall the gate. */
+const LAUNCH_TIMEOUT_MS = 30_000;
+
+/** Launch chromium bounded by a timeout; null (with a stderr notice) when it
+ *  fails or stalls, so `renderCheck` can skip cleanly like the no-playwright path. */
+async function launchBrowser(
+  chromium: typeof Chromium
+): Promise<Awaited<ReturnType<typeof Chromium.launch>> | null> {
+  let timer: ReturnType<typeof setTimeout> | undefined;
+
+  try {
+    const launched = chromium.launch({ args: ["--no-sandbox"] });
+    const timeout = new Promise<null>((resolve) => {
+      timer = setTimeout(() => {
+        resolve(null);
+      }, LAUNCH_TIMEOUT_MS);
+    });
+    const browser = await Promise.race([launched, timeout]);
+
+    if (browser === null) {
+      // Timed out. Reap the eventual browser so a slow-but-successful launch
+      // doesn't leak an orphaned process after we've moved on.
+      void launched
+        .then(async (b) => {
+          await b.close();
+        })
+        .catch(() => undefined);
+      process.stderr.write(
+        `browser render-check skipped: chromium did not launch within ${String(
+          LAUNCH_TIMEOUT_MS
+        )}ms\n`
+      );
+
+      return null;
+    }
+
+    return browser;
+  } catch (error) {
+    process.stderr.write(
+      "browser render-check skipped: chromium failed to launch " +
+        `(${error instanceof Error ? error.message : String(error)})\n`
+    );
+
+    return null;
+  } finally {
+    if (timer !== undefined) {
+      clearTimeout(timer);
+    }
+  }
+}
+
 export async function renderCheck(
   opts: IRenderOptions
 ): Promise<IRenderResult> {
@@ -206,7 +301,17 @@ export async function renderCheck(
     return { ok: true, errors: [], skipped: true };
   }
 
-  const browser = await chromium.launch({ args: ["--no-sandbox"] });
+  // Launch is bounded and guarded: a browser binary that's missing (`bunx
+  // playwright install` never ran, version drift) THROWS, and on WSL2/containers
+  // launch can HANG on missing shared libs. Either way the render check is an
+  // enhancement over an already-passing build (tsc/eslint/build ran), so a launch
+  // that fails or stalls degrades to a skip with a notice — never an unhandled
+  // throw or an unbounded hang that blocks the whole gate.
+  const browser = await launchBrowser(chromium);
+
+  if (browser === null) {
+    return { ok: true, errors: [], skipped: true };
+  }
 
   try {
     // Page via an explicit context (not browser.newPage()) — axe-core/playwright
@@ -279,7 +384,7 @@ async function runChecks(
   }
 
   if (opts.smoke === true) {
-    await runSmoke(page, errors);
+    await runSmoke(page, errors, opts.mountTimeoutMs);
   }
 
   await runQualityOracles(page, opts, "index", errors, screenshots);
@@ -295,9 +400,7 @@ async function runQualityOracles(
   screenshots: string[]
 ): Promise<void> {
   if (opts.a11y === true) {
-    const violations = extractAxeViolations(await runAxe(page));
-
-    errors.push(...summarizeAxeViolations(violations, where));
+    errors.push(...axeOutcomeToErrors(await runAxe(page), where));
   }
 
   if (opts.perfBudget !== undefined) {
@@ -364,8 +467,18 @@ export function startStaticServer(
   return serveEphemeral({
     fetch: async (req): Promise<Response> => {
       const path = new URL(req.url).pathname;
-      const rel =
-        path === "/" ? "index.html" : decodeURIComponent(path.slice(1));
+
+      // `decodeURIComponent` throws URIError on malformed %-encoding (`/%`,
+      // `/%E0%A4`). Un-guarded that surfaced as a 500 from the handler; a bad
+      // asset path is a miss, not a server error — treat it as a clean 404.
+      let rel: string;
+
+      try {
+        rel = path === "/" ? "index.html" : decodeURIComponent(path.slice(1));
+      } catch {
+        return new Response("not found", { status: 404 });
+      }
+
       const base = resolve(root);
       const full = resolve(base, rel);
 
@@ -422,7 +535,7 @@ async function crawlRoutes(
       // Poll for first paint before the blank check, so a route that mounts
       // ASYNCHRONOUSLY (after MSW's worker.start() resolves, or any await-before-
       // render bootstrap) isn't misjudged dead. Only a genuinely empty root fails.
-      if (!(await waitForMount(page))) {
+      if (!(await waitForMount(page, quality.opts.mountTimeoutMs))) {
         errors.push(`route ${route} rendered blank`);
         continue;
       }
@@ -466,7 +579,23 @@ async function waitForMount(page: Page, timeoutMs = 5000): Promise<boolean> {
           document.querySelector("#app") ??
           document.body;
 
-        return root.children.length > 0 && root.textContent.trim() !== "";
+        // A blank white screen is the failure we're catching, so "mounted" must
+        // mean VISIBLE content — not just any node with any text. `textContent`
+        // concatenates <script>/<style> SOURCE and hidden text, so a body holding
+        // only a bootstrap `<script>` (children.length>0, textContent=the script's
+        // code) satisfied the old check and greened a page that rendered nothing.
+        // Require (a) a non-script/style/template element child AND (b) non-empty
+        // `innerText` (rendered, visible text — excludes script/style and
+        // display:none). document.body is an HTMLElement; a queried #root/#app is
+        // an Element, so narrow before reading innerText.
+        const NON_VISUAL = new Set(["SCRIPT", "STYLE", "TEMPLATE", "LINK"]);
+        const hasVisibleChild = Array.from(root.children).some(
+          (child) => !NON_VISUAL.has(child.tagName)
+        );
+        const visibleText =
+          root instanceof HTMLElement ? root.innerText : root.textContent;
+
+        return hasVisibleChild && visibleText.trim() !== "";
       },
       undefined,
       { timeout: timeoutMs, polling: 100 }
@@ -475,8 +604,12 @@ async function waitForMount(page: Page, timeoutMs = 5000): Promise<boolean> {
     .catch(() => false);
 }
 
-async function runSmoke(page: Page, errors: string[]): Promise<void> {
-  const mounted = await waitForMount(page);
+async function runSmoke(
+  page: Page,
+  errors: string[],
+  mountTimeoutMs?: number
+): Promise<void> {
+  const mounted = await waitForMount(page, mountTimeoutMs);
 
   if (!mounted) {
     errors.push("app did not mount: root is blank after load");
@@ -540,10 +673,13 @@ async function checkExpectations(
     return;
   }
 
-  // No selector → an optional whole-page text check.
+  // No selector → an optional whole-page text check. Use `innerText` (RENDERED,
+  // visible text), never `textContent`: textContent concatenates <script>/<style>
+  // source and display:none content, so an assertion for "Saved!" passed when the
+  // string lived only in inline script source and the user never saw it rendered.
   if (expect.selector === undefined) {
     if (expect.text !== undefined) {
-      const body = (await page.textContent("body")) ?? "";
+      const body = await page.innerText("body").catch(() => "");
 
       if (!body.includes(expect.text)) {
         errors.push(`page is missing expected text: "${expect.text}"`);
@@ -562,7 +698,8 @@ async function checkExpectations(
   }
 
   if (expect.text !== undefined) {
-    const text = (await element.textContent()) ?? "";
+    // innerText, not textContent — same reason: match only what actually renders.
+    const text = await element.innerText().catch(() => "");
 
     if (!text.includes(expect.text)) {
       errors.push(

--- a/packages/core/tests/browser-oracle.test.ts
+++ b/packages/core/tests/browser-oracle.test.ts
@@ -92,6 +92,12 @@ test("static server: 404s missing assets, SPA-falls-back, blocks ../ traversal",
 
     expect(dotfile.status).toBe(200);
     expect(await dotfile.text()).toBe("ok-inside");
+
+    // S10: malformed %-encoding must be a clean 404, not a 500 from a thrown
+    // URIError inside the fetch handler.
+    const malformed = await fetch(`${base}/%E0%A4`);
+
+    expect(malformed.status).toBe(404);
   } finally {
     await server.stop(true);
     await rm(dir, { recursive: true, force: true });
@@ -185,11 +191,48 @@ browserTest("smoke: fails on a blank root (silent white screen)", async () => {
   const result = await renderCheck({
     html: `<div id="root"></div>`,
     smoke: true,
+    // A blank page always costs the full mount budget (the poll resolves early
+    // only on success), so keep it short — the 5s default collides with the
+    // test-runner timeout, making this regression test time out instead of assert.
+    mountTimeoutMs: 800,
   });
 
   expect(result.ok).toBe(false);
   expect(result.errors.join(" ")).toContain("did not mount");
 });
+
+// S3: a body that renders NOTHING visible but carries an inline <script> used to
+// green — document.body fell back as the mount root, its <script> counted as a
+// child, and textContent returned the script's SOURCE as "content". The mount
+// check now requires a non-script/style element child AND non-empty innerText.
+browserTest(
+  "smoke: a script-only body (no #root) is NOT mistaken for mounted",
+  async () => {
+    const result = await renderCheck({
+      html: `<body><script>const x = "not rendered"; void x;</script></body>`,
+      smoke: true,
+      mountTimeoutMs: 800,
+    });
+
+    expect(result.ok).toBe(false);
+    expect(result.errors.join(" ")).toContain("did not mount");
+  }
+);
+
+// S4: a content assertion must match RENDERED text, never text that lives only in
+// inline <script>/<style> source (which textContent would have concatenated).
+browserTest(
+  "expect.text does not match a string present only in <script> source",
+  async () => {
+    const result = await renderCheck({
+      html: `<body><div id="root"><h1>Hi</h1></div><script>const m = "Saved!"; void m;</script></body>`,
+      expect: { text: "Saved!" },
+    });
+
+    expect(result.ok).toBe(false);
+    expect(result.errors.join(" ")).toContain("missing expected text");
+  }
+);
 
 browserTest(
   "crawl: all routes render → ok (SPA fallback serves each path)",
@@ -214,7 +257,11 @@ browserTest("crawl: a route that throws is caught", async () => {
   const { file, cleanup } = await spaFixture();
 
   try {
-    const result = await renderCheck({ file, routes: ["/accounts", "/bad"] });
+    const result = await renderCheck({
+      file,
+      routes: ["/accounts", "/bad"],
+      mountTimeoutMs: 800,
+    });
 
     expect(result.ok).toBe(false);
     expect(result.errors.join(" ")).toContain("boom on /bad");
@@ -227,7 +274,11 @@ browserTest("crawl: a route that renders blank is caught", async () => {
   const { file, cleanup } = await spaFixture();
 
   try {
-    const result = await renderCheck({ file, routes: ["/blank"] });
+    const result = await renderCheck({
+      file,
+      routes: ["/blank"],
+      mountTimeoutMs: 800,
+    });
 
     expect(result.ok).toBe(false);
     expect(result.errors.join(" ")).toContain("/blank rendered blank");

--- a/packages/core/tests/browser-pure.test.ts
+++ b/packages/core/tests/browser-pure.test.ts
@@ -1,0 +1,155 @@
+import { test, expect, describe } from "bun:test";
+import {
+  summarizeAxeViolations,
+  checkPerfBudget,
+  axeOutcomeToErrors,
+} from "../src/browser/oracle";
+import { parseChecks } from "../src/browser/checks";
+
+// The pure pass/fail-deciding helpers of the browser oracle: they decide whether
+// a11y / perf budgets go green or red, yet had ZERO coverage. No browser needed,
+// so these run in the default suite (the in-browser behaviours are opt-in).
+
+describe("summarizeAxeViolations", () => {
+  test("only serious/critical impacts become errors", () => {
+    const out = summarizeAxeViolations(
+      [
+        { id: "color-contrast", impact: "serious", nodeCount: 2 },
+        { id: "region", impact: "moderate", nodeCount: 1 },
+        { id: "label", impact: "critical", nodeCount: 3 },
+        { id: "x", impact: "minor", nodeCount: 9 },
+      ],
+      "index"
+    );
+
+    expect(out).toHaveLength(2);
+    expect(out.join(" ")).toContain("color-contrast");
+    expect(out.join(" ")).toContain("label");
+    expect(out.join(" ")).not.toContain("region");
+    expect(out.join(" ")).not.toContain("minor");
+  });
+
+  test("an undefined impact never gates", () => {
+    expect(
+      summarizeAxeViolations(
+        [{ id: "x", impact: undefined, nodeCount: 1 }],
+        "p"
+      )
+    ).toEqual([]);
+  });
+
+  test("no violations → no errors", () => {
+    expect(summarizeAxeViolations([], "index")).toEqual([]);
+  });
+});
+
+describe("checkPerfBudget", () => {
+  test("flags DOM node count over budget", () => {
+    const out = checkPerfBudget(1500, 100, { maxDomNodes: 1000 }, "index");
+
+    expect(out).toHaveLength(1);
+    expect(out[0]).toContain("1500 DOM nodes > budget 1000");
+  });
+
+  test("flags mount time over budget", () => {
+    const out = checkPerfBudget(10, 2500, { maxMountMs: 2000 }, "index");
+
+    expect(out).toHaveLength(1);
+    expect(out[0]).toContain("mount 2500ms > budget 2000ms");
+  });
+
+  test("under budget (and boundary equality) → no errors", () => {
+    expect(
+      checkPerfBudget(1000, 2000, { maxDomNodes: 1000, maxMountMs: 2000 }, "p")
+    ).toEqual([]);
+  });
+
+  test("an unset budget field never gates", () => {
+    expect(checkPerfBudget(9999, 9999, {}, "index")).toEqual([]);
+  });
+});
+
+describe("axeOutcomeToErrors (S5)", () => {
+  test("unavailable (dep absent) → skip, no errors", () => {
+    expect(axeOutcomeToErrors({ kind: "unavailable" }, "index")).toEqual([]);
+  });
+
+  test("a crashed analyze surfaces as an error — never a silent clean", () => {
+    const out = axeOutcomeToErrors(
+      { kind: "error", message: "CSP blocked axe inject" },
+      "index"
+    );
+
+    expect(out).toHaveLength(1);
+    expect(out[0]).toContain("a11y check failed to run at index");
+    expect(out[0]).toContain("CSP blocked axe inject");
+  });
+
+  test("ok with serious violations → gate errors", () => {
+    const out = axeOutcomeToErrors(
+      {
+        kind: "ok",
+        result: {
+          violations: [{ id: "label", impact: "critical", nodes: [{}, {}] }],
+        },
+      },
+      "index"
+    );
+
+    expect(out).toHaveLength(1);
+    expect(out[0]).toContain("label");
+  });
+
+  test("ok with no violations → clean", () => {
+    expect(
+      axeOutcomeToErrors({ kind: "ok", result: { violations: [] } }, "index")
+    ).toEqual([]);
+  });
+});
+
+describe("parseChecks", () => {
+  test("parses a full expect + steps payload", () => {
+    const parsed = parseChecks({
+      expect: { selector: "#x", text: "ok" },
+      steps: [
+        { click: "#inc", expect: { selector: "#n", text: "1" } },
+        { fill: { selector: "#in", value: "hi" } },
+      ],
+    });
+
+    expect(parsed.expect).toEqual({ selector: "#x", text: "ok" });
+    expect(parsed.steps).toHaveLength(2);
+    expect(parsed.steps?.[0]).toEqual({
+      click: "#inc",
+      expect: { selector: "#n", text: "1" },
+    });
+    expect(parsed.steps?.[1]).toEqual({
+      fill: { selector: "#in", value: "hi" },
+    });
+  });
+
+  test("non-object / garbage input → empty parse (no throw)", () => {
+    expect(parseChecks(null)).toEqual({});
+    expect(parseChecks("nope")).toEqual({});
+    expect(parseChecks(42)).toEqual({});
+    expect(parseChecks([])).toEqual({});
+  });
+
+  test("drops malformed steps and mistyped fields, keeps valid ones", () => {
+    const parsed = parseChecks({
+      expect: { selector: 5, text: "keep" }, // selector wrong type → dropped
+      steps: [
+        { click: 10 }, // wrong type → whole step empty → dropped
+        { fill: { selector: "#in" } }, // missing value → fill dropped → step empty → dropped
+        { click: "#ok" }, // valid
+      ],
+    });
+
+    expect(parsed.expect).toEqual({ text: "keep" });
+    expect(parsed.steps).toEqual([{ click: "#ok" }]);
+  });
+
+  test("empty expect object and empty steps are omitted", () => {
+    expect(parseChecks({ expect: {}, steps: [] })).toEqual({});
+  });
+});


### PR DESCRIPTION
Eighth subsystem in the pre-feature hardening pass: **browser** — the headless-Chromium render oracle (`renderCheck`), the layer meant to catch web apps that type-check and build but don't actually *work*.

**Framing:** `renderCheck` is currently unwired in the runtime pipeline (only the `IStep` type is imported by the greenfield loop; the wired browser gate is the separate Playwright acceptance runner, which is well-covered). So these are pre-feature hardening fixes on an engine before it's switched on — no runtime regression today, but the three worst findings are silent GREENs that would let broken pages through once it is.

Verified against **real Chromium** (installed the matching build locally), not just unit tests.

## Findings fixed

**S3 (silent-wrong-apply) — a blank white screen reported as "mounted".** `waitForMount` fell back to `document.body` when neither `#root` nor `#app` existed; an inline `<script>` counted as a child (`children.length>0`) and `textContent` returned the script's *source* (non-empty), so a body holding only a bootstrap script greened. Now requires a non-script/style element child **and** non-empty `innerText` (rendered, visible text). Live: script-only body was `ok:true` → now `app did not mount`.

**S4 (silent-wrong-apply) — content assertions matched non-rendered text.** `expect.text` used `textContent`, which concatenates `<script>`/`<style>` source and `display:none` content — an assertion for `"Saved!"` passed when the string existed only in inline script. Now uses `innerText`. Live: was `ok:true` → now `missing expected text`.

**S5 (silent-wrong-apply) — a crashed a11y check reported "clean".** `runAxe`'s `catch` swallowed both the dep-absent case *and* any throw from `analyze()` (CSP block, version drift) → `null` → `[]` violations → `a11y: true` when axe never ran. Split into `unavailable | ok | error`; a crashed analyze now surfaces as a gate error (new pure `axeOutcomeToErrors`).

**S8 (robustness) — unguarded browser launch.** `chromium.launch()` had no guard: a missing browser binary **threw** out of `renderCheck` (hit in practice via version drift), and a WSL2 launch can **hang** unbounded. Now bounded by a 30s timeout and degraded to a skip+notice like the no-playwright path. Live: forced launch failure → `skipped:true`, not a throw.

**S9 (robustness) — hard-coded 5s mount poll broke its own regression tests.** The mount timeout equalled bun's default test timeout, so the blank/throw opt-in tests **timed out instead of asserting** (found while enabling `TSFORGE_BROWSER_TESTS=1`). Added `mountTimeoutMs`; tests set it low. Browser suite: **9 pass / 3 timeout → 14 pass, 16.6s → 5.2s**.

**S10 (fragile) — malformed `%`-encoding returned 500.** `decodeURIComponent` threw `URIError` on `/%E0%A4` inside the static handler → 500; now a clean 404.

## Tests
- **`browser-pure.test.ts` (NEW, hermetic — runs in default CI):** covers the pure pass/fail deciders that had **zero** coverage — `summarizeAxeViolations`, `checkPerfBudget`, `axeOutcomeToErrors`, `parseChecks`.
- **`browser-oracle.test.ts`:** adds S3/S4 regression cases + the S10 malformed-`%` case (hermetic), and the 3 previously-timing-out tests now complete.
- Every new hermetic test shown red with the src stashed; S3/S4/S8/S10 verified live against Chromium.

## Considered and deferred (rationale)
- **S1** `--no-sandbox` unconditional: bounded (loopback-only server, `../` guard); the rendered pages are the model's own build output, not attacker-controlled. Noted.
- **S2** lexical-only traversal guard (symlink escape): requires an attacker-planted symlink inside the model's own build dir — very low; realpath-on-every-request adds latency for a non-threat here.
- **S6** no post-load settle window (async errors after `load` can escape): fixing via `networkidle` trades one flake class for another; left as a note pending the wiring decision.
- **S7** perf `maxMountMs` is a no-op on the inline-`html` path (no navigation timing): documented; the inline path is the minor one.

Part of the pre-feature subsystem hardening program (8th of ~15). **No release** — held until the whole program wraps.
