### PR TITLE
Fix /reviewfix after a manual /review, and show a reviewing status

### DIFF
--- a/packages/core/ARCHITECTURE.md
+++ b/packages/core/ARCHITECTURE.md
@@ -104,7 +104,7 @@ Async functions returning an exit code, declared under the CLI — the commands.
 | `repl` | `cli/repl.ts:781` |
 | `reviewMode` | `cli.ts:188` |
 | `runOnce` | `cli.ts:94` |
-| `runTraceCommand` | `cli/repl-commands.ts:141` |
+| `runTraceCommand` | `cli/repl-commands.ts:148` |
 | `scaffoldMode` | `cli.ts:736` |
 | `setupMode` | `cli.ts:497` |
 | `traceMode` | `cli.ts:559` |

--- a/packages/core/src/cli/repl-commands.ts
+++ b/packages/core/src/cli/repl-commands.ts
@@ -3,7 +3,7 @@
 import { buildAndPersistMap, mapStatus, forgetMap } from "../codebase";
 import { reviewChange, formatReport, formatReviewCard } from "../loop";
 import { STYLE, paint } from "../render";
-import type { OpenAICompatibleProvider } from "../inference";
+import type { IProvider } from "../inference";
 import { parseEventLog, formatTrace } from "../eval";
 import { listSessions } from "../session-store";
 import { newestLogFile, resolveLogArg } from "./logging";
@@ -100,14 +100,15 @@ export async function runMapCommand(
 
 /** `/review` in the REPL — review the current change and print findings. `out` is
  *  the pane-aware sink; when `columns` is given the findings render as a colored,
- *  width-wrapped card (the TUI), otherwise plain text (CLI/pipe). */
+ *  width-wrapped card (the TUI), otherwise plain text (CLI/pipe). Returns the PLAIN
+ *  findings text (empty when clean/errored) so the caller can hand it to `/reviewfix`. */
 export async function runReviewCommand(
-  provider: OpenAICompatibleProvider,
+  provider: IProvider,
   dir: string,
   base: string,
   out: (s: string) => void = STDOUT,
   columns?: number
-): Promise<void> {
+): Promise<string> {
   out(
     `${paint("reviewing the current change…", STYLE.dim, columns !== undefined)}\n`
   );
@@ -127,10 +128,16 @@ export async function runReviewCommand(
         : formatReviewCard(report, columns, true);
 
     out(`\n${rendered}\n`);
+
+    // Plain text (never the colored card) so /reviewfix hands the agent readable
+    // findings, not ANSI. Empty when there's nothing to act on.
+    return report.findings.length > 0 ? formatReport(report) : "";
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err);
 
     out(`\nreview failed: ${message}\n`);
+
+    return "";
   }
 }
 

--- a/packages/core/src/cli/repl.ts
+++ b/packages/core/src/cli/repl.ts
@@ -1196,6 +1196,26 @@ export async function repl(args: ICliArgs): Promise<number> {
     return [...peeled.steer];
   };
 
+  // Show `● reviewing…` (spinner + live status) while `fn` runs, then restore the
+  // prior status. Shared by the manual /review command and the after-green review —
+  // both run AFTER the turn's spinner has stopped, so without this the bar reads
+  // "done" while the model is actually reviewing.
+  const withReviewingStatus = async <T>(fn: () => Promise<T>): Promise<T> => {
+    const prev = lastStatus;
+
+    lastStatus = "reviewing";
+    spinner.start();
+    paneScreen.setStatus(statusInfo());
+
+    try {
+      return await fn();
+    } finally {
+      spinner.stop();
+      lastStatus = prev;
+      paneScreen.setStatus(statusInfo());
+    }
+  };
+
   // Post-work agent review (interactive): after a turn lands GREEN and actually
   // changed code, review THIS turn's files and surface findings the gate can't —
   // then offer `/reviewfix` to hand them to the agent (report-then-fix). Scoped to
