### PR TITLE
Docs: document the automatic post-work agent review

### DIFF
--- a/apps/docs/src/content/docs/cli/review.mdx
+++ b/apps/docs/src/content/docs/cli/review.mdx
@@ -14,6 +14,14 @@ tsforge review --with-gate     # run the gate first; skip what it already covers
 
 Inside a session, the same review is available as `/review`.
 
+## Automatic after green
+
+You don't have to remember to run it. When a task lands **green** — in an interactive session and in headless runs alike — tsforge automatically reviews what just changed and surfaces its findings. The gate proves the change compiles, lints, and passes tests; this catches the substance the gate can't — an inverted condition, an unhandled edge case, a secret in a log line.
+
+It **reports** — it never edits your code on its own. Each finding comes with a concrete failure scenario and, when the reviewer is confident, a suggested fix. In an interactive session, if you want the agent to act on them, run **`/reviewfix`** and it hands the findings back to the agent to address (which then gets reviewed in turn). The auto phase reviews only the **current unit of work** (the files that turn touched), not the whole branch, so it stays fast and relevant.
+
+Turn the phase off with `TSFORGE_NO_REVIEW=1` — eval sweeps and cost-sensitive headless runs set this. The explicit `tsforge review` command and `/review` always work regardless.
+
 ## Gate-aware review
 
 With `--with-gate`, tsforge runs [the gate](/loop/gate-floor/) once before reviewing and tells the reviewer **which rules are already failing**, so it won't spend its attention re-reporting a type or lint error the gate loop will fix anyway. The review focuses on the behaviour of the code the gate already accepts (exactly the part the gate is blind to). The report notes how many gate rules were skipped. Without the flag, review runs as before (no gate run).
@@ -28,6 +36,8 @@ It looks at what you changed (working tree plus uncommitted edits, against the a
 - **Business logic**: money rounding, auth gating, invalid state transitions.
 - **Data and concurrency**: races, partial writes.
 - **API and contracts**: breaking a response shape or a serialized format.
+- **Security**: injection (SQL/command/path/XSS), a leaked secret, an ungated privileged path, unsafe deserialization or SSRF.
+- **Consistency**: a change that reimplements or diverges from how this codebase already does the same thing.
 
 Types, structure, and style are out of scope. [The gate](/loop/gate-floor/) already enforces those. Review is for judgment, not lint.
 

--- a/apps/docs/src/content/docs/reference/commands.mdx
+++ b/apps/docs/src/content/docs/reference/commands.mdx
@@ -57,7 +57,7 @@ tsforge review --with-gate     # run the gate first; skip what it already covers
 
 It is **functional** review: logic, regressions, edge cases, and business rules, guided by a built-in senior-review rubric (lenses), with each finding adversarially re-checked against the real code so false positives are dropped. Types, structure, and style are out of scope (the gate covers those). When a `tsconfig.json` is present it also feeds the reviewer a **caller blast-radius** signal (who calls each changed export, computed type-exactly) so the regression lens has concrete call sites to check. Exits non-zero if any **error**-severity finding survives, so it's CI-usable.
 
-The same review is available inside an interactive session as **`/review`** (optionally `/review <base>` to diff against a specific ref).
+The same review is available inside an interactive session as **`/review`** (optionally `/review <base>` to diff against a specific ref). A review also runs **automatically after a task goes green** (toggle with `TSFORGE_NO_REVIEW`); when it surfaces findings, **`/reviewfix`** hands them to the agent to address. See [Review your changes](/cli/review/).
 
 ## Recipes
 

--- a/apps/docs/src/content/docs/reference/flags.mdx
+++ b/apps/docs/src/content/docs/reference/flags.mdx
@@ -41,6 +41,7 @@ headless environments. Never change these interactively:
 | `TSFORGE_NO_GIT_TOOL` | off | withhold the `git_context` tool (`=1`) |
 | `TSFORGE_NO_SCRIPT` | off | withhold the `script` (programmatic tool calling) tool (`=1`) |
 | `TSFORGE_NO_DELEGATION` | off | withhold `spawn_agent`: run single-stream with no subagents (`=1`). See [delegation](/agent/delegation/) |
+| `TSFORGE_NO_REVIEW` | off | skip the automatic post-work [agent review](/cli/review/) after a task goes green (`=1`) |
 
 ## Git context
 


### PR DESCRIPTION
### Why

The last release made code review run automatically after a task goes green, but the docs still described review as something you trigger only by hand. Anyone reading them would miss the behaviour they actually get.

### What this does

- The **Review your changes** page now covers the automatic after-green phase: that it runs on its own in interactive and headless runs, reports rather than edits, offers `/reviewfix` to hand findings to the agent, adds the security and consistency checks, and can be turned off with `TSFORGE_NO_REVIEW`.
- The **Commands** and **Environment variables** references pick up `/reviewfix` and the toggle.

Docs-only; deploys on its own, so no release.

### Outcome

The review behaviour people get is now the behaviour the docs describe.
