### PR TITLE
chore(deps): document the TS7-native/typescript-JS-API split + stop the breaking typescript major bump

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,6 +10,16 @@ updates:
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 10
+    ignore:
+      # The `typescript` package here is the JS COMPILER-API library (ts.createSourceFile,
+      # LanguageService, the AST) that lsp / syntax-check / dependency-analyzer / proptest
+      # use programmatically. TypeScript 7 is a native (Go) rewrite that ships NO JS API —
+      # so `typescript@7.x` is an API-less stub and a major bump nulls every ts.* call.
+      # We already run TS7 for the actual typecheck via the separate aliased dep
+      # `@typescript/native` ("npm:typescript@7.0.2"), so the speed is already captured.
+      # Keep the JS-API library on 6.x: allow patch/minor, block the 7.x major.
+      - dependency-name: "typescript"
+        update-types: ["version-update:semver-major"]
     groups:
       # Bump the lint/format/type toolchain together so it moves as one unit
       # (mismatched patch versions are exactly what caused a formatting drift).


### PR DESCRIPTION
**TL;DR: we're already on TypeScript 7 for the typecheck (the ~10× native Go compiler). The remaining `typescript` 6.x dep is the JS compiler-API library, which can't move to 7 — TS7-native has no JS API.**

I attempted the TS7 migration end to end. Findings:

## Already on TS7 where it counts
`@typescript/native` is `"npm:typescript@7.0.2"` (an **aliased** dep). `resolveTs7Tsc()` resolves it to `node_modules/@typescript/native/bin/tsc` → **Version 7.0.2**, and `bun run typecheck` runs the whole project through it in **~0.9s**. The speed win is captured.

## Why the plain `typescript` dep can't move to 7
The `typescript` (6.0.3) dependency is the **JS compiler-API library** — `ts.createSourceFile`, `LanguageService`, the AST guards, `preProcessFile`, `resolveModuleName` — used programmatically by **lsp, syntax-check, dependency-analyzer, proptest, infer-rules/scan**. TS7 is a native (Go) rewrite that ships **no JS API**: I bumped it and probed — `typescript@7.0.2` exports only `{ version, versionMajorMinor }`, so every `ts.*` call becomes `undefined` (`arch:build` and `typecheck` both crash). It must stay on 6.x until the TS-Go project ships a JS API surface.

## This PR
The recurring dependabot `typescript` 6→7 PR (residual of the closed #279 group) is therefore a **false positive** — it would swap the JS-API library for an API-less stub. This adds a dependabot **ignore for the `typescript` major only** (6.x patch/minor still flow) so the breaking PR stops reappearing, with a comment recording the split for the next reader. **No code change** — the investigation's conclusion is "already optimal."