### PR TITLE
Render hardening: restore terminal on SIGTERM/SIGHUP + wizard init-throw; wrap-aware LiveRegion

### DIFF
--- a/packages/core/ARCHITECTURE.md
+++ b/packages/core/ARCHITECTURE.md
@@ -101,7 +101,7 @@ Async functions returning an exit code, declared under the CLI — the commands.
 | `main` | `cli.ts:755` |
 | `mapMode` | `cli.ts:482` |
 | `recipesMode` | `cli.ts:501` |
-| `repl` | `cli/repl.ts:720` |
+| `repl` | `cli/repl.ts:753` |
 | `reviewMode` | `cli.ts:181` |
 | `runOnce` | `cli.ts:93` |
 | `runTraceCommand` | `cli/repl-commands.ts:118` |

--- a/packages/core/src/cli/repl.ts
+++ b/packages/core/src/cli/repl.ts
@@ -716,6 +716,39 @@ function maybeWritePlanModeIntro(planMode: boolean): void {
   process.stdout.write(`  ${chip} ${body} ${approve} ${tail}\n`);
 }
 
+/**
+ * Wire terminal restoration for a pane-TUI session. `'exit'` covers a normal
+ * return/`process.exit`. But a signal the process doesn't HANDLE terminates it
+ * WITHOUT firing 'exit', leaving the pane on the alternate screen with SGR
+ * mouse tracking on and a colored/hidden cursor — spewing `\x1b[<…M` into the
+ * shell until a blind `reset`. SIGHUP (closed tab / ssh drop) and SIGTERM (a
+ * supervisor, `timeout tsforge …`) are the vectors; the editor's readline
+ * SIGINT handler covers Ctrl+C, and in raw editor mode Ctrl+C arrives as a
+ * keypress not a signal, so only these two need wiring. On a signal we restore,
+ * then re-raise with the default disposition so the exit status still reflects
+ * the signal (128+n). `leave`/`close` are idempotent. The editor handle is read
+ * through a getter because it's assigned later, inside the prompt loop.
+ */
+function installTerminalRestore(
+  paneScreen: { leave: () => void },
+  getEditor: () => { close: () => void } | null
+): void {
+  const restore = (): void => {
+    getEditor()?.close();
+    paneScreen.leave();
+  };
+
+  process.on("exit", restore);
+
+  for (const sig of ["SIGTERM", "SIGHUP"] as const) {
+    process.on(sig, () => {
+      restore();
+      process.removeAllListeners(sig);
+      process.kill(process.pid, sig);
+    });
+  }
+}
+
 /** Interactive REPL: a persistent gate-anchored conversation. */
 export async function repl(args: ICliArgs): Promise<number> {
   // Interactive sessions get web tools ON by default (an assistant that can't look
@@ -2310,11 +2343,10 @@ export async function repl(args: ICliArgs): Promise<number> {
   // Without that cleanup the shell sees Ctrl+C as literal `;5;99~` junk.
   let editorForExit: { close: () => void } | null = null;
 
-  // Restore the terminal even on an unexpected exit (leave/close are idempotent).
-  process.on("exit", () => {
-    editorForExit?.close();
-    paneScreen.leave();
-  });
+  // Restore the terminal on normal exit AND on the signals that would otherwise
+  // terminate the process without firing 'exit' (SIGTERM/SIGHUP). See
+  // installTerminalRestore.
+  installTerminalRestore(paneScreen, () => editorForExit);
 
   // Wipe the visible terminal. Pane console: clear scrollback + repaint. Pipes:
   // plain CSI wipe.

--- a/packages/core/src/render/live-region.ts
+++ b/packages/core/src/render/live-region.ts
@@ -8,13 +8,38 @@
  * `tsforge agents` tree). On a non-TTY sink every call is a no-op, so piped and
  * `--log` runs fall back to the caller's plain-text path unchanged.
  */
+import { displayWidth } from "./width";
+import { stripSgr } from "./frame/ansi-plain";
+
 const ESC = "\x1b";
 
 /** The minimal sink LiveRegion needs — matches `process.stdout` but injectable
- *  so a VirtualScreen test can capture the exact byte stream. */
+ *  so a VirtualScreen test can capture the exact byte stream. `columns` lets the
+ *  erase account for soft-wrapped lines (a line wider than the terminal occupies
+ *  more than one physical row). */
 export interface ILiveRegionOut {
   write(data: string): boolean;
   readonly isTTY?: boolean;
+  readonly columns?: number;
+}
+
+/** Physical terminal rows `lines` occupy at width `cols`: each logical line
+ *  soft-wraps to ceil(displayWidth/cols) rows (min 1 — a blank line is one row).
+ *  SGR is stripped first so color codes aren't counted as columns. `cols <= 0`
+ *  (width unknown) falls back to one row per line — no worse than the old
+ *  logical-line assumption. */
+function physicalRows(lines: readonly string[], cols: number): number {
+  if (cols <= 0) {
+    return lines.length;
+  }
+
+  let total = 0;
+
+  for (const line of lines) {
+    total += Math.max(1, Math.ceil(displayWidth(stripSgr(line)) / cols));
+  }
+
+  return total;
 }
 
 export class LiveRegion {
@@ -60,9 +85,14 @@ export class LiveRegion {
     }
 
     // Raw-mode terminals are ONLCR-off; joining with CRLF renders correctly in
-    // both raw and cooked sinks (a cooked terminal collapses the extra CR).
-    this.out.write(this.eraseCurrent() + lines.join("\r\n"));
-    this.rows = lines.length;
+    // both raw and cooked sinks (a cooked terminal collapses the extra CR). A
+    // trailing RESET closes any unbalanced SGR so a colored line can't bleed
+    // into the scrollback above the block.
+    this.out.write(this.eraseCurrent() + lines.join("\r\n") + `${ESC}[0m`);
+    // Track PHYSICAL rows, not logical lines: a line wider than the terminal
+    // wraps to several rows, and the next erase must climb ALL of them or it
+    // leaves ghost fragments of the previous block above the redraw.
+    this.rows = physicalRows(lines, this.out.columns ?? 0);
   }
 
   /** Erase the block and leave the cursor at its former top line. Idempotent. */

--- a/packages/core/src/render/wizard.ts
+++ b/packages/core/src/render/wizard.ts
@@ -977,10 +977,22 @@ export function runWizard(
 
     stdin.on("keypress", onKey);
 
-    if (view === undefined) {
-      out(`${ENTER_ALT}${HIDE_CURSOR}`);
-    }
+    // The initial enter + first draw run OUTSIDE onKey, so a synchronous throw
+    // here (a renderFrame bug, a width-math edge on a pathological terminal size)
+    // would abandon the Promise executor with the terminal stranded on the alt
+    // screen, raw mode on, cursor hidden — no keypress can ever reach finish().
+    // Route a failure through the same finish() restore and resolve as cancelled,
+    // mirroring onKey's own catch. finish() swallows a throwing `out`, so it
+    // can't itself throw back out here.
+    try {
+      if (view === undefined) {
+        out(`${ENTER_ALT}${HIDE_CURSOR}`);
+      }
 
-    draw();
+      draw();
+    } catch {
+      state = cancelled;
+      finish();
+    }
   });
 }

