### PR TITLE
test: lock /reviewfix worklist create + append against the real store

### DIFF
--- a/packages/core/tests/reviewfix-plan.test.ts
+++ b/packages/core/tests/reviewfix-plan.test.ts
@@ -1,5 +1,14 @@
-import { test, expect } from "bun:test";
+import { test, expect, afterEach } from "bun:test";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { reviewFindingsToDrafts } from "../src/cli/repl";
+import {
+  normalizePlanDraft,
+  persistPlanDocument,
+  loadPlan,
+} from "../src/loop/worklist";
+import type { IPlanDocument } from "../src/loop/worklist";
 import type { IReviewReport } from "../src/loop";
 
 function report(over: Partial<IReviewReport> = {}): IReviewReport {
@@ -74,4 +83,103 @@ test("includes the suggested fix in detail only when present", () => {
 
   expect(withFix?.detail).toContain("Suggested fix: return a - b;");
   expect(withoutFix?.detail).not.toContain("Suggested fix:");
+});
+
+// ── seedReviewFixPlan's store composition (create + append) ──────────────────
+// Mirrors what the repl closure does: draft findings → normalizePlanDraft →
+// persist; then APPEND a second review's findings to the live plan, keeping its
+// focus + done items. The closure needs a bound Session, so we drive the same
+// store calls directly to lock the create/append behaviour.
+
+let dir = "";
+
+afterEach(() => {
+  if (dir.length > 0) {
+    rmSync(dir, { recursive: true, force: true });
+    dir = "";
+  }
+});
+
+/** The repl closure's exact seeding step for a report → persisted plan. */
+function seed(cwd: string, rep: IReviewReport): IPlanDocument {
+  const goal = "Address code-review findings";
+  const norm = normalizePlanDraft(
+    { goal, items: reviewFindingsToDrafts(rep) },
+    goal
+  );
+
+  if (!norm.ok) {
+    throw new Error(norm.error);
+  }
+
+  return persistPlanDocument(cwd, norm.plan);
+}
+
+test("create: seeding a fresh review persists one open task per finding", () => {
+  dir = mkdtempSync(join(tmpdir(), "tsforge-reviewfix-"));
+  const plan = seed(
+    dir,
+    report({
+      findings: [
+        finding({ file: "a.ts", line: 1, severity: "error", claim: "one" }),
+        finding({ file: "b.ts", line: 2, severity: "warning", claim: "two" }),
+      ],
+    })
+  );
+
+  const reloaded = loadPlan(dir, plan.id);
+
+  expect(reloaded?.items).toHaveLength(2);
+  expect(reloaded?.items.every((i) => i.status === "pending")).toBe(true);
+  expect(reloaded?.activeItemId).toBeNull();
+});
+
+test("append: a second review adds tasks, keeping the active plan's focus + done items", () => {
+  dir = mkdtempSync(join(tmpdir(), "tsforge-reviewfix-"));
+  const first = seed(
+    dir,
+    report({ findings: [finding({ claim: "first finding" })] })
+  );
+
+  // Simulate the agent having focused + completed the first task, as the live
+  // worklist would before a second /reviewfix appends more.
+  const worked: IPlanDocument = {
+    ...first,
+    activeItemId: first.items[0]?.id ?? null,
+    items: first.items.map((i) => ({ ...i, status: "done" })),
+  };
+
+  persistPlanDocument(dir, worked);
+
+  // Second review → APPEND (the repl closure's else-branch).
+  const norm = normalizePlanDraft(
+    {
+      goal: "Address code-review findings",
+      items: reviewFindingsToDrafts(
+        report({ findings: [finding({ claim: "second finding" })] })
+      ),
+    },
+    "Address code-review findings"
+  );
+
+  if (!norm.ok) {
+    throw new Error(norm.error);
+  }
+
+  const merged = persistPlanDocument(dir, {
+    ...worked,
+    items: [...worked.items, ...norm.plan.items],
+  });
+  const reloaded = loadPlan(dir, merged.id);
+
+  expect(reloaded?.id).toBe(first.id); // same plan, extended
+  expect(reloaded?.items).toHaveLength(2);
+  expect(reloaded?.activeItemId).toBe(first.items[0]?.id ?? null); // focus kept
+  expect(reloaded?.items[0]?.status).toBe("done"); // prior work kept
+  expect(reloaded?.items[1]).toMatchObject({
+    title: "second finding",
+    status: "pending",
+  });
+  // No id collision — normalizePlanDraft assigns fresh ids.
+  expect(reloaded?.items[0]?.id).not.toBe(reloaded?.items[1]?.id);
 });


### PR DESCRIPTION
Test-only follow-up to #332. Extends `reviewfix-plan.test.ts` from the pure finding→draft mapping to the store composition `seedReviewFixPlan` performs:

- **create**: `normalizePlanDraft` → `persistPlanDocument` writes one open task per finding, `activeItemId` null.
- **append**: a second review's findings are appended to the live plan, and the test asserts the plan **id**, its **activeItemId** (focus), and **prior done items** are all preserved, and that appended items get **fresh, non-colliding ids**.

This covers the one seam the unit test can't reach without a bound `Session`. No runtime change — no release.

Green: typecheck + lint + full suite.