### PR TITLE
Show review as live progress, and run reviewers concurrently

### DIFF
--- a/apps/docs/src/content/docs/cli/review.mdx
+++ b/apps/docs/src/content/docs/cli/review.mdx
@@ -68,6 +68,8 @@ By default the **main model reviews its own work**. You can point review at a di
 
 For a quick one-off without editing the file, set `TSFORGE_REVIEW_MODEL` (naming a `models` entry) or the trio `TSFORGE_REVIEW_BASE_URL` / `TSFORGE_REVIEW_MODEL` / `TSFORGE_REVIEW_API_KEY` for an ad-hoc reviewer. While reviewing, the status bar shows `● reviewing…` (or `● reviewing ×N` for a panel).
 
+**Live progress.** The review streams into the same agent-tree UI as delegated subagents: each file (and each finding being verified) appears as a node that goes pending → running → done, so you can watch it advance instead of waiting on a silent prompt. A panel's reviewers run **concurrently** (they're independent — usually different remote endpoints), and files fan out several at a time, so a large review isn't one-call-at-a-time.
+
 ## Coverage on large changes
 
 Review covers up to `TSFORGE_REVIEW_MAX_FILES` changed files (default **100**) per run, and reads up to `TSFORGE_REVIEW_DIFF_CHARS` (default **12000**) of each file's diff. Excess files are queued through the same [concurrency](/guardrails/config/) limit, not dropped — raise the caps for very large changes. If a run does hit a cap, the report says so loudly (`⚠ coverage: reviewed N of M …`) so a partial review never reads as a clean bill of health.

--- a/packages/core/ARCHITECTURE.md
+++ b/packages/core/ARCHITECTURE.md
@@ -104,7 +104,7 @@ Async functions returning an exit code, declared under the CLI — the commands.
 | `repl` | `cli/repl.ts:782` |
 | `reviewMode` | `cli.ts:201` |
 | `runOnce` | `cli.ts:103` |
-| `runTraceCommand` | `cli/repl-commands.ts:150` |
+| `runTraceCommand` | `cli/repl-commands.ts:160` |
 | `scaffoldMode` | `cli.ts:749` |
 | `setupMode` | `cli.ts:510` |
 | `traceMode` | `cli.ts:572` |

--- a/packages/core/src/cli/repl-commands.ts
+++ b/packages/core/src/cli/repl-commands.ts
@@ -1,7 +1,12 @@
 /** Self-contained REPL commands shared with the CLI's one-shot modes:
  *  /sessions, /map, /review, /trace, and the /metrics turns-to-green line. */
 import { buildAndPersistMap, mapStatus, forgetMap } from "../codebase";
-import { reviewChange, formatReport, formatReviewCard } from "../loop";
+import {
+  reviewChange,
+  formatReport,
+  formatReviewCard,
+  type Reporter,
+} from "../loop";
 import { STYLE, paint } from "../render";
 import type { IProvider } from "../inference";
 import { parseEventLog, formatTrace } from "../eval";