--- a/packages/core/tests/cli.test.ts
+++ b/packages/core/tests/cli.test.ts
@@ -579,6 +579,23 @@ test("repl product path never constructs or installs StatusBar", async () => {
   expect(src).not.toMatch(/import\s*\{[^}]*\bStatusBar\b/);
 });
 
+test("repl restores the terminal on SIGTERM and SIGHUP (not just normal exit)", async () => {
+  // A signal the process doesn't handle terminates it WITHOUT firing 'exit', so
+  // the pane TUI would be left on the alt screen with mouse tracking + a colored
+  // cursor. Both signals must be wired to paneScreen.leave(). Source-scanned
+  // (the true check needs a pty + signal harness) — mirrors the StatusBar guard.
+  const src = await Bun.file(
+    new URL("../src/cli/repl.ts", import.meta.url)
+  ).text();
+
+  expect(src).toContain('"SIGTERM"');
+  expect(src).toContain('"SIGHUP"');
+  // The handler must actually restore (leave the pane screen) and re-raise the
+  // signal, not merely register a no-op listener.
+  expect(src).toContain("paneScreen.leave()");
+  expect(src).toContain("process.kill(process.pid, sig)");
+});
+
 test("agents subcommand: list mode, ids+task mode, recipe fill", () => {
   const list = parseArgs(["agents"]);
 

--- a/packages/core/tests/live-region.test.ts
+++ b/packages/core/tests/live-region.test.ts
@@ -1,0 +1,80 @@
+import { test, expect, describe } from "bun:test";
+import { LiveRegion, type ILiveRegionOut } from "../src/render/live-region";
+
+/** A capturing sink that records every write, with a fixed reported width. */
+function sink(columns: number): ILiveRegionOut & { writes: string[] } {
+  const writes: string[] = [];
+
+  return {
+    writes,
+    isTTY: true,
+    columns,
+    write(data: string): boolean {
+      writes.push(data);
+
+      return true;
+    },
+  };
+}
+
+describe("LiveRegion", () => {
+  test("erase climbs PHYSICAL rows, accounting for soft-wrapped lines", () => {
+    const out = sink(10);
+    const region = new LiveRegion(out);
+
+    // Two logical lines: the second is 60 cols wide at width 10 → 6 physical
+    // rows. Total drawn = 1 + 6 = 7 rows.
+    const wide = "x".repeat(60);
+
+    region.render(["short", wide]);
+    region.render(["again", wide]);
+
+    // The SECOND render must first climb 7-1 = 6 rows to reach the block top.
+    // The old logical-line count would have climbed only 2-1 = 1 row, leaving
+    // ghost fragments of the previous wrapped line.
+    expect(out.writes[1]?.startsWith("\x1b[6A")).toBe(true);
+  });
+
+  test("a non-wrapping block climbs one row per logical line", () => {
+    const out = sink(80);
+    const region = new LiveRegion(out);
+
+    region.render(["a", "b", "c"]);
+    region.render(["d", "e", "f"]);
+
+    // 3 lines, none wrap at width 80 → climb 3-1 = 2 rows.
+    expect(out.writes[1]?.startsWith("\x1b[2A")).toBe(true);
+  });
+
+  test("each render ends with an SGR reset so color can't bleed into scrollback", () => {
+    const out = sink(80);
+    const region = new LiveRegion(out);
+
+    region.render(["\x1b[31mred line"]);
+
+    expect(out.writes[0]?.endsWith("\x1b[0m")).toBe(true);
+  });
+
+  test("unknown width (columns 0) falls back to one row per line", () => {
+    const out = sink(0);
+    const region = new LiveRegion(out);
+
+    region.render(["x".repeat(200)]);
+    region.render(["y"]);
+
+    // No width to wrap against → one row for the single logical line → \r ESC[0J.
+    expect(out.writes[1]?.startsWith("\r\x1b[0J")).toBe(true);
+  });
+
+  test("a non-TTY sink is a no-op", () => {
+    const writes: string[] = [];
+    const region = new LiveRegion({
+      write: (d) => (writes.push(d), true),
+      isTTY: false,
+    });
+
+    region.render(["anything"]);
+
+    expect(writes).toHaveLength(0);
+  });
+});

--- a/packages/core/tests/wizard.test.ts
+++ b/packages/core/tests/wizard.test.ts
@@ -249,6 +249,48 @@ describe("runWizard interactive teardown", () => {
     }
   });
 
+  test("a throw during the INITIAL draw restores the terminal and resolves cancelled", async () => {
+    // The initial enter + first draw run outside onKey. A synchronous throw
+    // there used to abandon the Promise executor with the terminal stranded
+    // (view.close() / EXIT_ALT never reached, raw mode still on). The fix routes
+    // it through finish(): the wizard resolves cancelled and the surface closes.
+    const fake = new FakeStdin();
+    const realStdin = process.stdin;
+    let closed = 0;
+
+    Object.defineProperty(process, "stdin", {
+      value: fake,
+      configurable: true,
+    });
+
+    try {
+      const done = runWizard(STEPS, false, {
+        manageInput: false,
+        out: () => undefined,
+        view: {
+          render: () => {
+            throw new Error("renderFrame blew up on the first draw");
+          },
+          close: () => {
+            closed += 1;
+          },
+        },
+      });
+
+      // No keypress is ever emitted — the failure is on the first draw. The
+      // promise must still resolve (not reject/hang), and the surface restored.
+      const state = await done;
+
+      expect(state.status).toBe("cancel");
+      expect(closed).toBe(1);
+    } finally {
+      Object.defineProperty(process, "stdin", {
+        value: realStdin,
+        configurable: true,
+      });
+    }
+  });
+
   test("view mode paints host overlay and never opens a nested alt-screen", async () => {
     const fake = new FakeStdin();
     const realStdin = process.stdin;


### PR DESCRIPTION
Fifteenth and final subsystem in the pre-feature hardening program: **render** — the terminal UI layer. The core is well-built (synchronized paint, UTF-16-correct width math, bounded scrollback, image-flood cap). Three terminal-integrity fixes, headed by the worst-case failure for a TUI:

## Fixed

**Terminal corruption on SIGTERM/SIGHUP (headline).** The REPL restored the terminal only through a process `'exit'` hook — which a signal the process doesn't handle **never fires**. So **SIGHUP** (closed tab / ssh drop) and **SIGTERM** (a supervisor, `timeout tsforge …`) left the pane TUI on the **alternate screen** with **SGR mouse tracking on** and a **colored/hidden cursor** — spewing `\x1b[<…M` into the shell until a blind `reset`. New `installTerminalRestore` wires both signals to `paneScreen.leave()` + `editor.close()`, then re-raises with the default disposition so the exit status still reflects the signal. SIGINT is left alone (readline handles it; raw editor mode receives Ctrl+C as a keypress, not a signal).

**Terminal corruption on a wizard init-throw.** `runWizard`'s initial enter-alt-screen + first `draw()` ran **outside** `onKey`, so a synchronous throw there abandoned the Promise executor with the terminal stranded (alt screen, raw mode on, cursor hidden) — no keypress could ever reach `finish()`. Now wrapped in a `try/catch` that routes a failure through `finish()` (restore + resolve cancelled), mirroring `onKey`'s own catch.

**Silent-wrong `LiveRegion` erase (ghost fragments).** The in-place erase counted **logical** lines and climbed `rows-1` to the block top. A status line wider than the terminal soft-wraps to several **physical** rows, so the erase climbed too few and left ghost fragments of the previous block above the redraw (the `tsforge agents` fan-out tree with long paths on a narrow terminal). Now counts physical rows (`ceil(displayWidth/cols)` per line, SGR stripped first) and emits a trailing SGR reset so a colored line can't bleed into scrollback.

## Tests
- **`live-region.test.ts` (NEW — the surface had none):** wrap-aware erase, the SGR reset, unknown-width fallback, non-TTY no-op.
- `wizard.test.ts`: the initial-draw-throw restore case.
- `cli.test.ts`: source-scans the SIGTERM/SIGHUP restore wiring (mirrors the existing StatusBar guard; a true check needs a pty + signal harness).
- Each shown red before the fix.

## Deferred to a follow-up: deleting the dead `status-bar.ts` (670 LOC)
The plan slated `status-bar.ts` for deletion, and I confirmed it **is** dead in production — `cli.test.ts` already guards that the REPL never constructs `StatusBar`, and the editor renders via `PaneScreen`. But three editor e2e suites (`editor-e2e`, `editor-render-e2e`, `overlay-e2e`) use `StatusBar` as a **stand-in painter to assert editor-controller behaviour**, so deleting it needs those migrated onto `PaneScreen` (or they lose real coverage). That's careful test-migration work that shouldn't ride inside a terminal-integrity fix — I'll do it as a focused cleanup PR next.

Part of the pre-feature subsystem hardening program (final subsystem). After the follow-up cleanup, the program wraps and the bundled release comes off hold.
