### PR TITLE
Spec hardening: CRLF-safe parsing (stop mode-flip file deletion) + task parsing scoped to ## Tasks

### DIFF
--- a/packages/core/src/spec/parse.ts
+++ b/packages/core/src/spec/parse.ts
@@ -9,9 +9,19 @@ import type { ISpec, ITask } from "./spec.types";
  * lines. Richer fields (needs/covers/docs) land in the spec-engine slice.
  */
 export function parseSpec(markdown: string): ISpec {
-  const fm = parseFrontmatter(markdown);
-  const tasks = parseTasks(markdown);
-  const intent = parseSection(markdown, "Acceptance criteria");
+  // Normalize line endings first. A CRLF-authored spec otherwise fails the
+  // `^---\n` frontmatter match, dropping `mode`/`id`/`verify` to their defaults
+  // — silently flipping `mode: existing` to `scratch`, which then DELETES the
+  // task files (self-harness startRed). Fold CR/CRLF to LF so parsing is
+  // byte-ending-agnostic.
+  const md = markdown.replace(/\r\n?/g, "\n");
+  const fm = parseFrontmatter(md);
+  // Scope task parsing to the `## Tasks` section: a plain numbered list under
+  // `## Acceptance criteria` (`1. …`) would otherwise be scanned as phantom
+  // tasks with empty `accept`, colliding ids with the real tasks and blocking
+  // the spec on a task the author never wrote.
+  const tasks = parseTasks(parseSection(md, "Tasks"));
+  const intent = parseSection(md, "Acceptance criteria");
 
   if (intent.length > 0) {
     for (const task of tasks) {

--- a/packages/core/tests/spec-parse.test.ts
+++ b/packages/core/tests/spec-parse.test.ts
@@ -39,6 +39,34 @@ describe("parseSpec", () => {
     expect(s.tasks[0]!.id).toBe("1");
   });
 
+  test("a PLAIN numbered acceptance-criteria list is not scanned as phantom tasks", () => {
+    // `1.`/`2.` under `## Acceptance criteria` used to be parsed as tasks with
+    // empty accept, colliding ids with the real task and blocking the spec.
+    // Task parsing is now scoped to the `## Tasks` section.
+    const s = parseSpec(
+      `---\nid: x\n---\n\n## Acceptance criteria\n1. user can log in\n2. errors show\n\n## Tasks\n1. real task\n     accept: bun test\n     files: a.ts\n`
+    );
+
+    expect(s.tasks).toHaveLength(1);
+    expect(s.tasks[0]?.id).toBe("1");
+    expect(s.tasks[0]?.accept).toBe("bun test");
+    expect(s.tasks[0]?.files).toEqual(["a.ts"]);
+  });
+
+  test("a CRLF-authored spec keeps its frontmatter (mode/id/verify not silently lost)", () => {
+    // With a hard-coded `^---\n` regex a CRLF spec dropped ALL frontmatter,
+    // flipping `mode: existing` to the default `scratch` — which DELETES the
+    // task files. Line endings are normalized first.
+    const crlf =
+      "---\r\nid: fix-1\r\nverify: bun run validate\r\nmode: existing\r\n---\r\n\r\n## Tasks\r\n1. patch\r\n     accept: bun test\r\n     files: a.ts\r\n";
+    const s = parseSpec(crlf);
+
+    expect(s.mode).toBe("existing");
+    expect(s.id).toBe("fix-1");
+    expect(s.verify).toBe("bun run validate");
+    expect(s.tasks[0]?.files).toEqual(["a.ts"]);
+  });
+
   test("attaches the Acceptance criteria prose to each task as intent", () => {
     const s = parseSpec(
       `---\nid: x\n---\n\n## Acceptance criteria\nA1. discount is in CENTS: discounted = max(0, subtotal - discountCents).\n\n## Tasks\n1. [x] y\n     accept: bun test\n     files: a.ts\n`


### PR DESCRIPTION
Un-audited-tier sweep: **spec** — task/spec shapes, spec parsing, and test generation. `parseSpec` is otherwise pure/deterministic and the `review-tests` path is soundly guarded. Two parser defects that silently corrupt a **valid** author's spec:

## Fixed

**CRLF spec → files deleted (data-loss).** The frontmatter regex was `^---\n`, so a CRLF-authored spec never matched and **all** frontmatter fell to defaults — flipping `mode: existing` to the default `scratch`, which the self-harness `startRed` path acts on by **deleting every task file**. A Windows-authored bugfix/refactor spec (real code, `mode: existing`) could have its editable files removed. `parseSpec` now folds CR/CRLF→LF before parsing, so `mode`/`id`/`verify` survive regardless of line endings.

**Phantom tasks from a numbered acceptance list (silent-wrong).** `parseTasks` scanned the **whole** document for `^\d+\.`, so a plain numbered list under `## Acceptance criteria` (`1. user can log in`) was parsed as phantom tasks with empty `accept`, whose ids collided with the real tasks and **blocked the spec on a task the author never wrote**. Task parsing is now scoped to the `## Tasks` section (every spec uses that heading; backward-compatible with all existing tests).

## Tests
- A plain numbered acceptance-criteria list yields exactly the real task (not phantom empty-accept ones).
- A CRLF spec keeps `mode: existing` + `id` + `verify` (was silently `scratch`, id/verify blank).
- Both shown red first.

## Deferred (rationale)
- `assess` accepts a generated test that **calls** the stub but **asserts nothing** (it throws against the not-implemented stub, so it reads as RED and is seeded, then passes vacuously once implemented). A reliable no-assertion detector is fuzzy and deserves its own design.
- An empty `accept`/`verify` is a permissive no-op — guarded downstream by `requireRed`, but the guard burden sits on every caller.

Part of the pre-feature hardening program (un-audited-tier sweep). **No release** — held.
