### PR TITLE
/reviewfix seeds the worklist: one task per finding

### DIFF
--- a/packages/core/ARCHITECTURE.md
+++ b/packages/core/ARCHITECTURE.md
@@ -101,10 +101,10 @@ Async functions returning an exit code, declared under the CLI — the commands.
 | `main` | `cli.ts:776` |
 | `mapMode` | `cli.ts:500` |
 | `recipesMode` | `cli.ts:519` |
-| `repl` | `cli/repl.ts:782` |
+| `repl` | `cli/repl.ts:813` |
 | `reviewMode` | `cli.ts:201` |
 | `runOnce` | `cli.ts:103` |
-| `runTraceCommand` | `cli/repl-commands.ts:155` |
+| `runTraceCommand` | `cli/repl-commands.ts:160` |
 | `scaffoldMode` | `cli.ts:747` |
 | `setupMode` | `cli.ts:508` |
 | `traceMode` | `cli.ts:570` |

--- a/packages/core/src/cli/repl-commands.ts
+++ b/packages/core/src/cli/repl-commands.ts
@@ -1,7 +1,13 @@
 /** Self-contained REPL commands shared with the CLI's one-shot modes:
  *  /sessions, /map, /review, /trace, and the /metrics turns-to-green line. */
 import { buildAndPersistMap, mapStatus, forgetMap } from "../codebase";
-import { review, formatReport, formatReviewCard, type Reporter } from "../loop";
+import {
+  review,
+  formatReport,
+  formatReviewCard,
+  type Reporter,
+  type IReviewReport,
+} from "../loop";
 import { STYLE, paint } from "../render";
 import type { IProvider } from "../inference";
 import { parseEventLog, formatTrace } from "../eval";
