### PR TITLE
Self-harness hardening: bound overlay growth, atomic installs, and honest promotion docs

### DIFF
--- a/packages/core/scripts/self-harness-campaign.ts
+++ b/packages/core/scripts/self-harness-campaign.ts
@@ -10,10 +10,18 @@
 //      with 95% Wilson CIs and a two-proportion z-test (the paper's Fig-4
 //      analog). The proof split is NEVER used for mining (exam ≠ homework).
 //
-// Hard rules: nothing is ever installed to ~/.tsforge/self-harness (the
-// campaign overlay lives under evals/self-harness/campaign/); the gate,
-// acceptance rule, and tolerances are never touched at runtime; all model
-// traffic is sequential (single-connection endpoint).
+// Promotion: the campaign's working overlay lives under
+// evals/self-harness/campaign/, and NOTHING reaches live use until it clears the
+// strict proof gate (promotionVerdict: a significant, interval-surviving uplift
+// over the frozen baseline on the never-mined proof split). Only then does
+// settlePromotion install it to ~/.tsforge/self-harness/<model>/overlay.json —
+// the overlay a human's own interactive sessions then run under — and a later
+// proof that regresses rolls it back and halts. That live install is the ONE
+// thing the campaign writes outside its own directory; a run that never clears
+// the bar cannot change what the human's sessions use.
+//
+// Hard rules: the gate, acceptance rule, and tolerances are never touched at
+// runtime; all model traffic is sequential (single-connection endpoint).
 //
 // Run:  bun packages/core/scripts/self-harness-campaign.ts
 //         [--max-sessions N] [--proof-every 3] [--rounds 3] [--width 3] [--repeats 2]

--- a/packages/core/src/self-harness/overlay.ts
+++ b/packages/core/src/self-harness/overlay.ts
@@ -204,8 +204,20 @@ export function parseOverlay(value: unknown): IHarnessOverlay | null {
   };
 }
 
