### PR TITLE
LSP hardening: resolve symbols by real identifier token (not a word-boundary regex) so navigation can't report a live symbol as dead

### DIFF
--- a/packages/core/ARCHITECTURE.md
+++ b/packages/core/ARCHITECTURE.md
@@ -32,8 +32,8 @@ inventory, see the hand-drawn map on [Internals](/internals/).
 | `files` | Reading, creating, and hash-anchored editing of workspace files | core | 9 | 2k | 5 | 1 |
 | `policy` | Decides which actions are allowed in the current mode before they run | core | 5 | 1k | 5 | 3 |
 | `architecture` ⚠️ | Derives this map from source so the docs cannot drift from the code | optional | 8 | 1k | 0 | 0 |
-| `browser` | Headless Chromium oracle that render-checks a page as a gate stage | optional | 3 | <1k | 1 | 1 |
 | `lsp` | TypeScript language service powering navigation and write-time diagnostics | optional | 3 | <1k | 4 | 0 |
+| `browser` | Headless Chromium oracle that render-checks a page as a gate stage | optional | 3 | <1k | 1 | 1 |
 | `infer-rules` | Scans a repo for its conventions and turns them into rule overrides | core | 7 | <1k | 5 | 2 |
 | `mcp` | Model Context Protocol client that exposes external servers as tools | optional | 8 | <1k | 2 | 1 |
 | `validate` | Runs the gate command and parses tool output into structured errors | core | 7 | <1k | 7 | 2 |

--- a/packages/core/src/lsp/service.ts
+++ b/packages/core/src/lsp/service.ts
@@ -10,6 +10,61 @@ import type {
   ITsContext,
 } from "./lsp.types";
 
