### PR TITLE
Reviewers/eval hardening: verdict stops reporting 'all reviewers approved' when a reviewer dissented

### DIFF
--- a/packages/core/src/reviewers/aggregate.ts
+++ b/packages/core/src/reviewers/aggregate.ts
@@ -209,6 +209,20 @@ function decideReason(
   return "";
 }
 
+/** The reason string for a NON-blocked verdict. "all reviewers approved" is a
+ *  factual claim, so it must only be used when every reviewer actually approved:
+ *  a request-changes verdict that fell below the blocking threshold still means
+ *  a reviewer did NOT approve, and reporting otherwise misinforms whoever reads
+ *  the verdict (and any steer built from it). This changes only the reason TEXT
+ *  on the pass path — `blocked` is unchanged. */
+function approvalReason(reviews: IReview[]): string {
+  const dissent = reviews.filter((r) => r.verdict !== "approve").length;
+
+  return dissent === 0
+    ? "all reviewers approved"
+    : `passed: ${String(dissent)} of ${String(reviews.length)} reviewer(s) requested changes, below the blocking threshold`;
+}
+
 export function aggregate(
   outcomes: ReviewOutcome[],
   opts: { minReviewers: number; identity: string }
@@ -235,16 +249,17 @@ export function aggregate(
   const errored = failures.length;
 
   const ranked = rank(groupFindings(reviews));
-  const reason = decideReason(
+  const blockReason = decideReason(
     reviews,
     ranked,
     reviews.length,
     opts.minReviewers
   );
+  const blocked = blockReason.length > 0;
 
   return {
-    blocked: reason.length > 0,
-    reason: reason.length > 0 ? reason : "all reviewers approved",
+    blocked,
+    reason: blocked ? blockReason : approvalReason(reviews),
     reviewers: { ok: reviews.length, errored },
     ranked,
     perReviewer: reviews,

--- a/packages/core/tests/eval-infra.test.ts
+++ b/packages/core/tests/eval-infra.test.ts
@@ -34,6 +34,15 @@ describe("eval report: statistics", () => {
     expect(twoProportionZ(9, 10, 2, 10)).toBeGreaterThan(1.96);
     expect(twoProportionZ(1, 0, 1, 1)).toBe(0);
   });
+
+  test("twoProportionZ handles a zero standard error (both variants all-pass or all-fail)", () => {
+    // The pooled proportion is exactly 0 or 1, so the pooled SE is 0 — a real
+    // promotion scenario (baseline and candidate both perfect / both zero). The
+    // z is 0 (no distinguishable difference), NOT NaN from a divide-by-zero, so
+    // the promotion gate reads "no significant uplift" rather than crashing.
+    expect(twoProportionZ(10, 10, 10, 10)).toBe(0);
+    expect(twoProportionZ(0, 10, 0, 10)).toBe(0);
+  });
 });
 
 describe("eval report: buildSweepReport", () => {

--- a/packages/core/tests/reviewers-aggregate.test.ts
+++ b/packages/core/tests/reviewers-aggregate.test.ts
@@ -173,6 +173,40 @@ describe("aggregate", () => {
     expect(v.reason).toMatch(/agree/u);
   });
 
+  test("a below-threshold dissent passes but the reason does NOT claim everyone approved", () => {
+    // One reviewer requests changes with a CRITICAL (non-security) finding, the
+    // other approves. Corroboration policy is unchanged — a single uncorroborated
+    // non-security finding does not block — but the verdict used to report
+    // "all reviewers approved", a false statement that misinforms anyone reading
+    // it (and any steer built from the reason). blocked stays false; reason must
+    // reflect the dissent.
+    const v = aggregate(
+      [
+        ok("a", "request-changes", [
+          {
+            severity: "critical",
+            findingCode: "complexity",
+            file: "a.ts",
+            issue: "unbounded recursion, stack overflow on large N",
+          },
+        ]),
+        ok("b", "approve"),
+      ],
+      opts
+    );
+
+    expect(v.blocked).toBe(false);
+    expect(v.reason).not.toBe("all reviewers approved");
+    expect(v.reason).toMatch(/requested changes/u);
+  });
+
+  test("a genuinely unanimous approval still reads 'all reviewers approved'", () => {
+    const v = aggregate([ok("a", "approve"), ok("b", "approve")], opts);
+
+    expect(v.blocked).toBe(false);
+    expect(v.reason).toBe("all reviewers approved");
+  });
+
   test("majority request-changes with a major but no locus agreement → block", () => {
     const v = aggregate(
       [


### PR DESCRIPTION
Thirteenth pass in the pre-feature hardening program, covering two subsystems together: **reviewers** (the independent review-panel gate) and **eval** (the evaluation/statistics harness the self-harness promotion gate trusts).

**eval got a clean bill of health.** I verified the Wilson interval, the two-proportion z-test, and the errored-run handling are all mathematically correct and well-tested — and, importantly, that errored proof runs are *excluded by construction* at the promotion gate (retried up to 3×, discarded if still errored), not silently miscounted into a pass rate. So no eval fix was needed; one coverage gap closed (below).

The one real bug is in the review-panel verdict:

## Finding fixed

**`reviewers/aggregate.ts` (silent-wrong, reason text).** `blocked` is correctly `reason.length > 0`, but the non-blocked path hard-coded the reason `"all reviewers approved"`. That's a **false statement** whenever a reviewer emitted `request-changes` (say, with a critical non-security finding) that fell below the corroboration threshold: the panel passes — a single uncorroborated non-security finding doesn't block, by design — but reports that *everyone approved*, misinforming whoever reads the verdict and any steer built from its reason. The pass reason is now honest: `"all reviewers approved"` only when every reviewer actually approved, else `"passed: N of M reviewer(s) requested changes, below the blocking threshold"`. **Blocking behavior is unchanged** — only the reason text.

## Coverage
`eval/report.ts`: added a `twoProportionZ` test for the `se === 0` branch (both variants all-pass or all-fail → pooled proportion 0 or 1 → pooled SE 0), a real promotion scenario. Asserts `z = 0` (no distinguishable difference), not a divide-by-zero NaN. The guard existed; it was just untested.

## Deliberately NOT changed (gate semantics — flagged, not flipped solo)
- **The corroboration policy itself**: a single uncorroborated non-security critical does not block (only `reject` / critical-security / agreement ≥ 2 block). GitHub-style block-on-`request-changes` would be a policy shift.
- **`locusKey` grouping on `(file, findingCode)`**: two *different* issues sharing a file and code merge into one group and can manufacture `agreement ≥ 2` — over-blocking and citing one reviewer's issue text as "consensus". Real, but the fix changes blocking behavior and risks losing the intended line-insensitive agreement; flagged for a follow-up alongside the policy decision.
- `parseReview` not upgrading verdict from max finding severity; proof pass rates pooled across heterogeneous tasks + z-test at n=6 (a modeling choice, not a code error).

Part of the pre-feature subsystem hardening program (13th pass). **No release** — held until the whole program wraps.
