### PR TITLE
fix: TS quick-fix whole-repo scope + gate re-resolution on directory change

### DIFF
--- a/packages/core/ARCHITECTURE.md
+++ b/packages/core/ARCHITECTURE.md
@@ -101,7 +101,7 @@ Async functions returning an exit code, declared under the CLI — the commands.
 | `main` | `cli.ts:781` |
 | `mapMode` | `cli.ts:500` |
 | `recipesMode` | `cli.ts:519` |
-| `repl` | `cli/repl.ts:1054` |
+| `repl` | `cli/repl.ts:1096` |
 | `reviewMode` | `cli.ts:201` |
 | `runOnce` | `cli.ts:103` |
 | `runTraceCommand` | `cli/repl-commands.ts:160` |

--- a/packages/core/src/cli/repl.ts
+++ b/packages/core/src/cli/repl.ts
@@ -960,6 +960,48 @@ export function autoGateCarry(
   return autoGate !== undefined && active ? { autoGate } : {};
 }
 
+/**
+ * The gate a `clearConversation` rebuild should use: the CURRENT session's gate
+ * carried forward (via `autoGateCarry`) when the directory is unchanged, or a
+ * FRESH resolution against the NEW directory when it changed (scaffold, `/dir`).
+ *
+ * A directory change must never carry the OLD auto-gate resolver forward: its
+ * `tscPart()` overlay is an EPHEMERAL file written relative to whatever
+ * directory it was resolved against (`.tsforge/tsconfig.gate.json`). Reusing it
+ * for a session whose cwd is now a DIFFERENT directory detaches the overlay
+ * from where the gate actually executes — the resolver keeps writing it under
+ * the OLD dir while every gate run's relative `-p` path resolves against the
+ * NEW one, so the gate fails with `TS5058: path does not exist` forever, on
+ * every cycle, unfixable by the model (it is a harness artifact, not something
+ * in the model's editable scope). Re-resolving fresh against the new directory
+ * — exactly what a cold boot into that directory would do — is the only way to
+ * keep the overlay and the execution cwd pointed at the same place.
+ */
+export async function reboundGateForRebuild(
+  args: ICliArgs,
+  dirChanged: boolean,
+  current: {
+    readonly accept: string;
+    readonly autoGate: AutoGateResolver | undefined;
+    readonly autoGateActive: boolean;
+  },
+  resolve: typeof resolveGate = resolveGate
+): Promise<{ accept: string; autoGate?: AutoGateResolver }> {
+  if (!dirChanged) {
+    return {
+      accept: current.accept,
+      ...autoGateCarry(current.autoGate, current.autoGateActive),
+    };
+  }
+
+  const resolved = await resolve(args, null);
+
+  return {
+    accept: resolved.accept,
+    ...(resolved.autoGate === undefined ? {} : { autoGate: resolved.autoGate }),
+  };
+}
+
 /** The effective `--profile` for a run: a resumed session's saved profile fills in when the
  *  user didn't pass one THIS run, so `--continue` keeps the strictness the build was started
  *  with. An explicit CLI `--profile` always wins. Only a VALID saved id is restored — a
@@ -1924,10 +1966,20 @@ export async function repl(args: ICliArgs): Promise<number> {
     readonly dest?: string;
     readonly silent?: boolean;
   }): Promise<void> => {
+    const dirChanged = opts?.dest !== undefined;
+
     if (opts?.dest !== undefined) {
       args.dir = opts.dest;
       process.chdir(opts.dest);
     }
+
+    // See reboundGateForRebuild's doc comment: a directory change must re-resolve
+    // the gate fresh rather than carry the old auto-gate resolver forward.
+    const rebound = await reboundGateForRebuild(args, dirChanged, {
+      accept: session.gate,
+      autoGate,
+      autoGateActive: session.autoGateActive,
+    });
 
     // Rebuild the session with the current state (config is not reused;
     // repl's /clear creates a fresh Session.create call)
@@ -1945,7 +1997,7 @@ export async function repl(args: ICliArgs): Promise<number> {
       provider,
       cwd: args.dir,
       files: session.scope,
-      accept: session.gate,
+      accept: rebound.accept,
       contextWindow,
       report: makeReporter(logFile, id, id),
       enableThinking: false,
@@ -1966,10 +2018,12 @@ export async function repl(args: ICliArgs): Promise<number> {
       // Keep the AUTO gate re-detecting across /clear — else the rebuild freezes on
       // the last static command and stops picking up new framework packs. Withheld
       // once a manual /gate has taken over (autoGateActive false), so the rebuild
-      // never silently re-arms the auto gate over the user's command.
-      ...autoGateCarry(autoGate, session.autoGateActive),
+      // never silently re-arms the auto gate over the user's command. A directory
+      // change resolves a FRESH resolver instead of carrying the old one forward —
+      // see reboundGateForRebuild.
+      ...(rebound.autoGate === undefined ? {} : { autoGate: rebound.autoGate }),
       // Same gated-build contract as init — /clear must not drop on-demand `check`.
-      ...(autoGate !== undefined || session.gate.length > 0
+      ...(rebound.autoGate !== undefined || rebound.accept.length > 0
         ? {
             executionMode: "drive-to-green" as const,
             offerCheck: true as const,

--- a/packages/core/src/loop/turn.ts
+++ b/packages/core/src/loop/turn.ts
@@ -14,7 +14,7 @@ import { TOOL_NAME } from "../agent/agent.constants";
 import { isInScope } from "../lib/scope";
 import { trace } from "../lib/trace";
 import type { PolicyMode, IPolicyRules } from "../policy";
-import { fileExists, resolveScopeFiles } from "../lib/fs";
+import { fileExists } from "../lib/fs";
 import {
   snapshotFixState,
   buildAutoFixSummary,
@@ -1144,11 +1144,15 @@ async function applyIdiomRewrites(
 async function applyDeterministicFixes(
   ctx: ILoopCtx
 ): Promise<Map<string, IFixCounts>> {
-  const { task, cwd, report } = ctx;
-  // Resolve globs to concrete files — iterating task.files literally would skip a
-  // glob scope like `["**/*"]` (the common interactive default), so the fixes
-  // never ran there. See P1 review.
-  const files = await resolveScopeFiles(cwd, task.files);
+  const { task, report } = ctx;
+  // Scoped to files the model ACTUALLY wrote this session (`ctx.tool.touched`) —
+  // never the whole tree. `task.files` defaults to `["**/*"]` in the interactive
+  // REPL, and resolving that glob re-expanded to the entire scaffold (capped at
+  // MAX_GLOB_FILES) on EVERY gate cycle, so the TS language service re-scanned
+  // and "fixed" hundreds of untouched template files each turn — the same
+  // whole-repo trap the format step below was already fixed to avoid (see its
+  // comment). Matches that precedent instead of duplicating the bug.
+  const files = touchedInScope(ctx);
   const counts = new Map<string, IFixCounts>();
 
   const tsFixed = await applyTsQuickFixes(ctx, files, counts);