@@ -1219,7 +1239,9 @@ export async function repl(args: ICliArgs): Promise<number> {
     }
 
     try {
-      const review = await reviewChange(provider, args.dir, { files: changed });
+      const review = await withReviewingStatus(() =>
+        reviewChange(provider, args.dir, { files: changed })
+      );
 
       if (review.findings.length === 0) {
         return; // clean — stay quiet, don't nag on every green turn
@@ -1600,7 +1622,11 @@ export async function repl(args: ICliArgs): Promise<number> {
         break;
 
       case "review":
-        await runReviewCommand(provider, args.dir, arg, echo, transcriptCols());
+        // Store the findings so /reviewfix can act on a manual review too (not just
+        // the automatic after-green one). Plain text; empty when clean.
+        lastReviewFindings = await withReviewingStatus(() =>
+          runReviewCommand(provider, args.dir, arg, echo, transcriptCols())
+        );
         break;
 
       case "reviewfix":

--- a/packages/core/tests/review-command.test.ts
+++ b/packages/core/tests/review-command.test.ts
@@ -1,0 +1,108 @@
+import { test, expect, beforeEach, afterEach } from "bun:test";
+import { execFileSync } from "node:child_process";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { IProvider } from "../src/inference";
+import { runReviewCommand } from "../src/cli/repl-commands";
+import { stripSgr } from "../src/render";
+
+/** Same two-pass stub as review-change.test.ts: find vs verify keyed on prompt. */
+function stub(findings: string, verifyReal: boolean): IProvider {
+  return {
+    async complete(messages) {
+      const sys = messages.find((m) => m.role === "system")?.content ?? "";
+      const body = sys.includes("verifying a code-review finding")
+        ? JSON.stringify({ real: verifyReal, verdict: "judged" })
+        : findings;
+
+      return { content: body, toolCalls: [] };
+    },
+  };
+}
+
+const FINDINGS = JSON.stringify({
+  findings: [
+    {
+      line: 2,
+      severity: "error",
+      lens: "correctness",
+      claim: "subtraction is reversed",
+      reason: "returns a negative discount",
+    },
+  ],
+});
+
+let repo: string;
+const git = (...a: string[]): void =>
+  void execFileSync("git", a, { cwd: repo, stdio: "ignore" });
+
+beforeEach(() => {
+  repo = mkdtempSync(join(tmpdir(), "tsforge-revcmd-"));
+  git("init", "-q");
+  git("config", "user.email", "t@t.t");
+  git("config", "user.name", "t");
+  git("config", "commit.gpgsign", "false");
+  writeFileSync(
+    join(repo, "discount.ts"),
+    "export const a = 1;\nexport const b = 2;\n"
+  );
+  git("add", "-A");
+  git("commit", "-q", "-m", "init");
+  writeFileSync(
+    join(repo, "discount.ts"),
+    "export const a = 1;\nexport const b = 99;\n"
+  );
+});
+
+afterEach(() => {
+  rmSync(repo, { recursive: true, force: true });
+});
+
+// The /review → /reviewfix contract: the command must RETURN the plain findings so
+// the REPL can store them for /reviewfix (the bug was it returned nothing, so
+// /reviewfix always said "no findings" after a manual /review).
+test("returns the plain findings text when there are findings (feeds /reviewfix)", async () => {
+  const out: string[] = [];
+  const findings = await runReviewCommand(
+    stub(FINDINGS, true),
+    repo,
+    "",
+    (s) => out.push(s),
+    80
+  );
+
+  expect(findings).toContain("subtraction is reversed");
+  expect(findings).toContain("discount.ts:2");
+  // Plain text (no ANSI) — /reviewfix hands it to the agent verbatim.
+  expect(stripSgr(findings)).toBe(findings);
+});
+
+test("returns an empty string when the review is clean (so /reviewfix says nothing to fix)", async () => {
+  // Verify rejects the finding ⇒ zero verified findings ⇒ empty return.
+  const findings = await runReviewCommand(
+    stub(FINDINGS, false),
+    repo,
+    "",
+    () => {},
+    80
+  );
+
+  expect(findings).toBe("");
+});
+
+test("still renders to the sink (the display path is unaffected)", async () => {
+  let printed = "";
+
+  await runReviewCommand(
+    stub(FINDINGS, true),
+    repo,
+    "",
+    (s) => {
+      printed += s;
+    },
+    80
+  );
+
+  expect(printed).toContain("subtraction is reversed");
+});


### PR DESCRIPTION
### Why

Two review problems, reported from real use:

1. **`/reviewfix` said "no findings to fix" after a manual `/review`.** Only the *automatic* after-green review remembered its findings; the `/review` command showed them but never stored them, so `/reviewfix` had nothing to act on.
2. **Nothing showed while a review ran** — the review happens after the turn's activity indicator has already stopped, so the top-right read "done" while the model was actually reviewing.

Both slipped because the `/review → /reviewfix` flow wasn't exercised end to end.

### What this does

- The `/review` command now stores its findings the same way the automatic review does, so **`/reviewfix` works after either** (and correctly says nothing to fix when the review was clean).
- While reviewing — manual or automatic — the harness shows **`● reviewing…`** in the top-right, so it's clear the model is working, not idle.

### Outcome

Review and review-fix work together, and the harness tells you when it's reviewing. Covered by a test on the `/review → /reviewfix` contract (the gap that let this through).
