### PR TITLE
Validate hardening: ANSI/CRLF blob-collapse, eslint-warning data-loss, and test-count spoofing closed

### DIFF
--- a/packages/core/ARCHITECTURE.md
+++ b/packages/core/ARCHITECTURE.md
@@ -35,8 +35,8 @@ inventory, see the hand-drawn map on [Internals](/internals/).
 | `browser` | Headless Chromium oracle that render-checks a page as a gate stage | optional | 3 | <1k | 1 | 1 |
 | `lsp` | TypeScript language service powering navigation and write-time diagnostics | optional | 3 | <1k | 4 | 0 |
 | `infer-rules` | Scans a repo for its conventions and turns them into rule overrides | core | 7 | <1k | 5 | 2 |
-| `mcp` | Model Context Protocol client that exposes external servers as tools | optional | 8 | <1k | 2 | 1 |
 | `validate` | Runs the gate command and parses tool output into structured errors | core | 7 | <1k | 7 | 2 |
+| `mcp` | Model Context Protocol client that exposes external servers as tools | optional | 8 | <1k | 2 | 1 |
 | `spec` | Task and spec shapes, spec parsing, and test generation from intent | core | 6 | <1k | 6 | 6 |
 | `stack-detection` | Detects the project's stack and picks which rule packs apply | core | 4 | <1k | 8 | 1 |
 | `setup` | Onboarding wizard that writes a project's initial tsforge config | optional | 4 | <1k | 2 | 5 |

--- a/packages/core/src/validate/index.ts
+++ b/packages/core/src/validate/index.ts
@@ -7,6 +7,9 @@ export {
   combinedParser,
   parserFor,
   isEslintJsonLine,
+  normalizeGateOutput,
+  eslintMessageSummary,
+  parseTestFailures,
 } from "./parse";
 export { diffErrorSets, shrank, sameErrorSet } from "./errors";
 export { runTests, isRealRed } from "./run-tests";

--- a/packages/core/src/validate/parse.ts
+++ b/packages/core/src/validate/parse.ts
@@ -1,6 +1,27 @@
 import type { IErrorItem, ErrorParserFn } from "./validate.types";
 import { isArray, isRecord } from "../lib/guards";
 
+/** ANSI SGR color codes. Built from `String.fromCharCode(27)` rather than a
+ *  literal ESC so the pattern doesn't trip `no-control-regex` (same technique as
+ *  render/frame/ansi-plain.ts). */
+const ANSI_SGR = new RegExp(`${String.fromCharCode(27)}\\[[0-9;]*m`, "gu");
+
+/**
+ * Normalize raw tool output before any regex parsing. Two failure modes this
+ * closes, both of which silently reduced a whole gate wall to one opaque blob:
+ *  - COLOR: under CI / `FORCE_COLOR`, tsc/eslint/bun/vitest wrap output in ANSI
+ *    SGR codes. A leading `ESC[..m` is not `\s`, so glyph-/`^`-anchored regexes
+ *    (`× case`, the vitest header, `(fail)`) never matched and parsed to zero.
+ *  - CRLF: parsers `split("\n")`, so CRLF output left a trailing `\r` on every
+ *    line; `.` doesn't match `\r`, so every `(.+)$`-anchored regex (TSC, the bun
+ *    `(fail)` line, vitest reasons) failed to anchor. Fold CR/CRLF to LF.
+ * A blob fallback isn't just less useful — its constant `nonzero` key makes the
+ * stuck-detector (sameErrorSet) read "no progress" while the model is fixing.
+ */
+export function normalizeGateOutput(output: string): string {
+  return output.replace(ANSI_SGR, "").replace(/\r\n?/g, "\n");
+}
+
 const TSC = /^(.+?)\((\d+),(\d+)\): error (TS\d+): (.+)$/;
 /** File-less tsc diagnostics — config/project-level errors like TS18003
  *  ("No inputs were found"). They carry no `file(line,col):` prefix, so the
@@ -17,7 +38,8 @@ export function capWithNotice(text: string, cap: number): string {
 }
 
 /** Parse `tsc` output into a structured error set (one item per diagnostic). */
