### PR TITLE
chore: point GitHub URLs and CI at boringstack-xyz/tsforge

### DIFF
--- a/.github/desired-repo-settings.json
+++ b/.github/desired-repo-settings.json
@@ -1,5 +1,5 @@
 {
-  "description": "Desired GitHub settings for agjs/tsforge (mirrors boringstack-xyz/boringstack). Applied via scripts/audit-repo-settings.sh. Note: branch protection + GitHub secret scanning require a public repo or GitHub Pro on private repos — merge settings apply on all plans.",
+  "description": "Desired GitHub settings for boringstack-xyz/tsforge (mirrors boringstack-xyz/boringstack). Applied via scripts/audit-repo-settings.sh. Note: branch protection + GitHub secret scanning require a public repo or GitHub Pro on private repos — merge settings apply on all plans.",
   "security_and_analysis": {
     "secret_scanning": "enabled",
     "secret_scanning_push_protection": "enabled",

--- a/.github/workflows/docs-linkcheck.yml
+++ b/.github/workflows/docs-linkcheck.yml
@@ -92,7 +92,7 @@ jobs:
             --max-retries 0
             --root-dir ${{ github.workspace }}/apps/docs/dist
             --exclude '^https?://(localhost|127\.0\.0\.1|.*\.localhost)'
-            --exclude 'github\.com/agjs/tsforge'
+            --exclude 'github\.com/boringstack-xyz/tsforge'
             '${{ github.workspace }}/apps/docs/dist/**/*.html'
           fail: false
         env:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -39,7 +39,7 @@ CI runs on every PR and push to `main` — see the workflow table in `CONTRIBUTI
 before every push. `bun run validate` alone is not enough — CI fails on ARCHITECTURE.md
 / RULES.md drift even when validate is green.
 
-Remote: https://github.com/agjs/tsforge
+Remote: https://github.com/boringstack-xyz/tsforge
 
 ## House rules
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 <p align="center">
   <a href="https://tsforge.dev"><img src="https://img.shields.io/badge/tsforge.dev-2563eb?style=for-the-badge&logo=safari&logoColor=2563eb&labelColor=090909" alt="tsforge.dev"></a>
-  <a href="https://github.com/agjs/tsforge"><img src="https://img.shields.io/badge/GitHub-2563eb?style=for-the-badge&logo=github&logoColor=2563eb&labelColor=090909" alt="GitHub"></a>
+  <a href="https://github.com/boringstack-xyz/tsforge"><img src="https://img.shields.io/badge/GitHub-2563eb?style=for-the-badge&logo=github&logoColor=2563eb&labelColor=090909" alt="GitHub"></a>
   <a href="https://tsforge.dev/quickstart/"><img src="https://img.shields.io/badge/Quickstart-2563eb?style=for-the-badge&logo=readthedocs&logoColor=2563eb&labelColor=090909" alt="Quickstart"></a>
 </p>
 
@@ -22,8 +22,8 @@
 </p>
 
 <p align="center">
-  <a href="https://github.com/agjs/tsforge/tree/main/packages/core"><img src="https://img.shields.io/badge/packages--core-2563eb?style=for-the-badge&labelColor=090909" alt="packages/core"></a>
-  <a href="https://github.com/agjs/tsforge/tree/main/apps/docs"><img src="https://img.shields.io/badge/apps--docs-2563eb?style=for-the-badge&labelColor=090909" alt="apps/docs"></a>
+  <a href="https://github.com/boringstack-xyz/tsforge/tree/main/packages/core"><img src="https://img.shields.io/badge/packages--core-2563eb?style=for-the-badge&labelColor=090909" alt="packages/core"></a>
+  <a href="https://github.com/boringstack-xyz/tsforge/tree/main/apps/docs"><img src="https://img.shields.io/badge/apps--docs-2563eb?style=for-the-badge&labelColor=090909" alt="apps/docs"></a>
 </p>
 
 Documentation lives at [tsforge.dev](https://tsforge.dev). Start with the [Quickstart](https://tsforge.dev/quickstart/).

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -16,6 +16,6 @@ tsforge is a local AI coding harness. Treat it like running an untrusted develop
 
 ## Reporting
 
-Report vulnerabilities via [GitHub security advisories](https://github.com/agjs/tsforge/security/advisories/new) on agjs/tsforge.
+Report vulnerabilities via [GitHub security advisories](https://github.com/boringstack-xyz/tsforge/security/advisories/new) on boringstack-xyz/tsforge.
 
 Do not open public issues for exploitable findings.

--- a/apps/docs/DEPLOY.md
+++ b/apps/docs/DEPLOY.md
@@ -8,7 +8,7 @@ The site in `apps/docs/` is an [Astro Starlight](https://starlight.astro.build) 
 
 2. **Create a Pages project.**
    - Cloudflare dashboard → Workers & Pages → Create application → Pages → Connect to Git.
-   - Authorize GitHub and select the `agjs/tsforge` repository.
+   - Authorize GitHub and select the `boringstack-xyz/tsforge` repository.
    - Project name: `tsforge-docs` (becomes the `*.pages.dev` subdomain).
 
 3. **Build settings.**

--- a/apps/docs/DEPLOY.md
+++ b/apps/docs/DEPLOY.md
@@ -9,7 +9,7 @@ The site in `apps/docs/` is an [Astro Starlight](https://starlight.astro.build) 
 2. **Create a Pages project.**
    - Cloudflare dashboard → Workers & Pages → Create application → Pages → Connect to Git.
    - Authorize GitHub and select the `boringstack-xyz/tsforge` repository.
-   - Project name: `tsforge-docs` (becomes the `*.pages.dev` subdomain).
+   - Project name: `tsforge` (must match `wrangler.jsonc` `name`; becomes the `*.pages.dev` subdomain).
 
 3. **Build settings.**
 
@@ -42,7 +42,7 @@ The rule catalog page is generated at build time from `packages/core/RULES.md` v
 ## How deploys work
 
 - Push to `main` (docs paths) → Cloudflare auto-builds with `bun run build:ci`.
-- Pushes to other branches → preview deployment at `<branch>.tsforge-docs.pages.dev`.
+- Pushes to other branches → preview deployment at `<branch>.tsforge.pages.dev`.
 - Manual production deploy: `bun run deploy` (runs `build:ci` then `wrangler deploy`).
 - Rollback: Pages dashboard → Deployments → pick a previous deployment → Rollback.
 

--- a/apps/docs/astro.config.mjs
+++ b/apps/docs/astro.config.mjs
@@ -149,11 +149,11 @@ export default defineConfig({
         {
           icon: "github",
           label: "GitHub",
-          href: "https://github.com/agjs/tsforge",
+          href: "https://github.com/boringstack-xyz/tsforge",
         },
       ],
       editLink: {
-        baseUrl: "https://github.com/agjs/tsforge/edit/main/apps/docs/",
+        baseUrl: "https://github.com/boringstack-xyz/tsforge/edit/main/apps/docs/",
       },
       lastUpdated: true,
       sidebar: [

--- a/apps/docs/public/install.sh
+++ b/apps/docs/public/install.sh
@@ -7,12 +7,12 @@
 # Environment:
 #   TSFORGE_REF=main|v0.1.0     git ref when installing from GitHub (default: main)
 #   TSFORGE_LIB=~/.local/share/tsforge   clone location for git install
-#   TSFORGE_REPO=https://github.com/agjs/tsforge.git
+#   TSFORGE_REPO=https://github.com/boringstack-xyz/tsforge.git
 #   BUN_INSTALL=~/.bun          Bun install root (installed automatically if missing)
 
 set -euo pipefail
 
-TSFORGE_REPO="${TSFORGE_REPO:-https://github.com/agjs/tsforge.git}"
+TSFORGE_REPO="${TSFORGE_REPO:-https://github.com/boringstack-xyz/tsforge.git}"
 TSFORGE_REF="${TSFORGE_REF:-main}"
 TSFORGE_LIB="${TSFORGE_LIB:-${HOME}/.local/share/tsforge}"
 

--- a/apps/docs/src/components/Footer.astro
+++ b/apps/docs/src/components/Footer.astro
@@ -39,9 +39,9 @@ const cols: { title: string; links: { label: string; href: string }[] }[] = [
   {
     title: "Project",
     links: [
-      { label: "GitHub", href: "https://github.com/agjs/tsforge" },
+      { label: "GitHub", href: "https://github.com/boringstack-xyz/tsforge" },
       { label: "npm", href: "https://www.npmjs.com/package/@agjs/tsforge" },
-      { label: "License", href: "https://github.com/agjs/tsforge/blob/main/LICENSE" },
+      { label: "License", href: "https://github.com/boringstack-xyz/tsforge/blob/main/LICENSE" },
     ],
   },
 ];

--- a/apps/docs/src/components/Header.astro
+++ b/apps/docs/src/components/Header.astro
@@ -24,7 +24,7 @@ const version = `v${pkg.version}`;
 const FALLBACK_STARS = 19;
 let stars: number = FALLBACK_STARS;
 try {
-  const res = await fetch("https://api.github.com/repos/agjs/tsforge", {
+  const res = await fetch("https://api.github.com/repos/boringstack-xyz/tsforge", {
     headers: { "User-Agent": "tsforge-docs", Accept: "application/vnd.github+json" },
   });
   if (res.ok) {
@@ -66,7 +66,7 @@ const starLabel = formatStars(stars);
     {shouldRenderSearch && <div class="tf-nav-search min-w-0 print:hidden"><Search /></div>}
     <a
       class="flex items-center gap-2 border border-border h-9 px-3 text-[12px] text-foreground no-underline hover:border-border-strong transition-colors"
-      href="https://github.com/agjs/tsforge"
+      href="https://github.com/boringstack-xyz/tsforge"
       rel="noopener noreferrer"
       target="_blank"
       aria-label="tsforge on GitHub"
@@ -112,7 +112,7 @@ const starLabel = formatStars(stars);
     }
 
     try {
-      const res = await fetch("https://api.github.com/repos/agjs/tsforge", {
+      const res = await fetch("https://api.github.com/repos/boringstack-xyz/tsforge", {
         headers: { Accept: "application/vnd.github+json" },
       });
 

--- a/apps/docs/src/components/landing/Hero.astro
+++ b/apps/docs/src/components/landing/Hero.astro
@@ -43,7 +43,7 @@ const INSTALL = "curl -fsSL https://tsforge.dev/install.sh | bash";
           <Icon name="arrow-right" class="h-3.5 w-3.5 transition-transform group-hover:translate-x-0.5" />
         </a>
         <a
-          href="https://github.com/agjs/tsforge"
+          href="https://github.com/boringstack-xyz/tsforge"
           rel="noopener noreferrer"
           target="_blank"
           class="inline-flex items-center gap-2 border border-border h-11 px-5 text-[13px] hover:border-border-strong transition-colors"

--- a/apps/docs/src/content/docs/agent/skills-and-harness.mdx
+++ b/apps/docs/src/content/docs/agent/skills-and-harness.mdx
@@ -58,4 +58,4 @@ Skills compose **methodology**: repro-before-report harness reviews, release scr
 
 tsforge mines gate failure→fix pairs into [`.tsforge/learned-rules.json`](/uplift/memory/) and promotes recurring patterns to TTSR triggers. These are repo-local "micro-skills": machine triggers, not markdown runbooks. High-confidence patterns can later be promoted to committed `IRuleDoc` entries or maintainer skills.
 
-→ [Recipes](/cli/recipes/) · [Rule packs](/guardrails/rule-packs/) · [When the gate fails](/loop/validation/) · [Contributing](https://github.com/agjs/tsforge/blob/main/CONTRIBUTING.md)
+→ [Recipes](/cli/recipes/) · [Rule packs](/guardrails/rule-packs/) · [When the gate fails](/loop/validation/) · [Contributing](https://github.com/boringstack-xyz/tsforge/blob/main/CONTRIBUTING.md)

--- a/apps/docs/src/content/docs/eval/ab-testing.mdx
+++ b/apps/docs/src/content/docs/eval/ab-testing.mdx
@@ -21,7 +21,7 @@ Running a sweep drives a real model, so you need an OpenAI-compatible endpoint (
 
 ## Seeds
 
-A **seed** is the task you run the model against. Committed seeds live in [`evals/corpus/`](https://github.com/agjs/tsforge/tree/main/evals/corpus) and ship with the repo, so the examples work on a fresh clone:
+A **seed** is the task you run the model against. Committed seeds live in [`evals/corpus/`](https://github.com/boringstack-xyz/tsforge/tree/main/evals/corpus) and ship with the repo, so the examples work on a fresh clone:
 
 - `math`: single-file pure logic (currency-safe cent arithmetic with half-up rounding).
 - `slugify`: single-file string normalization with Unicode edge cases.

--- a/apps/docs/src/content/docs/quickstart.mdx
+++ b/apps/docs/src/content/docs/quickstart.mdx
@@ -28,7 +28,7 @@ bun install -g @agjs/tsforge
 **From source** (contributors and bleeding edge):
 
 ```bash
-git clone https://github.com/agjs/tsforge.git
+git clone https://github.com/boringstack-xyz/tsforge.git
 cd tsforge
 bun install
 bun link --global --cwd packages/core   # installs `tsforge` on PATH

--- a/apps/docs/src/content/docs/spec/format.mdx
+++ b/apps/docs/src/content/docs/spec/format.mdx
@@ -77,7 +77,7 @@ bun run eval:spec
 TSFORGE_SEED=math bun run eval:sweep
 ```
 
-Benchmark seeds ship as `<seed>.spec.md` under [`evals/corpus/`](https://github.com/agjs/tsforge/tree/main/evals/corpus) (e.g. `evals/corpus/math/`, `evals/corpus/auth/`); the harness copies a seed into a fresh run directory under `evals/` for each run. See [Spec runner](/loop/spec-runner/) and [A/B testing](/eval/ab-testing/).
+Benchmark seeds ship as `<seed>.spec.md` under [`evals/corpus/`](https://github.com/boringstack-xyz/tsforge/tree/main/evals/corpus) (e.g. `evals/corpus/math/`, `evals/corpus/auth/`); the harness copies a seed into a fresh run directory under `evals/` for each run. See [Spec runner](/loop/spec-runner/) and [A/B testing](/eval/ab-testing/).
 
 ## Related tools
 

--- a/apps/docs/wrangler.jsonc
+++ b/apps/docs/wrangler.jsonc
@@ -5,7 +5,8 @@
 // straight to Cloudflare's edge.
 {
   "$schema": "node_modules/wrangler/config-schema.json",
-  "name": "tsforge-docs",
+  // Must match the Cloudflare Pages project name (dashboard).
+  "name": "tsforge",
   "compatibility_date": "2026-06-12",
   "observability": {
     "enabled": true

--- a/docs/plans/2026-08-02-core-audit-findings.md
+++ b/docs/plans/2026-08-02-core-audit-findings.md
@@ -45,8 +45,8 @@ except F15, which is explicitly recorded as UNPROVEN on this platform.**
 
 | PR | Findings | State |
 |----|----------|-------|
-| [#223](https://github.com/agjs/tsforge/pull/223) — `fix/gate-never-silently-drops-rule-packs` | F1, F4 (+ F19 documented) | **MERGED** as `db6ba79e`. Panel PASS r5. |
-| [#224](https://github.com/agjs/tsforge/pull/224) — `fix/profiles-never-lower-below-pack-default` | F2, F20 (+ class guard; F21 raised) | panel **PASS** (r2, 4 reviewers / 0 errored, no findings); validate green, 3352 tests. **Awaiting ag's signed merge.** |
+| [#223](https://github.com/boringstack-xyz/tsforge/pull/223) — `fix/gate-never-silently-drops-rule-packs` | F1, F4 (+ F19 documented) | **MERGED** as `db6ba79e`. Panel PASS r5. |
+| [#224](https://github.com/boringstack-xyz/tsforge/pull/224) — `fix/profiles-never-lower-below-pack-default` | F2, F20 (+ class guard; F21 raised) | panel **PASS** (r2, 4 reviewers / 0 errored, no findings); validate green, 3352 tests. **Awaiting ag's signed merge.** |
 | next | F3, F5 (args parser) | not started |
 | next | F14 (normalization) | not started |
 | next | F7, F8, F9, F12 (small fixes) | not started |
@@ -462,7 +462,7 @@ in-process and 0 in the spawned gate.
 
 ### F20 — P1 — The `frontend` profile weakened two React correctness rules below the default profile
 
-- **status:** CONFIRMED and FIXED in [#224](https://github.com/agjs/tsforge/pull/224)
+- **status:** CONFIRMED and FIXED in [#224](https://github.com/boringstack-xyz/tsforge/pull/224)
 - **location:** `/Users/ag/Documents/Code/tsforge/packages/core/src/config/profiles.ts` (frontend
   `ruleOverrides`)
 - **evidence:** the block set three rules to `warn`; measured against the packs, one was a no-op and

--- a/docs/plans/2026-08-02-core-harness-audit.md
+++ b/docs/plans/2026-08-02-core-harness-audit.md
@@ -31,7 +31,7 @@ panel-gated PRs** (ag signs every merge + release — never merge to main yourse
 ## Starting state (2026-08-02)
 
 - On `main`, clean, version **0.35.0** (just released; #105 merged as squash `54d49250`).
-- `origin` = `https://github.com/agjs/tsforge.git` (SSH is broken here — push via origin, it's https).
+- `origin` = `https://github.com/boringstack-xyz/tsforge.git` (SSH is broken here — push via origin, it's https).
 - **CORRECTED 2026-08-02 (verified in code — do not relearn this):** the 4-model panel is
   **diff-based, not subsystem-based**. `bun run packages/core/src/cli.ts harness-review`
   accepts only `--base / --intent / --quick / --ci / --install-hook`

--- a/docs/plans/v0.1-release-and-docs.md
+++ b/docs/plans/v0.1-release-and-docs.md
@@ -6,7 +6,7 @@ Validated against the repo on branch `feature/guardrail-packs-local-uplift` (680
 
 - LICENSE copyright: **Aleksandar Grbic**
 - Root `package.json`: remove `"private": true` (npm-publishable later); keep `packages/core/package.json` private until a separate publish story exists
-- README badges: **https://github.com/agjs/tsforge** (adjust if the final org/repo name differs at D3)
+- README badges: **https://github.com/boringstack-xyz/tsforge** (adjust if the final org/repo name differs at D3)
 
 ---
 

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -6,11 +6,11 @@
   "description": "TypeScript coding harness with a deterministic gate, stack-aware guardrails, and stream-level correction.",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/agjs/tsforge.git",
+    "url": "git+https://github.com/boringstack-xyz/tsforge.git",
     "directory": "packages/core"
   },
   "homepage": "https://tsforge.dev",
-  "bugs": "https://github.com/agjs/tsforge/issues",
+  "bugs": "https://github.com/boringstack-xyz/tsforge/issues",
   "bin": {
     "tsforge": "./bin/tsforge.js"
   },

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -7,12 +7,12 @@
 # Environment:
 #   TSFORGE_REF=main|v0.1.0     git ref when installing from GitHub (default: main)
 #   TSFORGE_LIB=~/.local/share/tsforge   clone location for git install
-#   TSFORGE_REPO=https://github.com/agjs/tsforge.git
+#   TSFORGE_REPO=https://github.com/boringstack-xyz/tsforge.git
 #   BUN_INSTALL=~/.bun          Bun install root (installed automatically if missing)
 
 set -euo pipefail
 
-TSFORGE_REPO="${TSFORGE_REPO:-https://github.com/agjs/tsforge.git}"
+TSFORGE_REPO="${TSFORGE_REPO:-https://github.com/boringstack-xyz/tsforge.git}"
 TSFORGE_REF="${TSFORGE_REF:-main}"
 TSFORGE_LIB="${TSFORGE_LIB:-${HOME}/.local/share/tsforge}"
 

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -252,7 +252,7 @@ run_id=$(gh run list --repo "$(gh repo view --json nameWithOwner -q .nameWithOwn
   --workflow release.yml --limit 1 --json databaseId --jq '.[0].databaseId')
 
 if [[ -z "$run_id" || "$run_id" == "null" ]]; then
-  warn "could not find release workflow run; check https://github.com/agjs/tsforge/actions"
+  warn "could not find release workflow run; check https://github.com/boringstack-xyz/tsforge/actions"
   exit 0
 fi
 


### PR DESCRIPTION
## Summary

GitHub transfer: `agjs/tsforge` → [`boringstack-xyz/tsforge`](https://github.com/boringstack-xyz/tsforge).

This retargets clone URLs, badges, docs (including tsforge.dev GitHub / star-count API), security advisories, `package.json` `repository`/`bugs`, install.sh default repo, release script, and the docs-linkcheck exclude. Workflows already use `${{ github.repository }}` so they follow the transfer; the one hardcoded GitHub path was the lychee exclude.

**Unchanged:** npm package name `@agjs/tsforge` (installs, update-check, provenance publish). Renaming the npm scope is a separate breaking release.

## Operator notes (not in this PR)

- Cloudflare Pages Git connection: confirm the Pages project still tracks this repo after the org move (`apps/docs/DEPLOY.md` now names `boringstack-xyz/tsforge`).
- If npm trusted publishing is pinned to a GitHub repo, update it to `boringstack-xyz/tsforge` before the next `v*` tag.

## Test plan

- [x] No remaining `github.com/agjs/tsforge` in source (npm `@agjs/tsforge` kept)
- [ ] Docs linkcheck on this PR
- [ ] Star count on tsforge.dev still loads (`api.github.com/repos/boringstack-xyz/tsforge`)
- [ ] After docs deploy, `curl -fsSL https://tsforge.dev/install.sh` clones `boringstack-xyz/tsforge`