### PR TITLE
Models-config hardening: validate baseUrl (where the key goes), key-field types, and the review quorum

### DIFF
--- a/packages/core/ARCHITECTURE.md
+++ b/packages/core/ARCHITECTURE.md
@@ -22,8 +22,8 @@ inventory, see the hand-drawn map on [Internals](/internals/).
 | `meta-rules` | Gate rules that need no AST — config shape, CI wiring, supply chain | core | 42 | 3k | 1 | 2 |
 | `self-harness` | Lets the harness propose, trial, and keep edits to its own prompts and rules | optional | 15 | 3k | 2 | 9 |
 | `config` | tsforge.config.json, profiles, recipes, agent specs, and external plugins | core | 12 | 3k | 8 | 8 |
-| `scaffold` | Stands up a new project from an archetype and configures its gate | optional | 15 | 3k | 3 | 3 |
 | `(root)` | CLI entry, model registry, session persistence — the loose files in src/ | core | 6 | 3k | 6 | 15 |
+| `scaffold` | Stands up a new project from an archetype and configures its gate | optional | 15 | 3k | 3 | 3 |
 | `editor` | The terminal input-line editor behind the REPL prompt | core | 10 | 2k | 2 | 2 |
 | `gate` | Composes and runs the deterministic gate: linter, stages, tool paths | core | 15 | 2k | 5 | 8 |
 | `reviewers` | Independent review panel that grades a change before it is trusted | optional | 9 | 2k | 1 | 3 |

--- a/packages/core/src/models-config.ts
+++ b/packages/core/src/models-config.ts
@@ -200,6 +200,62 @@ function assertNumericFields(name: string, entry: unknown): void {
   }
 }
 
+/** `apiKey`/`apiKeyEnv` are unchecked by `isModelEntry`. A hand-edited non-string
+ *  (`"apiKey": 12345`) then fails silently: `entry.apiKey.length > 0` is false,
+ *  so resolution falls through to no Authorization header and the provider
+ *  returns a 401 that reads like an account problem, not the config typo it is.
+ *  Fail loud at the boundary, matching the numeric guard. */
+function assertKeyFields(name: string, entry: unknown): void {
+  if (!isRecord(entry)) {
+    return;
+  }
+
+  for (const field of ["apiKey", "apiKeyEnv"]) {
+    if (entry[field] !== undefined && typeof entry[field] !== "string") {
+      throw new Error(
+        `models.json: model "${name}" field ${field} must be a string`
+      );
+    }
+  }
+}
+
+/** `baseUrl` is the one field that decides WHERE the API key is sent, yet
+ *  `isModelEntry` only checks it's a string. A malformed value (no scheme,
+ *  `"api.host/v1"`) otherwise throws `Invalid URL` mid-turn instead of at load;
+ *  validate it here (fail loud at the boundary). A non-`https` URL carrying a
+ *  key is warned — a committed registry edit shouldn't silently ship the secret
+ *  over cleartext — but not rejected (localhost/dev over http is legitimate). */
+function assertBaseUrl(name: string, entry: unknown): void {
+  if (!isRecord(entry) || typeof entry.baseUrl !== "string") {
+    return; // isModelEntry already rejects a missing/non-string baseUrl
+  }
+
+  let url: URL;
+
+  try {
+    url = new URL(entry.baseUrl);
+  } catch {
+    throw new Error(
+      `models.json: model "${name}" baseUrl is not a valid URL: "${entry.baseUrl}"`
+    );
+  }
+
+  const hasKey =
+    typeof entry.apiKey === "string" || typeof entry.apiKeyEnv === "string";
+
+  if (
+    hasKey &&
+    url.protocol === "http:" &&
+    url.hostname !== "localhost" &&
+    url.hostname !== "127.0.0.1"
+  ) {
+    process.stderr.write(
+      `models.json: model "${name}" sends its API key to ${url.origin} over ` +
+        `plaintext http — use https for a remote endpoint.\n`
+    );
+  }
+}
+
 /** A hand-edited `imageApi` typo (e.g. "chat-modality") would otherwise pass the
  *  baseUrl/model-only guard and silently fall back to the chat-modalities wire
  *  path in image-gen — fail loud with the valid options instead. */