@@ -108,7 +113,9 @@ export async function runReviewCommand(
   base: string,
   out: (s: string) => void = STDOUT,
   columns?: number,
-  reviewProviders: readonly IProvider[] = []
+  reviewProviders: readonly IProvider[] = [],
+  onEvent?: Reporter,
+  concurrency?: number
 ): Promise<string> {
   out(
     `${paint("reviewing the current change…", STYLE.dim, columns !== undefined)}\n`
@@ -119,6 +126,9 @@ export async function runReviewCommand(
     const report = await reviewChange(provider, dir, {
       ...(base.length > 0 ? { base } : {}),
       ...(reviewProviders.length > 0 ? { reviewProviders } : {}),
+      // Stream the fan-out into the live agent tree (visible progress).
+      ...(onEvent === undefined ? {} : { onEvent }),
+      ...(concurrency === undefined ? {} : { concurrency }),
       log: (m) => {
         out(`  ↳ ${m}\n`);
       },

--- a/packages/core/src/cli/repl.ts
+++ b/packages/core/src/cli/repl.ts
@@ -793,6 +793,7 @@ export async function repl(args: ICliArgs): Promise<number> {
     id,
     gateLabel: initialGateLabel,
     logFile,
+    report,
     resumed,
     activeModelEntry,
     autoGate,
@@ -806,6 +807,12 @@ export async function repl(args: ICliArgs): Promise<number> {
     reviewProviders.length > 1
       ? `reviewing ×${String(reviewProviders.length)}`
       : "reviewing";
+  // File-level fan-out for the review. A configured panel is remote + independent
+  // (e.g. OpenRouter), so it's safe to overlap several files at once (a floor of 4)
+  // instead of one-at-a-time. Self-review (the main model, one endpoint) respects
+  // the configured delegation cap so a serial endpoint isn't swamped.
+  const reviewConcurrency = (): number =>
+    reviewProviders.length > 0 ? Math.max(delegationCap, 4) : delegationCap;
 
   // Load delegation inputs HERE — before readline is created below. Any `await`
   // between `createInterface` and the `rl.on("line")` listener would yield the
@@ -1252,6 +1259,10 @@ export async function repl(args: ICliArgs): Promise<number> {
       const review = await withReviewingStatus(() =>
         reviewChange(provider, args.dir, {
           files: changed,
+          // Stream the fan-out into the live agent tree so each file/finding node
+          // appears → runs → completes (visible progress, not a silent wait).
+          onEvent: report,
+          concurrency: reviewConcurrency(),
           ...(reviewProviders.length > 0 ? { reviewProviders } : {}),
         })
       );
@@ -1269,6 +1280,9 @@ export async function repl(args: ICliArgs): Promise<number> {
       );
     } catch {
       // A review failure (git/model/fs) is non-fatal — the turn already succeeded.
+    } finally {
+      // Clear the review's live nodes so they don't linger until the next turn.
+      resetTree();
     }
   };
 
@@ -1636,17 +1650,25 @@ export async function repl(args: ICliArgs): Promise<number> {
 
       case "review":
         // Store the findings so /reviewfix can act on a manual review too (not just
-        // the automatic after-green one). Plain text; empty when clean.
-        lastReviewFindings = await withReviewingStatus(() =>
-          runReviewCommand(
-            provider,
-            args.dir,
-            arg,
-            echo,
-            transcriptCols(),
-            reviewProviders
-          )
-        );
+        // the automatic after-green one). Plain text; empty when clean. `report` +
+        // concurrency stream the fan-out into the live agent tree (visible progress).
+        try {
+          lastReviewFindings = await withReviewingStatus(() =>
+            runReviewCommand(
+              provider,
+              args.dir,
+              arg,
+              echo,
+              transcriptCols(),
+              reviewProviders,
+              report,
+              reviewConcurrency()
+            )
+          );
+        } finally {
+          resetTree();
+        }
+
         break;
 
       case "reviewfix":

--- a/packages/core/src/loop/review/review-change.ts
+++ b/packages/core/src/loop/review/review-change.ts
@@ -95,7 +95,12 @@ function unitReporter(
   return (id, status): void => {
     const base = {
       task: REVIEW_TASK,
-      message: id,
+      // Human-readable node label for the live tree: `find:src/a.ts` → `review src/a.ts`,
+      // `verify:src/a.ts:12#3` → `verify src/a.ts:12`. The agentId keeps the raw id.
+      message: id
+        .replace(/^find:/, "review ")
+        .replace(/^verify:/, "verify ")
+        .replace(/#\d+$/, ""),
       agentId: `${REVIEW_TASK}:${id}`,
       parentTask: REVIEW_TASK,
     };
@@ -655,11 +660,13 @@ async function findFileOutcome(
     ctx.staged,
     ctx.untracked.has(file)
   );
-  const found: IRepoFinding[] = [];
-
-  for (const rp of findProviders) {
-    found.push(
-      ...(await safeFind(
+  // Reviewers fire CONCURRENTLY: a panel is independent providers (usually
+  // different remote hosts), so there's no reason to serialize them — that just
+  // multiplied latency by the reviewer count. safeFind never throws (errors → []),
+  // so this never rejects. A single-reviewer find is a one-element race (unchanged).
+  const perReviewer = await Promise.all(
+    findProviders.map((rp) =>
+      safeFind(
         rp,
         ctx.system,
         ctx.svc,
@@ -669,9 +676,10 @@ async function findFileOutcome(
         ctx.gateFailingRules,
         ctx.log,
         signal
-      ))
-    );
-  }
+      )
+    )
+  );
+  const found: IRepoFinding[] = perReviewer.flat();
 
   // A finding on a pre-existing (unchanged) line isn't a regression in THIS change.
   // Skip the filter when no hunks parsed (can't tell), so we never drop everything.

--- a/packages/core/tests/review-change.test.ts
+++ b/packages/core/tests/review-change.test.ts
@@ -298,6 +298,39 @@ test("a reviewer panel pools findings and dedups same file:line:lens", async () 
   expect(line2).toHaveLength(1);
 });
 
+test("reviewers in a panel fire CONCURRENTLY, not one after another", async () => {
+  // Each reviewer's find call bumps an in-flight counter and holds briefly. If the
+  // panel ran serially the max in-flight would be 1; concurrently it reaches 2.
+  let inFlight = 0;
+  let maxInFlight = 0;
+
+  const reviewer = (): IProvider => ({
+    async complete(messages) {
+      const sys = messages.find((m) => m.role === "system")?.content ?? "";
+
+      if (sys.includes("verifying a code-review finding")) {
+        return {
+          content: JSON.stringify({ real: true, verdict: "" }),
+          toolCalls: [],
+        };
+      }
+
+      inFlight += 1;
+      maxInFlight = Math.max(maxInFlight, inFlight);
+      await new Promise((r) => setTimeout(r, 25));
+      inFlight -= 1;
+
+      return { content: FINDINGS, toolCalls: [] };
+    },
+  });
+
+  await reviewChange(stub(FINDINGS, true), repo, {
+    reviewProviders: [reviewer(), reviewer()],
+  });
+
+  expect(maxInFlight).toBeGreaterThanOrEqual(2);
+});
+
 test("the security and consistency lenses ship in the rubric", () => {
   const ids = LENSES.map((l) => l.id);
 


### PR DESCRIPTION
### Why

Two real problems with the review, reported from use:

1. **It ran serially** — each reviewer in a panel waited for the previous one, and files were reviewed one at a time. A 3-model panel over 50 files was ~150 sequential remote calls.
2. **No progress on screen** — the review runs after the turn's activity indicator has stopped, and it never fed its events to the live UI. So it was a 5–10 minute silent wait with no sign anything was happening.

### What this does

- **Live progress:** the review now streams into the same agent-tree the harness already uses for delegated subagents — each file (and each finding being verified) appears as a node that goes running → done, and the tree clears when the review finishes. You watch it advance instead of staring at a silent prompt.
- **Concurrency:** a panel's reviewers fire **at the same time** (they're independent, usually different endpoints), and files fan out several at a time. Self-review on a single local model stays gentle — it respects the configured delegation cap so a serial endpoint isn't swamped.

Node labels are readable (`review src/foo.ts`, `verify src/foo.ts:12`). Covered by a concurrency test (reviewers overlap) and the existing event-emission tests; `e2e:pty` (real REPL) stays green.

### Outcome

The review is visibly working and much faster — especially with a multi-model panel — instead of a silent, serial crawl.
