### PR TITLE
CLI hardening: --policy-mode fails loud on a typo (no silent permissive fallback) and is honored in one-shot/greenfield

### DIFF
--- a/packages/core/ARCHITECTURE.md
+++ b/packages/core/ARCHITECTURE.md
@@ -23,7 +23,7 @@ inventory, see the hand-drawn map on [Internals](/internals/).
 | `self-harness` | Lets the harness propose, trial, and keep edits to its own prompts and rules | optional | 15 | 3k | 2 | 9 |
 | `config` | tsforge.config.json, profiles, recipes, agent specs, and external plugins | core | 12 | 3k | 8 | 8 |
 | `scaffold` | Stands up a new project from an archetype and configures its gate | optional | 15 | 3k | 3 | 3 |
-| `(root)` | CLI entry, model registry, session persistence — the loose files in src/ | core | 6 | 2k | 6 | 15 |
+| `(root)` | CLI entry, model registry, session persistence — the loose files in src/ | core | 6 | 3k | 6 | 15 |
 | `editor` | The terminal input-line editor behind the REPL prompt | core | 10 | 2k | 2 | 2 |
 | `gate` | Composes and runs the deterministic gate: linter, stages, tool paths | core | 15 | 2k | 5 | 8 |
 | `reviewers` | Independent review panel that grades a change before it is trusted | optional | 9 | 2k | 1 | 3 |
@@ -56,8 +56,8 @@ buries the ones someone can actually go and break.
 
 | Pair | One way | The other |
 | --- | --- | --- |
-| `(root)` ↔ `cli` | `cli.ts:29` → `./cli/args` | `cli/config-menu.ts:10` → `../models-config` |
-| `(root)` ↔ `gate` | `cli.ts:31` → `./gate/gate-runner` | `gate/core-gate.ts:3` → `../update-check` |
+| `(root)` ↔ `cli` | `cli.ts:30` → `./cli/args` | `cli/config-menu.ts:10` → `../models-config` |
+| `(root)` ↔ `gate` | `cli.ts:32` → `./gate/gate-runner` | `gate/core-gate.ts:3` → `../update-check` |
 | `(root)` ↔ `inference` | `classify.ts:1` → `./inference` | `inference/image-gen.ts:4` → `../models-config` |
 | `(root)` ↔ `loop` | `cli.ts:13` → `./loop` | `loop/expert-handoff.ts:21` → `../models-config` |
 | `agent` ↔ `inference` | `agent/agent-runner.ts:18` → `../inference` | `inference/wire.ts:9` → `../agent` |
@@ -67,7 +67,7 @@ buries the ones someone can actually go and break.
 | `cli` ↔ `render` | `cli/banner.ts:9` → `../render` | `render/command-menu.ts:2` → `../cli/commands` |
 | `config` ↔ `rule-packs` | `config/external-plugins.ts:5` → `../rule-packs` | `rule-packs/index.ts:131` → `../config/plugin-fingerprint` |
 | `editor` ↔ `render` | `editor/view.ts:2` → `../render/style` | `render/frame/input-seq.ts:1` → `../../editor/segments` |
-| `eval` ↔ `loop` | `eval/failure-class.ts:1` → `../loop/loop.types` | `loop/loop.types.ts:5` → `../eval/failure-class` |
+| `eval` ↔ `loop` | `eval/failure-class.ts:1` → `../loop/loop.types` | `loop/loop.types.ts:6` → `../eval/failure-class` |
 | `inference` ↔ `loop` | `inference/wire.ts:10` → `../loop/context-hygiene` | `loop/assistant-message.ts:1` → `../inference` |
 | `loop` ↔ `render` | `loop/worklist/panel.ts:3` → `../../render/frame/ansi-plain` | `render/agent-tree.ts:8` → `../loop/loop.types` |
 | `loop` ↔ `self-harness` | `loop/feedback/rule-docs.ts:3` → `../../self-harness/overlay` | `self-harness/build-evidence.ts:3` → `../loop` |
@@ -94,20 +94,20 @@ Async functions returning an exit code, declared under the CLI — the commands.
 
 | Function | Declared |
 | --- | --- |
-| `agentsMode` | `cli.ts:346` |
-| `greenfieldMode` | `cli.ts:644` |
+| `agentsMode` | `cli.ts:350` |
+| `greenfieldMode` | `cli.ts:651` |
 | `harnessDiagnoseMode` | `cli/harness-diagnose-mode.ts:211` |
 | `harnessReviewMode` | `cli/harness-review-mode.ts:684` |