@@ -409,6 +465,19 @@ function parseReviewPanel(
     );
   }
 
+  // minReviewers is the quorum floor a blocking review must clear. A `0` (or
+  // negative/float) would let the panel be satisfied by ZERO independent votes —
+  // a change trusted unreviewed — so require a positive integer, matching the
+  // maxTokens/contextWindow guard. Absent → default 2.
+  if (
+    raw.minReviewers !== undefined &&
+    (!Number.isInteger(raw.minReviewers) || Number(raw.minReviewers) <= 0)
+  ) {
+    throw new Error(
+      "models.json: reviewPanel.minReviewers must be a positive integer"
+    );
+  }
+
   const minReviewers =
     typeof raw.minReviewers === "number" ? raw.minReviewers : 2;
   const reviewers = raw.reviewers.map((r) => parseReviewer(r, models));
@@ -456,6 +525,8 @@ export function parseModelsConfig(raw: unknown): IModelsConfig {
     }
 
     assertNumericFields(name, entry);
+    assertKeyFields(name, entry);
+    assertBaseUrl(name, entry);
     assertImageApi(name, entry);
     assertReasoning(name, entry);
     models[name] = entry;

--- a/packages/core/tests/models-config.test.ts
+++ b/packages/core/tests/models-config.test.ts
@@ -133,7 +133,7 @@ test("parseModelsConfig rejects bad shapes with actionable errors", () => {
   expect(() =>
     parseModelsConfig({
       active: "ghost",
-      models: { a: { baseUrl: "u", model: "m" } },
+      models: { a: { baseUrl: "http://localhost:1234/v1", model: "m" } },
     })
   ).toThrow(/not one of/);
 });