--- a/packages/core/tests/gate-redetect.test.ts
+++ b/packages/core/tests/gate-redetect.test.ts
@@ -6,7 +6,11 @@ import { resolveGate } from "../src/cli/gate-setup";
 import { parseArgs } from "../src/cli";
 import { profileFlagError, policyModeFlagError } from "../src/cli/args";
 import { isProfileId } from "../src/config/profiles";
-import { autoGateCarry, resumedProfileArg } from "../src/cli/repl";
+import {
+  autoGateCarry,
+  reboundGateForRebuild,
+  resumedProfileArg,
+} from "../src/cli/repl";
 import {
   saveSession,
   loadSession,
@@ -647,6 +651,74 @@ test("resumedProfileArg keeps a resumed session's profile unless the CLI passes 
   // A corrupted / hand-edited saved profile is IGNORED (never applied or re-persisted).
   expect(resumedProfileArg("", rec("bogus"))).toBe("");
   expect(resumedProfileArg("", rec("__proto__"))).toBe("");
+});
+
+// TS5058: `.tsforge/tsconfig.gate.json` is an EPHEMERAL overlay `tscPart()` writes
+// fresh relative to whatever directory the gate was resolved against. A /scaffold
+// or /dir directory change must re-resolve the gate fresh against the NEW cwd, not
+// carry the OLD directory's auto-gate resolver forward — else the resolver keeps
+// writing the overlay under the OLD dir while the gate's `-p` path resolves
+// against the NEW one, and every gate run fails forever with a path the model can
+// never fix (it's a harness artifact, not something in its editable scope).
+test("reboundGateForRebuild re-resolves fresh on a directory change, not the old dir's gate", async () => {
+  const oldDirGate = {
+    accept: "tsc -p OLD/.tsforge/tsconfig.gate.json",
+    autoGate: async () => ({
+      command: "tsc -p OLD/.tsforge/tsconfig.gate.json",
+      stackProfile: {
+        name: "old",
+        packs: [],
+        confidence: "guess" as const,
+        reason: "",
+      },
+    }),
+    autoGateActive: true,
+  };
+
+  let resolveCalls = 0;
+
+  const fakeResolve = async () => {
+    resolveCalls += 1;
+
+    return {
+      accept: "tsc -p NEW/.tsforge/tsconfig.gate.json",
+      gateLabel: "auto gate (tsc)",
+      autoGate: async () => ({
+        command: "tsc -p NEW/.tsforge/tsconfig.gate.json",
+        stackProfile: {
+          name: "new",
+          packs: [],
+          confidence: "guess" as const,
+          reason: "",
+        },
+      }),
+    };
+  };
+
+  const args = { ...parseArgs([]), dir: "/new/dir" };
+
+  const unchanged = await reboundGateForRebuild(
+    args,
+    false,
+    oldDirGate,
+    fakeResolve
+  );
+
+  expect(unchanged.accept).toBe(oldDirGate.accept);
+  expect(unchanged.autoGate).toBe(oldDirGate.autoGate);
+  expect(resolveCalls).toBe(0);
+
+  const changed = await reboundGateForRebuild(
+    args,
+    true,
+    oldDirGate,
+    fakeResolve
+  );
+
+  expect(resolveCalls).toBe(1);
+  expect(changed.accept).toBe("tsc -p NEW/.tsforge/tsconfig.gate.json");
+  expect(changed.accept).not.toBe(oldDirGate.accept);
+  expect(changed.autoGate).not.toBe(oldDirGate.autoGate);
 });
 
 // A typo'd or value-less `--profile` must fail loudly (return an error), not silently run

