### PR TITLE
Fix Gate rail surface cycling on Mac terminals

### DIFF
--- a/apps/docs/src/content/docs/cli/interactive.mdx
+++ b/apps/docs/src/content/docs/cli/interactive.mdx
@@ -68,7 +68,7 @@ On a tall enough terminal, tsforge opens a **two-column pane console**: transcri
 | Action                        | Default chord                          |
 | ----------------------------- | -------------------------------------- |
 | Toggle rail                   | `ctrl+g`                               |
-| Cycle Tasks ↔ Gate            | `ctrl+shift+g`                         |
+| Cycle Tasks ↔ Gate            | `f6` (also `ctrl+shift+g` when your terminal sends modifyOtherKeys) |
 | Focus rail / return to prompt | `Tab` / `Esc`                          |
 | Move selection                | `↑`/`↓` or `k`/`j` (when rail focused) |
 | Keymap overlay                | `?` (idle, empty prompt)               |

--- a/apps/docs/src/content/docs/guardrails/config.mdx
+++ b/apps/docs/src/content/docs/guardrails/config.mdx
@@ -89,7 +89,7 @@ Optional pane-console shortcuts under `tui.keybindings` in `tsforge.config.json`
 | Action id | Default | Purpose |
 | --- | --- | --- |
 | `pane.toggle` | `ctrl+g` | show/hide the right rail |
-| `pane.cycleSurface` | `ctrl+shift+g` | Tasks ↔ Gate |
+| `pane.cycleSurface` | `f6`, `ctrl+shift+g` | Tasks ↔ Gate |
 | `pane.focus` | `tab` | focus rail when visible |
 | `pane.unfocus` | `escape` | return to prompt |
 | `pane.moveUp` / `pane.moveDown` | `up`/`k`, `down`/`j` | selection when rail focused |

