### PR TITLE
Rule-packs hardening: reject rules/rulesConfig key disagreement + pin latent silent-disable invariants

### DIFF
--- a/packages/core/src/config/external-plugins.ts
+++ b/packages/core/src/config/external-plugins.ts
@@ -83,14 +83,33 @@ export function isRulePack(value: unknown): value is IRulePack {
     return false;
   }
 
-  if (!isRecord(value.rules) || !isRecord(value.rulesConfig)) {
+  const { rules, rulesConfig } = value;
+
+  if (!isRecord(rules) || !isRecord(rulesConfig)) {
     return false;
   }
 
-  for (const severity of Object.values(value.rulesConfig)) {
+  for (const severity of Object.values(rulesConfig)) {
     if (severity !== "error" && severity !== "warn") {
       return false;
     }
+  }
+
+  // `rules` and `rulesConfig` MUST agree on keys. A rule present in `rules` but
+  // absent from `rulesConfig` registers as available yet is never enabled — it
+  // silently does nothing (a flat-config rule only runs with a severity), which
+  // is exactly the "rule meant to constrain the model never fires" footgun for
+  // a rules-driven gate. The reverse (a severity for a rule that doesn't exist)
+  // makes ESLint error at config-build. Reject both: an external pack must ship
+  // a severity for every rule it defines, and no severity for one it doesn't.
+  const ruleKeys = Object.keys(rules);
+  const configKeys = Object.keys(rulesConfig);
+
+  if (
+    ruleKeys.length !== configKeys.length ||
+    !ruleKeys.every((k) => Object.hasOwn(rulesConfig, k))
+  ) {
+    return false;
   }
 
   return true;

--- a/packages/core/tests/external-plugins.test.ts
+++ b/packages/core/tests/external-plugins.test.ts
@@ -77,6 +77,42 @@ describe("external-plugins: isRulePack", () => {
     expect(isRulePack({ id: "x" })).toBe(false);
     expect(isRulePack(null)).toBe(false);
   });
+
+  test("rejects a pack whose rules and rulesConfig keys disagree", () => {
+    const stub = { meta: {}, create: () => ({}) };
+
+    // A rule with a severity for every rule it defines → valid.
+    expect(
+      isRulePack({
+        id: "x",
+        description: "d",
+        rules: { r1: stub },
+        rulesConfig: { r1: "error" },
+      })
+    ).toBe(true);
+
+    // A rule present in `rules` but MISSING from `rulesConfig` would register as
+    // available yet never run (silently disabled) — must be rejected.
+    expect(
+      isRulePack({
+        id: "x",
+        description: "d",
+        rules: { r1: stub, r2: stub },
+        rulesConfig: { r1: "error" },
+      })
+    ).toBe(false);
+
+    // A severity for a rule that doesn't exist (ESLint would error at build) —
+    // rejected too.
+    expect(
+      isRulePack({
+        id: "x",
+        description: "d",
+        rules: { r1: stub },
+        rulesConfig: { r1: "error", ghost: "warn" },
+      })
+    ).toBe(false);
+  });
 });
 
 describe("external-plugins: loading", () => {
@@ -251,13 +287,14 @@ describe("external-plugins: content freeze (F19)", () => {
     const dir = await mkdtemp(join(tmpdir(), "tsforge-plugin-drift-"));
     const entry = join(dir, "plugin.ts");
 
-    // Minimal valid pack (no createRule) — enough to register + fingerprint.
+    // Minimal valid pack — rules and rulesConfig keys agree (a severity for the
+    // one rule it defines), enough to register + fingerprint.
     await writeFile(
       entry,
       `export const pack = {
   id: "drift-pack",
   description: "strong",
-  rules: {},
+  rules: { "no-bar": { meta: {}, create: () => ({}) } },
   rulesConfig: { "no-bar": "error" },
 };
 `

--- a/packages/core/tests/rule-packs-invariants.test.ts
+++ b/packages/core/tests/rule-packs-invariants.test.ts
@@ -1,0 +1,88 @@
+import { test, expect, describe } from "bun:test";
+import { RULE_PACKS, buildPackEslintConfig } from "../src/rule-packs";
+import { PACK_REGISTRY } from "../src/stack-detection";
+
+// Latent silent-wrong-apply guards for the rules-driven gate. None of these
+// catch a current bug — they pin invariants a future pack edit would otherwise
+// break silently (a rule that registers but never runs; a detected pack that
+// enforces nothing while appearing "applied").
+
+describe("rule-pack invariants", () => {
+  test("every built-in pack's rules and rulesConfig keys agree exactly", () => {
+    // A rule in `rules` but not `rulesConfig` is registered yet never enabled
+    // (a flat-config rule only runs with a severity) — it silently constrains
+    // nothing. The reverse makes ESLint error at config build.
+    for (const [id, pack] of Object.entries(RULE_PACKS)) {
+      const ruleKeys = Object.keys(pack.rules).sort();
+      const configKeys = Object.keys(pack.rulesConfig).sort();
+
+      expect(
+        configKeys,
+        `pack "${id}": rulesConfig keys must match rules keys`
+      ).toEqual(ruleKeys);
+    }
+  });
+
+  test("every PACK_REGISTRY id contributes rules OR is an explicit guidance-only pack", () => {
+    // A pack that stack-detection can select but that has no RULE_PACKS entry
+    // contributes ZERO gate rules while still appearing "applied" (folded into
+    // the stack name + prompt). Only these two are intentionally guidance-only
+    // (their enforcement lives in the bundled strict config). A future typo'd or
+    // forgotten pack id must trip THIS test, not silently enforce nothing.
+    const GUIDANCE_ONLY = new Set(["generic-ts", "react"]);
+
+    for (const id of Object.keys(PACK_REGISTRY)) {
+      const contributesRules = Object.hasOwn(RULE_PACKS, id);
+
+      expect(
+        contributesRules || GUIDANCE_ONLY.has(id),
+        `PACK_REGISTRY id "${id}" has no RULE_PACKS entry and is not a known guidance-only pack — it would be detected and shown as applied while enforcing nothing`
+      ).toBe(true);
+    }
+  });
+
+  test("overrides drop or replace a rule; a mistargeted override is a silent no-op", () => {
+    const entry = Object.entries(RULE_PACKS).find(
+      ([, pack]) => Object.keys(pack.rules).length > 0
+    );
+
+    expect(entry).toBeDefined();
+
+    if (entry === undefined) {
+      return;
+    }
+
+    const [packId, pack] = entry;
+    const ruleName = Object.keys(pack.rules)[0];
+
+    expect(ruleName).toBeDefined();
+
+    if (ruleName === undefined) {
+      return;
+    }
+
+    const key = `tsforge/${ruleName}`;
+    const base = buildPackEslintConfig([packId]);
+
+    expect(base.rules[key]).toBeDefined();
+
+    // "off" removes the rule from the gate config entirely.
+    const off = buildPackEslintConfig([packId], { [ruleName]: "off" });
+
+    expect(off.rules[key]).toBeUndefined();
+
+    // "warn"/"error" replaces the severity.
+    const warned = buildPackEslintConfig([packId], { [ruleName]: "warn" });
+
+    expect(warned.rules[key]).toBe("warn");
+
+    // An override keyed to a rule NOT in the active pack set is silently
+    // ignored (documents the footgun: strengthening a rule from an inactive
+    // pack does nothing).
+    const mistargeted = buildPackEslintConfig([packId], {
+      "this-rule-is-in-no-active-pack": "error",
+    });
+
+    expect(mistargeted.rules).toEqual(base.rules);
+  });
+});


### PR DESCRIPTION
Fourteenth pass in the pre-feature hardening program: **rule-packs** — the loader/merge/resolve core that turns detected-stack pack ids into the ESLint rules the gate enforces.

**This subsystem is unusually well-hardened already** — I found no active bug and no security hole. Fail-closed on unknown packs at every consumer, a loud rule-collision throw (never last-wins/silent-drop), deterministic ordering end-to-end, prototype-pollution guards, and a genuinely exemplary external-pack fingerprint/freeze path. So this PR closes two **latent** silent-wrong-apply footguns before a future pack edit trips them.

## Fixed

**`isRulePack` now enforces `rules` ↔ `rulesConfig` key parity (external-plugins.ts).** It validated that both are records but not that their keys agree. A rule present in `rules` but missing from `rulesConfig` **registers as available yet never runs** — a flat-config rule only fires with a severity — so an external pack could ship a rule that silently constrains nothing (and the reverse makes ESLint error at config build). Now rejects any key disagreement in both directions. Shown **red** against the old validator.

## Invariants pinned (regression guards)
- Every built-in `RULE_PACKS` entry has exact `rules` ↔ `rulesConfig` key parity (all 21 hold today; a future copy-paste slip now fails the test instead of silently disabling a rule).
- Every stack-detection `PACK_REGISTRY` id either contributes `RULE_PACKS` rules **or** is one of the two explicit guidance-only packs (`generic-ts`/`react`). A pack in the registry with no `RULE_PACKS` entry is detected, folded into the stack name + prompt, and shown as "applied" while enforcing **nothing** — a typo'd or forgotten id now trips this test.
- First coverage of `applyOverrides`: `off` drops a rule, a severity replaces it, and a mistargeted override (a rule not in the active pack set) is a documented **silent no-op**.

## Fixture note
The F19 content-freeze test's "strong" pack used `rulesConfig:{no-bar}` with `rules:{}` — now a real rule+severity, so it satisfies the new parity guard while still exercising the drift check.

## Deferred (rationale)
- Coarse dep-gating can apply `react-component-architecture` to a non-web project that merely depends on `react` (Ink CLI, react-email) — the intended coarseness of dep-presence detection.
- `config.stack` skips the unknown-id warning that `packs.include` emits (it still fails closed at gate build); `packs.exclude` deletes silently.

Verified on a branch **rebased onto the five already-merged hardening PRs** — full `ci:local` green, confirming all six subsystems' changes compose. Part of the pre-feature hardening program (14th pass). **No release** — held until the whole program wraps (render is the last subsystem).
