### PR TITLE
Scaffold hardening: contain manifest-derived write paths (no write-outside-dest) + fail loud on malformed crossRules

### DIFF
--- a/packages/core/src/scaffold/boringstack-manifest.ts
+++ b/packages/core/src/scaffold/boringstack-manifest.ts
@@ -177,6 +177,15 @@ export function parseManifest(raw: unknown): IScaffoldManifest {
     };
   });
 
+  // crossRules are the SAFETY validation (mutually-exclusive / implies checks
+  // that assertValid enforces). optArray would silently coerce a wrong TYPE
+  // (an object, string, null) to `[]` — defeating validation while the config
+  // scaffolds as "valid". Present-but-not-an-array must fail loud, like every
+  // other required field in this parser. (Absent → [] is fine.)
+  if (raw.crossRules !== undefined && !isArray(raw.crossRules)) {
+    throw new Error("scaffold manifest: crossRules must be an array");
+  }
+
   const crossRules = optArray(raw, "crossRules").map(
     (r, i): IConfigCrossRule => {
       if (!isRecord(r)) {

--- a/packages/core/src/scaffold/configure.ts
+++ b/packages/core/src/scaffold/configure.ts
@@ -1,4 +1,5 @@
 import { randomBytes } from "node:crypto";
+import { assertSafeScaffoldRel } from "./io";
 import type { IScaffoldFs, IScaffoldRunner } from "./io";
 import { allocateHostPorts } from "./ports";
 import type {
@@ -185,6 +186,11 @@ export async function applyScaffold(
     if (file.length === 0) {
       continue;
     }
+
+    // A manifest-supplied env-file name must stay inside `dir` — otherwise a
+    // crafted `envFile: "../../../.bashrc"` would read+rewrite a file outside
+    // the scaffold destination (readOrSeed + writeText below).
+    assertSafeScaffoldRel(file, "write env file");
 
     const path = `${dir}/${file}`;
     const base = await readOrSeed(fs, path);

--- a/packages/core/src/scaffold/io.ts
+++ b/packages/core/src/scaffold/io.ts
@@ -10,6 +10,24 @@ import { dirname } from "node:path";
 import { runArgvCommand, type IShellRun } from "../lib/fs/process";
 import { pollUntilReady } from "../../scripts/boot-check";
 
+/** Reject a manifest-derived relative path that would escape the destination —
+ *  empty, absolute, or containing a `..` segment (either separator). Scaffold
+ *  manifest values are semi-trusted: the manifest is read from a CLONED repo,
+ *  redirectable via BORINGSTACK_REPO/`--ref`, so every on-disk path built from
+ *  it — env files to WRITE, template paths to DELETE — must be contained, or an
+ *  `envFile: "../../../.bashrc"` writes (or an unsafe strip deletes) outside the
+ *  scaffold destination. Lexical + both separators; the caller joins to `dest`. */
+export function assertSafeScaffoldRel(rel: string, verb: string): void {
+  if (
+    rel.length === 0 ||
+    rel.startsWith("/") ||
+    rel.startsWith("\\") ||
+    rel.split(/[\\/]/u).includes("..")
+  ) {
+    throw new Error(`scaffold: refusing to ${verb} unsafe path "${rel}"`);
+  }
+}
+
 /** Runs an explicit argv (no shell) in `cwd`. Matches `runArgvCommand` so the real
  *  adapter is a direct pass-through; tests inject a recording fake to assert the
  *  exact command sequence without spawning git/Docker. */

--- a/packages/core/src/scaffold/run-scaffold.ts
+++ b/packages/core/src/scaffold/run-scaffold.ts
@@ -3,7 +3,13 @@ import { cloneRepo, scaffoldRecord } from "./clone";
 import { bootStack, type IBootDeps } from "./boot";
 import { answersToPlan } from "./plan";
 import { parseManifest } from "./boringstack-manifest";
-import { realRunner, realFs, realPoller, type IScaffoldFs } from "./io";
+import {
+  realRunner,
+  realFs,
+  realPoller,
+  assertSafeScaffoldRel,
+  type IScaffoldFs,
+} from "./io";
 import { seedReactGreenfieldOpinionated } from "../config/seed-greenfield-profile";
 import type {
   IArchetypeProfile,
@@ -226,13 +232,7 @@ async function stripTemplatePaths(
   paths: readonly string[]
 ): Promise<void> {
   for (const rel of paths) {
-    if (
-      rel.length === 0 ||
-      rel.startsWith("/") ||
-      rel.split("/").includes("..")
-    ) {
-      throw new Error(`scaffold: refusing to strip unsafe path "${rel}"`);
-    }
+    assertSafeScaffoldRel(rel, "strip");
 
     await fs.remove(`${dest}/${rel}`);
   }

--- a/packages/core/tests/scaffold-configure-apply.test.ts
+++ b/packages/core/tests/scaffold-configure-apply.test.ts
@@ -4,7 +4,11 @@ import { join } from "node:path";
 import { applyScaffold } from "../src/scaffold/configure";
 import { answersToPlan } from "../src/scaffold/plan";
 import { parseManifest } from "../src/scaffold/boringstack-manifest";
-import type { IScaffoldFs, IScaffoldRunner } from "../src/scaffold/io";
+import {
+  assertSafeScaffoldRel,
+  type IScaffoldFs,
+  type IScaffoldRunner,
+} from "../src/scaffold/io";
 import type { IShellRun } from "../src/lib/fs/process";
 
 const MANIFEST = parseManifest(
@@ -229,5 +233,65 @@ describe("applyScaffold — initial superuser", () => {
 
     expect(compose).not.toContain("SUPERUSER_EMAIL");
     expect(compose).not.toContain("SUPERUSER_PASSWORD");
+  });
+});
+
+// ── Path-traversal + safety-validation hardening ────────────────────────────
+describe("assertSafeScaffoldRel", () => {
+  test("rejects escaping paths, accepts a contained relative path", () => {
+    expect(() => assertSafeScaffoldRel("compose/.env", "write")).not.toThrow();
+    expect(() => assertSafeScaffoldRel("../escape.env", "write")).toThrow(
+      /unsafe path/u
+    );
+    expect(() => assertSafeScaffoldRel("a/../../etc/x", "write")).toThrow(
+      /unsafe path/u
+    );
+    expect(() => assertSafeScaffoldRel("/etc/passwd", "write")).toThrow(
+      /unsafe path/u
+    );
+    expect(() => assertSafeScaffoldRel("..\\win", "write")).toThrow(
+      /unsafe path/u
+    );
+    expect(() => assertSafeScaffoldRel("", "write")).toThrow(/unsafe path/u);
+  });
+});
+
+describe("applyScaffold — refuses a manifest env-file that escapes the dest", () => {
+  test("an envEdit targeting ../ throws instead of writing outside dest", async () => {
+    const base = answersToPlan(MANIFEST, {
+      archetype: "boringstack",
+      stack: "dev",
+      values: {},
+    });
+    // A manifest-derived env-file name that escapes the scaffold destination.
+    const plan = {
+      ...base,
+      envEdits: [
+        { key: "X", value: "1", secret: false, file: "../../../.bashrc" },
+      ],
+    };
+    const { run } = recorder();
+    const { fs, store } = memFs();
+
+    await expect(
+      applyScaffold(DIR, MANIFEST, plan, { run, fs })
+    ).rejects.toThrow(/refusing to write env file/u);
+    // Nothing was written outside (or anywhere).
+    expect(store.size).toBe(0);
+  });
+});
+
+describe("parseManifest — crossRules type is validated (safety layer)", () => {
+  test("a non-array crossRules fails loud, not silently dropped", () => {
+    const raw = JSON.parse(
+      readFileSync(
+        join(import.meta.dir, "fixtures/scaffold/scaffold-manifest.json"),
+        "utf8"
+      )
+    );
+
+    raw.crossRules = { bogus: true }; // object, not an array
+
+    expect(() => parseManifest(raw)).toThrow(/crossRules must be an array/u);
   });
 });


### PR DESCRIPTION
Un-audited-tier sweep: **scaffold** — the greenfield wizard that clones a boringstack template and writes a project's initial files. The overwrite surface is mostly protected (clone-first ordering; the delete/strip path already rejects `..`). Two real holes, both driven by the **manifest** — which is read from the **cloned** repo and redirectable via `BORINGSTACK_REPO`/`--ref`:

## Fixed

**Write-outside-destination via a manifest env-file name (security).** The env-file **write** path built `${dir}/${file}` from a manifest `envFile`/`envFileDefault` with **no** containment check — while the sibling **delete** path *was* guarded (the tell-tale asymmetry). A manifest `envFileDefault: "../../../.bashrc"` made `configure` read+seed+**rewrite** a file *outside* the scaffold destination (`mkdir -p` even creates the intermediate dirs). Extracted the delete-path guard into a shared `assertSafeScaffoldRel` (now also rejects a Windows `..\`) and applied it to the env-file write before any read/write.

**Malformed `crossRules` silently defeated the safety validation (silent-wrong).** `crossRules` — the mutually-exclusive/implies checks that `assertValid` enforces — were parsed with `optArray`, which silently coerces a wrong **top-level type** (object/string/null) to `[]`. A fat-fingered `"crossRules": { … }` then made `violations` always empty, so an **invalid** stack combination scaffolded and booted as "valid". Present-but-not-an-array now fails loud, like every other required manifest field.

## Tests
- `assertSafeScaffoldRel`: escapes rejected (`..`, absolute, both separators, empty), contained path accepted.
- `applyScaffold` rejects an `envEdit` whose file escapes the dest — nothing written.
- `parseManifest` throws on a non-array `crossRules`.
- Both behaviors shown red first.

## Deferred (rationale)
- Env **values** are written raw/unescaped (a newline injects extra assignments; a `$` is re-interpolated when the `.env` is sourced), including `SUPERUSER_PASSWORD` — needs value quoting/escaping.
- No rollback of a half-written tree on a mid-run failure (the docstring promises all-or-nothing; a partial tree then wedges the retry via git's non-empty-dir refusal).
- The non-empty-destination guard is implicit in `git clone` and untested.

Part of the pre-feature hardening program (un-audited-tier sweep). **No release** — held.