--- a/packages/core/src/cli/repl.ts
+++ b/packages/core/src/cli/repl.ts
@@ -2079,7 +2079,10 @@ export async function repl(args: ICliArgs): Promise<number> {
 
   const railHasItems = (): boolean => {
     if (paneScreen.focusState.railSurface === "gate") {
-      return gateView.gateConfigured;
+      // Gate surface always keeps the rail open — formatGateLines renders the
+      // empty / not-configured states; gating on gateConfigured hid the rail the
+      // moment the user cycled to Gate.
+      return true;
     }
 
     return railPlan !== null && railPlan.items.length > 0;

--- a/packages/core/src/config/tui-keybindings.ts
+++ b/packages/core/src/config/tui-keybindings.ts
@@ -28,7 +28,9 @@ export const DEFAULT_TUI_KEYBINDINGS: Readonly<
   Record<TuiPaneAction, readonly string[]>
 > = {
   "pane.toggle": ["ctrl+g"],
-  "pane.cycleSurface": ["ctrl+shift+g"],
+  // f6 first: ctrl+shift+letter needs Kitty/modifyOtherKeys; many Mac terminals
+  // (incl. Cursor) send plain "G" instead, which would type into the prompt.
+  "pane.cycleSurface": ["f6", "ctrl+shift+g"],
   "pane.focus": ["tab"],
   "pane.unfocus": ["escape"],
   "pane.moveUp": ["up", "k"],
@@ -333,6 +335,10 @@ export function matchPaneAction(
 function parseKeybindingsBlock(
   value: unknown
 ): Partial<Record<TuiPaneAction, string | readonly string[]>> {
+  if (value === undefined) {
+    return {};
+  }
+
   if (!isRecord(value)) {
     warnKeybinding('tsforge: "tui.keybindings" must be an object — ignored');
 

--- a/packages/core/src/render/frame/focus.ts
+++ b/packages/core/src/render/frame/focus.ts
@@ -79,9 +79,22 @@ export class PaneFocus {
    */
   togglePanel(hasItems: boolean): FocusAction {
     if (!this.userCollapsed) {
-      this.userCollapsed = true;
-      this.panel = "hidden";
-      this.active = "prompt";
+      if (this.panel !== "hidden") {
+        this.userCollapsed = true;
+        this.panel = "hidden";
+        this.active = "prompt";
+
+        return "changed";
+      }
+
+      // Auto-hidden (no checklist yet) — first Ctrl+G opens, don't arm collapse.
+      if (hasItems) {
+        this.panel = "visibleFocused";
+        this.active = "panel";
+      } else {
+        this.panel = "visibleUnfocused";
+        this.active = "prompt";
+      }
 
       return "changed";
     }
@@ -99,10 +112,14 @@ export class PaneFocus {
     return "changed";
   }
 
-  /** Cycle Tasks ↔ Gate when the rail is visible. Resets row selection. */
+  /** Cycle Tasks ↔ Gate when the rail column is shown (!userCollapsed). Resets row selection. */
   cycleSurface(): FocusAction {
-    if (this.userCollapsed || this.panel === "hidden") {
+    if (this.userCollapsed) {
       return "ignored";
+    }
+
+    if (this.panel === "hidden") {
+      this.panel = "visibleUnfocused";
     }
 
     this.railSurface = this.railSurface === "tasks" ? "gate" : "tasks";

--- a/packages/core/src/render/frame/pane-keys.ts
+++ b/packages/core/src/render/frame/pane-keys.ts
@@ -38,6 +38,7 @@ function handleToggle(deps: IPaneKeyDeps): PaneKeyResult {
 
 function handleCycleSurface(deps: IPaneKeyDeps): PaneKeyResult {
   if (deps.focus.cycleSurface() === "changed") {
+    deps.invalidate();
     deps.onRailRefresh?.();
     deps.paint();
   }

--- a/packages/core/tests/focus.test.ts
+++ b/packages/core/tests/focus.test.ts
@@ -2,6 +2,17 @@ import { test, expect, describe } from "bun:test";
 import { PaneFocus } from "../src/render/frame/focus";
 
 describe("PaneFocus", () => {
+  test("togglePanel opens auto-hidden rail on first Ctrl+G", () => {
+    const f = new PaneFocus();
+
+    expect(f.panel).toBe("hidden");
+    expect(f.userCollapsed).toBe(false);
+
+    expect(f.togglePanel(false)).toBe("changed");
+    expect(f.panel).toBe("visibleUnfocused");
+    expect(f.userCollapsed).toBe(false);
+  });
+
   test("togglePanel hides and shows (Ctrl+G visibility)", () => {
     const f = new PaneFocus();
 
@@ -85,13 +96,22 @@ describe("PaneFocus", () => {
     expect(f.railSurface).toBe("tasks");
   });
 
-  test("cycleSurface ignored when panel hidden", () => {
+  test("cycleSurface ignored when user collapsed the rail", () => {
     const f = new PaneFocus();
 
     f.syncHasItems(true);
     f.togglePanel(true);
     expect(f.cycleSurface()).toBe("ignored");
     expect(f.railSurface).toBe("tasks");
+  });
+
+  test("cycleSurface works when rail column is up but panel state is hidden (empty checklist)", () => {
+    const f = new PaneFocus();
+
+    expect(f.panel).toBe("hidden");
+    expect(f.cycleSurface()).toBe("changed");
+    expect(f.railSurface).toBe("gate");
+    expect(f.panel).toBe("visibleUnfocused");
   });
 
   test("emptied worklist hides the panel but keeps a user collapse", () => {

--- a/packages/core/tests/frame-tui.test.ts
+++ b/packages/core/tests/frame-tui.test.ts
@@ -638,6 +638,27 @@ describe("PaneScreen", () => {
     expect(term.writes.length).toBeGreaterThan(afterEnter);
   });
 
+  test("F6 cycles Tasks rail title to Gate (full repaint, not scroll-only patch)", () => {
+    const term = new FakeTerm();
+    const panes = new PaneScreen(term, 24, 100);
+
+    panes.enter();
+    panes.setPanel(["worklist  0/1", "[>] First"]);
+    expect(panes.focusState.panel).toBe("visibleUnfocused");
+
+    panes.handleKey("\x07");
+    panes.handleKey("\x07");
+    expect(term.text()).toContain("Tasks");
+
+    term.writes = [];
+    panes.handleKey("\x1b[17~");
+    panes.flushPendingPaint();
+
+    expect(panes.focusState.railSurface).toBe("gate");
+    expect(term.text()).toContain("Gate");
+    expect(term.text()).not.toContain("Tasks");
+  });
+
   test("Ctrl+O requests dump; scrollMain moves transcript", () => {
     const term = new FakeTerm();
     const panes = new PaneScreen(term, 24, 100);

--- a/packages/core/tests/pane-keys.test.ts
+++ b/packages/core/tests/pane-keys.test.ts
@@ -76,23 +76,33 @@ describe("handleFocusKey", () => {
     expect(handleFocusKey("\r", d)).toBeNull();
   });
 
-  test("cycle surface binding toggles railSurface", () => {
+  test("cycle surface binding toggles railSurface and invalidates frame", () => {
     const bindings = resolveTuiKeybindings();
+    let invalidated = 0;
     const d = {
       ...deps(),
       keybindings: bindings,
       refreshed: 0,
+      invalidate: () => {
+        invalidated += 1;
+      },
       onRailRefresh: () => {
         d.refreshed += 1;
       },
     };
 
     expect(d.focus.railSurface).toBe("tasks");
-    expect(handleFocusKey(`${String.fromCharCode(27)}[103;6u`, d)).toBe(
-      "handled"
-    );
+    expect(handleFocusKey(`${String.fromCharCode(27)}[17~`, d)).toBe("handled");
     expect(d.focus.railSurface).toBe("gate");
+    expect(invalidated).toBe(1);
     expect(d.refreshed).toBe(1);
+  });
+
+  test("plain G passthrough does not cycle surface", () => {
+    const d = deps();
+
+    expect(handleFocusKey("G", d)).toBeNull();
+    expect(d.focus.railSurface).toBe("tasks");
   });
 });
 

--- a/packages/core/tests/tui-keybindings.test.ts
+++ b/packages/core/tests/tui-keybindings.test.ts
@@ -27,11 +27,26 @@ describe("tui-keybindings", () => {
     expect(matchPaneAction("\x1c", bindings)).toBe("pane.toggle");
   });
 
-  test("ctrl+shift+g cycles surface", () => {
+  test("ctrl+shift+g still matches when terminal sends CSI-u", () => {
     const bindings = resolveTuiKeybindings();
     const csi = `${String.fromCharCode(27)}[103;6u`;
 
     expect(matchPaneAction(csi, bindings)).toBe("pane.cycleSurface");
+  });
+
+  test("f6 is the primary default cycle chord", () => {
+    const bindings = resolveTuiKeybindings();
+    const f6 = `${String.fromCharCode(27)}[17~`;
+
+    expect(bindings.display["pane.cycleSurface"][0]).toBe("f6");
+    expect(matchPaneAction(f6, bindings)).toBe("pane.cycleSurface");
+  });
+
+  test("plain G does not match cycle (Mac/Cursor without modifyOtherKeys)", () => {
+    const bindings = resolveTuiKeybindings();
+
+    expect(matchPaneAction("G", bindings)).toBeNull();
+    expect(matchPaneAction("g", bindings)).toBeNull();
   });
 
   test("invalid chord is dropped with warning", () => {

--- a/scripts/e2e-iterm-panes.py
+++ b/scripts/e2e-iterm-panes.py
@@ -43,8 +43,9 @@ def main() -> int:
 
     set_winsize(master, 24, 100)
     buf = b""
-    deadline = time.time() + 8.0
+    deadline = time.time() + 20.0
     saw_enter = False
+    keys_sent = False
 
     try:
         while time.time() < deadline:
@@ -56,15 +57,30 @@ def main() -> int:
                 buf += chunk
                 if ENTER_ALT in buf:
                     saw_enter = True
-                    # Show rail, cycle to Gate, then exit.
-                    os.write(master, b"\x07")
-                    time.sleep(0.2)
-                    os.write(master, b"\x1b[103;6u")
+                text = buf.decode("utf-8", "replace")
+                # Wait until the editor is accepting input — keys sent too early
+                # (right after alt-screen enter) are lost or go to the wrong layer.
+                if (
+                    saw_enter
+                    and not keys_sent
+                    and "describe a task" in text.lower()
+                ):
+                    keys_sent = True
+                    # Rail is visible at idle — cycle directly (do not Ctrl+G: that hides it).
                     time.sleep(0.3)
-                    os.write(master, b"/copy\n")
-                    time.sleep(0.3)
+                    os.write(master, b"\x1b[17~")
+                    time.sleep(0.8)
                     os.write(master, b"/exit\n")
-                    time.sleep(0.5)
+                    # Keep reading until the child exits so Gate repaint lands in buf.
+                    exit_deadline = time.time() + 5.0
+                    while time.time() < exit_deadline:
+                        r2, _, _ = select.select([master], [], [], 0.2)
+                        if master not in r2:
+                            continue
+                        chunk2 = os.read(master, 4096)
+                        if not chunk2:
+                            break
+                        buf += chunk2
                     break
     finally:
         try:
@@ -79,6 +95,10 @@ def main() -> int:
     if not saw_enter:
         sys.stderr.write("e2e-iterm-panes: never saw alternate-screen enter\n")
         sys.stderr.write(buf[-2000:].decode("utf-8", "replace"))
+        return 1
+
+    if not keys_sent:
+        sys.stderr.write("e2e-iterm-panes: prompt never became ready for key injection\n")
         return 1
 
     text = buf.decode("utf-8", "replace")


### PR DESCRIPTION
## Summary
- **Default cycle chord is `F6`** — `ctrl+shift+g` only works when the terminal sends Kitty/modifyOtherKeys; Mac/Cursor often emit plain `G` into the prompt instead.
- **`cycleSurface()` works at idle** when the rail column is painted but `focusState.panel` was still `"hidden"` (empty checklist) — the main reason cycling appeared dead after #337.
- **Surface switch forces full repaint** (`invalidate()` on cycle) so the panel title actually changes Tasks → Gate.
- **Ctrl+G from auto-hidden opens the rail** instead of arming collapse on an already-hidden panel.
- **Gate surface keeps the rail open** even when gate is not configured (empty state copy).
- **Pane e2e** waits for the prompt, injects `F6`, drains stdout — no longer relies on CSI-u or a single Ctrl+G.

## Test plan
- [x] `bun test` — focus, tui-keybindings, pane-keys, frame-tui (F6 title repaint), gate-panel
- [x] `python3 scripts/e2e-iterm-panes.py` — Gate title observed after F6
- [x] `bun run ci:local` (rules + arch + validate + e2e PTY)

## Usage
With the rail visible (default on a wide TTY): press **`F6`** to cycle Tasks ↔ Gate. Press **`?`** at idle for effective bindings.