### PR TITLE
MCP hardening: canonical (sanitized) server identity stops wrongly-denied servers; cap untrusted result size

### DIFF
--- a/packages/core/src/mcp/registry.ts
+++ b/packages/core/src/mcp/registry.ts
@@ -1,10 +1,31 @@
 import type { IMcpTransport } from "./mcp.types";
-import { mapMcpTool, mcpToolName, type IToolSchema } from "./schema-mapping";
+import {
+  mapMcpTool,
+  mcpToolName,
+  sanitizeMcpName,
+  type IToolSchema,
+} from "./schema-mapping";
 
 interface IRegisteredTool {
   readonly server: string;
   readonly toolName: string;
   readonly transport: IMcpTransport;
+}
+
+/** Upper bound on an MCP tool result fed into the model's context (~64KB). An
+ *  external server is untrusted; an unbounded reply is a memory + context-flood
+ *  vector. Beyond this the result is truncated with a visible marker. */
+const MAX_MCP_RESULT_CHARS = 64_000;
+
+/** Cap an MCP result string, appending a truncation notice when it's clipped. */
+function capMcpResult(text: string): string {
+  if (text.length <= MAX_MCP_RESULT_CHARS) {
+    return text;
+  }
+
+  return `${text.slice(0, MAX_MCP_RESULT_CHARS)}\n… (MCP result truncated: ${String(
+    text.length
+  )} chars from an external server)`;
 }
 
 /**
@@ -60,14 +81,25 @@ export class McpRegistry {
     return this.byName.has(name);
   }
 
-  /** Distinct registered server names — the policy layer denies an
-   *  `mcp__<server>__*` call whose server isn't in this set. */
+  /** Distinct registered server IDENTITIES for the policy layer — the SANITIZED
+   *  server name, matching what the model's `mcp__<server>__*` call name carries
+   *  and what policy's classifier parses back out. Returning the raw config name
+   *  here (e.g. `my.server`) while the classifier sees `my_server` made every
+   *  tool from a server whose name has a `.`/space wrongly read as an
+   *  unregistered server and denied. */
   serverNames(): string[] {
-    return [...new Set([...this.byName.values()].map((t) => t.server))];
+    return [
+      ...new Set(
+        [...this.byName.values()].map((t) => sanitizeMcpName(t.server))
+      ),
+    ];
   }
 
   /** Call a registered MCP tool. Never throws: a transport failure is returned
-   *  as text so the model treats it as a tool result. */
+   *  as text so the model treats it as a tool result. The result is capped:
+   *  an external server is untrusted, and an unbounded result would blow up
+   *  memory and flood the model's context (the built-in `read`/shell paths are
+   *  bounded too) — an oversized reply is truncated with a visible notice. */
   async callTool(name: string, args: Record<string, unknown>): Promise<string> {
     const entry = this.byName.get(name);
 
@@ -76,7 +108,7 @@ export class McpRegistry {
     }
 
     try {
-      return await entry.transport.callTool(entry.toolName, args);
+      return capMcpResult(await entry.transport.callTool(entry.toolName, args));
     } catch (err) {
       const message = err instanceof Error ? err.message : String(err);
 

--- a/packages/core/src/mcp/schema-mapping.ts
+++ b/packages/core/src/mcp/schema-mapping.ts
@@ -10,15 +10,21 @@ export interface IToolSchema {
   };
 }
 
-/** OpenAI function names allow [a-zA-Z0-9_-]; replace anything else with "_". */
-function sanitize(value: string): string {
+/** OpenAI function names allow [a-zA-Z0-9_-]; replace anything else with "_".
+ *  This is the canonical MCP name normalization: the wire tool name the model
+ *  sees is `mcp__${sanitizeMcpName(server)}__${sanitizeMcpName(tool)}`, so the
+ *  SANITIZED server segment is the identity the policy layer parses back out of
+ *  a call name. Anything comparing against that identity (the registered-server
+ *  check) must sanitize too, or a server whose config name has a `.`/space is
+ *  advertised under one name but checked under another → wrongly denied. */
+export function sanitizeMcpName(value: string): string {
   return value.replace(/[^a-zA-Z0-9_-]/g, "_");
 }
 
 /** The namespaced name advertised to the model for an MCP tool. The double-underscore
  *  separators mirror the conventional `mcp__<server>__<tool>` form. */
 export function mcpToolName(server: string, tool: string): string {
-  return `mcp__${sanitize(server)}__${sanitize(tool)}`;
+  return `mcp__${sanitizeMcpName(server)}__${sanitizeMcpName(tool)}`;
 }
 
 /** A tool with no declared parameters still needs a valid object schema. */

--- a/packages/core/tests/mcp-unit.test.ts
+++ b/packages/core/tests/mcp-unit.test.ts
@@ -234,6 +234,35 @@ describe("mcp: registry", () => {
     expect(count).toBe(1);
   });
 
+  test("serverNames() returns the SANITIZED identity (matches the wire tool name)", async () => {
+    // A server whose config name has a `.` is advertised as `mcp__my_server__…`
+    // and the policy classifier parses `my_server` back out. serverNames() must
+    // return that same sanitized identity, or the registered-server check denies
+    // every tool from the server as "unregistered".
+    const registry = new McpRegistry();
+
+    await registry.addServer("my.server", new FakeTransport([ECHO_TOOL]));
+
+    expect(registry.toolSchemas()[0]?.function.name).toBe(
+      "mcp__my_server__echo"
+    );
+    expect(registry.serverNames()).toEqual(["my_server"]);
+  });
+
+  test("callTool caps an oversized result from an untrusted server", async () => {
+    const registry = new McpRegistry();
+
+    await registry.addServer(
+      "big",
+      new FakeTransport([ECHO_TOOL], () => Promise.resolve("x".repeat(200_000)))
+    );
+
+    const out = await registry.callTool("mcp__big__echo", {});
+
+    expect(out.length).toBeLessThan(200_000);
+    expect(out).toContain("MCP result truncated");
+  });
+
   test("closeAll closes every transport", async () => {
     const registry = new McpRegistry();
     const transport = new FakeTransport([ECHO_TOOL]);


### PR DESCRIPTION
Un-audited-tier sweep: **mcp** — the Model Context Protocol client (connects to external, untrusted MCP servers and exposes their tools to the model). **The security boundary is largely sound** — MCP tool calls go through the *same* `evaluatePolicy` gate as built-ins, namespacing structurally prevents a server from shadowing `edit`/`run`, an unregistered/forged server is a critical-deny, server errors surface as failures, and there's a per-call timeout. Two real fixes:

## Fixed

**Server-name sanitize divergence → legit servers wrongly denied (silent-wrong).** The wire tool name is `mcp__${sanitize(server)}__${sanitize(tool)}`, and the policy classifier parses the **sanitized** server segment back out — but `registry.serverNames()` (the set the policy registered-server check compares against) returned the **raw** config name. So a server whose config name has a `.`/space — `my.server`, advertised as `mcp__my_server__…` — was checked as `my_server ∉ {my.server}` and **every tool from it was critically denied** as an unregistered server. `serverNames()` now returns the sanitized identity, matching the classifier. Fail-closed before (no bypass), but legitimate servers were unusable.

**Unbounded untrusted result (fragile / DoS / context-flood).** An external server's `tools/call` result flowed into model context with **no size bound** — unlike the built-in `read` (1500-line cap) and shell condensing. `callTool` now caps at 64 KB with a visible truncation marker, bounding both memory and context flooding from an untrusted server.

## Tests (`mcp-unit`)
- `serverNames()` returns the sanitized identity for a dotted server name (was raw → wrongly denied).
- `callTool` truncates a 200 KB result with a notice.
- Both shown red first.

## Deferred (noted, rationale)
- A per-server policy **allow** rule keyed to a raw dotted name is still inert (`rule.mcpServer` raw vs the sanitized action) — **fail-closed**, and a clean fix needs a shared sanitizer between policy-rule matching and mcp naming (a policy↔mcp coupling decision).
- A malformed server-advertised JSON Schema is forwarded verbatim and could 400 the whole tool list — schema validation/isolation is a larger change.
- `LineDecoder` buffer is unbounded (already time-bounded by the per-call timeout).

Part of the pre-feature hardening program (un-audited-tier sweep). **No release** — held until you give the word.
