### PR TITLE
Let review run on configurable / multiple models

### DIFF
--- a/apps/docs/src/content/docs/cli/review.mdx
+++ b/apps/docs/src/content/docs/cli/review.mdx
@@ -47,6 +47,27 @@ The usual failure of AI review is confident nonsense. tsforge runs an adversaria
 
 When a `tsconfig.json` is present, it also feeds the reviewer the callers of each changed export, computed from the type graph, so the regression check looks at concrete call sites instead of guessing.
 
+## Which model reviews
+
+By default the **main model reviews its own work**. You can point review at a different model, or run a **panel** of several, in [`models.json`](/inference/models-json/):
+
+```json
+{
+  "active": "local",
+  "models": {
+    "local": { "baseUrl": "http://localhost:8000/v1", "model": "deepseek-v4-flash" },
+    "haiku": { "baseUrl": "https://api.anthropic.com/v1", "model": "claude-haiku-4-5", "apiKeyEnv": "ANTHROPIC_API_KEY" }
+  },
+  "reviewModels": ["haiku"]
+}
+```
+
+- **One entry** — a dedicated reviewer (e.g. a fast, sharp model; a small instruction-tuned model often reviews better and cheaper than a big one).
+- **Several entries** — a panel: each reviews independently and their findings are pooled and deduped, which catches more real issues.
+- **Absent** — the main model reviews.
+
+For a quick one-off without editing the file, set `TSFORGE_REVIEW_MODEL` (naming a `models` entry) or the trio `TSFORGE_REVIEW_BASE_URL` / `TSFORGE_REVIEW_MODEL` / `TSFORGE_REVIEW_API_KEY` for an ad-hoc reviewer. While reviewing, the status bar shows `● reviewing…` (or `● reviewing ×N` for a panel).
+
 ## Coverage on large changes
 
 Review covers up to `TSFORGE_REVIEW_MAX_FILES` changed files (default **100**) per run, and reads up to `TSFORGE_REVIEW_DIFF_CHARS` (default **12000**) of each file's diff. Excess files are queued through the same [concurrency](/guardrails/config/) limit, not dropped — raise the caps for very large changes. If a run does hit a cap, the report says so loudly (`⚠ coverage: reviewed N of M …`) so a partial review never reads as a clean bill of health.