@@ -100,8 +106,9 @@ export async function runMapCommand(
 
 /** `/review` in the REPL — review the current change and print findings. `out` is
  *  the pane-aware sink; when `columns` is given the findings render as a colored,
- *  width-wrapped card (the TUI), otherwise plain text (CLI/pipe). Returns the PLAIN
- *  findings text (empty when clean/errored) so the caller can hand it to `/reviewfix`. */
+ *  width-wrapped card (the TUI), otherwise plain text (CLI/pipe). Returns the
+ *  structured report so the caller can seed `/reviewfix`'s task list; null when the
+ *  review errored (git/fs/model). */
 export async function runReviewCommand(
   provider: IProvider,
   dir: string,
@@ -111,7 +118,7 @@ export async function runReviewCommand(
   reviewProviders: readonly IProvider[] = [],
   onEvent?: Reporter,
   concurrency?: number
-): Promise<string> {
+): Promise<IReviewReport | null> {
   out(
     `${paint("reviewing the current change…", STYLE.dim, columns !== undefined)}\n`
   );
@@ -136,15 +143,13 @@ export async function runReviewCommand(
 
     out(`\n${rendered}\n`);
 
-    // Plain text (never the colored card) so /reviewfix hands the agent readable
-    // findings, not ANSI. Empty when there's nothing to act on.
-    return report.findings.length > 0 ? formatReport(report) : "";
+    return report;
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err);
 
     out(`\nreview failed: ${message}\n`);
 
-    return "";
+    return null;
   }
 }
 

--- a/packages/core/src/cli/repl.ts
+++ b/packages/core/src/cli/repl.ts
@@ -43,10 +43,10 @@ import {
   PLAN_APPROVED_NOTE,
   isEphemeralUserInject,
   review,
-  formatReport,
   formatReviewCard,
   type Reporter,
   type ILoopEvent,
+  type IReviewReport,
 } from "../loop";
 import { runPlanning } from "../loop/planning/run-planning";
 import type { IPlanConstraints } from "../loop/planning/plan-types";
@@ -148,14 +148,45 @@ import {
   pendingPlanBadge,
   seedWorklistFromPlan,
   persistPlanDocument,
+  normalizePlanDraft,
   goalFromMessages,
   loadPlan,
 } from "../loop/worklist";
-import type { IPlanDocument } from "../loop/worklist";
+import type { IPlanDocument, IChecklistItemDraft } from "../loop/worklist";
 
 /** A unique-enough id for a new session (time + a little randomness). */
 function newSessionId(): string {
   return `${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 8)}`;
+}
+
+/** Guidance handed to the agent after `/reviewfix` seeds the worklist. Short on
+ *  purpose — the task list carries the findings; this only sets the protocol. */
+const REVIEWFIX_INSTRUCTION =
+  "I've added the code-review findings to your task list. Work them ONE AT A TIME: `task_focus` the first open finding, address it (fix the code, or if it isn't a real problem say why in one line), then `task_complete` it — which only succeeds once the gate is green — and move to the next. Don't batch them.";
+
+const REVIEWFIX_SEVERITY_RANK = { error: 0, warning: 1, info: 2 };
+
+/** One worklist task per review finding, worst-severity first (the worklist enforces
+ *  top-to-bottom focus order, so the highest-risk issue is worked first). Title is
+ *  the claim; detail carries file:line, lens, the reason, and any suggested fix.
+ *  Exported for tests. */
+export function reviewFindingsToDrafts(
+  report: IReviewReport
+): IChecklistItemDraft[] {
+  const sorted = [...report.findings].sort(
+    (a, b) =>
+      REVIEWFIX_SEVERITY_RANK[a.severity] - REVIEWFIX_SEVERITY_RANK[b.severity]
+  );
+
+  return sorted.map((f): IChecklistItemDraft => {
+    const where = `${f.file}:${String(f.line)} [${f.lens}] (${f.severity})`;
+    const detail =
+      f.suggestedFix === undefined
+        ? `${where}\n${f.reason}`
+        : `${where}\n${f.reason}\nSuggested fix: ${f.suggestedFix}`;
+
+    return { title: f.claim, detail, files: [f.file], kind: "modify" };
+  });
 }
 
 /** Wide approval — the staged-web checkpoint explicitly prompted "type
@@ -1179,9 +1210,10 @@ export async function repl(args: ICliArgs): Promise<number> {
   let lastTurnsToGreen: number | null = null;
   let lastElapsedMs = 0;
   let lastStatus = "ready";
-  // The last post-green review's formatted findings, kept so `/reviewfix` can hand
-  // them to the agent to address (the "offer to fix" half of report-then-fix).
-  let lastReviewFindings = "";
+  // The last review's report (structured findings), kept so `/reviewfix` can seed
+  // the worklist — one task per finding — and hand the agent a real map to work
+  // through (the "offer to fix" half of report-then-fix). null ⇒ nothing to fix.
+  let lastReviewReport: IReviewReport | null = null;
 
   // Set when the user types approve mid-turn (or it was drained from the steer
   // queue). Must NOT be injected as chat — that leaves plan mode on, withholds
@@ -1243,7 +1275,7 @@ export async function repl(args: ICliArgs): Promise<number> {
     status: string,
     touchedBefore: ReadonlySet<string>
   ): Promise<void> => {
-    lastReviewFindings = "";
+    lastReviewReport = null;
 
     if (status !== "done" || flags.noReview()) {
       return;
@@ -1272,9 +1304,9 @@ export async function repl(args: ICliArgs): Promise<number> {
         return; // clean — stay quiet, don't nag on every green turn
       }
 
-      // Display the colored, wrapped card in the pane; keep a PLAIN copy for
-      // /reviewfix (the agent gets text, never ANSI escapes).
-      lastReviewFindings = formatReport(result);
+      // Display the colored, wrapped card in the pane; keep the structured report
+      // so /reviewfix can seed the worklist with one task per finding.
+      lastReviewReport = result;
       echo(`\n${formatReviewCard(result, transcriptCols(), true)}\n`);
       echo(
         `${paint("↳ /reviewfix", STYLE.dim, true)} to have the agent address these findings.\n`
@@ -1431,6 +1463,43 @@ export async function repl(args: ICliArgs): Promise<number> {
     await persist();
     echo("  ✓ plan approved — implementing\n");
     await drive((opts) => session.send(PLAN_APPROVED_NOTE, opts));
+  };
+
+  /** Seed (or extend) the worklist from a review report — one task per finding —
+   *  then bind + paint it (mirrors approveBoundPlan). Appends to the active plan if
+   *  one is bound (keeping its focus + done items), else creates a new one. Returns
+   *  the persisted plan, or null if the draft was rejected. */
+  const seedReviewFixPlan = async (
+    report: IReviewReport
+  ): Promise<IPlanDocument | null> => {
+    const goal = "Address code-review findings";
+    const norm = normalizePlanDraft(
+      { goal, items: reviewFindingsToDrafts(report) },
+      goal
+    );
+
+    if (!norm.ok) {
+      echo(`  ✗ ${norm.error}\n`);
+
+      return null;
+    }
+
+    const activeId = session.getActivePlanId();
+    const existing = activeId === null ? null : loadPlan(args.dir, activeId);
+    const doc: IPlanDocument =
+      existing === null
+        ? norm.plan
+        : { ...existing, items: [...existing.items, ...norm.plan.items] };
+    const plan = persistPlanDocument(args.dir, doc);
+
+    if (existing === null) {
+      session.setActivePlanId(plan.id);
+    }
+
+    syncWorklistPanel(plan);
+    await persist();
+
+    return plan;
   };
 
   const discussInPlanMode = async (line: string): Promise<void> => {
@@ -1650,11 +1719,11 @@ export async function repl(args: ICliArgs): Promise<number> {
         break;
 
       case "review":
-        // Store the findings so /reviewfix can act on a manual review too (not just
-        // the automatic after-green one). Plain text; empty when clean. `report` +
+        // Store the report so /reviewfix can act on a manual review too (not just
+        // the automatic after-green one). null when clean/errored. `report` +
         // concurrency stream the fan-out into the live agent tree (visible progress).
         try {
-          lastReviewFindings = await withReviewingStatus(() =>
+          lastReviewReport = await withReviewingStatus(() =>
             runReviewCommand(
               provider,
               args.dir,
@@ -1672,21 +1741,32 @@ export async function repl(args: ICliArgs): Promise<number> {
 
         break;
 
-      case "reviewfix":
-        if (lastReviewFindings.length === 0) {
+      case "reviewfix": {
+        const report = lastReviewReport;
+
+        if (report === null || report.findings.length === 0) {
           echo("no review findings to fix (run a change first, or /review).\n");
-        } else {
-          // Hand the last review's findings to the agent as the next instruction —
-          // the fix turn itself re-triggers the after-green review on its edits.
-          await drive((opts) =>
-            session.send(
-              `Address these code-review findings in the change you just made. For each, either fix it or briefly say why it is not a real problem:\n\n${lastReviewFindings}`,
-              opts
-            )
-          );
+          break;
         }
 
+        // Seed the worklist — one task per finding — so the Tasks rail becomes the
+        // map the agent works through (focus → fix → complete), instead of a single
+        // prose dump. Creates a plan if none is bound, else appends to the current
+        // one. The fix turns re-trigger the after-green review on their edits.
+        const plan = await seedReviewFixPlan(report);
+
+        if (plan === null) {
+          echo("couldn't build the fix task list.\n");
+          break;
+        }
+
+        echo(
+          `${paint(`↳ added ${String(report.findings.length)} finding(s) to the task list`, STYLE.dim, true)} — working them one at a time.\n`
+        );
+        await drive((opts) => session.send(REVIEWFIX_INSTRUCTION, opts));
+
         break;
+      }
 
       case "map":
         await runMapCommand(args.dir, arg, echo);

--- a/packages/core/tests/review-command.test.ts
+++ b/packages/core/tests/review-command.test.ts
@@ -5,7 +5,6 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import type { IProvider } from "../src/inference";
 import { runReviewCommand } from "../src/cli/repl-commands";
-import { stripSgr } from "../src/render";
 
 /** A provider that drives one review AGENT: first call → investigate (git_context
  *  diff, the read-only step the runner requires before a result), then →
@@ -85,12 +84,12 @@ afterEach(() => {
   rmSync(repo, { recursive: true, force: true });
 });
 
-// The /review → /reviewfix contract: the command must RETURN the plain findings so
-// the REPL can store them for /reviewfix (the bug was it returned nothing, so
-// /reviewfix always said "no findings" after a manual /review).
-test("returns the plain findings text when there are findings (feeds /reviewfix)", async () => {
+// The /review → /reviewfix contract: the command must RETURN the structured report
+// so the REPL can seed /reviewfix's task list (one task per finding). The bug it
+// guards was returning nothing, so /reviewfix always said "no findings".
+test("returns the structured report with grounded findings (feeds /reviewfix)", async () => {
   const out: string[] = [];
-  const findings = await runReviewCommand(
+  const report = await runReviewCommand(
     reviewerStub(FINDING),
     repo,
     "",
@@ -98,15 +97,17 @@ test("returns the plain findings text when there are findings (feeds /reviewfix)
     80
   );
 
-  expect(findings).toContain("subtraction is reversed");
-  expect(findings).toContain("discount.ts:2");
-  // Plain text (no ANSI) — /reviewfix hands it to the agent verbatim.
-  expect(stripSgr(findings)).toBe(findings);
+  expect(report).not.toBeNull();
+  expect(report?.findings).toHaveLength(1);
+  expect(report?.findings[0]).toMatchObject({
+    file: "discount.ts",
+    line: 2,
+    claim: expect.stringContaining("subtraction is reversed"),
+  });
 });
 
-test("returns an empty string when the review is clean (so /reviewfix says nothing to fix)", async () => {
-  // The agent reports no findings ⇒ empty return.
-  const findings = await runReviewCommand(
+test("returns a report with no findings when the review is clean (so /reviewfix says nothing to fix)", async () => {
+  const report = await runReviewCommand(
     reviewerStub(null),
     repo,
     "",
@@ -114,7 +115,8 @@ test("returns an empty string when the review is clean (so /reviewfix says nothi
     80
   );
 
-  expect(findings).toBe("");
+  expect(report).not.toBeNull();
+  expect(report?.findings).toHaveLength(0);
 });
 
 test("still renders to the sink (the display path is unaffected)", async () => {

--- a/packages/core/tests/reviewfix-plan.test.ts
+++ b/packages/core/tests/reviewfix-plan.test.ts
@@ -1,0 +1,77 @@
+import { test, expect } from "bun:test";
+import { reviewFindingsToDrafts } from "../src/cli/repl";
+import type { IReviewReport } from "../src/loop";
+
+function report(over: Partial<IReviewReport> = {}): IReviewReport {
+  return {
+    base: "HEAD",
+    changedFiles: ["a.ts"],
+    findings: [],
+    rejected: 0,
+    ...over,
+  };
+}
+
+const finding = (
+  over: Partial<IReviewReport["findings"][number]> = {}
+): IReviewReport["findings"][number] => ({
+  file: "a.ts",
+  line: 10,
+  severity: "warning",
+  lens: "review",
+  claim: "a claim",
+  reason: "the reason",
+  verified: true,
+  verdict: "reviewed",
+  ...over,
+});
+
+test("one draft per finding: title=claim, files=[file], kind=modify", () => {
+  const drafts = reviewFindingsToDrafts(
+    report({
+      findings: [finding({ file: "src/x.ts", line: 3, claim: "off-by-one" })],
+    })
+  );
+
+  expect(drafts).toHaveLength(1);
+  expect(drafts[0]).toMatchObject({
+    title: "off-by-one",
+    files: ["src/x.ts"],
+    kind: "modify",
+  });
+  // detail carries the grounding: file:line, lens, severity, and the reason.
+  expect(drafts[0]?.detail).toContain("src/x.ts:3");
+  expect(drafts[0]?.detail).toContain("the reason");
+});
+
+test("orders worst-severity first (error → warning → info)", () => {
+  const drafts = reviewFindingsToDrafts(
+    report({
+      findings: [
+        finding({ severity: "info", claim: "info one" }),
+        finding({ severity: "error", claim: "error one" }),
+        finding({ severity: "warning", claim: "warn one" }),
+      ],
+    })
+  );
+
+  expect(drafts.map((d) => d.title)).toEqual([
+    "error one",
+    "warn one",
+    "info one",
+  ]);
+});
+
+test("includes the suggested fix in detail only when present", () => {
+  const [withFix, withoutFix] = reviewFindingsToDrafts(
+    report({
+      findings: [
+        finding({ severity: "error", suggestedFix: "return a - b;" }),
+        finding({ severity: "warning" }),
+      ],
+    })
+  );
+
+  expect(withFix?.detail).toContain("Suggested fix: return a - b;");
+  expect(withoutFix?.detail).not.toContain("Suggested fix:");
+});


### PR DESCRIPTION
## What

`/reviewfix` now turns each code-review finding into its own worklist task, so the **Tasks rail becomes the map** the agent works through — instead of dumping every finding into one prose message with an empty rail.

> "The task list for me means a lot, and I always want it to be a map so I also know what the agent is working on — the entire harness has to be centered around small and well-defined tasks."

## How

- Seeds the worklist from the **structured** `IReviewReport`: one task per finding. Title = the finding's claim; `detail` carries `file:line`, lens, severity, the reason, and any suggested fix. Ordered **worst-severity first** (error → warning → info) — the worklist enforces top-to-bottom focus, so the highest-risk issue is worked first.
- **Create-or-update**: if no plan is bound it creates one; if a plan is already active it **appends** the findings (keeping the existing focus + done items). Matches "create the task list if it doesn't exist, update it if it does."
- Binds + paints the Tasks rail (mirrors `approveBoundPlan`), then hands the agent a short protocol: `task_focus` the first open finding → fix it → `task_complete` (which only succeeds once the gate is green) → next. No batching.
- The REPL now keeps the structured `IReviewReport` instead of a formatted string. `runReviewCommand` returns `IReviewReport | null`, so a manual `/review` feeds `/reviewfix` the same structured findings the automatic after-green review does.

## Tests

- `reviewfix-plan.test.ts`: the finding→draft mapping — one draft per finding, severity ordering, suggested-fix inclusion, grounding in `detail`.
- `review-command.test.ts`: updated to the structured-report return contract.

## Verification

`ci:local` green — 5490 pass / 0 fail (3 new), e2e:pty 10/10, typecheck + lint + arch + rules + format clean.