### PR TITLE
Infer-rules hardening: minimum evidence + deterministic scan so inference can't silently disable a rule from noise

### DIFF
--- a/packages/core/src/infer-rules/scan.ts
+++ b/packages/core/src/infer-rules/scan.ts
@@ -129,10 +129,23 @@ export async function scanRepo(cwd: string): Promise<IScanReport> {
   let enumFiles = 0;
   let filesScanned = 0;
 
+  // Collect + SORT before sampling: `Glob.scan` yields in filesystem order,
+  // which isn't stable across machines/runs, so at/above the MAX_FILES cap the
+  // recommendation depended on WHICH files were seen (a large repo could infer
+  // different rules run-to-run). A lexical sort makes the sampled set — and thus
+  // the inferred conventions — deterministic.
+  const all: string[] = [];
+
   for await (const rel of new Glob("**/*.{ts,tsx}").scan({
     cwd,
     onlyFiles: true,
   })) {
+    all.push(rel);
+  }
+
+  all.sort();
+
+  for (const rel of all) {
     if (ignored(rel)) {
       continue;
     }
@@ -147,8 +160,18 @@ export async function scanRepo(cwd: string): Promise<IScanReport> {
       continue;
     }
 
+    // Ambient declarations (`.d.ts`) are generated/third-party, not the repo's
+    // AUTHORED convention — never let them decide a rule.
+    if (rel.endsWith(".d.ts")) {
+      continue;
+    }
+
     try {
-      if (tallyFile(await file.text(), rel, iface)) {
+      const hasEnum = tallyFile(await file.text(), rel, iface);
+
+      // A test-file enum (a fixture) is not the repo's source policy — a single
+      // one must not flip the whole-repo enum ban off.
+      if (hasEnum && !TEST_FILE.test(rel)) {
         enumFiles += 1;
       }
     } catch {
@@ -238,9 +261,16 @@ function dominant<T>(a: { v: T; n: number }, b: { v: T; n: number }): T | null {
   return null;
 }
 
+/** Below this many interfaces there isn't enough evidence to infer a house
+ *  convention — one or two examples would let a single file flip the whole
+ *  repo's naming rule (or disable it). Fall back to the tsforge default. */
+const MIN_INTERFACE_SAMPLE = 3;
+
 function recommendInterfaces(scan: IInterfaceScan): IConventions["interfaces"] {
-  if (scan.total === 0) {
-    return "i-prefix"; // greenfield → tsforge house style
+  if (scan.total < MIN_INTERFACE_SAMPLE) {
+    // Too few to generalize (incl. greenfield total===0) → the house default,
+    // never an inference from 1–2 files.
+    return "i-prefix";
   }
 
   const winner = dominant<IConventions["interfaces"]>(
@@ -248,7 +278,8 @@ function recommendInterfaces(scan: IInterfaceScan): IConventions["interfaces"] {
     { v: "bare-pascal-case", n: scan.bare }
   );
 
-  // A genuinely split repo: don't impose a contested naming rule.
+  // A genuinely split repo (enough evidence, but contested): don't impose a
+  // contested naming rule.
   return winner ?? "off";
 }
 

--- a/packages/core/tests/scan.test.ts
+++ b/packages/core/tests/scan.test.ts
@@ -70,7 +70,27 @@ describe("interface naming scan + recommendation", () => {
     });
   });
 
-  test("a split repo recommends off (contested)", async () => {
+  test("a genuinely split repo (enough evidence) recommends off (contested)", async () => {
+    // 2 i-prefix / 2 bare = 50/50 above the min-sample floor → no dominant → off.
+    const files: IFixtureFile[] = [
+      { path: "src/a.ts", content: "export interface IUser { id: string; }" },
+      { path: "src/b.ts", content: "export interface IOrder { n: number; }" },
+      { path: "src/c.ts", content: "export interface Order { n: number; }" },
+      { path: "src/d.ts", content: "export interface Widget { n: number; }" },
+    ];
+
+    await withRepo(files, async (cwd) => {
+      const report = await scanRepo(cwd);
+
+      expect(report.interfaces.total).toBe(4);
+      expect(recommendConventions(report).interfaces).toBe("off");
+    });
+  });
+
+  test("too few interfaces to generalize → house default, never a 1–2 file inference", async () => {
+    // A 1-i-prefix / 1-bare split is too small to infer anything (the old code
+    // returned "off", silently DISABLING naming enforcement from 2 files). Below
+    // the min-sample floor it falls back to the house default instead.
     const files: IFixtureFile[] = [
       { path: "src/a.ts", content: "export interface IUser { id: string; }" },
       { path: "src/b.ts", content: "export interface Order { n: number; }" },
@@ -79,7 +99,8 @@ describe("interface naming scan + recommendation", () => {
     await withRepo(files, async (cwd) => {
       const report = await scanRepo(cwd);
 
-      expect(recommendConventions(report).interfaces).toBe("off");
+      expect(report.interfaces.total).toBe(2);
+      expect(recommendConventions(report).interfaces).toBe("i-prefix");
     });
   });
 
@@ -111,6 +132,23 @@ describe("enum scan", () => {
         expect(recommendConventions(await scanRepo(cwd)).enums).toBe("ban");
       }
     );
+  });
+
+  test("an enum only in a test file or .d.ts does NOT disable the ban", async () => {
+    // A fixture enum in a `.test.ts`, or an ambient enum in a `.d.ts`, is not the
+    // repo's source policy — it must not flip the whole-repo enum ban to allow.
+    const files: IFixtureFile[] = [
+      { path: "src/real.ts", content: "export const x = 1;" },
+      { path: "src/e.test.ts", content: "enum Fixture { A, B }" },
+      { path: "types/ambient.d.ts", content: "declare enum Ambient { X, Y }" },
+    ];
+
+    await withRepo(files, async (cwd) => {
+      const report = await scanRepo(cwd);
+
+      expect(report.enums.fileCount).toBe(0);
+      expect(recommendConventions(report).enums).toBe("ban");
+    });
   });
 });
 

--- a/packages/core/tests/setup-flow.test.ts
+++ b/packages/core/tests/setup-flow.test.ts
@@ -72,13 +72,15 @@ describe("wizard flow mapping", () => {
     const dir = repo([
       { path: "src/a.ts", content: "export interface User { id: string; }" },
       { path: "src/b.ts", content: "export interface Order { n: number; }" },
+      { path: "src/c.ts", content: "export interface Invoice { n: number; }" },
     ]);
 
     try {
       const report = await scanRepo(dir);
       const steps = buildSteps(report);
 
-      // The interfaces step preselects the recommendation (bare-pascal-case).
+      // Enough bare interfaces (>= the min-sample floor) to infer bare-pascal-case;
+      // the interfaces step preselects that recommendation.
       const actions: IWizardAction[] = [
         ...steps.map((): IWizardAction => "confirm"),
         "confirm", // overview → apply
@@ -125,6 +127,7 @@ describe("runSetup orchestration", () => {
     const dir = repo([
       { path: "src/a.ts", content: "export interface User { id: string; }" },
       { path: "src/b.ts", content: "export interface Order { n: number; }" },
+      { path: "src/c.ts", content: "export interface Invoice { n: number; }" },
       { path: "src/e.ts", content: "export enum Color { Red }" },
     ]);
     let out = "";


### PR DESCRIPTION
Un-audited-tier sweep: **infer-rules** — scans a repo for its conventions and turns them into rule overrides at `tsforge setup`. The env/config *parse* side is soundly hardened; the *inference* side let a tiny or unrepresentative sample silently weaken the gate — and `setup --yes` writes the inference with no confirmation. Three fixes, all "don't infer a rule-disabling override from noise":

## Fixed

**One enum disabled the ban repo-wide (silent-wrong).** `enums: fileCount > 0 ? "allow" : "ban"` flipped the whole-repo enum ban off on a **single** enum anywhere — including a `.test.ts` fixture or an ambient `.d.ts` (both match the `**/*.ts` glob). Now `.d.ts` files are excluded from the scan entirely (ambient, not authored), and a test-file enum no longer counts — a lone fixture/ambient enum keeps the ban.

**One interface decided the whole repo's naming rule; a 1–2 file split *disabled* it (silent-wrong).** `dominant` needs only 60% of a tiny total, so a single interface set the project's naming rule, and a 1–2 file split returned `"off"` — silently **disabling** naming enforcement (weaker than either choice *and* weaker than the house default). New `MIN_INTERFACE_SAMPLE = 3` floor: below it, fall back to the house default (`i-prefix`), never a 1–2 file inference. A genuine contested split **above** the floor still yields `"off"` (the deliberate "don't impose a contested rule" behavior is preserved).

**Non-deterministic inference on large repos (fragile).** The 800-file scan cap sampled in **unsorted** glob order, so a repo over the cap could infer different rules run-to-run depending on which 800 files were seen. The glob stream is now sorted before sampling → deterministic conventions.

## Tests
- Min-sample floor: a 2-file split → house default; a 4-file contested split → `off`.
- An enum only in a `.test.ts`/`.d.ts` does not disable the ban.
- Two consumer fixtures (`setup-flow`) that encoded the old 2-interface inference were bumped to ≥ the floor.
- Shown red first.

## Deferred (rationale)
- The exact 60% dominance boundary (tightening, not a hole).
- Folder inference by bare dir-existence (taste, not a gate hole).
- Whether `"off"` should ever be *inferred* for a large contested repo — kept as a deliberate product choice.

Part of the pre-feature hardening program (un-audited-tier sweep). **No release** — held.
