### PR TITLE
Fix core audit follow-ups: review visibility, config warnings, test hardening

### DIFF
--- a/docs/internals/session-turn-decomposition.md
+++ b/docs/internals/session-turn-decomposition.md
@@ -1,0 +1,62 @@
+# session.ts / turn.ts decomposition plan
+
+Phase 3 of the core systems audit. **Do not refactor for aesthetics** — slice only at invariant boundaries where a dedicated module + contract test reduces risk.
+
+## Current state
+
+| File | Lines | Role |
+| --- | ---: | --- |
+| [`session.ts`](../../packages/core/src/loop/session.ts) | ~4200 | Session lifecycle, gate-runner closure, REPL turn loop, integration wiring |
+| [`turn.ts`](../../packages/core/src/loop/turn.ts) | ~3250 | Tool dispatch, settleGate, escalation, near-green, write accounting |
+
+Behavior is proven piecemeal across ~20 test files. No holistic contract suite covers either megamodule.
+
+## Extraction slices (priority order)
+
+### 1. Gate-runner closure (`session.ts` ~1165–1295)
+
+**Invariant boundary:** FG-1 dirty-package detection, FG-2 stage floor, workspace-container flip floor.
+
+**Target:** `loop/gate-session.ts` (or extend `gate/dirty-packages.ts` + thin session adapter).
+
+**Contract tests:** Session-level test simulating turn-1 shell write vs baseline capture; stage-floor downgrade reds session (extend `gate-redetect.test.ts` patterns).
+
+### 2. Mutation accounting block (`turn.ts` ~810–900)
+
+**Invariant boundary:** `wrote` vs `mutated`, write-guard dispatch, `recordTouched`, re-gate signal.
+
+**Target:** `loop/mutation-accounting.ts` — `runOneToolCall` write accounting extracted; `turn.ts` calls into it.
+
+**Contract tests:** Extend `tool-accounting.test.ts` as the living table (semantic mutation skips write-guard — now covered).
+
+### 3. Review finish hook (`run.ts` ~1286–1325, `repl.ts` reviewAfterGreen)
+
+**Invariant boundary:** Post-green review default-on, scope to turn-touched files, non-fatal errors.
+
+**Target:** `loop/review/post-green.ts` — shared between headless `run.ts` and REPL.
+
+**Contract tests:** `runTask` → `finish()` → review path; REPL `reviewAfterGreen` skip reason on failure.
+
+### 4. Integration capability wiring (`session.ts` ~2353–2416)
+
+**Invariant boundary:** GitHub/Linear/Notion/Sentry caps → tool schema trim.
+
+**Target:** `loop/integration-caps.ts` — resolve caps once, pass to session/tool context.
+
+**Contract tests:** Existing `tools-gating.test.ts`, `policy-integration.test.ts` (integration writes in plan/ci).
+
+## Mutual dependencies to respect
+
+Loop has six mutual-dependency pairs (`agent`, `eval`, `inference`, `render`, `self-harness`, `spec`). New modules must not deepen cycles — prefer `loop/*` importing `gate/*`, `lib/*`, `policy/*`; never `gate` → `loop`.
+
+## Done criteria per slice
+
+1. Extracted module has a behavioral test sibling (house rule).
+2. No change to observable harness behavior without a failing-then-passing test.
+3. Cyclomatic complexity ≤ 20 per function in new code.
+4. `bun run ci:local` green.
+
+## Not in scope
+
+- Splitting `file-ops.ts` (1166 LOC) — adjacent to mutation accounting but stable; revisit only when editing edit primitives.
+- Splitting `validate/parse.ts` — separate subsystem; parser fallback work is its own slice.

--- a/packages/core/ARCHITECTURE.md
+++ b/packages/core/ARCHITECTURE.md
@@ -32,11 +32,11 @@ inventory, see the hand-drawn map on [Internals](/internals/).
 | `files` | Reading, creating, and hash-anchored editing of workspace files | core | 9 | 2k | 5 | 1 |
 | `policy` | Decides which actions are allowed in the current mode before they run | core | 5 | 1k | 5 | 3 |
 | `architecture` ⚠️ | Derives this map from source so the docs cannot drift from the code | optional | 8 | 1k | 0 | 0 |
+| `mcp` | Model Context Protocol client that exposes external servers as tools | optional | 8 | <1k | 2 | 1 |
 | `lsp` | TypeScript language service powering navigation and write-time diagnostics | optional | 3 | <1k | 4 | 0 |
 | `browser` | Headless Chromium oracle that render-checks a page as a gate stage | optional | 3 | <1k | 1 | 1 |
 | `infer-rules` | Scans a repo for its conventions and turns them into rule overrides | core | 7 | <1k | 5 | 2 |
 | `validate` | Runs the gate command and parses tool output into structured errors | core | 7 | <1k | 7 | 2 |