--- a/packages/core/tests/settle-steps.test.ts
+++ b/packages/core/tests/settle-steps.test.ts
@@ -8,6 +8,7 @@ import { LOOP_LIMITS, RUN_STATUS } from "../src/loop";
 import { STEER_LADDER_MAX } from "../src/loop/feedback/steer";
 import type { IErrorItem } from "../src/validate";
 import { commandGate } from "../src/gate/gate-runner";
+import { TsService } from "../src/lsp";
 
 /** The settleGate steps extracted for unit testing (review item 4): checkStuck
  *  composes the three convergence guards; autoFixStep reports what the janitor
@@ -363,6 +364,55 @@ describe("autoFixStep", () => {
     // …the now-out-of-scope touched file is left exactly as it was.
     expect(readFileSync(join(dir, "out.ts"), "utf8")).toBe(messy);
   }, 30_000);
+
+  // Same #103-shaped bug, but for the TS quick-fix janitor rather than the format
+  // step: task.files defaults to the whole repo in the interactive REPL, and
+  // resolving that glob made tsFixAll re-scan and "fix" every file in the
+  // scaffold on every gate cycle, not just what the model wrote this turn. It
+  // must scope to ctx.tool.touched like the format step already does.
+  test("whole-repo scope → tsFixAll only fixes the TOUCHED file, untouched sibling left alone", async () => {
+    const events: ILoopEvent[] = [];
+    const dir = mkdtempSync(join(tmpdir(), "settle-autofix-tsfix-"));
+
+    writeFileSync(
+      join(dir, "tsconfig.json"),
+      JSON.stringify({
+        compilerOptions: {
+          target: "ES2022",
+          module: "ES2022",
+          strict: true,
+          noUnusedLocals: true,
+          noEmit: true,
+          skipLibCheck: true,
+        },
+        include: ["*.ts"],
+      })
+    );
+
+    const withUnusedLocal =
+      "export function f(): number {\n  const unused = 1;\n  return 2;\n}\n";
+
+    writeFileSync(join(dir, "touched.ts"), withUnusedLocal);
+    writeFileSync(join(dir, "sibling.ts"), withUnusedLocal);
+
+    const base = makeCtx(events, dir);
+    const ctx: ILoopCtx = {
+      ...base,
+      task: { ...base.task, files: ["**/*"] },
+      tool: { touched: new Set(["touched.ts"]) },
+      tsService: new TsService(dir),
+    };
+
+    await autoFixStep(ctx);
+
+    // The touched file's unused local was fixed away…
+    expect(readFileSync(join(dir, "touched.ts"), "utf8")).not.toContain(
+      "unused"
+    );
+    // …and the untouched sibling — in scope via the whole-repo glob, but never
+    // written by the model — is left exactly as it was.
+    expect(readFileSync(join(dir, "sibling.ts"), "utf8")).toBe(withUnusedLocal);
+  });
 });
 
 describe("relentless-loop escalation-ladder centerpiece (fixes A/B/C)", () => {


### PR DESCRIPTION
## Summary
- `applyDeterministicFixes` scoped the TS quick-fixer and ast-grep idiom rewriter to `touchedInScope(ctx)` instead of glob-expanding `task.files` (`["**/*"]` in the interactive REPL) every gate cycle — matches the precedent already established for the format step. Verified live against a real scaffolded Phaser project: only the touched file changed, 268 other real project files (140 other `.ts`/`.tsx`) were left byte-identical.
- `clearConversation()` now re-resolves the gate fresh (`reboundGateForRebuild`) when `/scaffold` or `/dir` changes the working directory, instead of carrying the old directory's auto-gate resolver forward. The old resolver kept writing `.tsforge/tsconfig.gate.json` under the OLD directory while the gate's `-p` path resolved against the NEW one, so every gate run failed forever with `TS5058` — a harness artifact the model could never fix itself.

## Test plan
- [x] `bun run typecheck` clean
- [x] `bun run lint` / `bun run format:check` clean
- [x] `bun run test` — 5851 pass (1 unrelated pre-existing flaky timing test in `script-tool.test.ts`, reproduces identically on clean `main`)
- [x] `bun run e2e:pty` — all pass
- [x] New regression tests for both fixes, each confirmed to fail without its fix and pass with it
- [x] Live-verified the scope fix against a real scaffolded project directory (not just synthetic temp dirs)