-| `main` | `cli.ts:755` |
-| `mapMode` | `cli.ts:482` |
-| `recipesMode` | `cli.ts:501` |
+| `main` | `cli.ts:762` |
+| `mapMode` | `cli.ts:486` |
+| `recipesMode` | `cli.ts:505` |
 | `repl` | `cli/repl.ts:753` |
-| `reviewMode` | `cli.ts:181` |
-| `runOnce` | `cli.ts:93` |
+| `reviewMode` | `cli.ts:185` |
+| `runOnce` | `cli.ts:94` |
 | `runTraceCommand` | `cli/repl-commands.ts:118` |
-| `scaffoldMode` | `cli.ts:726` |
-| `setupMode` | `cli.ts:490` |
-| `traceMode` | `cli.ts:552` |
+| `scaffoldMode` | `cli.ts:733` |
+| `setupMode` | `cli.ts:494` |
+| `traceMode` | `cli.ts:556` |
 
 ## Imports that leave `src/`
 

--- a/packages/core/src/cli.ts
+++ b/packages/core/src/cli.ts
@@ -24,6 +24,7 @@ import {
   cliUsage,
   resolveCliProfile,
   profileFlagError,
+  policyModeFlagError,
   valueFlagError,
   type ICliArgs,
 } from "./cli/args";
@@ -119,6 +120,9 @@ async function runOnce(args: ICliArgs): Promise<number> {
     ...(args.maxTurns > 0 ? { maxTurns: args.maxTurns } : {}),
     ...(args.scout ? { scout: true } : {}),
     ...(profile === undefined ? {} : { profile }),
+    // Honor `--policy-mode` in one-shot too (validated in main()); without this
+    // the documented flag was a silent no-op on the headless path.
+    ...(isPolicyMode(args.policyMode) ? { policyMode: args.policyMode } : {}),
   });
   const ok = result.status === RUN_STATUS.done;
 