+/** Offset of the first identifier TOKEN named `symbol` in `sf`, preferring a
+ *  DECLARATION name (so `type_at`/`impact` land on the definition, not an
+ *  earlier `import { X }` use — both resolve the same symbol for references, but
+ *  the declaration is the more useful anchor). Returns undefined when the name
+ *  appears only in comments/strings/not at all. Skips comments and string
+ *  literals intrinsically: those are not Identifier nodes. */
+function firstIdentifierOffset(
+  sf: ts.SourceFile,
+  symbol: string
+): number | undefined {
+  let declPos: number | undefined;
+  let usePos: number | undefined;
+
+  const visit = (node: ts.Node): void => {
+    if (ts.isIdentifier(node) && node.text === symbol) {
+      const pos = node.getStart(sf);
+
+      usePos ??= pos;
+
+      if (declPos === undefined && isDeclarationName(node)) {
+        declPos = pos;
+      }
+    }
+
+    ts.forEachChild(node, visit);
+  };
+
+  visit(sf);
+
+  return declPos ?? usePos;
+}
+
+/** True when `id` is the NAME of a declaration (class/function/interface/type/
+ *  enum/variable/param/property/method) rather than a reference to one. */
+function isDeclarationName(id: ts.Identifier): boolean {
+  const parent = id.parent;
+
+  return (
+    (ts.isClassDeclaration(parent) ||
+      ts.isFunctionDeclaration(parent) ||
+      ts.isInterfaceDeclaration(parent) ||
+      ts.isTypeAliasDeclaration(parent) ||
+      ts.isEnumDeclaration(parent) ||
+      ts.isModuleDeclaration(parent) ||
+      ts.isVariableDeclaration(parent) ||
+      ts.isParameter(parent) ||
+      ts.isPropertyDeclaration(parent) ||
+      ts.isPropertySignature(parent) ||
+      ts.isMethodDeclaration(parent) ||
+      ts.isMethodSignature(parent) ||
+      ts.isBindingElement(parent)) &&
+    parent.name === id
+  );
+}
+
 /**
  * Quick-fixes safe to apply automatically — they align with our strict gate.
  * Deliberately EXCLUDES:
@@ -664,12 +719,49 @@ export class TsService {
 
   /**
    * Ergonomic position lookup: the model addresses symbols by NAME, not byte
-   * offset. Returns the offset of the first word-boundary occurrence of `symbol`
-   * in `file`, or undefined. Crude but practical (rename re-validates via the
-   * gate; references/typeAt are read-only).
+   * offset. Returns the offset of the first real IDENTIFIER TOKEN named `symbol`,
+   * or undefined.
+   *
+   * Token-aware on purpose: a naive `\b`-regex matched the name inside comments,
+   * string literals, or an earlier `import { X }` line and returned that offset —
+   * at which `getReferencesAtPosition` finds no symbol and the tool reports
+   * "no references to X", so the model concludes a live symbol is dead and
+   * deletes it. Walking the AST for an Identifier node skips comments/strings
+   * (they aren't identifiers) and lands on a position TS can actually resolve.
+   * Uses the program's SourceFile so the offset is consistent with the program
+   * that references/type_at then query; falls back to a standalone parse for a
+   * file outside the tsconfig, then to the old regex if it can't be read/parsed.
    */
   positionOfSymbol(file: string, symbol: string): number | undefined {
-    const text = ts.sys.readFile(this.toAbs(file));
+    const abs = this.toAbs(file);
+    const sf =
+      this.service.getProgram()?.getSourceFile(abs) ??
+      this.parseStandalone(abs);
+
+    // A parsed file is authoritative: if it has no identifier of this name, the
+    // answer is honestly `undefined` — do NOT regex-fall-back, or a name that
+    // exists only in a comment/string would resolve to that non-token offset,
+    // the exact bug this rewrite closes. The regex is the last resort ONLY when
+    // the file couldn't be parsed at all.
+    return sf === undefined
+      ? this.regexPosition(abs, symbol)
+      : firstIdentifierOffset(sf, symbol);
+  }
+
+  /** Parse a file NOT in the program (outside the tsconfig scope) into a
+   *  throwaway SourceFile so identifier lookup still works for it. */
+  private parseStandalone(abs: string): ts.SourceFile | undefined {
+    const text = ts.sys.readFile(abs);
+
+    return text === undefined
+      ? undefined
+      : ts.createSourceFile(abs, text, ts.ScriptTarget.Latest, true);
+  }
+
+  /** Last-resort word-boundary match (a file that parsed to no identifier of
+   *  this name, or couldn't be read as a SourceFile). */
+  private regexPosition(abs: string, symbol: string): number | undefined {
+    const text = ts.sys.readFile(abs);
 
     if (text === undefined) {
       return undefined;
@@ -689,8 +781,20 @@ export class TsService {
     this.service.dispose();
   }
 
-  /** 1-based line number of a byte offset in a file (for readable tool output). */
+  /** 1-based line number of a UTF-16 offset in a file (for readable tool output).
+   *  Uses the program's SourceFile line map: (a) the offset came from that same
+   *  program, so line and offset agree even if disk has since diverged (a
+   *  disk-read here would count lines in DIFFERENT content and mispoint the
+   *  model), and (b) it's a precomputed binary search, not an O(filesize)
+   *  whole-file slice per reference. Falls back to a disk read only for a file
+   *  outside the program. */
   private lineOf(file: string, position: number): number {
+    const sf = this.service.getProgram()?.getSourceFile(file);
+
+    if (sf !== undefined) {
+      return sf.getLineAndCharacterOfPosition(position).line + 1;
+    }
+
     const text = ts.sys.readFile(file) ?? "";
 
     return text.slice(0, position).split("\n").length;

--- a/packages/core/tests/lsp-navigation.test.ts
+++ b/packages/core/tests/lsp-navigation.test.ts
@@ -229,3 +229,53 @@ test("organizeImports removes an unused import", async () => {
     await rm(dir, { recursive: true, force: true });
   }
 });
+
+test("positionOfSymbol resolves a real token, not a same-named comment or string", async () => {
+  // A `\b`-regex matched the FIRST textual occurrence, so a name in a comment or
+  // string literal that appeared before the declaration won — getReferences at
+  // that offset finds no symbol, the tool reports "no references", and the model
+  // deletes a live symbol as dead. The resolver must land on an identifier token.
+  const dir = await project({
+    "types.ts":
+      "// A User record used across the whole app.\n" + // 'User' in a comment, FIRST
+      'const label = "User settings panel";\n' + // 'User' inside a string
+      "export interface User {\n  id: number;\n}\n", // the real declaration
+    "a.ts":
+      'import type { User } from "./types";\n' +
+      "export const u = (x: User): number => x.id;\n",
+  });
+
+  try {
+    const svc = new TsService(dir);
+    const pos = svc.positionOfSymbol("types.ts", "User");
+
+    expect(pos).not.toBeUndefined();
+
+    // The offset resolves to a symbol TS can follow — references finds the
+    // cross-file use (the old regex offset, inside the comment, found none).
+    const refs = svc.references("types.ts", pos ?? 0);
+    const files = new Set(refs.map((r) => r.file.split("/").slice(-1)[0]));
+
+    expect(files.has("types.ts")).toBe(true);
+    expect(files.has("a.ts")).toBe(true);
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test("positionOfSymbol returns undefined when the name is ONLY in a comment/string", async () => {
+  // No identifier token of that name anywhere → honestly undefined (the tool
+  // then says 'no such symbol'), not a comment offset that silently resolves to
+  // nothing downstream.
+  const dir = await project({
+    "only.ts": '// mentions Ghost in a comment\nconst s = "Ghost here too";\n',
+  });
+
+  try {
+    const svc = new TsService(dir);
+
+    expect(svc.positionOfSymbol("only.ts", "Ghost")).toBeUndefined();
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
Twelfth subsystem in the pre-feature hardening pass: **lsp** — the TypeScript language-service layer powering navigation (find-references / type-at / rename) and write-time diagnostics.

**The core is small and genuinely sound** — I verified the offset math is UTF-16-consistent end-to-end (no surrogate/multibyte off-by-one), `dispose()` is called before rebuild (no program leak), and the edit rollback is atomic. Two fixes in `service.ts`:

## Findings fixed

**#1 (silent-wrong-apply) — `positionOfSymbol` matched a word-boundary regex, not a real token.** This is the *sole* name→offset resolver for every trusted read-only navigation tool (`type_at`, `find_references`, `rename`, `impact`). It returned the first `\b`-bounded textual occurrence of the name — so a name in a **comment**, a **string literal**, or an earlier **`import { X }`** line that appeared before the declaration won. At a comment/string offset `getReferencesAtPosition` finds no symbol, so `find_references` reports **"no references to X"** — and the model deletes a live, cross-file-referenced symbol as dead. That's the dangerous shape: a confident wrong "unused".

Now it walks the AST for an identifier **token** (comments/strings aren't identifier nodes, so they're skipped intrinsically), preferring a **declaration name** over a use. A name present only in a comment/string now honestly resolves to `undefined`. It uses the program's SourceFile (consistent with the program that references/type_at then query), parses a standalone SourceFile for a file outside the tsconfig, and falls back to the old regex **only** when the file can't be parsed at all.

**#4 (fragile) — `lineOf` re-read disk while the offset came from the cached program.** It computed 1-based line numbers by reading the file fresh from disk and slicing to `position` — but `position` came from the (possibly diverged) cached program, so a disk/program mismatch pointed the model at the **wrong line** — and it re-read + re-sliced the whole file for **each** reference (O(refs × filesize) on hub files). Now uses the program SourceFile's line map (`getLineAndCharacterOfPosition`): same content as the offset, binary-search fast. Disk fallback only for a file outside the program.

## Tests
`lsp-navigation`: a name in a comment + string **before** its declaration now resolves to the declaration and `references` crosses files (shown **red** against the old regex — zero refs found); a name present **only** in a comment/string resolves to `undefined`.

## Considered and deferred (rationale)
- The write-guard's diagnostic-suppression filters (`{}`/`never` TS2339, `".."`-union assignability, transient TS2307) are broader than their intent — but they're acknowledged trade-offs **backstopped by the authoritative `tsc -p` gate** (deferred detection, not a permanent miss), and live in `loop/write-guard.ts` not `lsp/`.
- The read tools don't defensively `refresh()` — the main model-edit path is refreshed by the write-guard, so this is fragile-by-construction, not a live bug.
- Single-project / no-solution-references tsconfig assumptions.

Part of the pre-feature subsystem hardening program (12th of ~15). **No release** — held until the whole program wraps.