-export function parseTsc(output: string): IErrorItem[] {
+export function parseTsc(rawOutput: string): IErrorItem[] {
+  const output = normalizeGateOutput(rawOutput);
   const items: IErrorItem[] = [];
 
   for (const line of output.split("\n")) {
@@ -62,7 +84,7 @@ export function parseTsc(output: string): IErrorItem[] {
 
 /** Fallback when we have no tool-specific parser: the whole output is one error. */
 export function genericErrors(output: string): IErrorItem[] {
-  const text = output.trim();
+  const text = normalizeGateOutput(output).trim();
 
   return text.length > 0
     ? [{ key: "raw", message: capWithNotice(text, GENERIC_CAP) }]
@@ -105,7 +127,8 @@ function tryParseArray(s: string): unknown[] | null {
  * JSON-array line(s) and union them — the chain can run eslint twice (syntactic
  * + type-aware), each emitting its own array.
  */
-export function parseEslintJson(output: string): IErrorItem[] {
+export function parseEslintJson(rawOutput: string): IErrorItem[] {
+  const output = normalizeGateOutput(rawOutput);
   const whole = tryParseArray(output);
 
   if (whole !== null) {
@@ -127,6 +150,63 @@ export function parseEslintJson(output: string): IErrorItem[] {
   }
 
   return items;
+}
+
+/**
+ * Human-readable one-line summaries of EVERY eslint message (warnings included),
+ * for the fallback path. `parseEslintJson` keeps only errors (severity 2), so a
+ * gate that fails purely on WARNINGS (`--max-warnings 0`, exit 1) parsed to zero
+ * items AND then had its only description — the JSON line — stripped by
+ * `fallbackMessage`, leaving the loop a contentless "command exited non-zero".
+ * This recovers the warning text so the model can actually see what to fix.
+ */
+export function eslintMessageSummary(rawOutput: string): string[] {
+  const output = normalizeGateOutput(rawOutput);
+  const lines: string[] = [];
+
+  for (const line of output.split("\n")) {
+    if (!isEslintJsonLine(line)) {
+      continue;
+    }
+
+    const arr = tryParseArray(line.trim());
+
+    if (arr === null) {
+      continue;
+    }
+
+    for (const file of arr) {
+      collectEslintMessages(file, lines);
+    }
+  }
+
+  return lines;
+}
+
+/** Append `file:line:col sev rule: message` for each message in one eslint file
+ *  entry (both warnings and errors). */
+function collectEslintMessages(file: unknown, out: string[]): void {
+  if (!isRecord(file) || !isArray(file.messages)) {
+    return;
+  }
+
+  const filePath = typeof file.filePath === "string" ? file.filePath : "?";
+
+  for (const m of file.messages) {
+    if (!isRecord(m)) {
+      continue;
+    }
+
+    const lineNo = typeof m.line === "number" ? m.line : 0;
+    const col = typeof m.column === "number" ? m.column : 0;
+    const rule = typeof m.ruleId === "string" ? m.ruleId : "syntax";
+    const sev = m.severity === 1 ? "warning" : "error";
+    const message = typeof m.message === "string" ? m.message : "";
+
+    out.push(
+      `${filePath}:${String(lineNo)}:${String(col)} ${sev} ${rule}: ${message}`
+    );
+  }
 }
 
 /** Error items from one eslint JSON file entry (severity-2 messages only). */
@@ -178,7 +258,8 @@ function eslintFileItems(file: unknown): IErrorItem[] {
  * Structured failures from bun test / vitest / jest output — failures only.
  * Used by brownfield gates so `bun test` is not a 500-char opaque blob.
  */
-export function parseTestFailures(output: string): IErrorItem[] {
+export function parseTestFailures(rawOutput: string): IErrorItem[] {
+  const output = normalizeGateOutput(rawOutput);
   const items: IErrorItem[] = [];
   let bunFileCtx = "";
   // Vitest's DEFAULT reporter file context (`❯ file (N tests | M failed)`) —
@@ -331,14 +412,22 @@ export function combinedParser(output: string): IErrorItem[] {
   });
 }
 
+/** A whole-word match where `-` counts as part of the word, so `tsc` does NOT
+ *  match inside `tsc-alias`/`tsc-watch` (a plain `\btsc\b` does, because `-` is a
+ *  word boundary — that mis-selected the tsc parser for a gate whose real
+ *  compiler never ran). */
+function hasWord(command: string, word: string): boolean {
+  return new RegExp(`(?<![\\w-])${word}(?![\\w-])`, "u").test(command);
+}
+
 /** Pick a parser from the command. Add tools here as we support them. */
 export function parserFor(command: string): ErrorParserFn {
-  const hasTsc = /\btsc\b/.test(command);
-  const hasEslint = /\beslint\b/.test(command);
+  const hasTsc = hasWord(command, "tsc");
+  const hasEslint = hasWord(command, "eslint");
   const hasTest =
-    /\bbun\s+test\b/.test(command) ||
-    /\bvitest\b/.test(command) ||
-    /\bjest\b/.test(command);
+    /(?<![\w-])bun\s+test(?![\w-])/u.test(command) ||
+    hasWord(command, "vitest") ||
+    hasWord(command, "jest");
 
   // A chained tsc+eslint(+tests) gate needs the combined parser (see above).
   if (hasTsc && hasEslint) {

--- a/packages/core/src/validate/run-tests.ts
+++ b/packages/core/src/validate/run-tests.ts
@@ -7,6 +7,7 @@
  * the collected count (`total >= 1`) proves the suite actually asserts anything.
  */
 import { runArgvCommand } from "../lib/fs";
+import { normalizeGateOutput } from "./parse";
 
 import type { IRunTestsResult } from "./validate.types";
 
@@ -33,27 +34,46 @@ export function isRealRed(run: IRunTestsResult): boolean {
   return run.errors === 0 && run.total >= 1 && run.pass === 0;
 }
 
-function countTests(output: string): {
+function countTests(rawOutput: string): {
   pass: number;
   fail: number;
   total: number;
   errors: number;
 } {
-  const pass = firstNumber(/(\d+)\s+pass/.exec(output));
-  const fail = firstNumber(/(\d+)\s+fail/.exec(output));
-  const ran = /Ran\s+(\d+)\s+tests?/.exec(output);
-  const total = ran !== null ? firstNumber(ran) : pass + fail;
+  const output = normalizeGateOutput(rawOutput);
+  // Anchor to bun's SUMMARY lines (` N pass`, ` N fail`, ` N error`, `Ran N
+  // tests …`) — the count must be the line's first token — and take the LAST
+  // match. The old code took the FIRST `\d+ pass|fail` ANYWHERE in the merged
+  // stdout+stderr, so a test's own console output (e.g. `console.log("0 pass 5
+  // fail")`) or an assertion diff spoofed the counts, and `isRealRed` could
+  // accept a passing suite as a real RED one — a false TDD-floor pass.
+  const pass = lastLineNumber(output, /^\s*(\d+)\s+pass\b/) ?? 0;
+  const fail = lastLineNumber(output, /^\s*(\d+)\s+fail\b/) ?? 0;
+  const ran = lastLineNumber(output, /^\s*Ran\s+(\d+)\s+tests?\b/);
+  const total = ran ?? pass + fail;
 
-  const counted = firstNumber(/(\d+)\s+error/.exec(output));
-  // bun sometimes prints the banner without a count; treat it as one error.
-  const errors =
-    counted > 0 || !output.includes("Unhandled error") ? counted : 1;
+  const counted = lastLineNumber(output, /^\s*(\d+)\s+errors?\b/);
+  // bun sometimes prints the load-error banner without a leading count; treat a
+  // present-but-uncounted `Unhandled error` as one error so a load failure is
+  // never scored as a clean (errors:0) RED suite.
+  const errors = counted ?? (output.includes("Unhandled error") ? 1 : 0);
 
   return { pass, fail, total, errors };
 }
 
-function firstNumber(match: RegExpExecArray | null): number {
-  const raw = match?.[1];
+/** The number captured by `re` on the LAST line that matches it, or undefined
+ *  when no line does. Per-line + last-match so a summary line wins over any
+ *  earlier log/diff text that happens to contain the same tokens. */
+function lastLineNumber(output: string, re: RegExp): number | undefined {
+  let found: number | undefined;
 
-  return raw === undefined ? 0 : Number(raw);
+  for (const line of output.split("\n")) {
+    const m = re.exec(line);
+
+    if (m?.[1] !== undefined) {
+      found = Number(m[1]);
+    }
+  }
+
+  return found;
 }

--- a/packages/core/src/validate/validate.ts
+++ b/packages/core/src/validate/validate.ts
@@ -1,7 +1,12 @@
 import type { ITask } from "../spec";
 import type { ErrorParser, ErrorSet, IValidateResult } from "./validate.types";
 import { runAccept, type IAcceptOptions } from "./accept";
-import { capWithNotice, parserFor, isEslintJsonLine } from "./parse";
+import {
+  capWithNotice,
+  parserFor,
+  isEslintJsonLine,
+  eslintMessageSummary,
+} from "./parse";
 
 /** Longest fallback message we'll surface — a vite/render error fits; a wall of
  *  build logs does not. */
@@ -18,11 +23,21 @@ export function fallbackMessage(output: string): string {
     .join("\n")
     .trim();
 
-  if (cleaned.length === 0) {
-    return "command exited non-zero";
+  if (cleaned.length > 0) {
+    return capWithNotice(cleaned, FALLBACK_CAP);
   }
 
-  return capWithNotice(cleaned, FALLBACK_CAP);
+  // Nothing readable remained after dropping eslint's JSON — but the gate DID
+  // fail. If the JSON carried messages (e.g. a warnings-only `--max-warnings`
+  // failure, which `parseEslintJson` drops as non-errors), surface those so the
+  // loop has something concrete to fix instead of an opaque "non-zero".
+  const eslintSummary = eslintMessageSummary(output);
+
+  if (eslintSummary.length > 0) {
+    return capWithNotice(eslintSummary.join("\n"), FALLBACK_CAP);
+  }
+
+  return "command exited non-zero";
 }
 
 /**

--- a/packages/core/tests/parse.test.ts
+++ b/packages/core/tests/parse.test.ts
@@ -7,6 +7,9 @@ import {
   parserFor,
   isEslintJsonLine,
   fallbackMessage,
+  parseTestFailures,
+  normalizeGateOutput,
+  eslintMessageSummary,
 } from "../src/validate";
 
 test("parseTsc extracts file/line/rule per diagnostic", () => {
@@ -246,4 +249,73 @@ test("parseTsc surfaces file-less diagnostics like TS18003 (config-level errors)
   expect(items.find((e) => e.key === "tsc:TS18003")?.message).toContain(
     "No inputs were found"
   );
+});
+
+// ── validate hardening: ANSI/CRLF normalization + tsc-alias + eslint warnings ──
+const ESC = String.fromCharCode(27);
+
+test("normalizeGateOutput strips ANSI SGR codes and folds CRLF/CR to LF", () => {
+  const out = normalizeGateOutput(`${ESC}[31mred${ESC}[0m\r\nplain\rmid`);
+
+  expect(out).toBe("red\nplain\nmid");
+});
+
+test("parseTsc parses a diagnostic even with a trailing CR (CRLF output)", () => {
+  // `.` never matches `\r`, so the old `(.+)$` anchor failed on every CRLF line.
+  const items = parseTsc("src/a.ts(3,5): error TS2322: Type 'x'.\r");
+
+  expect(items).toHaveLength(1);
+  expect(items[0]?.rule).toBe("TS2322");
+});
+
+test("parseTestFailures parses bun/vitest failures wrapped in ANSI color", () => {
+  const bun = parseTestFailures(
+    `  ${ESC}[31m(fail)${ESC}[0m suite > does a thing`
+  );
+
+  expect(bun).toHaveLength(1);
+  expect(bun[0]?.message).toBe("suite > does a thing");
+
+  const vitest = parseTestFailures(
+    `${ESC}[2m❯${ESC}[0m foo.test.ts (3 tests ${ESC}[2m|${ESC}[0m 1 failed)\n` +
+      ` ${ESC}[31m×${ESC}[0m renders the header`
+  );
+
+  expect(vitest.length).toBeGreaterThanOrEqual(1);
+  expect(vitest.some((e) => e.message === "renders the header")).toBe(true);
+});
+
+test("parserFor does not pick the tsc parser for tsc-alias", () => {
+  // `\btsc\b` matched inside `tsc-alias`, selecting parseTsc for a gate whose
+  // real compiler never ran.
+  expect(parserFor("tsc-alias && vite build")).toBe(genericErrors);
+  expect(parserFor("tsc -p tsconfig.json")).toBe(parseTsc);
+});
+
+test("eslintMessageSummary surfaces warnings (which parseEslintJson drops)", () => {
+  const json =
+    '[{"filePath":"/a.ts","messages":[' +
+    '{"ruleId":"no-console","severity":1,"message":"Unexpected console","line":3,"column":1}' +
+    "]}]";
+
+  // parseEslintJson keeps errors only → nothing for a warnings-only failure.
+  expect(parseEslintJson(json)).toHaveLength(0);
+
+  const summary = eslintMessageSummary(json);
+
+  expect(summary).toHaveLength(1);
+  expect(summary[0]).toContain("no-console");
+  expect(summary[0]).toContain("warning");
+});
+
+test("fallbackMessage recovers eslint warnings instead of an opaque non-zero", () => {
+  const json =
+    '[{"filePath":"/a.ts","messages":[' +
+    '{"ruleId":"no-console","severity":1,"message":"Unexpected console","line":3,"column":1}],' +
+    '"errorCount":0,"warningCount":1}]';
+
+  const msg = fallbackMessage(json);
+
+  expect(msg).not.toBe("command exited non-zero");
+  expect(msg).toContain("no-console");
 });

--- a/packages/core/tests/run-tests.test.ts
+++ b/packages/core/tests/run-tests.test.ts
@@ -2,7 +2,7 @@ import { test, expect } from "bun:test";
 import { mkdtemp, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { runTests } from "../src/validate";
+import { runTests, isRealRed } from "../src/validate";
 
 test("counts collected tests (pass + fail) from a real run", async () => {
   const dir = await mkdtemp(join(tmpdir(), "tsforge-runtests-"));
@@ -63,6 +63,37 @@ test("surfaces a load failure as an error, not a real test", async () => {
     const r = await runTests("broken.test.ts", dir);
 
     expect(r.errors).toBeGreaterThanOrEqual(1);
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+// 1.2: count derivation must read bun's SUMMARY lines, not the first `\d+ pass`
+// found anywhere. A passing test whose console output contains a summary-shaped
+// string used to spoof pass:0/fail:5 from the log line — flipping isRealRed to
+// accept a passing suite as a real RED one (a false TDD-floor pass).
+test("test log output cannot spoof the collected counts", async () => {
+  const dir = await mkdtemp(join(tmpdir(), "tsforge-runtests-"));
+
+  try {
+    await Bun.write(
+      join(dir, "spoof.test.ts"),
+      [
+        'import { test, expect } from "bun:test";',
+        'test("logs a summary-shaped string", () => {',
+        '  console.log("simulating: 0 pass 5 fail  Ran 9 tests");',
+        "  expect(1).toBe(1);",
+        "});",
+      ].join("\n")
+    );
+
+    const r = await runTests("spoof.test.ts", dir);
+
+    // The REAL summary is 1 pass / 0 fail / 1 total, not the logged 0/5/9.
+    expect(r.pass).toBe(1);
+    expect(r.fail).toBe(0);
+    expect(r.total).toBe(1);
+    expect(isRealRed(r)).toBe(false);
   } finally {
     await rm(dir, { recursive: true, force: true });
   }


### PR DESCRIPTION
Ninth subsystem in the pre-feature hardening pass: **validate** — the parser that turns raw gate-tool output (tsc / eslint / bun test / vitest) into the structured error set the drive-to-green loop descends.

**Framing (bounds the blast radius):** the accept/reject decision is exit-code based (`accept.ts`: `passed = exitCode === 0`), and `validate` only parses on the `!passed` branch with a `nonzero` fallback. So a mis-parse on a *failing* run can't flip the gate to green — it degrades to a blob. The real damage is twofold: (a) a whole error wall collapses to one opaque `"nonzero"` blob the model can't act on, and because that blob's key is constant, the stuck-detector (`sameErrorSet`) reads "no progress" while the model is actually fixing — a wrongful abort; and (b) `run-tests.ts`, which scores RED/vacuous **independently of the exit code**, where a mis-count is a genuine silent-wrong-apply on the TDD floor.

Each finding was confirmed empirically (Bun) before fixing.

## Findings fixed

**4.1 ANSI + 4.2 CRLF (fragile — both confirmed live).** Under CI/`FORCE_COLOR`, tsc/eslint/bun/vitest wrap output in ANSI SGR codes; CRLF output leaves a trailing `\r` on every `split("\n")` line. A leading `ESC[..m` isn't `\s` and `\r` isn't matched by `.`, so **every** glyph-/`(.+)$`-anchored regex (`TSC`, the bun `(fail)` line, the vitest `❯` header + `×` case) matched nothing → zero structured errors → blob. New `normalizeGateOutput()` strips SGR and folds CR/CRLF→LF at every parser entry. Before: CRLF tsc / ANSI bun-fail both parsed to **0**; after: **1** each.

**2.1 eslint warnings-only (data-loss).** A `--max-warnings 0` failure (exit 1, all severity-1) parsed to zero errors (`parseEslintJson` keeps severity 2 only), and `fallbackMessage` then stripped the JSON line — the only description — down to `"command exited non-zero"`. The loop was handed a failing gate with nothing to fix. New `eslintMessageSummary()` recovers the warning text. Before: `"command exited non-zero"`; after: `/a.ts:3:1 warning no-console: Unexpected console`.

**1.2 count spoofing (silent-wrong-apply).** `countTests` took the **first** `\d+ pass` found **anywhere** in merged stdout+stderr, so a test's own `console.log("0 pass 5 fail  Ran 9 tests")` spoofed the counts — and with `pass:0, total>0, errors:0`, `isRealRed` accepted a **passing** suite as a real RED one (a false TDD-floor pass). Now anchors to bun's summary lines (the count must be the line's first token) and takes the **last** match. Verified through a real `bun test` run of a spoofing fixture: reads `pass:1` (was `0`), `isRealRed:false`.

**4.3 tsc-alias (fragile).** `\btsc\b` matched inside `tsc-alias`/`tsc-watch` (`-` is a word boundary), selecting the tsc parser for a gate whose real compiler never ran. New hyphen-aware `hasWord()`. Before: `tsc-alias && vite build` → `parseTsc`; after → `genericErrors`; real `tsc` still → `parseTsc`.

## Tests
- `parse.test.ts`: ANSI/CRLF normalization, tsc-alias parser selection, and eslint-warning recovery cases.
- `run-tests.test.ts`: the console-spoof fixture, shown **red** against the old `countTests`.
- ANSI / CRLF / warnings / spoof each verified empirically before→after.

## Considered and deferred (rationale)
- **1.1** (load failure with no count *and* no `Unhandled error` banner → false RED): could not reproduce on bun 1.3.14 — every load failure I tried prints ` 1 error` in the summary, which the anchored error-count now reads. The `Unhandled error` fallback is retained. Latent, not live.
- **2.2** (dedup collapses two diagnostics sharing `file:line:rule`): real but low-likelihood; the key scheme is intentional for cross-cycle progress tracking, and widening it (add column) risks perturbing `sameErrorSet`. Noted.
- **4.4 / 4.5** (vitest header opened from a stray log line; stdout/stderr concatenated block-wise): low likelihood / latent given bun & vitest keep streams together today. Noted.

Part of the pre-feature subsystem hardening program (9th of ~15). **No release** — held until the whole program wraps.