+/** A learned prompt block past this many characters is bloat, not signal:
+ *  every future run pays for it in system-prompt size and dilution. An append
+ *  that would breach the ceiling is dropped (the block keeps what it has) rather
+ *  than growing without bound across a long campaign. */
+const MAX_BLOCK_CHARS = 8000;
+
 /** Compose two edits to the same prompt block: a replace supersedes what came
- *  before it; an append stacks below the existing edit. */
+ *  before it; an append stacks below the existing edit. Two safeguards on the
+ *  append path (a plain concat grew forever and duplicated on any re-merge):
+ *  - IDEMPOTENT: an append whose text is already present is a no-op, so
+ *    replaying/relaunching a campaign that reprocesses the same lineage can't
+ *    stack duplicate copies of the same learned guidance.
+ *  - BOUNDED: an append that would push the block past MAX_BLOCK_CHARS is
+ *    dropped, capping unbounded growth over many accepted rounds. */
 function composeBlockEdit(
   base: IPromptBlockEdit | undefined,
   patch: IPromptBlockEdit
@@ -214,7 +226,16 @@ function composeBlockEdit(
     return patch;
   }
 
-  return { mode: base.mode, text: `${base.text}\n${patch.text}` };
+  // Already contains this exact text (a re-merge of the same patch) → no-op.
+  if (base.text === patch.text || base.text.includes(patch.text)) {
+    return base;
+  }
+
+  const composed = `${base.text}\n${patch.text}`;
+
+  return composed.length > MAX_BLOCK_CHARS
+    ? base
+    : { mode: base.mode, text: composed };
 }
 
 /** Merge a candidate patch onto an overlay (both already validated). TTSR

--- a/packages/core/src/self-harness/promote.ts
+++ b/packages/core/src/self-harness/promote.ts
@@ -1,7 +1,8 @@
 import { existsSync } from "node:fs";
-import { mkdir, rename, rm } from "node:fs/promises";
+import { mkdir, rm } from "node:fs/promises";
 import { dirname } from "node:path";
 import type { ISweepReport } from "../eval";
+import { writeFileAtomic } from "../lib/fs";
 import { overlayPathFor } from "./overlay";
 import type { IHarnessOverlay } from "./self-harness.types";
 
@@ -99,9 +100,13 @@ function describe(
 
 /**
  * Install an overlay for live use, keeping the displaced one as the rollback
- * point. Written to a temp file and renamed, so a session starting mid-write
- * can never read half an overlay — `activeOverlay()` reads this path
- * synchronously on a hot path with no locking.
+ * point. Both the `.prev` backup AND the live write go through
+ * `writeFileAtomic` (write-a-uniquely-named-temp, then rename): a session
+ * starting mid-write can never read half an overlay (`activeOverlay()` reads
+ * this path synchronously with no locking), the rollback backup can never be
+ * left truncated by a crash, and a fixed temp name no longer lets a second
+ * concurrent install (a campaign racing a manual promote, or a relaunch)
+ * interleave into the same `.tmp` and publish a half-merged document.
  */
 export async function installOverlay(
   modelId: string,
@@ -112,13 +117,10 @@ export async function installOverlay(
   await mkdir(dirname(live), { recursive: true });
 
   if (existsSync(live)) {
-    await Bun.write(previousPath(live), await Bun.file(live).text());
+    await writeFileAtomic(previousPath(live), await Bun.file(live).text());
   }
 
-  const tmp = `${live}.tmp`;
-
-  await Bun.write(tmp, JSON.stringify(overlay, null, 2));
-  await rename(tmp, live);
+  await writeFileAtomic(live, JSON.stringify(overlay, null, 2));
 }
 
 /**
@@ -132,7 +134,7 @@ export async function revertOverlay(modelId: string): Promise<boolean> {
   const prev = previousPath(live);
 
   if (existsSync(prev)) {
-    await Bun.write(live, await Bun.file(prev).text());
+    await writeFileAtomic(live, await Bun.file(prev).text());
     await rm(prev, { force: true });
 
     return true;

--- a/packages/core/tests/self-harness-overlay.test.ts
+++ b/packages/core/tests/self-harness-overlay.test.ts
@@ -130,6 +130,50 @@ describe("mergeOverlay", () => {
     });
   });
 
+  test("re-merging the same append is idempotent (no duplicate stacking)", () => {
+    // A campaign relaunch that reprocesses the same lineage used to append the
+    // same learned text again and again, bloating the block with duplicates.
+    const base = mergeOverlay(emptyOverlay(), {
+      promptBlocks: { bootstrap: { mode: "append", text: "learned rule X" } },
+    });
+    const again = mergeOverlay(base, {
+      promptBlocks: { bootstrap: { mode: "append", text: "learned rule X" } },
+    });
+
+    expect(again.promptBlocks.bootstrap?.text).toBe("learned rule X");
+  });
+
+  test("distinct appends still stack (learning accumulates)", () => {
+    let overlay = emptyOverlay();
+
+    for (const text of ["one", "two", "three"]) {
+      overlay = mergeOverlay(overlay, {
+        promptBlocks: { execution: { mode: "append", text } },
+      });
+    }
+
+    expect(overlay.promptBlocks.execution?.text).toBe("one\ntwo\nthree");
+  });
+
+  test("append growth is bounded — a block never grows without limit", () => {
+    let overlay = emptyOverlay();
+
+    // Far more appends than the ceiling allows; each is distinct so dedup can't
+    // hide the growth. The block must stay within a bounded size.
+    for (let i = 0; i < 2000; i += 1) {
+      overlay = mergeOverlay(overlay, {
+        promptBlocks: {
+          verification: { mode: "append", text: `distinct learned line ${i}` },
+        },
+      });
+    }
+
+    const len = overlay.promptBlocks.verification?.text.length ?? 0;
+
+    expect(len).toBeGreaterThan(0);
+    expect(len).toBeLessThanOrEqual(8000);
+  });
+
   test("ttsr rules dedupe by name with the patch winning", () => {
     const base = mergeOverlay(emptyOverlay(), {
       ttsrRules: [

--- a/packages/core/tests/self-harness-promote.test.ts
+++ b/packages/core/tests/self-harness-promote.test.ts
@@ -287,4 +287,38 @@ describe("install and rollback", () => {
       await rm(dir, { recursive: true, force: true });
     }
   });
+
+  test("concurrent installs never interleave into a corrupt live overlay", async () => {
+    // A campaign install racing a manual one (or a relaunch) both wrote the same
+    // fixed `${live}.tmp`; the two writes interleaved and `rename` could publish
+    // a half-merged document. A per-write unique temp name makes the winner one
+    // whole overlay — never a byte-interleave of two.
+    const dir = await home();
+
+    try {
+      const a = {
+        ...emptyOverlay(),
+        promptBlocks: {
+          extra: { mode: "append" as const, text: "A".repeat(90_000) },
+        },
+      };
+      const b = {
+        ...emptyOverlay(),
+        promptBlocks: {
+          extra: { mode: "append" as const, text: "B".repeat(90_000) },
+        },
+      };
+
+      await Promise.all([installOverlay("m", a), installOverlay("m", b)]);
+
+      // The live file is exactly ONE of the two overlays, intact — not a splice.
+      const live = overlayPathFor("m");
+      const parsed = JSON.parse(await readFile(live, "utf8"));
+
+      expect([a, b]).toContainEqual(parsed);
+      expect(existsSync(`${live}.tmp`)).toBe(false);
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
 });


### PR DESCRIPTION
Tenth subsystem in the pre-feature hardening pass: **self-harness** — the self-improvement loop where a fixed model rewrites the prompt/rule/agent-spec **overlay** its own future runs use. Once a candidate overlay clears a strict proof gate, the campaign installs it to `~/.tsforge/self-harness/<model>/overlay.json`, which the live harness injects into **every** subsequent interactive session. A bad persisted change here silently degrades every future run, so the merge + install path is the integrity surface.

3,352 LOC; the pure logic (acceptance, promotion verdict, mining, overlay parse/merge) is well covered, but the merge-growth and install-atomicity edges were not.

## Findings fixed

**F8 (fragile) — `composeBlockEdit` grew unbounded and non-idempotently.** Appending to a prompt block was a plain `${base}\n${patch}` concat with no cap and no dedup, so:
- a campaign **relaunch reprocessing the same lineage** stacked duplicate copies of the same learned text (non-idempotent);
- a long campaign grew a block **without bound**, bloating every future system prompt (cost + dilution).

Now a re-merge of already-present text is a no-op (idempotent), and an append that would push a block past an 8 KB ceiling is dropped (bounded). Distinct appends still accumulate. Shown red against the old code.

**F1 (data-loss) — non-atomic backup + shared temp name in `installOverlay`.** The `.prev` rollback backup was written with a plain `Bun.write` — a crash mid-write left a **truncated backup**, so the documented single-level rollback silently restored garbage (degrading to the base harness). And the live write used a **fixed `${live}.tmp`** shared across concurrent installs (a campaign racing a manual promote, or a relaunch), which could rename a half-written or already-renamed temp. Both writes — plus the rollback restore — now route through `writeFileAtomic` (unique temp + rename), the atomic helper added in the files-hardening PR. Correctness-by-construction; a regression test documents the concurrent-install guarantee.

**F3 (misleading docs) — the campaign header lied about what it installs.** The header read *"Hard rules: nothing is ever installed to `~/.tsforge/self-harness`"* — directly contradicting `settlePromotion` (whose own doc says *"the only place the campaign touches `~/.tsforge`"*) and its `installOverlay` call. The gated auto-promotion **is** the intended behavior; the header was a stale invariant that misrepresented what the unattended loop does to the user's live environment. Rewritten to describe the real promotion (strict proof gate) → install → rollback-on-regression flow.

## Considered and deferred (rationale)
- **F2** rollback depth is exactly one: documented as intentional ("keep the displaced one").
- **F4/F5** merged overlay not re-validated as a combination / regression measured on the campaign overlay but applied to the live one: these live in the untested campaign **driver** (`self-harness-campaign.ts`); the pure decision functions (`promotionVerdict`/`regressed`) are covered, but the driver's `settlePromotion`/`chainAcceptedPatches` have no fixtures — a real S5 coverage gap worth a dedicated follow-up rather than folding into this integrity pass.
- **F6** a promoted, syntactically-valid but catastrophically-backtracking TTSR regex runs on the stream hot path (no ReDoS bound) — worth a complexity guard, but it spans the ttsr subsystem.
- **F7** `runSeedSetup` shell-execs `setup.sh` from the corpus dir — corpus is trusted/own-code in the shipped drivers.
- **F10** `activeOverlay()` caches by model and never invalidates on an on-disk change — a freshly promoted (or reverted) overlay may not take effect mid-session in a long-lived process.
- **F11/F12/F13** build-evidence parse fragilities (filename-vs-mtime "newest", payload blind-merge, progress denominator from a compound gate).

These are noted for a possible follow-up but are lower-severity or cross-subsystem; this PR takes the two data-integrity fixes (F8, F1) plus the dangerous-doc correction (F3).

Part of the pre-feature subsystem hardening program (10th of ~15). **No release** — held until the whole program wraps.