-| `mcp` | Model Context Protocol client that exposes external servers as tools | optional | 8 | <1k | 2 | 1 |
 | `spec` | Task and spec shapes, spec parsing, and test generation from intent | core | 6 | <1k | 6 | 6 |
 | `stack-detection` | Detects the project's stack and picks which rule packs apply | core | 4 | <1k | 8 | 1 |
 | `setup` | Onboarding wizard that writes a project's initial tsforge config | optional | 4 | <1k | 2 | 5 |
@@ -97,11 +97,11 @@ Async functions returning an exit code, declared under the CLI — the commands.
 | `agentsMode` | `cli.ts:364` |
 | `greenfieldMode` | `cli.ts:665` |
 | `harnessDiagnoseMode` | `cli/harness-diagnose-mode.ts:211` |
-| `harnessReviewMode` | `cli/harness-review-mode.ts:684` |
+| `harnessReviewMode` | `cli/harness-review-mode.ts:700` |
 | `main` | `cli.ts:776` |
 | `mapMode` | `cli.ts:500` |
 | `recipesMode` | `cli.ts:519` |
-| `repl` | `cli/repl.ts:813` |
+| `repl` | `cli/repl.ts:815` |
 | `reviewMode` | `cli.ts:201` |
 | `runOnce` | `cli.ts:103` |
 | `runTraceCommand` | `cli/repl-commands.ts:160` |

--- a/packages/core/src/cli/harness-review-mode.ts
+++ b/packages/core/src/cli/harness-review-mode.ts
@@ -11,7 +11,11 @@ import {
   type IModelEntry,
   type BinaryInputMode,
 } from "../models-config";