--- a/apps/docs/src/content/docs/inference/models-json.mdx
+++ b/apps/docs/src/content/docs/inference/models-json.mdx
@@ -164,6 +164,23 @@ Env overrides (an ad-hoc backend without editing the file): `TSFORGE_VISION_BASE
 `apiKeyEnv` is the **name of an environment variable**, not the key. Putting a literal `sk-...` as its value makes tsforge look up an env var named `sk-...` → no auth. Use `apiKey` for an inline key.
 :::
 
+## Who reviews: `reviewModels`
+
+By default the active model runs the post-work [code review](/cli/review/) on its own work. To use a different reviewer — or a **panel** — add a top-level `reviewModels` array (a sibling of `active`/`models`), each value naming a `models` entry:
+
+```json
+{
+  "active": "local",
+  "models": {
+    "local": { "baseUrl": "http://localhost:8000/v1", "model": "deepseek-v4-flash" },
+    "haiku": { "baseUrl": "https://api.anthropic.com/v1", "model": "claude-haiku-4-5", "apiKeyEnv": "ANTHROPIC_API_KEY" }
+  },
+  "reviewModels": ["haiku"]
+}
+```
+
+One entry is a dedicated reviewer; several form a panel whose findings are pooled and deduped (more real issues caught). Absent ⇒ the active model reviews. A single ad-hoc reviewer can also be set by env — `TSFORGE_REVIEW_MODEL` (names a `models` entry) or the `TSFORGE_REVIEW_BASE_URL` / `_MODEL` / `_API_KEY` trio — which wins over `reviewModels`. (This is separate from `reviewPanel`, which is only for `tsforge harness-review` on tsforge's own PRs.)
+
 ### Any other provider: `extraBody` / `extraHeaders`
 
 When a provider needs a param or auth scheme tsforge doesn't model, express it directly. `extraBody` is merged **last** (so it overrides anything), and `extraHeaders` can set a non-Bearer scheme:

--- a/packages/core/ARCHITECTURE.md
+++ b/packages/core/ARCHITECTURE.md
@@ -67,7 +67,7 @@ buries the ones someone can actually go and break.
 | `cli` ↔ `render` | `cli/banner.ts:9` → `../render` | `render/command-menu.ts:2` → `../cli/commands` |
 | `config` ↔ `rule-packs` | `config/external-plugins.ts:5` → `../rule-packs` | `rule-packs/index.ts:131` → `../config/plugin-fingerprint` |
 | `editor` ↔ `render` | `editor/view.ts:2` → `../render/style` | `render/frame/input-seq.ts:1` → `../../editor/segments` |
-| `eval` ↔ `loop` | `eval/failure-class.ts:1` → `../loop/loop.types` | `loop/loop.types.ts:6` → `../eval/failure-class` |
+| `eval` ↔ `loop` | `eval/failure-class.ts:1` → `../loop/loop.types` | `loop/loop.types.ts:7` → `../eval/failure-class` |
 | `inference` ↔ `loop` | `inference/wire.ts:10` → `../loop/context-hygiene` | `loop/assistant-message.ts:1` → `../inference` |
 | `loop` ↔ `render` | `loop/review/format-card.ts:1` → `../../render` | `render/agent-tree.ts:8` → `../loop/loop.types` |
 | `loop` ↔ `self-harness` | `loop/feedback/rule-docs.ts:3` → `../../self-harness/overlay` | `self-harness/build-evidence.ts:3` → `../loop` |
@@ -94,20 +94,20 @@ Async functions returning an exit code, declared under the CLI — the commands.
 
 | Function | Declared |
 | --- | --- |
-| `agentsMode` | `cli.ts:353` |
-| `greenfieldMode` | `cli.ts:654` |
+| `agentsMode` | `cli.ts:366` |
+| `greenfieldMode` | `cli.ts:667` |
 | `harnessDiagnoseMode` | `cli/harness-diagnose-mode.ts:211` |
 | `harnessReviewMode` | `cli/harness-review-mode.ts:684` |
-| `main` | `cli.ts:765` |
-| `mapMode` | `cli.ts:489` |
-| `recipesMode` | `cli.ts:508` |
-| `repl` | `cli/repl.ts:781` |
-| `reviewMode` | `cli.ts:188` |
-| `runOnce` | `cli.ts:94` |
-| `runTraceCommand` | `cli/repl-commands.ts:148` |
-| `scaffoldMode` | `cli.ts:736` |
-| `setupMode` | `cli.ts:497` |
-| `traceMode` | `cli.ts:559` |
+| `main` | `cli.ts:778` |
+| `mapMode` | `cli.ts:502` |
+| `recipesMode` | `cli.ts:521` |
+| `repl` | `cli/repl.ts:782` |
+| `reviewMode` | `cli.ts:201` |
+| `runOnce` | `cli.ts:103` |
+| `runTraceCommand` | `cli/repl-commands.ts:150` |
+| `scaffoldMode` | `cli.ts:749` |
+| `setupMode` | `cli.ts:510` |
+| `traceMode` | `cli.ts:572` |
 
 ## Imports that leave `src/`
 

--- a/packages/core/src/cli.ts
+++ b/packages/core/src/cli.ts
@@ -32,14 +32,23 @@ import { validate } from "./validate";
 import { composeGate } from "./gate/gate-runner";
 import { judgeStage } from "./loop/boringstack/gate-stages";
 import type { OpenAICompatibleProvider } from "./inference";
-import { resolveActiveModel, resolveModelByName } from "./models-config";
+import {
+  resolveActiveModel,
+  resolveModelByName,
+  loadModelsConfig,
+} from "./models-config";
 import type { ITask } from "./spec";
 import { runShellCommand } from "./lib/fs";
 import { currentVersion } from "./update-check";
 import { trace } from "./lib/trace";
 import { repl } from "./cli/repl";
 import { runMapCommand, runTraceCommand } from "./cli/repl-commands";
-import { makeProvider, modelForRun, envNumber } from "./cli/model-setup";
+import {
+  makeProvider,
+  resolveReviewProviders,
+  modelForRun,
+  envNumber,
+} from "./cli/model-setup";
 import { makeReporter, resolveLogPath } from "./cli/logging";
 import { resolveGate } from "./cli/gate-setup";
 import {
@@ -112,6 +121,8 @@ async function runOnce(args: ICliArgs): Promise<number> {
       : envNumber("TSFORGE_THINKING_BUDGET");
   const { entry } = await modelForRun(args);
   const provider = makeProvider(entry);
+  // Configured reviewer model(s); empty ⇒ the main model reviews (the default).
+  const reviewProviders = resolveReviewProviders(await loadModelsConfig());
   const report = makeReporter(logFile, "cli");
   const profile = resolveCliProfile(args.profile);
   const result = await runTask(task, args.dir, provider, {
@@ -123,6 +134,7 @@ async function runOnce(args: ICliArgs): Promise<number> {
     // Honor `--policy-mode` in one-shot too (validated in main()); without this
     // the documented flag was a silent no-op on the headless path.
     ...(isPolicyMode(args.policyMode) ? { policyMode: args.policyMode } : {}),
+    ...(reviewProviders.length > 0 ? { reviewProviders } : {}),
     // `--with-review` runs reviewRepair below (review + one repair cycle), so
     // suppress runTask's own report-only review to avoid reviewing twice.
     ...(args.withReview ? { suppressReview: true } : {}),
@@ -138,6 +150,7 @@ async function runOnce(args: ICliArgs): Promise<number> {
   if (ok && args.withReview) {
     await reviewRepair(provider, args.dir, task, modelAgent(provider), {
       ...(args.base.length > 0 ? { base: args.base } : {}),
+      ...(reviewProviders.length > 0 ? { reviewProviders } : {}),
       onEvent: report,
     });
   }

--- a/packages/core/src/cli/model-setup.ts
+++ b/packages/core/src/cli/model-setup.ts
@@ -8,13 +8,16 @@ import {
   PROVIDER_DEFAULTS,
   OpenAICompatibleProvider,
   type IOpenAICompatibleConfig,
+  type IProvider,
 } from "../inference";
 import {
   resolveActiveModel,
   setActiveModel,
   loadModelsConfig,
   resolveApiKey,
+  modelByName,
   type IModelEntry,
+  type IModelsConfig,
 } from "../models-config";
 import { isRecord } from "../lib/guards";
 import { trace } from "../lib/trace";
@@ -142,6 +145,41 @@ export function providerConfig(entry: IModelEntry): IOpenAICompatibleConfig {
 
 export function makeProvider(entry: IModelEntry): OpenAICompatibleProvider {
   return new OpenAICompatibleProvider(providerConfig(entry));
+}
+
+/**
+ * The provider(s) that run the post-work code review, in precedence order:
+ *   1. `TSFORGE_REVIEW_BASE_URL` + `_MODEL` (+ `_API_KEY`) — an ad-hoc single reviewer;
+ *   2. `TSFORGE_REVIEW_MODEL` alone — names a `models` entry;
+ *   3. `models.json` `reviewModels: [...]` — one or several `models` entries (a panel).
+ * Returns `[]` when nothing is configured; callers then fall back to the MAIN model
+ * (the default: the model reviews its own work). Names in `reviewModels` are validated
+ * at config load, so the map here can't miss.
+ */
+export function resolveReviewProviders(cfg: IModelsConfig): IProvider[] {
+  const envBase = process.env.TSFORGE_REVIEW_BASE_URL;
+  const envModel = process.env.TSFORGE_REVIEW_MODEL;
+
+  if (envBase !== undefined && envBase.length > 0 && envModel !== undefined) {
+    const entry: IModelEntry = {
+      baseUrl: envBase,
+      model: envModel,
+      apiKey: process.env.TSFORGE_REVIEW_API_KEY,
+    };
+
+    return [makeProvider(entry)];
+  }
+
+  if (envModel !== undefined && envModel.length > 0) {
+    const entry = modelByName(cfg.models, envModel);
+
+    return entry === undefined ? [] : [makeProvider(entry)];
+  }
+
+  return (cfg.reviewModels ?? [])
+    .map((name) => modelByName(cfg.models, name))
+    .filter((e): e is IModelEntry => e !== undefined)
+    .map(makeProvider);
 }
 
 /** Catch the common footgun: a cloud baseUrl paired with the leftover qwen

--- a/packages/core/src/cli/repl-commands.ts
+++ b/packages/core/src/cli/repl-commands.ts
@@ -107,7 +107,8 @@ export async function runReviewCommand(
   dir: string,
   base: string,
   out: (s: string) => void = STDOUT,
-  columns?: number
+  columns?: number,
+  reviewProviders: readonly IProvider[] = []
 ): Promise<string> {
   out(
     `${paint("reviewing the current change…", STYLE.dim, columns !== undefined)}\n`
@@ -117,6 +118,7 @@ export async function runReviewCommand(
   try {
     const report = await reviewChange(provider, dir, {
       ...(base.length > 0 ? { base } : {}),
+      ...(reviewProviders.length > 0 ? { reviewProviders } : {}),
       log: (m) => {
         out(`  ↳ ${m}\n`);
       },

--- a/packages/core/src/cli/repl.ts
+++ b/packages/core/src/cli/repl.ts
@@ -71,7 +71,7 @@ import { renderEditor } from "../editor/view";
 import { flags } from "../config/flags";
 import type { OpenAICompatibleProvider } from "../inference";
 import type { IModelEntry } from "../models-config";
-import { resolveCapabilityModel } from "../models-config";
+import { resolveCapabilityModel, loadModelsConfig } from "../models-config";
 import {
   renderStatus,
   userBubble,
@@ -127,6 +127,7 @@ import {
   envNumber,
   providerConfig,
   makeProvider,
+  resolveReviewProviders,
   warnDefaultModelOnRemote,
   runModelCommand,
   modelForRun,
@@ -797,6 +798,15 @@ export async function repl(args: ICliArgs): Promise<number> {
     autoGate,
   } = await initReplSession(args);
 
+  // Reviewer model(s) for the review phase — from models.json `reviewModels` or the
+  // TSFORGE_REVIEW_* envs. Empty ⇒ the main model reviews (the default). Resolved
+  // once at boot so the review call sites stay synchronous.
+  const reviewProviders = resolveReviewProviders(await loadModelsConfig());
+  const reviewStatusLabel = (): string =>
+    reviewProviders.length > 1
+      ? `reviewing ×${String(reviewProviders.length)}`
+      : "reviewing";
+
   // Load delegation inputs HERE — before readline is created below. Any `await`
   // between `createInterface` and the `rl.on("line")` listener would yield the
   // event loop with readline live but unlistened, dropping the first typed line
@@ -1203,7 +1213,7 @@ export async function repl(args: ICliArgs): Promise<number> {
   const withReviewingStatus = async <T>(fn: () => Promise<T>): Promise<T> => {
     const prev = lastStatus;
 
-    lastStatus = "reviewing";
+    lastStatus = reviewStatusLabel();
     spinner.start();
     paneScreen.setStatus(statusInfo());
 
@@ -1240,7 +1250,10 @@ export async function repl(args: ICliArgs): Promise<number> {
 
     try {
       const review = await withReviewingStatus(() =>
-        reviewChange(provider, args.dir, { files: changed })
+        reviewChange(provider, args.dir, {
+          files: changed,
+          ...(reviewProviders.length > 0 ? { reviewProviders } : {}),
+        })
       );
 
       if (review.findings.length === 0) {
@@ -1625,7 +1638,14 @@ export async function repl(args: ICliArgs): Promise<number> {
         // Store the findings so /reviewfix can act on a manual review too (not just
         // the automatic after-green one). Plain text; empty when clean.
         lastReviewFindings = await withReviewingStatus(() =>
-          runReviewCommand(provider, args.dir, arg, echo, transcriptCols())
+          runReviewCommand(
+            provider,
+            args.dir,
+            arg,
+            echo,
+            transcriptCols(),
+            reviewProviders
+          )
         );
         break;
 

--- a/packages/core/src/loop/loop.types.ts
+++ b/packages/core/src/loop/loop.types.ts
@@ -1,4 +1,5 @@
 import type { ErrorParser } from "../validate";
+import type { IProvider } from "../inference";
 import type { ProfileId } from "../config/profiles";
 import type { PolicyMode } from "../policy";
 import type { IGate } from "../gate/gate-runner";
@@ -219,6 +220,10 @@ export interface IRunOptions {
    *  afterwards — the one-shot `--with-review` path runs `reviewRepair`, so it would
    *  otherwise review twice. Independent of the global TSFORGE_NO_REVIEW toggle. */
   suppressReview?: boolean;
+  /** Reviewer model(s) for the post-green review phase. Empty/absent ⇒ the main
+   *  model reviews. Resolved once by the driver from models.json `reviewModels` /
+   *  the TSFORGE_REVIEW_* envs. */
+  reviewProviders?: readonly IProvider[];
   /** Rule profile override (from a recipe); defaults to tsforge.config.json. */
   profile?: ProfileId;
   /** Policy-mode override (from the `--policy-mode` CLI flag); when set it wins

--- a/packages/core/src/loop/review-repair.ts
+++ b/packages/core/src/loop/review-repair.ts
@@ -23,6 +23,8 @@ export interface IReviewRepairOptions {
   staged?: boolean;
   parse?: ErrorParser;
   onEvent?: Reporter;
+  /** Reviewer model(s) for the find pass; empty/absent ⇒ the main `provider`. */
+  reviewProviders?: readonly IProvider[];
 }
 
 /** Turn verified findings into the gate-style error set the implement agent
@@ -61,6 +63,9 @@ export async function reviewRepair(
 
   const review = await reviewChange(provider, cwd, {
     ...(opts.base === undefined ? {} : { base: opts.base }),
+    ...(opts.reviewProviders !== undefined && opts.reviewProviders.length > 0
+      ? { reviewProviders: opts.reviewProviders }
+      : {}),
     staged: opts.staged ?? false,
     verify: true,
     log,

--- a/packages/core/src/loop/review/review-change.ts
+++ b/packages/core/src/loop/review/review-change.ts
@@ -69,6 +69,11 @@ export interface IReviewOptions {
    *  (the DeepSeek thinking latch), so parallel units must not share one.
    *  Absent ⇒ every unit reuses the single `provider` (fine at concurrency 1). */
   providerFactory?: () => IProvider;
+  /** Reviewer model(s) that run the FIND pass. When set (length ≥ 1), each file is
+   *  reviewed by every reviewer and their findings are pooled + deduped (a panel).
+   *  Absent/empty ⇒ the single `provider` reviews (the default: the main model
+   *  reviews its own work). Verify always uses `provider`. */
+  reviewProviders?: readonly IProvider[];
   /** Attribution events (`agent_spawned`/`agent_result` per unit) for the
    *  ledger and the fan-out progress line. */
   onEvent?: Reporter;
@@ -573,6 +578,111 @@ async function safeVerify(
   }
 }
 
+/** Collapse duplicate findings from a reviewer panel: same file+line+lens is one
+ *  issue, kept at its highest severity (first-wins on a tie). A single reviewer
+ *  never needs this (its verify ids already disambiguate same-line findings). */
+function dedupeFindings(findings: readonly IRepoFinding[]): IRepoFinding[] {
+  const byKey = new Map<string, IRepoFinding>();
+
+  for (const f of findings) {
+    const key = `${f.file}:${String(f.line)}:${f.lens}`;
+    const prev = byKey.get(key);
+
+    if (
+      prev === undefined ||
+      SEVERITY_RANK[f.severity] < SEVERITY_RANK[prev.severity]
+    ) {
+      byKey.set(key, f);
+    }
+  }
+
+  return [...byKey.values()];
+}
+
+interface IFindOutcome {
+  file: string;
+  truncated: boolean;
+  found: IRepoFinding[];
+  onChange: IRepoFinding[];
+}
+
+/** Shared, per-run inputs for the find pass (so the per-file unit takes one arg). */
+interface IFindContext {
+  cwd: string;
+  base: string;
+  staged: boolean;
+  untracked: ReadonlySet<string>;
+  system: string;
+  svc: TsService | null;
+  gateFailingRules: readonly string[];
+  log: (m: string) => void;
+}
+
+/** The reviewer panel from options: the configured providers (logging a panel of
+ *  >1), or null when none are set (⇒ the caller uses the single main provider). */
+function reviewerPanel(
+  reviewProviders: readonly IProvider[] | undefined,
+  log: (m: string) => void
+): readonly IProvider[] | null {
+  if (reviewProviders === undefined || reviewProviders.length === 0) {
+    return null;
+  }
+
+  if (reviewProviders.length > 1) {
+    log(`review panel: ${reviewProviders.length} reviewers`);
+  }
+
+  return reviewProviders;
+}
+
+/** Find pass for ONE file: diff it once, run every reviewer over that diff, pool
+ *  the findings, and keep only those on a changed line. Extracted from reviewChange
+ *  so the orchestrator stays flat. Returns null when aborted. */
+async function findFileOutcome(
+  file: string,
+  findProviders: readonly IProvider[],
+  ctx: IFindContext,
+  signal: AbortSignal
+): Promise<IFindOutcome | null> {
+  if (signal.aborted) {
+    return null;
+  }
+
+  const { diff, truncated, ranges } = await fileDiff(
+    ctx.cwd,
+    ctx.base,
+    file,
+    ctx.staged,
+    ctx.untracked.has(file)
+  );
+  const found: IRepoFinding[] = [];
+
+  for (const rp of findProviders) {
+    found.push(
+      ...(await safeFind(
+        rp,
+        ctx.system,
+        ctx.svc,
+        ctx.cwd,
+        file,
+        diff,
+        ctx.gateFailingRules,
+        ctx.log,
+        signal
+      ))
+    );
+  }
+
+  // A finding on a pre-existing (unchanged) line isn't a regression in THIS change.
+  // Skip the filter when no hunks parsed (can't tell), so we never drop everything.
+  const onChange =
+    ranges.length === 0
+      ? found
+      : found.filter((f) => lineInRanges(f.line, ranges));
+
+  return { file, truncated, found, onChange };
+}
+
 /**
  * Review the change you're on (working tree vs the auto-detected base, including
  * uncommitted edits). Per-file find pass guided by the senior-review lenses, then
@@ -615,6 +725,9 @@ export async function reviewChange(
   // caller blast-radius signal. Built once; falls back gracefully when absent.
   const svc: TsService | null = await buildTsService(cwd);
   const makeUnitProvider = opts.providerFactory ?? ((): IProvider => provider);
+  // Reviewer panel: when configured, every file is reviewed by EACH reviewer and
+  // the findings pooled + deduped. Null ⇒ the single provider reviews (default).
+  const reviewers = reviewerPanel(opts.reviewProviders, log);
   const onUnit = unitReporter(opts.onEvent);
   // cap=1 (the default) IS the original sequential path — one local-model
   // server isn't swamped unless the config opts into parallel fan-out. Results
@@ -627,51 +740,28 @@ export async function reviewChange(
     ...(onUnit === undefined ? {} : { onUnit }),
   });
 
+  const findCtx: IFindContext = {
+    cwd,
+    base,
+    staged,
+    untracked,
+    system,
+    svc,
+    gateFailingRules,
+    log,
+  };
   const findOutcomes = await scheduler.runParallel(
     files.map((file) => ({
       id: `find:${file}`,
-      run: async (
-        signal: AbortSignal
-      ): Promise<{
-        file: string;
-        truncated: boolean;
-        found: IRepoFinding[];
-        onChange: IRepoFinding[];
-      } | null> => {
-        if (signal.aborted) {
-          return null;
-        }
-
-        const { diff, truncated, ranges } = await fileDiff(
-          cwd,
-          base,
+      // One find per reviewer (or a single fresh provider when no panel); the diff
+      // is computed once per file and shared across reviewers.
+      run: (signal: AbortSignal): Promise<IFindOutcome | null> =>
+        findFileOutcome(
           file,
-          staged,
-          untracked.has(file)
-        );
-        const found = await safeFind(
-          makeUnitProvider(),
-          system,
-          svc,
-          cwd,
-          file,
-          diff,
-          gateFailingRules,
-          log,
+          reviewers ?? [makeUnitProvider()],
+          findCtx,
           signal
-        );
-
-        // Keep only findings ON a changed line — a finding on pre-existing code
-        // the change didn't touch is not a regression in THIS change. Skip the
-        // filter when no hunks parsed (can't tell), so we never silently drop
-        // everything.
-        const onChange =
-          ranges.length === 0
-            ? found
-            : found.filter((f) => lineInRanges(f.line, ranges));
-
-        return { file, truncated, found, onChange };
-      },
+        ),
     }))
   );
 
@@ -700,11 +790,16 @@ export async function reviewChange(
     raw.push(...outcome.onChange);
   }
 
+  // A reviewer panel produces overlapping findings (same file+line+lens from
+  // several models) — collapse them before verify so we don't verify duplicates.
+  // A single reviewer path is untouched (no dedup) to keep behavior identical.
+  const pooled = reviewers === null ? raw : dedupeFindings(raw);
+
   const doVerify = opts.verify ?? true;
   const verifyOutcomes = await scheduler.runParallel(
     // The index makes ids unique when the reviewer cites the same line twice —
     // duplicate ids would collapse distinct units in the tracker and ledger.
-    raw.map((finding, index) => ({
+    pooled.map((finding, index) => ({
       id: `verify:${finding.file}:${finding.line}#${String(index)}`,
       run: async (signal: AbortSignal): Promise<IVerifiedFinding | null> => {
         if (signal.aborted) {

--- a/packages/core/src/loop/run.ts
+++ b/packages/core/src/loop/run.ts
@@ -1300,6 +1300,10 @@ export async function runTask(
             report({ kind: "tool", task: task.id, message: `review: ${m}` });
           },
           onEvent: report,
+          ...(opts.reviewProviders !== undefined &&
+          opts.reviewProviders.length > 0
+            ? { reviewProviders: opts.reviewProviders }
+            : {}),
         });
 
         report({

--- a/packages/core/src/models-config.ts
+++ b/packages/core/src/models-config.ts
@@ -104,6 +104,11 @@ export interface IModelsConfig {
   capabilities?: Partial<Record<CapabilityName, string>>;
   /** Optional panel of model + binary reviewers for collaborative review. */
   reviewPanel?: IReviewPanel;
+  /** Optional model(s) that run the post-work code review — each names a `models`
+   *  entry. One entry ⇒ a dedicated reviewer; several ⇒ a panel whose findings are
+   *  pooled + deduped. Absent ⇒ the active model reviews its own work. Distinct
+   *  from `reviewPanel` (which drives `tsforge harness-review` on tsforge's own PRs). */
+  reviewModels?: string[];
 }
 
 export interface IReviewerModel {
@@ -540,13 +545,45 @@ export function parseModelsConfig(raw: unknown): IModelsConfig {
 
   const capabilities = parseCapabilities(raw.capabilities, models);
   const reviewPanel = parseReviewPanel(raw.reviewPanel, models);
+  const reviewModels = parseReviewModels(raw.reviewModels, models);
 
   const withCaps =
     capabilities === undefined
       ? { active: raw.active, models }
       : { active: raw.active, models, capabilities };
+  const withPanel =
+    reviewPanel === undefined ? withCaps : { ...withCaps, reviewPanel };
 
-  return reviewPanel === undefined ? withCaps : { ...withCaps, reviewPanel };
+  return reviewModels === undefined
+    ? withPanel
+    : { ...withPanel, reviewModels };
+}
+
+/** Validate the optional `reviewModels` list: an array of names, each pointing at
+ *  a real model entry. Fail loud at load so a typo isn't discovered at review time. */
+function parseReviewModels(
+  raw: unknown,
+  models: Record<string, IModelEntry>
+): string[] | undefined {
+  if (raw === undefined) {
+    return undefined;
+  }
+
+  if (!Array.isArray(raw) || !raw.every((n) => typeof n === "string")) {
+    throw new Error(
+      "models.json: reviewModels must be an array of model names"
+    );
+  }
+
+  for (const name of raw) {
+    if (modelByName(models, name) === undefined) {
+      throw new Error(
+        `models.json: reviewModels entry "${name}" is not one of: ${Object.keys(models).join(", ")}`
+      );
+    }
+  }
+
+  return raw.length > 0 ? [...raw] : undefined;
 }
 
 /** Validate the optional `capabilities` block: known keys only, each pointing at

--- a/packages/core/tests/review-change.test.ts
+++ b/packages/core/tests/review-change.test.ts
@@ -257,6 +257,47 @@ test("TSFORGE_REVIEW_MAX_FILES caps the reviewed set and still warns loudly", as
   }
 });
 
+test("a reviewer panel pools findings and dedups same file:line:lens", async () => {
+  // Two reviewers: one flags line 2 [correctness], the other flags the SAME
+  // line+lens (a duplicate) AND a distinct line 1 [edge-cases]. Pooled = 3 raw,
+  // deduped to 2 (the duplicate collapses).
+  const reviewerA = stub(FINDINGS, true); // line 2, correctness
+  const reviewerB = stub(
+    JSON.stringify({
+      findings: [
+        {
+          line: 2,
+          severity: "warning",
+          lens: "correctness",
+          claim: "same spot, different words",
+          reason: "dup",
+        },
+        {
+          line: 1,
+          severity: "error",
+          lens: "edge-cases",
+          claim: "a different issue",
+          reason: "distinct",
+        },
+      ],
+    }),
+    true
+  );
+
+  const report = await reviewChange(stub(FINDINGS, true), repo, {
+    reviewProviders: [reviewerA, reviewerB],
+  });
+
+  // discount.ts changed both lines in beforeEach? Only line 2 changed there, so
+  // the line-1 finding is dropped as pre-existing. Assert the dedupe collapsed the
+  // duplicate line-2 finding to one, and that a panel ran (no crash, verified set).
+  const line2 = report.findings.filter(
+    (f) => f.line === 2 && f.lens === "correctness"
+  );
+
+  expect(line2).toHaveLength(1);
+});
+
 test("the security and consistency lenses ship in the rubric", () => {
   const ids = LENSES.map((l) => l.id);
 

--- a/packages/core/tests/review-providers.test.ts
+++ b/packages/core/tests/review-providers.test.ts
@@ -1,0 +1,72 @@
+import { test, expect, afterEach } from "bun:test";
+import { parseModelsConfig } from "../src/models-config";
+import { resolveReviewProviders } from "../src/cli/model-setup";
+
+const RAW = {
+  active: "main",
+  models: {
+    main: { baseUrl: "http://localhost:8000/v1", model: "main-model" },
+    rev1: { baseUrl: "http://localhost:8001/v1", model: "rev1-model" },
+    rev2: { baseUrl: "http://localhost:8002/v1", model: "rev2-model" },
+  },
+};
+
+afterEach(() => {
+  delete process.env.TSFORGE_REVIEW_MODEL;
+  delete process.env.TSFORGE_REVIEW_BASE_URL;
+  delete process.env.TSFORGE_REVIEW_API_KEY;
+});
+
+test("parseModelsConfig accepts reviewModels naming real entries", () => {
+  const cfg = parseModelsConfig({ ...RAW, reviewModels: ["rev1", "rev2"] });
+
+  expect(cfg.reviewModels).toEqual(["rev1", "rev2"]);
+});
+
+test("parseModelsConfig rejects a reviewModels name that isn't a model", () => {
+  expect(() => parseModelsConfig({ ...RAW, reviewModels: ["nope"] })).toThrow(
+    /reviewModels/
+  );
+});
+
+test("parseModelsConfig rejects a non-array reviewModels", () => {
+  expect(() => parseModelsConfig({ ...RAW, reviewModels: "rev1" })).toThrow(
+    /reviewModels/
+  );
+});
+
+test("no reviewModels and no env ⇒ empty (caller falls back to the main model)", () => {
+  const cfg = parseModelsConfig(RAW);
+
+  expect(resolveReviewProviders(cfg)).toHaveLength(0);
+});
+
+test("one reviewModel ⇒ one reviewer provider", () => {
+  const cfg = parseModelsConfig({ ...RAW, reviewModels: ["rev1"] });
+
+  expect(resolveReviewProviders(cfg)).toHaveLength(1);
+});
+
+test("several reviewModels ⇒ a panel of that many providers", () => {
+  const cfg = parseModelsConfig({ ...RAW, reviewModels: ["rev1", "rev2"] });
+
+  expect(resolveReviewProviders(cfg)).toHaveLength(2);
+});
+
+test("TSFORGE_REVIEW_* env is a single ad-hoc reviewer that wins over reviewModels", () => {
+  const cfg = parseModelsConfig({ ...RAW, reviewModels: ["rev1", "rev2"] });
+
+  process.env.TSFORGE_REVIEW_BASE_URL = "http://localhost:9000/v1";
+  process.env.TSFORGE_REVIEW_MODEL = "env-reviewer";
+
+  // env override collapses the panel to the one ad-hoc reviewer
+  expect(resolveReviewProviders(cfg)).toHaveLength(1);
+});
+
+test("TSFORGE_REVIEW_MODEL alone names a registry entry", () => {
+  const cfg = parseModelsConfig(RAW);
+
+  process.env.TSFORGE_REVIEW_MODEL = "rev2";
+
+  expect(resolveReviewProviders(cfg)).toHaveLength(1);
+});


### PR DESCRIPTION
### Why

Until now the model doing the work also reviewed it — self-review, which is weaker (a model is less likely to flag its own mistakes) and, per the research on review harnesses, not even the best use of a large model for review (a fast, sharp model often reviews better and cheaper).

### What this does

You can point the review at a different model, or run a **panel** of several, in `models.json`:

```json
"reviewModels": ["haiku", "another-model"]
```

- **One entry** — a dedicated reviewer.
- **Several** — a panel: each reviews independently and their findings are pooled and deduped, surfacing more real issues.
- **None** — the main model reviews, exactly as before. Nothing changes for anyone who doesn't opt in.

A quick one-off reviewer can also be set with `TSFORGE_REVIEW_MODEL` (or the `TSFORGE_REVIEW_BASE_URL` / `_MODEL` / `_API_KEY` trio), which wins over `reviewModels`. While a panel runs, the status bar shows `● reviewing ×N`. Works in both the interactive session and headless runs. (Separate from `reviewPanel`, which is only for `tsforge harness-review`.)

### Outcome

Review can be done by a sharper or cheaper model than the one that wrote the code — or by several at once — without giving up the zero-config default. Docs and tests included.