@@ -595,6 +599,9 @@ function greenfieldDeps(
         gate,
         ...(thinkingTokenBudget === undefined ? {} : { thinkingTokenBudget }),
         ...(args.maxTurns > 0 ? { maxTurns: args.maxTurns } : {}),
+        ...(isPolicyMode(args.policyMode)
+          ? { policyMode: args.policyMode }
+          : {}),
       });
 
       return {
@@ -828,6 +835,21 @@ export async function main(): Promise<number> {
 
   if (profileErr !== null) {
     process.stdout.write(`${profileErr}\n`);
+
+    return 1;
+  }
+
+  // A typo'd `--policy-mode` must fail loudly for the same reason — but the
+  // stakes are higher: an unvalidated value was silently discarded and the
+  // session fell to a MORE PERMISSIVE posture (plan-first off, or a config
+  // bypassPermissions winning). A safety flag never fails open on a typo.
+  const policyErr = policyModeFlagError(
+    args.policyMode,
+    raw.includes("--policy-mode")
+  );
+
+  if (policyErr !== null) {
+    process.stdout.write(`${policyErr}\n`);
 
     return 1;
   }

--- a/packages/core/src/cli/args.ts
+++ b/packages/core/src/cli/args.ts
@@ -1,6 +1,7 @@
 import { join, isAbsolute } from "node:path";
 import type { ITaskRecipe } from "../config/recipes";
 import { isProfileId, PROFILE_IDS, type ProfileId } from "../config/profiles";
+import { isPolicyMode, POLICY_MODES } from "../policy";
 
 /**
  * CLI argument parsing + recipe overlay — pure, no I/O, no module state. Extracted
@@ -455,6 +456,28 @@ export function profileFlagError(
   }
 
   return `unknown --profile "${profile}" — valid: ${PROFILE_IDS.join(", ")}`;
+}
+
+/** Reject an invalid `--policy-mode` value LOUDLY — the mirror of
+ *  `profileFlagError`. Without this a typo (`--policy-mode plna`) was silently
+ *  discarded by every `isPolicyMode(...) ? … : fallback` consumer, landing the
+ *  session on a MORE PERMISSIVE posture than the user asked for (plan-first
+ *  turned off, or a config `bypassPermissions` winning over an intended
+ *  restriction). A safety flag must never fail open on a typo. Returns null when
+ *  the flag is absent (empty) or the value is a valid mode. */
+export function policyModeFlagError(
+  policyMode: string,
+  flagPresent: boolean
+): string | null {
+  if (!flagPresent && policyMode.length === 0) {
+    return null;
+  }
+
+  if (isPolicyMode(policyMode)) {
+    return null;
+  }
+
+  return `unknown --policy-mode "${policyMode}" — valid: ${POLICY_MODES.join(", ")}`;
 }
 
 /** Recipe greenfield role models (split out to keep applyRecipe's complexity in

--- a/packages/core/src/loop/loop.types.ts
+++ b/packages/core/src/loop/loop.types.ts
@@ -1,5 +1,6 @@
 import type { ErrorParser } from "../validate";
 import type { ProfileId } from "../config/profiles";
+import type { PolicyMode } from "../policy";
 import type { IGate } from "../gate/gate-runner";
 import type { MetaBaseline } from "../meta-rules";
 import type { FailureClass } from "../eval/failure-class";
@@ -215,6 +216,10 @@ export interface IRunOptions {
   requireRed?: boolean;
   /** Rule profile override (from a recipe); defaults to tsforge.config.json. */
   profile?: ProfileId;
+  /** Policy-mode override (from the `--policy-mode` CLI flag); when set it wins
+   *  over `tsforge.config.json`'s `policy.mode` for this run. Without it a
+   *  headless/one-shot run ignored the documented flag entirely. */
+  policyMode?: PolicyMode;
   /** The composed gate this run's loop checks each cycle. Defaults to a command
    *  gate built from `task.accept` (brownfield behavior). Modes inject a richer
    *  composed gate (command + differential + judge + …) so the escalation ladder

--- a/packages/core/src/loop/run.ts
+++ b/packages/core/src/loop/run.ts
@@ -344,12 +344,19 @@ function effectiveParserFor(
  *  rule packs from configured external plugins. */
 /** The optional policy fields for the loop context (kept off `runTask` so its
  *  `exactOptionalPropertyTypes` spreads don't inflate its cognitive complexity). */
-function policyCtxFields(policy: ITsforgeProjectConfig["policy"]): {
+export function policyCtxFields(
+  policy: ITsforgeProjectConfig["policy"],
+  override?: PolicyMode
+): {
   policyMode?: PolicyMode;
   policyRules?: IPolicyRules;
 } {
+  // A `--policy-mode` CLI override wins over the config's `policy.mode` for this
+  // run; the config still supplies the rules.
+  const mode = override ?? policy?.mode;
+
   return {
-    ...(policy?.mode === undefined ? {} : { policyMode: policy.mode }),
+    ...(mode === undefined ? {} : { policyMode: mode }),
     ...(policy?.rules === undefined ? {} : { policyRules: policy.rules }),
   };
 }
@@ -1347,7 +1354,10 @@ export async function runTask(
     messages,
     // Config-driven policy applies to headless runs too (the critical denies
     // already do, mode-independent; this adds `policy.mode`/`rules`).
-    tool: { touched: new Set<string>(), ...policyCtxFields(policy) },
+    tool: {
+      touched: new Set<string>(),
+      ...policyCtxFields(policy, opts.policyMode),
+    },
     gate: {
       parse: effectiveParse,
       stackProfile,

--- a/packages/core/tests/gate-redetect.test.ts
+++ b/packages/core/tests/gate-redetect.test.ts
@@ -4,7 +4,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { resolveGate } from "../src/cli/gate-setup";
 import { parseArgs } from "../src/cli";
-import { profileFlagError } from "../src/cli/args";
+import { profileFlagError, policyModeFlagError } from "../src/cli/args";
 import { isProfileId } from "../src/config/profiles";
 import { autoGateCarry, resumedProfileArg } from "../src/cli/repl";
 import {
@@ -665,6 +665,28 @@ test("profileFlagError rejects invalid/value-less --profile, accepts valid or ab
   expect(profileFlagError("", true)).toContain("unknown --profile");
   // A prototype-chain name → error (not a real id).
   expect(profileFlagError("constructor", true)).toContain("unknown --profile");
+});
+
+// The higher-stakes twin: a typo'd `--policy-mode` must fail loudly, NOT silently
+// discard the value and fall to a MORE PERMISSIVE posture (plan-first off, or a
+// config bypassPermissions winning over an intended restriction).
+test("policyModeFlagError rejects invalid/value-less --policy-mode, accepts valid or absent", () => {
+  // Valid modes → no error.
+  expect(policyModeFlagError("plan", true)).toBeNull();
+  expect(policyModeFlagError("bypassPermissions", true)).toBeNull();
+  expect(policyModeFlagError("acceptEdits", false)).toBeNull();
+  // Not indicated at all → no error (config/default drives it).
+  expect(policyModeFlagError("", false)).toBeNull();
+  // A typo → error (this is what used to silently weaken the posture).
+  expect(policyModeFlagError("plna", true)).toContain(
+    'unknown --policy-mode "plna"'
+  );
+  // Trailing `--policy-mode` with no value → error.
+  expect(policyModeFlagError("", true)).toContain("unknown --policy-mode");
+  // A prototype-chain name → error (Set-backed isPolicyMode rejects it).
+  expect(policyModeFlagError("constructor", true)).toContain(
+    "unknown --policy-mode"
+  );
 });
 
 // A THIS-run explicit gate override must win over a resumed AUTO session — `--continue

--- a/packages/core/tests/policy-ctx-fields.test.ts
+++ b/packages/core/tests/policy-ctx-fields.test.ts
@@ -1,0 +1,43 @@
+import { test, expect, describe } from "bun:test";
+import { policyCtxFields } from "../src/loop/run";
+
+// The `--policy-mode` CLI flag threads into a headless/one-shot run through this
+// helper. Before it took an override the flag was a silent no-op on those paths
+// (runOnce/greenfield never passed it), so `policyCtxFields` is the seam that
+// makes the documented flag actually apply.
+
+describe("policyCtxFields", () => {
+  test("a CLI override wins over the config's policy.mode", () => {
+    const fields = policyCtxFields({ mode: "bypassPermissions" }, "plan");
+
+    expect(fields.policyMode).toBe("plan");
+  });
+
+  test("no override → the config's policy.mode drives it", () => {
+    expect(policyCtxFields({ mode: "acceptEdits" }).policyMode).toBe(
+      "acceptEdits"
+    );
+  });
+
+  test("an override applies even when the config sets no mode", () => {
+    const fields = policyCtxFields(undefined, "plan");
+
+    expect(fields.policyMode).toBe("plan");
+  });
+
+  test("no override and no config mode → policyMode is omitted", () => {
+    expect(policyCtxFields(undefined).policyMode).toBeUndefined();
+    expect(policyCtxFields({}).policyMode).toBeUndefined();
+  });
+
+  test("rules always come from the config, independent of the mode override", () => {
+    const rules = { allow: [], ask: [], deny: [] };
+    const fields = policyCtxFields(
+      { mode: "default", rules },
+      "bypassPermissions"
+    );
+
+    expect(fields.policyMode).toBe("bypassPermissions");
+    expect(fields.policyRules).toBe(rules);
+  });
+});


### PR DESCRIPTION
Continuing the hardening sweep into the un-audited tier (the prioritized 15-subsystem queue is merged): **cli**. The parser core is well-built — the findings concentrate on **one flag, `--policy-mode`**, the single safety control that was both unvalidated and, on two dispatch paths, a silent no-op.

## Fixed

**Fail-open on a typo (silent-wrong, safety).** `--profile` has a loud `profileFlagError`; `--policy-mode` had **no** equivalent. Every consumer used `isPolicyMode(v) ? v : fallback`, so a typo (`--policy-mode plna`) was silently discarded and the session landed on a **more permissive** posture — plan-first turned **off**, or a repo config's `bypassPermissions` winning over the restriction the user was trying to impose. New `policyModeFlagError` (mirrors `profileFlagError`) is checked in `main()` right after the profile check, so an invalid value now errors before **any** dispatch path runs. (The `repl.ts` comment that claimed the value was "(validated)" is now actually true.)

**A documented flag that did nothing (silent-wrong, no-op).** `--policy-mode` is a COMMON FLAG, but `runOnce`/greenfield never passed it to `runTask` — `IRunOptions` had no `policyMode` field — so a valid `--policy-mode plan` (or `bypassPermissions`) on the headless path did nothing and said nothing. Added `IRunOptions.policyMode`; `policyCtxFields` now takes it as an override that wins over config `policy.mode` (rules still come from config); `runOnce` and greenfield thread `args.policyMode`. The flag now applies on **every** path, not just the REPL and `agents` subcommand.

## Tests
- `policyModeFlagError` hostile-input cases (mirrors `profileFlagError`'s, incl. a prototype-chain name) in `gate-redetect.test.ts`.
- `policy-ctx-fields.test.ts` (new): override-wins / config-fallback / rules-independent logic.
- Both shown red first.

## Deferred (rationale)
- `harness-review` / `harness-diagnose` hand-rolled value-flag parsers blindly consume the next token — internal-facing entry points, lower exposure.
- An empty / all-empty `--files` silently widens scope to the whole repo — borderline by-design (the REPL documents "empty = all").

## Loop-core audit (companion, no PR)
I also audited the un-audited **loop drive core** (`run.ts`/`turn.ts`/tool-dispatch). It's **sound** — the gate is the sole authority on "done", `evaluateGate` is shared verbatim between settle and the `check` tool, tool throws never dangle a `tool_call`. Two clean fragility fixes surfaced (edits/regressions dropped on the no-tool-call settle terminal → sweep undercounts regressions; expert-repaired files bypass `recordTouched`) — I'll land those as a separate small loop PR next.

Part of the pre-feature hardening program (un-audited-tier sweep). **No release** — held until you give the word.