-import { resolvePanel, type IPanel } from "../reviewers/registry";
+import {
+  resolvePanel,
+  warnPanelQuorum,
+  type IPanel,
+} from "../reviewers/registry";
 import {
   gatherChange,
   reviewRequest,
@@ -622,6 +626,20 @@ export function formatVerdict(v: IVerdict): string {
 }
 
 /**
+ * The roster panel actually used for a harness review run. Quick mode slices to
+ * one reviewer AND drops the quorum floor so a diagnostic run can succeed.
+ */
+export function effectiveReviewPanel(panel: IPanel, quick: boolean): IPanel {
+  return quick
+    ? {
+        ...panel,
+        reviewers: panel.reviewers.slice(0, 1),
+        minReviewers: 1,
+      }
+    : panel;
+}
+
+/**
  * Wire the resolved CLI pieces (full panel + quick flag, args, git/validate, providers, cache
  * seams) into the runReviewFlow deps — exported so the CLI's central wiring is unit-tested.
  * The EFFECTIVE roster is derived HERE (quick mode → a 1-reviewer slice), so the cache key's
@@ -649,9 +667,7 @@ export function buildReviewFlowDeps(input: {
 }): IReviewFlowDeps {
   // `quick` reviews with a REDUCED roster (the first reviewer only). The effective roster
   // feeds BOTH the cache key and the review, so its verdict never satisfies a full review.
-  const effective: IPanel = input.quick
-    ? { ...input.panel, reviewers: input.panel.reviewers.slice(0, 1) }
-    : input.panel;
+  const effective = effectiveReviewPanel(input.panel, input.quick);
   const rosterHash = panelIdentityHash(effective, input.identity);
 
   return {
@@ -695,6 +711,8 @@ export async function harnessReviewMode(argv: string[]): Promise<number> {
   const cfg = await loadModelsConfig();
   const active = await resolveActiveModel();
   const panel = resolvePanel(cfg, active);
+
+  warnPanelQuorum(panel);
 
   for (const s of panel.skipped) {
     // Config-derived, so no more ours than a reviewer's own output.

--- a/packages/core/src/cli/model-setup.ts
+++ b/packages/core/src/cli/model-setup.ts
@@ -147,15 +147,6 @@ export function makeProvider(entry: IModelEntry): OpenAICompatibleProvider {
   return new OpenAICompatibleProvider(providerConfig(entry));
 }
 
-/**
- * The provider(s) that run the post-work code review, in precedence order:
- *   1. `TSFORGE_REVIEW_BASE_URL` + `_MODEL` (+ `_API_KEY`) — an ad-hoc single reviewer;
- *   2. `TSFORGE_REVIEW_MODEL` alone — names a `models` entry;
- *   3. `models.json` `reviewModels: [...]` — one or several `models` entries (a panel).
- * Returns `[]` when nothing is configured; callers then fall back to the MAIN model
- * (the default: the model reviews its own work). Names in `reviewModels` are validated
- * at config load, so the map here can't miss.
- */
 export function resolveReviewProviders(cfg: IModelsConfig): IProvider[] {
   const envBase = process.env.TSFORGE_REVIEW_BASE_URL;
   const envModel = process.env.TSFORGE_REVIEW_MODEL;
@@ -180,6 +171,30 @@ export function resolveReviewProviders(cfg: IModelsConfig): IProvider[] {
     .map((name) => modelByName(cfg.models, name))
     .filter((e): e is IModelEntry => e !== undefined)
     .map(makeProvider);
+}
+
+/** Clarify the two review config surfaces so users don't configure one and expect the other. */
+export function warnReviewConfigSplit(cfg: IModelsConfig): void {
+  const hasPanel =
+    cfg.reviewPanel !== undefined && cfg.reviewPanel.reviewers.length > 0;
+  const hasModels = (cfg.reviewModels?.length ?? 0) > 0;
+
+  if (hasPanel && !hasModels) {
+    process.stdout.write(
+      "  ↳ reviewPanel drives `tsforge harness-review` (pre-push); /review uses `reviewModels` — add reviewModels for interactive review.\n"
+    );
+  }
+}
+
+/** The active builder reviewing its own diff is allowed but worth calling out. */
+export function warnSelfReview(reviewProviders: readonly IProvider[]): void {
+  if (reviewProviders.length > 0) {
+    return;
+  }
+
+  process.stdout.write(
+    "  ⚠ no reviewModels configured — post-work /review uses the active builder model (self-review).\n"
+  );
 }
 
 /** Catch the common footgun: a cloud baseUrl paired with the leftover qwen

--- a/packages/core/src/cli/repl.ts
+++ b/packages/core/src/cli/repl.ts
@@ -129,6 +129,8 @@ import {
   makeProvider,
   resolveReviewProviders,
   warnDefaultModelOnRemote,
+  warnReviewConfigSplit,
+  warnSelfReview,
   runModelCommand,
   modelForRun,
 } from "./model-setup";
@@ -833,7 +835,11 @@ export async function repl(args: ICliArgs): Promise<number> {
   // Reviewer model(s) for the review phase — from models.json `reviewModels` or the
   // TSFORGE_REVIEW_* envs. Empty ⇒ the main model reviews (the default). Resolved
   // once at boot so the review call sites stay synchronous.
-  const reviewProviders = resolveReviewProviders(await loadModelsConfig());
+  const modelsCfg = await loadModelsConfig();
+  const reviewProviders = resolveReviewProviders(modelsCfg);
+
+  warnReviewConfigSplit(modelsCfg);
+  warnSelfReview(reviewProviders);
   const reviewStatusLabel = (): string =>
     reviewProviders.length > 1
       ? `reviewing ×${String(reviewProviders.length)}`
@@ -1311,8 +1317,10 @@ export async function repl(args: ICliArgs): Promise<number> {
       echo(
         `${paint("↳ /reviewfix", STYLE.dim, true)} to have the agent address these findings.\n`
       );
-    } catch {
-      // A review failure (git/model/fs) is non-fatal — the turn already succeeded.
+    } catch (err) {
+      echo(
+        `${paint("review skipped:", STYLE.dim, true)} ${err instanceof Error ? err.message : String(err)}\n`
+      );
     } finally {
       // Clear the review's live nodes so they don't linger until the next turn.
       resetTree();

--- a/packages/core/src/config/tsforge-config.ts
+++ b/packages/core/src/config/tsforge-config.ts
@@ -1,7 +1,11 @@
 import { join, dirname, resolve, isAbsolute } from "node:path";
 import { isRecord } from "../lib/guards";
 import { PACK_REGISTRY } from "../stack-detection";
-import { parseMcpServers, type IMcpServerConfig } from "../mcp";
+import {
+  parseMcpServers,
+  warnMcpConfigIssues,
+  type IMcpServerConfig,
+} from "../mcp";
 import {
   isPolicyMode,
   isActionKind,
@@ -653,6 +657,8 @@ function buildConfigFields(
 
   if (parsed.mcpServers !== undefined) {
     const servers = parseMcpServers(parsed.mcpServers, process.env);
+
+    warnMcpConfigIssues(parsed.mcpServers, servers, process.env);
 
     if (Object.keys(servers).length > 0) {
       configFields.mcpServers = servers;

--- a/packages/core/src/loop/review/format-card.ts
+++ b/packages/core/src/loop/review/format-card.ts
@@ -90,19 +90,32 @@ function renderFinding(
  *  findings. (The agentic reviewer reads the whole change with no file cap or diff
  *  truncation, so there are no coverage/truncation notes to show.) */
 function noteLines(report: IReviewReport, color: boolean): string[] {
-  const gateRules = report.gateFailingRules ?? [];
+  const lines: string[] = [];
+  const failed = report.failedReviewers ?? [];
 
-  if (gateRules.length === 0) {
-    return [];
+  if (failed.length > 0) {
+    lines.push(
+      paint(
+        `(${String(failed.length)} reviewer(s) failed: ${failed.join(", ")})`,
+        STYLE.yellow,
+        color
+      )
+    );
   }
 
-  return [
-    paint(
-      `(gate-aware: skipped ${String(gateRules.length)} failing gate rule(s) the gate already covers)`,
-      STYLE.dim,
-      color
-    ),
-  ];
+  const gateRules = report.gateFailingRules ?? [];
+
+  if (gateRules.length > 0) {
+    lines.push(
+      paint(
+        `(gate-aware: skipped ${String(gateRules.length)} failing gate rule(s) the gate already covers)`,
+        STYLE.dim,
+        color
+      )
+    );
+  }
+
+  return lines;
 }
 
 /**

--- a/packages/core/src/loop/review/review-agents.ts
+++ b/packages/core/src/loop/review/review-agents.ts
@@ -264,18 +264,26 @@ export async function reviewAgents(
               : { contextWindow: opts.contextWindow }),
           });
 
+          if (result.status !== "done") {
+            emit({ kind: "agent_result", ...node, passed: false });
+            log(`  ${label}: failed (${result.status})`);
+
+            return null;
+          }
+
           const mapped = findingsFrom(result.structured);
 
           emit({
             kind: "agent_result",
             ...node,
-            passed: result.status === "done",
+            passed: true,
           });
           log(`  ${label}: ${String(mapped.findings.length)} finding(s)`);
 
           return mapped;
         } catch {
           emit({ kind: "agent_result", ...node, passed: false });
+          log(`  ${label}: failed`);
 
           return null;
         }
@@ -285,9 +293,15 @@ export async function reviewAgents(
 
   const raw: IRepoFinding[] = [];
   let rejected = 0;
+  const failedReviewers: string[] = [];
 
-  for (const outcome of outcomes) {
-    if (outcome === null) {
+  for (let i = 0; i < outcomes.length; i += 1) {
+    const outcome = outcomes.at(i);
+
+    if (outcome === null || outcome === undefined) {
+      failedReviewers.push(
+        reviewers.length > 1 ? `reviewer ${String(i + 1)}` : "review"
+      );
       continue;
     }
 
@@ -312,6 +326,7 @@ export async function reviewAgents(
     rejected,
     gateFailingRules,
     totalChangedFiles: collected.totalCandidates,
+    ...(failedReviewers.length > 0 ? { failedReviewers } : {}),
   };
 }
 

--- a/packages/core/src/loop/review/review-change.ts
+++ b/packages/core/src/loop/review/review-change.ts
@@ -136,6 +136,13 @@ export function formatReport(report: IReviewReport): string {
 
   const reviewed = report.changedFiles.length;
   const gateFailingRules = report.gateFailingRules ?? [];
+  const failedReviewers = report.failedReviewers ?? [];
+  const failedNote =
+    failedReviewers.length > 0
+      ? [
+          `(${String(failedReviewers.length)} reviewer(s) failed: ${failedReviewers.join(", ")})`,
+        ]
+      : [];
   const gateNote =
     gateFailingRules.length > 0
       ? [
@@ -146,6 +153,7 @@ export function formatReport(report: IReviewReport): string {
   if (report.findings.length === 0) {
     return [
       `No issues found across ${reviewed} reviewed file(s).`,
+      ...failedNote,
       ...gateNote,
     ].join("\n");
   }
@@ -164,6 +172,7 @@ export function formatReport(report: IReviewReport): string {
   return [
     `Review of ${reviewed} changed file(s) vs ${report.base}:`,
     `${report.findings.length} finding(s).`,
+    ...failedNote,
     ...gateNote,
     "",
     ...lines,

--- a/packages/core/src/loop/review/review.types.ts
+++ b/packages/core/src/loop/review/review.types.ts
@@ -53,6 +53,8 @@ export interface IReviewReport {
    *  empty/omitted when review ran without a gate signal. Optional so a report from
    *  an older/external caller (without the field) stays valid. */
   gateFailingRules?: string[];
+  /** Reviewer labels that threw or failed before returning findings (agentic panel). */
+  failedReviewers?: string[];
   /** Total changed source files detected. Differs from `changedFiles.length` only
    *  when the caller scoped the review to a subset (`opts.files`). Kept for report
    *  bookkeeping. */

--- a/packages/core/src/mcp/config.ts
+++ b/packages/core/src/mcp/config.ts
@@ -1,6 +1,9 @@
 import { isRecord } from "../lib/guards";
 import type { IMcpServerConfig } from "./mcp.types";
 
+/** MCP server keys the curated Linear/Notion/Sentry integrations require. */
+const INTEGRATION_MCP_KEYS = ["linear", "notion", "sentry"] as const;
+
 type EnvLookup = Readonly<Record<string, string | undefined>>;
 
 /** Interpolate `${VAR}` references from `env` into a string (missing → ""). */
@@ -103,4 +106,182 @@ export function parseMcpServers(
   }
 
   return servers;
+}
+
+/** Scan a string for `${VAR}` refs that are unset or empty in `env`. */
+function emptyEnvRefs(original: string, env: EnvLookup): string[] {
+  const missing: string[] = [];
+  const re = /\$\{([A-Za-z0-9_]+)\}/g;
+  let match: RegExpExecArray | null = re.exec(original);
+
+  while (match !== null) {
+    const name = match[1] ?? "";
+    const value = env[name];
+
+    if (value === undefined || value.length === 0) {
+      missing.push(name);
+    }
+
+    match = re.exec(original);
+  }
+
+  return missing;
+}
+
+function scanRecordEnv(
+  record: Record<string, unknown> | undefined,
+  env: EnvLookup,
+  prefix: string,
+  warnings: string[]
+): void {
+  if (record === undefined) {
+    return;
+  }
+
+  for (const [key, rawVal] of Object.entries(record)) {
+    if (typeof rawVal !== "string") {
+      continue;
+    }
+
+    for (const varName of emptyEnvRefs(rawVal, env)) {
+      warnings.push(
+        `${prefix} env.${key}: \${${varName}} is unset or empty — the MCP server may start without credentials.`
+      );
+    }
+  }
+}
+
+function scanStringField(
+  original: string | undefined,
+  env: EnvLookup,
+  label: string,
+  warnings: string[]
+): void {
+  if (original === undefined) {
+    return;
+  }
+
+  for (const varName of emptyEnvRefs(original, env)) {
+    warnings.push(
+      `${label}: \${${varName}} is unset or empty — the MCP server may start misconfigured.`
+    );
+  }
+}
+
+function integrationNamingWarnings(
+  parsed: Record<string, IMcpServerConfig>
+): string[] {
+  const warnings: string[] = [];
+  const keys = new Set(Object.keys(parsed));
+
+  for (const expected of INTEGRATION_MCP_KEYS) {
+    if (!keys.has(expected)) {
+      const near = Object.keys(parsed).filter((k) =>
+        k.toLowerCase().includes(expected)
+      );
+
+      if (near.length > 0) {
+        warnings.push(
+          `mcpServers: integration "${expected}" must be keyed exactly "${expected}" (found: ${near.join(", ")}) — curated ${expected}_* tools stay disabled.`
+        );
+      }
+    }
+  }
+
+  if (INTEGRATION_MCP_KEYS.every((s) => !keys.has(s))) {
+    warnings.push(
+      `mcpServers: no integration keys (${INTEGRATION_MCP_KEYS.join(", ")}) — Linear/Notion/Sentry curated tools need servers keyed exactly those names.`
+    );
+  }
+
+  return warnings;
+}
+
+function scanArgsEnv(
+  args: unknown,
+  env: EnvLookup,
+  prefix: string,
+  warnings: string[]
+): void {
+  if (!Array.isArray(args)) {
+    return;
+  }
+
+  for (const [i, entry] of args.entries()) {
+    if (typeof entry !== "string") {
+      continue;
+    }
+
+    for (const varName of emptyEnvRefs(entry, env)) {
+      warnings.push(
+        `${prefix}.args[${String(i)}]: \${${varName}} is unset or empty.`
+      );
+    }
+  }
+}
+
+function scanOneMcpServerEntry(
+  name: string,
+  value: Record<string, unknown>,
+  env: EnvLookup,
+  warnings: string[]
+): void {
+  const prefix = `mcpServers.${name}`;
+
+  scanStringField(
+    typeof value.command === "string" ? value.command : undefined,
+    env,
+    `${prefix}.command`,
+    warnings
+  );
+  scanStringField(
+    typeof value.url === "string" ? value.url : undefined,
+    env,
+    `${prefix}.url`,
+    warnings
+  );
+  scanRecordEnv(
+    isRecord(value.env) ? value.env : undefined,
+    env,
+    prefix,
+    warnings
+  );
+  scanArgsEnv(value.args, env, prefix, warnings);
+}
+
+/**
+ * Config-time diagnostics for MCP servers: empty env interpolation and
+ * integration server naming (Linear/Notion/Sentry require exact keys).
+ */
+export function diagnoseMcpServers(
+  raw: unknown,
+  parsed: Record<string, IMcpServerConfig>,
+  env: EnvLookup
+): string[] {
+  if (!isRecord(raw) || Object.keys(parsed).length === 0) {
+    return [];
+  }
+
+  const warnings = integrationNamingWarnings(parsed);
+
+  for (const [name, value] of Object.entries(raw)) {
+    if (!isRecord(value) || parsed[name] === undefined) {
+      continue;
+    }
+
+    scanOneMcpServerEntry(name, value, env, warnings);
+  }
+
+  return warnings;
+}
+
+/** Emit MCP config diagnostics to stderr (load-time footgun prevention). */
+export function warnMcpConfigIssues(
+  raw: unknown,
+  parsed: Record<string, IMcpServerConfig>,
+  env: EnvLookup
+): void {
+  for (const line of diagnoseMcpServers(raw, parsed, env)) {
+    process.stderr.write(`  ⚠ ${line}\n`);
+  }
 }

--- a/packages/core/src/mcp/index.ts
+++ b/packages/core/src/mcp/index.ts
@@ -6,6 +6,11 @@ export type {
 export { McpRegistry } from "./registry";
 export { connectMcpServers } from "./setup";
 export { StdioMcpTransport } from "./stdio-transport";
-export { parseMcpServers, interpolateEnv } from "./config";
+export {
+  parseMcpServers,
+  interpolateEnv,
+  diagnoseMcpServers,
+  warnMcpConfigIssues,
+} from "./config";
 export { mcpToolName, mapMcpTool, type IToolSchema } from "./schema-mapping";
 export { LineDecoder, encodeMessage } from "./jsonrpc";

--- a/packages/core/src/reviewers/registry.ts
+++ b/packages/core/src/reviewers/registry.ts
@@ -234,3 +234,21 @@ export function resolvePanel(
 
   return { reviewers, minReviewers, skipped };
 }
+
+/** Warn when the resolved panel cannot satisfy its quorum floor. */
+export function warnPanelQuorum(panel: IPanel): void {
+  if (panel.reviewers.length >= panel.minReviewers) {
+    return;
+  }
+
+  const have = String(panel.reviewers.length);
+  const need = String(panel.minReviewers);
+  const skipped =
+    panel.skipped.length > 0
+      ? ` (${String(panel.skipped.length)} skipped: ${panel.skipped.map((s) => s.id).join(", ")})`
+      : "";
+
+  process.stderr.write(
+    `  ⚠ reviewPanel: only ${have} reviewer(s) resolved but minReviewers is ${need}${skipped} — harness-review will block with noQuorum until the panel is fixed.\n`
+  );
+}

--- a/packages/core/tests/dirty-packages.test.ts
+++ b/packages/core/tests/dirty-packages.test.ts
@@ -63,7 +63,7 @@ describe("dirty-packages — git-baseline detection (the FG-1 seam)", () => {
     } finally {
       await rm(container, { recursive: true, force: true });
     }
-  });
+  }, 30_000);
 
   test("a write followed by a COMMIT inside the child still counts (HEAD moved)", async () => {
     const container = await mkdtemp(join(tmpdir(), "tsforge-dirty-commit-"));
@@ -92,7 +92,7 @@ describe("dirty-packages — git-baseline detection (the FG-1 seam)", () => {
     } finally {
       await rm(container, { recursive: true, force: true });
     }
-  });
+  }, 30_000);
 
   test("a pre-existing dirty tree is NOT dragged in (baseline diffing, not absolute dirtiness)", async () => {
     const container = await mkdtemp(join(tmpdir(), "tsforge-dirty-pre-"));

--- a/packages/core/tests/harness-review-mode.test.ts
+++ b/packages/core/tests/harness-review-mode.test.ts
@@ -1,5 +1,8 @@
 import { test, expect, describe } from "bun:test";
-import { buildReviewFlowDeps } from "../src/cli/harness-review-mode";
+import {
+  buildReviewFlowDeps,
+  effectiveReviewPanel,
+} from "../src/cli/harness-review-mode";
 import { panelIdentityHash } from "../src/reviewers/harness-review";
 import type { IReviewRequest } from "../src/reviewers/schema";
 import type { IPanel } from "../src/reviewers/registry";
@@ -165,11 +168,9 @@ describe("buildReviewFlowDeps (CLI wiring)", () => {
 
     expect(quick.rosterHash).not.toBe(full.rosterHash);
     expect(quick.rosterHash).toBe(
-      panelIdentityHash(
-        { ...twoReviewers, reviewers: twoReviewers.reviewers.slice(0, 1) },
-        "local/flash"
-      )
+      panelIdentityHash(effectiveReviewPanel(twoReviewers, true), "local/flash")
     );
+    expect(effectiveReviewPanel(twoReviewers, true).minReviewers).toBe(1);
   });
 
   test("mode maps from --quick and ci maps from --ci", () => {

--- a/packages/core/tests/mcp-unit.test.ts
+++ b/packages/core/tests/mcp-unit.test.ts
@@ -5,6 +5,7 @@ import {
   McpRegistry,
   parseMcpServers,
   interpolateEnv,
+  diagnoseMcpServers,
   mcpToolName,
   mapMcpTool,
   type IMcpToolInfo,
@@ -168,6 +169,20 @@ describe("mcp: config parsing", () => {
 
     expect(ok.s?.type).toBe("http");
     expect(bad.s).toBeUndefined();
+  });
+
+  test("diagnoseMcpServers flags empty env interpolation and misnamed integration keys", () => {
+    const raw = {
+      "linear-mcp": { command: "linear", env: { TOKEN: "${MISSING}" } },
+      ctx7: { command: "npx", args: ["-y", "mcp"] },
+    };
+    const parsed = parseMcpServers(raw, {});
+
+    const warnings = diagnoseMcpServers(raw, parsed, {});
+
+    expect(warnings.some((w) => w.includes("linear-mcp"))).toBe(true);
+    expect(warnings.some((w) => w.includes("MISSING"))).toBe(true);
+    expect(warnings.some((w) => w.includes("no integration keys"))).toBe(true);
   });
 });
 

--- a/packages/core/tests/policy-integration.test.ts
+++ b/packages/core/tests/policy-integration.test.ts
@@ -4,6 +4,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { executeTool, type IToolContext } from "../src/loop/tools";
 import { McpRegistry } from "../src/mcp";
+import { TOOL_NAME } from "../src/agent";
 import type { PolicyMode } from "../src/policy";
 
 async function withDir<T>(fn: (dir: string) => Promise<T>): Promise<T> {
@@ -139,6 +140,43 @@ describe("policy integration — every tool routes through the policy", () => {
 
       expect(out.toLowerCase()).not.toContain("policy deny");
       expect(await Bun.file(join(dir, "ok.ts")).exists()).toBe(true);
+    });
+  });
+
+  test("plan/ci deny integration and GitHub writes before handlers run", async () => {
+    await withDir(async (dir) => {
+      const capCtx = (mode: PolicyMode): IToolContext =>
+        ctx(dir, mode, {
+          github: true,
+          linear: true,
+          notion: true,
+          sentry: true,
+        });
+
+      for (const mode of ["plan", "ci"] as const) {
+        for (const call of [
+          {
+            name: TOOL_NAME.githubWrite,
+            arguments: { op: "pr_comment", body: "Looks good.", pr: "1" },
+          },
+          {
+            name: TOOL_NAME.linearWrite,
+            arguments: { op: "comment", id: "ENG-1", body: "Ship it." },
+          },
+          {
+            name: TOOL_NAME.notionWrite,
+            arguments: { op: "append", id: "page-1", content: "Note." },
+          },
+          {
+            name: TOOL_NAME.sentryWrite,
+            arguments: { op: "resolve", id: "issue-1" },
+          },
+        ]) {
+          const out = await executeTool(call, capCtx(mode));
+
+          expect(out.toLowerCase()).toContain("policy deny");
+        }
+      }
     });
   });
 });