@@ -146,21 +146,39 @@ test("parseModelsConfig requires maxTokens / contextWindow to be positive intege
   expect(() =>
     parseModelsConfig({
       active: "a",
-      models: { a: { baseUrl: "u", model: "m", maxTokens: "8192" } },
+      models: {
+        a: {
+          baseUrl: "http://localhost:1234/v1",
+          model: "m",
+          maxTokens: "8192",
+        },
+      },
     })
   ).toThrow(/maxTokens must be a positive integer/);
 
   expect(() =>
     parseModelsConfig({
       active: "a",
-      models: { a: { baseUrl: "u", model: "m", maxTokens: 8192.5 } },
+      models: {
+        a: {
+          baseUrl: "http://localhost:1234/v1",
+          model: "m",
+          maxTokens: 8192.5,
+        },
+      },
     })
   ).toThrow(/maxTokens must be a positive integer/);
 
   expect(() =>
     parseModelsConfig({
       active: "a",
-      models: { a: { baseUrl: "u", model: "m", contextWindow: 0 } },
+      models: {
+        a: {
+          baseUrl: "http://localhost:1234/v1",
+          model: "m",
+          contextWindow: 0,
+        },
+      },
     })
   ).toThrow(/contextWindow must be a positive integer/);
 
@@ -168,9 +186,59 @@ test("parseModelsConfig requires maxTokens / contextWindow to be positive intege
   expect(
     parseModelsConfig({
       active: "a",
-      models: { a: { baseUrl: "u", model: "m", maxTokens: 8192 } },
+      models: {
+        a: { baseUrl: "http://localhost:1234/v1", model: "m", maxTokens: 8192 },
+      },
     }).models.a?.maxTokens
   ).toBe(8192);
+});
+
+test("parseModelsConfig requires apiKey/apiKeyEnv to be strings (else the key silently vanishes)", () => {
+  expect(() =>
+    parseModelsConfig({
+      active: "a",
+      models: {
+        a: { baseUrl: "http://localhost:1234/v1", model: "m", apiKey: 12345 },
+      },
+    })
+  ).toThrow(/apiKey must be a string/);
+
+  expect(() =>
+    parseModelsConfig({
+      active: "a",
+      models: {
+        a: { baseUrl: "http://localhost:1234/v1", model: "m", apiKeyEnv: true },
+      },
+    })
+  ).toThrow(/apiKeyEnv must be a string/);
+});
+
+test("parseModelsConfig rejects a malformed baseUrl at the JSON boundary (not mid-turn)", () => {
+  expect(() =>
+    parseModelsConfig({
+      active: "a",
+      models: { a: { baseUrl: "api.host/v1", model: "m" } }, // no scheme
+    })
+  ).toThrow(/baseUrl is not a valid URL/);
+});
+
+test("parseModelsConfig rejects minReviewers <= 0 (a 0 would satisfy review with zero votes)", () => {
+  expect(() =>
+    parseModelsConfig({
+      active: "a",
+      models: { a: { baseUrl: "http://localhost:1234/v1", model: "m" } },
+      reviewPanel: { minReviewers: 0, reviewers: [] },
+    })
+  ).toThrow(/minReviewers must be a positive integer/);
+
+  // A valid positive integer still parses.
+  expect(
+    parseModelsConfig({
+      active: "a",
+      models: { a: { baseUrl: "http://localhost:1234/v1", model: "m" } },
+      reviewPanel: { minReviewers: 3, reviewers: [] },
+    }).reviewPanel?.minReviewers
+  ).toBe(3);
 });
 
 test("setActiveModel switches + persists; unknown name throws with the options", async () => {
@@ -223,17 +291,27 @@ test("setActiveModel preserves the capabilities block (does not drop it)", async
 });
 
 test("resolveApiKey: inline wins, else apiKeyEnv, else undefined", () => {
-  expect(resolveApiKey({ baseUrl: "u", model: "m", apiKey: "inline" })).toBe(
-    "inline"
-  );
+  expect(
+    resolveApiKey({
+      baseUrl: "http://localhost:1234/v1",
+      model: "m",
+      apiKey: "inline",
+    })
+  ).toBe("inline");
 
   process.env.DEEPSEEK_API_KEY = "from-env";
   expect(
-    resolveApiKey({ baseUrl: "u", model: "m", apiKeyEnv: "DEEPSEEK_API_KEY" })
+    resolveApiKey({
+      baseUrl: "http://localhost:1234/v1",
+      model: "m",
+      apiKeyEnv: "DEEPSEEK_API_KEY",
+    })
   ).toBe("from-env");
   delete process.env.DEEPSEEK_API_KEY;
 
-  expect(resolveApiKey({ baseUrl: "u", model: "m" })).toBeUndefined();
+  expect(
+    resolveApiKey({ baseUrl: "http://localhost:1234/v1", model: "m" })
+  ).toBeUndefined();
 });
 
 test("explicit TSFORGE_* env overrides the registry's active model", async () => {
@@ -273,7 +351,7 @@ test("capabilities: parse validates known keys + real entry targets, round-trips
   expect(() =>
     parseModelsConfig({
       active: "a",
-      models: { a: { baseUrl: "u", model: "m" } },
+      models: { a: { baseUrl: "http://localhost:1234/v1", model: "m" } },
       capabilities: { audio: "a" },
     })
   ).toThrow(/unknown capability "audio"/);
@@ -282,7 +360,7 @@ test("capabilities: parse validates known keys + real entry targets, round-trips
   expect(() =>
     parseModelsConfig({
       active: "a",
-      models: { a: { baseUrl: "u", model: "m" } },
+      models: { a: { baseUrl: "http://localhost:1234/v1", model: "m" } },
       capabilities: { vision: "ghost" },
     })
   ).toThrow(/capability "vision" must name a model/);
@@ -295,7 +373,7 @@ test("capabilities: every CAPABILITY_NAMES key (incl. planner + expert) is a val
   // CAPABILITY_NAMES, so config and env agree on the full capability set.
   const cfg = parseModelsConfig({
     active: "a",
-    models: { a: { baseUrl: "u", model: "m" } },
+    models: { a: { baseUrl: "http://localhost:1234/v1", model: "m" } },
     capabilities: {
       vision: "a",
       imageGen: "a",
@@ -314,7 +392,13 @@ test("parseModelsConfig rejects a bad imageApi (fails loud, no silent fallback)"
   expect(() =>
     parseModelsConfig({
       active: "a",
-      models: { a: { baseUrl: "u", model: "m", imageApi: "chat-modality" } },
+      models: {
+        a: {
+          baseUrl: "http://localhost:1234/v1",
+          model: "m",
+          imageApi: "chat-modality",
+        },
+      },
     })
   ).toThrow(/imageApi must be/);
 
@@ -323,7 +407,11 @@ test("parseModelsConfig rejects a bad imageApi (fails loud, no silent fallback)"
     parseModelsConfig({
       active: "a",
       models: {
-        a: { baseUrl: "u", model: "m", imageApi: "images-generations" },
+        a: {
+          baseUrl: "http://localhost:1234/v1",
+          model: "m",
+          imageApi: "images-generations",
+        },
       },
     }).models.a?.imageApi
   ).toBe("images-generations");
@@ -404,7 +492,9 @@ test("planner is a routable capability role", () => {
 test("parseModelsConfig accepts a preset NAME or a well-formed reasoning profile", () => {
   const entry = (reasoning: unknown) => ({
     active: "a",
-    models: { a: { baseUrl: "u", model: "m", reasoning } },
+    models: {
+      a: { baseUrl: "http://localhost:1234/v1", model: "m", reasoning },
+    },
   });
 
   const presets: ReasoningStyle[] = [
@@ -434,7 +524,7 @@ test("parseModelsConfig accepts a preset NAME or a well-formed reasoning profile
   expect(
     parseModelsConfig({
       active: "a",
-      models: { a: { baseUrl: "u", model: "m" } },
+      models: { a: { baseUrl: "http://localhost:1234/v1", model: "m" } },
     }).models.a?.reasoning
   ).toBeUndefined();
 });
@@ -443,7 +533,9 @@ test("parseModelsConfig rejects a bad reasoning value at the JSON boundary", () 
   const bad = (reasoning: unknown) => () =>
     parseModelsConfig({
       active: "a",
-      models: { a: { baseUrl: "u", model: "m", reasoning } },
+      models: {
+        a: { baseUrl: "http://localhost:1234/v1", model: "m", reasoning },
+      },
     });
 
   // A typo would otherwise behave as an empty profile: load fine, then silently


### PR DESCRIPTION
Un-audited-tier sweep: **models-config** — provider/model registry + API-key/endpoint resolution. **Good news first:** the subsystem is already well-hardened, and I verified it **never logs the API key** (checked every error/response/transcript sink — no leak). Four fail-loud-at-the-boundary gaps closed, matching the file's stated contract:

## Fixed

**`baseUrl` — the field that decides *where the key is sent* — was only checked to be a string (security/fragile).** A malformed value (`"api.host/v1"`, no scheme) threw `Invalid URL` **mid-turn**, not at load. `assertBaseUrl` now validates it with `new URL()` at parse, and **warns** (doesn't reject) when a key would ride a **non-https remote** endpoint over plaintext (localhost/127.0.0.1 over http stays fine for dev).

**Non-string `apiKey`/`apiKeyEnv` silently sent no key (silent-wrong).** `"apiKey": 12345` passed `isModelEntry`, then `.length > 0` was false → the request went out with **no Authorization header**, and the provider's 401 read like an account problem, not the config typo it was. Now required to be strings when present.

**`minReviewers` accepted `0` (safety).** `reviewPanel.minReviewers` took any number, so `0` (or negative/float) let a blocking review be **satisfied by zero independent votes** — a change trusted unreviewed. Now must be a positive integer (absent → default 2), matching the `maxTokens`/`contextWindow` guard.

## Tests
- Non-string `apiKey`/`apiKeyEnv`, malformed `baseUrl`, and `minReviewers <= 0` each rejected at parse (shown red first).
- Existing fixtures using the placeholder `baseUrl: "u"` were updated to a real URL now that `baseUrl` is validated.

## Deferred (rationale)
- An unknown `--work-model`/recipe name silently resolves to the **active** model (`resolveModelByName`) — inconsistent with its siblings (`modelForRun` warns, `resolveCapabilityModel` throws). A warning is the fix, but it's a UX behavior change worth a separate look.
- `extraHeaders`/`extraBody` remain unvalidated escape hatches.

Part of the pre-feature hardening program (un-audited-tier sweep). **No release** — held.
