### PR TITLE
Loop hardening: keep regression metrics on the narration terminal; record expert-repaired files in the change-set

### DIFF
--- a/packages/core/src/loop/run.ts
+++ b/packages/core/src/loop/run.ts
@@ -809,8 +809,18 @@ async function handleModelResponse(args: {
         announceTaskDone(args.report, args.taskId, settled.cycles);
       }
 
+      // Merge edits/regressions like the tool-call and readonly terminals below
+      // — settleGate's result omits them, relying on the caller to attach. This
+      // branch used to return `settled` RAW, so a run that edited + regressed and
+      // then parked via narration-while-red (or flipped green on a non-edit turn)
+      // reported regressions:undefined, which the sweep sums as 0 — zeroing the
+      // regression signal for exactly the runs that stalled after regressing.
       return {
-        action: settled,
+        action: {
+          ...settled,
+          edits: args.state.edits,
+          regressions: args.state.regressions,
+        },
         readonlyStreak: args.readonlyStreak,
         readonlyRecoveries: args.readonlyRecoveries,
         historyMetaStreak: args.historyMetaStreak,

--- a/packages/core/src/loop/turn.ts
+++ b/packages/core/src/loop/turn.ts
@@ -1873,6 +1873,13 @@ export async function tryExpertRescue(
     return false;
   }
 
+  // Record the expert's write in the change-set. Every model-driven write goes
+  // through recordTouched; the expert write did not, so a file the expert
+  // created/repaired (that the model never touched itself) was invisible to the
+  // change-scoped meta-rules (runMetaRulesStep reads ctx.tool.touched) — e.g. a
+  // logic module the expert introduced would skip logic-files-require-test-sibling.
+  recordTouched(ctx, [targetFile]);
+
   // The expert fixed it — give the primary model a fresh run at the ladder to
   // verify and finish (reset guards + steer level; record R4 as tried for this block).
   state.triedLeversByBlock.set(

--- a/packages/core/tests/expert-rescue.test.ts
+++ b/packages/core/tests/expert-rescue.test.ts
@@ -136,6 +136,9 @@ describe("tryExpertRescue", () => {
       expect(await Bun.file(join(dir, "x.ts")).text()).toBe(
         "export const s = String(v);\n"
       );
+      // The expert's write is recorded in the change-set, so change-scoped
+      // meta-rules enforce on it (they used to skip a file only the expert touched).
+      expect(ctx.tool.touched?.has("x.ts")).toBe(true);
       // Guards + steer level reset so the primary model gets a fresh run.
       // R4 should be recorded for the block (novelty gate).
       expect(state.steerLevel).toBe(0);

--- a/packages/core/tests/run-branches.test.ts
+++ b/packages/core/tests/run-branches.test.ts
@@ -71,6 +71,28 @@ test("stuck when the model never makes the goalpost pass", async () => {
   }
 });
 
+test("a stuck terminal from a narration (no-tool-call) turn reports edits/regressions as numbers", async () => {
+  // The no-tool-call settle terminal used to return settleGate's result RAW,
+  // which omits edits/regressions. The sweep does `r.regressions ?? 0`, so an
+  // undefined here silently zeroed the regression signal for exactly the runs
+  // that stalled while narrating. They must be numbers (like the other terminals).
+  const dir = await mkdtemp(join(tmpdir(), "tsforge-noedit-metrics-"));
+
+  try {
+    const r = await runTask(
+      { id: "1", accept: "test -f done.txt", files: ["done.txt"] },
+      dir,
+      scripted([STOP]) // never creates the file → red → narrate → stuck
+    );
+
+    expect(r.status).toBe("stuck");
+    expect(typeof r.regressions).toBe("number");
+    expect(typeof r.edits).toBe("number");
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
 test("done when the model creates the file the goalpost needs", async () => {
   const dir = await mkdtemp(join(tmpdir(), "tsforge-done-"));
 


### PR DESCRIPTION
Un-audited-tier sweep, companion to the CLI PR: the **loop drive core** (`run.ts` / `turn.ts` / tool dispatch). I audited it and it's **sound** — the gate is the sole authority on "done", `evaluateGate` is shared verbatim between settle and the `check` tool so they can't disagree, and a tool throw never dangles a `tool_call`. No defect accepts broken code as green. Two clean fragility fixes:

## Fixed

**Regression metric silently lost on the narration terminal (metrics integrity).** The no-tool-call settle terminal in `handleModelResponse` returned `settleGate`'s result **raw**, while the tool-call and readonly terminals both merge `edits`/`regressions` (`settleGate` omits them, relying on the caller to attach). So a run that edited + regressed and then **parked via narration-while-red** (or flipped green on a non-edit turn) reported `regressions: undefined` — and the sweep's `r.regressions ?? 0` counted it as **0**, zeroing the regression signal for exactly the runs that stalled after regressing. Now merges `edits`/`regressions` like the sibling terminals.

**Expert-repaired files bypassed the change-set (meta-rule coverage).** `tryExpertRescue` wrote the repaired file via `runExpertHandoff` but never called `recordTouched`, so a file the expert created/repaired that the model never touched itself was invisible to the change-scoped meta-rules (`runMetaRulesStep` reads `ctx.tool.touched`) — e.g. a logic module the expert introduced would skip `logic-files-require-test-sibling`. Now records the expert's write. (Bounded before — the gate still ran on the file — this closes the meta-rules gap.)

## Tests
- `run-branches`: a narration-stuck terminal now reports `edits`/`regressions` as numbers (was `undefined`).
- `expert-rescue`: the happy path asserts `ctx.tool.touched` includes the repaired file.
- Both shown red first.

## Audited, NOT changed (sound / scope-limited)
- Gate-authority + settle/`check` parity: verbatim-shared, correct.
- Truncation discards complete tool calls along with the partial one — recoverable (nothing written; the model resteers), and the partial handling lives in the already-audited assistant-message layer.
- `readonly-spin` is defeatable by `check`/task-tool-only turns, but that combination is **unreachable on the headless `runTask` path** (`toolsFor` leaves those tools off); only an interactive Session offering them could hit it.
- `worklist` `BULLET_RE` sub-bullet fragility — human-authored-file parsing only.

Part of the pre-feature hardening program (un-audited-tier sweep). **No release** — held until you give the word.