--- a/packages/core/tests/review-agents.test.ts
+++ b/packages/core/tests/review-agents.test.ts
@@ -163,3 +163,19 @@ test("no changed files → empty report, no agents", async () => {
   expect(report.changedFiles).toHaveLength(0);
   expect(report.findings).toHaveLength(0);
 });
+
+test("a failed reviewer is surfaced on the report when another succeeds", async () => {
+  const failing: IProvider = {
+    async complete() {
+      throw new Error("reviewer down");
+    },
+  };
+
+  const report = await reviewAgents(reviewerStub("discount.ts:2"), repo, {
+    reviewProviders: [failing, reviewerStub("discount.ts:2")],
+    concurrency: 2,
+  });
+
+  expect(report.findings).toHaveLength(1);
+  expect(report.failedReviewers).toEqual(["reviewer 1"]);
+});

--- a/packages/core/tests/reviewers-registry.test.ts
+++ b/packages/core/tests/reviewers-registry.test.ts
@@ -1,5 +1,9 @@
-import { test, expect, describe } from "bun:test";
-import { resolvePanel, MIN_REVIEWERS_FLOOR } from "../src/reviewers/registry";
+import { test, expect, describe, spyOn, afterEach } from "bun:test";
+import {
+  resolvePanel,
+  warnPanelQuorum,
+  MIN_REVIEWERS_FLOOR,
+} from "../src/reviewers/registry";
 import type { IModelsConfig } from "../src/models-config";
 
 function cfg(over: Partial<IModelsConfig>): IModelsConfig {
@@ -107,5 +111,30 @@ describe("resolvePanel independence", () => {
 
     expect(p.reviewers).toEqual([]);
     expect(p.minReviewers).toBe(MIN_REVIEWERS_FLOOR);
+  });
+});
+
+describe("warnPanelQuorum", () => {
+  afterEach(() => {
+    spyOn(process.stderr, "write").mockRestore();
+  });
+
+  test("warns when resolved reviewers cannot satisfy minReviewers", () => {
+    const spy = spyOn(process.stderr, "write").mockImplementation(() => true);
+    const panel = resolvePanel(
+      cfg({
+        reviewPanel: {
+          minReviewers: 3,
+          reviewers: [{ kind: "model", id: "opus", entry: "opus" }],
+        },
+      }),
+      active
+    );
+
+    warnPanelQuorum(panel);
+
+    expect(spy.mock.calls.some((c) => String(c[0]).includes("noQuorum"))).toBe(
+      true
+    );
   });
 });

--- a/packages/core/tests/tool-accounting.test.ts
+++ b/packages/core/tests/tool-accounting.test.ts
@@ -1,4 +1,4 @@
-import { test, expect } from "bun:test";
+import { test, expect, spyOn } from "bun:test";
 import { existsSync } from "node:fs";
 import { mkdtemp, rm, mkdir, chmod } from "node:fs/promises";
 import { tmpdir } from "node:os";
@@ -13,6 +13,7 @@ import {
 import { TsService } from "../src/lsp";
 import { TOOL_NAME, READ_ONLY_TOOL_NAMES } from "../src/agent";
 import { commandGate } from "../src/gate/gate-runner";
+import * as writeGuardMod from "../src/loop/write-guard";
 
 // P1 (review): add_dependency rewrites package.json even in a narrow-scoped task
 // where it isn't in the editable globs. That sanctioned manifest change MUST still
@@ -251,6 +252,70 @@ test("a move_file re-gates even though it is not an edit/create", async () => {
     // The moved file joins the change scope (so test-sibling et al. cover it).
     expect([...(ctx.tool.touched ?? [])]).toContain("lib/types.ts");
   } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+// Semantic mutations re-gate but skip the per-write guard (the model did not
+// hand-write those paths — runWriteGuard is for edit/create only).
+test("move_file re-gates without invoking runWriteGuard", async () => {
+  const dir = await mkdtemp(join(tmpdir(), "tsforge-acct-wg-skip-"));
+  const guardSpy = spyOn(writeGuardMod, "runWriteGuard").mockResolvedValue(
+    "\n[write-guard-marker]"
+  );
+
+  try {
+    await Bun.write(
+      join(dir, "tsconfig.json"),
+      JSON.stringify({
+        compilerOptions: {
+          target: "ES2022",
+          module: "ES2022",
+          moduleResolution: "bundler",
+          strict: true,
+          skipLibCheck: true,
+        },
+        include: ["**/*.ts"],
+      })
+    );
+    await Bun.write(
+      join(dir, "types.ts"),
+      "export interface IThing {\n  value: number;\n}\n"
+    );
+    await Bun.write(
+      join(dir, "use.ts"),
+      'import type { IThing } from "./types";\nexport const f = (t: IThing): number => t.value;\n'
+    );
+
+    const task = { id: "t", accept: "true", files: ["**/*"] };
+    const ctx: ILoopCtx = {
+      task,
+      cwd: dir,
+      tsService: new TsService(dir),
+      report: () => undefined,
+      messages: [],
+      tool: {},
+      gate: {
+        parse: undefined,
+        runner: commandGate(task, undefined),
+      },
+    };
+    const state = freshState();
+    const touched = await runToolCalls(
+      [
+        {
+          name: "move_file",
+          arguments: { from: "types.ts", to: "lib/types.ts" },
+        },
+      ],
+      ctx,
+      state
+    );
+
+    expect(touched).toBe(true);
+    expect(guardSpy.mock.calls.length).toBe(0);
+  } finally {
+    guardSpy.mockRestore();
     await rm(dir, { recursive: true, force: true });
   }
 });


### PR DESCRIPTION
## Summary

- Fix `--quick` harness review inheriting a full-panel quorum (quick mode now uses `minReviewers: 1`).
- Surface agentic review partial failures via `failedReviewers` on reports and TUI cards.
- Add config-time warnings for reviewPanel vs reviewModels, self-review fallback, MCP integration naming, and empty `${VAR}` secrets.
- Warn when harness review panel cannot satisfy `minReviewers`; log post-green review skip reasons in the REPL.
- Harden tests: dirty-packages timeout flake, integration write policy in plan/ci, semantic mutation write-guard skip, reviewer failure reporting.
- Add Phase 3 decomposition plan for `session.ts` / `turn.ts`.

## Test plan

- [x] `bun run ci:local` green locally
- [x] New/updated unit tests for review quorum, MCP diagnostics, policy integration, review agents, tool accounting