### PR TITLE
fix: work around two Bun 1.4.x global-install bugs in install.sh

### DIFF
--- a/apps/docs/public/install.sh
+++ b/apps/docs/public/install.sh
@@ -29,7 +29,7 @@ ensure_bun() {
     return 0
   fi
 
-  info "Bun not found. Installing Bun (tsforge requires Bun >= 1.3.14)..."
+  info "Bun not found. Installing Bun (tsforge requires Bun >= 1.4.0)..."
   curl -fsSL https://bun.sh/install | bash
   export BUN_INSTALL="${BUN_INSTALL:-${HOME}/.bun}"
   export PATH="${BUN_INSTALL}/bin:${PATH}"
@@ -42,6 +42,25 @@ ensure_bun() {
 }
 
 install_from_npm() {
+  # Prefer real npm over `bun install -g` here: as of Bun 1.4.x, the global
+  # installer mishandles @agjs/tsforge's `@typescript/native` dependency
+  # (TypeScript 7's platform-specific optionalDependencies — only one of
+  # ~20 resolves on any given machine, and an unresolved one can be left
+  # with an internal empty name that Bun's global-install safety check then
+  # rejects outright instead of skipping). Bun fixed the same class of bug
+  # in its dependency-tree builder (oven-sh/bun#31652) but not in this
+  # installer-level check, so it's still broken on 1.4.0. npm doesn't share
+  # that code path.
+  if command -v npm >/dev/null 2>&1; then
+    info "Trying npm registry (npm install -g @agjs/tsforge)..."
+    if npm install -g @agjs/tsforge@latest; then
+      info "Installed tsforge from npm."
+      print_done
+      return 0
+    fi
+    return 1
+  fi
+
   info "Trying npm registry (bun install -g @agjs/tsforge)..."
   if bun install -g @agjs/tsforge@latest; then
     info "Installed tsforge from npm."
@@ -67,7 +86,23 @@ install_from_git() {
   (
     cd "${TSFORGE_LIB}/packages/core"
     bun install
-    bun link --global
+    # NOT `bun link --global`: on Bun 1.4.x it fails with `error: package.json
+    # missing "name"` against the global project file it just created itself
+    # (a separate Bun 1.4 regression from the one in install_from_npm above).
+    # A direct symlink into Bun's own global bin dir sidesteps it — but that
+    # global project file has to exist with a "name" first, or a totally
+    # fresh Bun install fails the same way on `bun pm bin -g` itself. Seed a
+    # minimal one (only if missing, so a real one is never overwritten).
+    bun_install_dir="${BUN_INSTALL:-${HOME}/.bun}"
+    global_dir="${bun_install_dir}/install/global"
+    if [ ! -f "${global_dir}/package.json" ]; then
+      mkdir -p "${global_dir}"
+      printf '{"name":"bun-global","dependencies":{}}' >"${global_dir}/package.json"
+    fi
+
+    bin_dir="$(bun pm bin -g)"
+    mkdir -p "${bin_dir}"
+    ln -sf "${TSFORGE_LIB}/packages/core/bin/tsforge.js" "${bin_dir}/tsforge"
   )
 
   info "Linked tsforge globally from ${TSFORGE_LIB}/packages/core"
@@ -84,9 +119,10 @@ tsforge is installed.
 Configure your model in ~/.tsforge/models.json — see:
   https://tsforge.dev/quickstart/
 
-If \`tsforge\` is not found, add Bun's global bin dir to PATH:
+If \`tsforge\` is not found, add your package manager's global bin dir to PATH:
 
-  export PATH="\$(bun pm bin -g):\${PATH}"
+  npm:  export PATH="\$(npm config get prefix)/bin:\${PATH}"
+  bun:  export PATH="\$(bun pm bin -g):\${PATH}"
 
 EOF
 }

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -29,7 +29,7 @@ ensure_bun() {
     return 0
   fi
 
-  info "Bun not found. Installing Bun (tsforge requires Bun >= 1.3.14)..."
+  info "Bun not found. Installing Bun (tsforge requires Bun >= 1.4.0)..."
   curl -fsSL https://bun.sh/install | bash
   export BUN_INSTALL="${BUN_INSTALL:-${HOME}/.bun}"
   export PATH="${BUN_INSTALL}/bin:${PATH}"
@@ -42,6 +42,25 @@ ensure_bun() {
 }
 
 install_from_npm() {
+  # Prefer real npm over `bun install -g` here: as of Bun 1.4.x, the global
+  # installer mishandles @agjs/tsforge's `@typescript/native` dependency
+  # (TypeScript 7's platform-specific optionalDependencies — only one of
+  # ~20 resolves on any given machine, and an unresolved one can be left
+  # with an internal empty name that Bun's global-install safety check then
+  # rejects outright instead of skipping). Bun fixed the same class of bug
+  # in its dependency-tree builder (oven-sh/bun#31652) but not in this
+  # installer-level check, so it's still broken on 1.4.0. npm doesn't share
+  # that code path.
+  if command -v npm >/dev/null 2>&1; then
+    info "Trying npm registry (npm install -g @agjs/tsforge)..."
+    if npm install -g @agjs/tsforge@latest; then
+      info "Installed tsforge from npm."
+      print_done
+      return 0
+    fi
+    return 1
+  fi
+
   info "Trying npm registry (bun install -g @agjs/tsforge)..."
   if bun install -g @agjs/tsforge@latest; then
     info "Installed tsforge from npm."
@@ -67,7 +86,23 @@ install_from_git() {
   (
     cd "${TSFORGE_LIB}/packages/core"
     bun install
-    bun link --global
+    # NOT `bun link --global`: on Bun 1.4.x it fails with `error: package.json
+    # missing "name"` against the global project file it just created itself
+    # (a separate Bun 1.4 regression from the one in install_from_npm above).
+    # A direct symlink into Bun's own global bin dir sidesteps it — but that
+    # global project file has to exist with a "name" first, or a totally
+    # fresh Bun install fails the same way on `bun pm bin -g` itself. Seed a
+    # minimal one (only if missing, so a real one is never overwritten).
+    bun_install_dir="${BUN_INSTALL:-${HOME}/.bun}"
+    global_dir="${bun_install_dir}/install/global"
+    if [ ! -f "${global_dir}/package.json" ]; then
+      mkdir -p "${global_dir}"
+      printf '{"name":"bun-global","dependencies":{}}' >"${global_dir}/package.json"
+    fi
+
+    bin_dir="$(bun pm bin -g)"
+    mkdir -p "${bin_dir}"
+    ln -sf "${TSFORGE_LIB}/packages/core/bin/tsforge.js" "${bin_dir}/tsforge"
   )
 
   info "Linked tsforge globally from ${TSFORGE_LIB}/packages/core"
@@ -84,9 +119,10 @@ tsforge is installed.
 Configure your model in ~/.tsforge/models.json — see:
   https://tsforge.dev/quickstart/
 
-If \`tsforge\` is not found, add Bun's global bin dir to PATH:
+If \`tsforge\` is not found, add your package manager's global bin dir to PATH:
 
-  export PATH="\$(bun pm bin -g):\${PATH}"
+  npm:  export PATH="\$(npm config get prefix)/bin:\${PATH}"
+  bun:  export PATH="\$(bun pm bin -g):\${PATH}"
 
 EOF
 }


### PR DESCRIPTION
## Summary

`curl -fsSL https://tsforge.dev/install.sh | bash` is currently broken for every user on Bun 1.4.0 (which we just made the pinned/required version in #350). Root-caused both failures against the actual published `@agjs/tsforge@0.53.0` package:

1. **`bun install -g @agjs/tsforge` fails**: `error: refusing to install dependency with unsafe name`. `@typescript/native` (`typescript@7.0.2`) declares ~20 platform-specific `optionalDependencies`; on any single machine only one resolves, and Bun leaves the unresolved ones with an internal empty name. Bun's global installer (`PackageInstaller.rs`) rejects that outright instead of skipping it — the same class of bug Bun already fixed in its dependency-tree builder ([oven-sh/bun#31652](https://github.com/oven-sh/bun/issues/31652) / [#31655](https://github.com/oven-sh/bun/pull/31655)), but that fix never touched this installer-level check, so it's still broken on 1.4.0 stable.
   - **Fix**: prefer real `npm install -g` (doesn't share this code path) when npm is available, falling back to the old `bun install -g` only when it isn't.

2. **The git-fallback's `bun link --global` fails separately**: `error: package.json missing "name"`, against the global project file Bun creates itself. A totally fresh Bun install hits the same wall even earlier, on `bun pm bin -g` itself (no global project file exists yet at all).
   - **Fix**: seed a minimal valid global `package.json` first (only if one doesn't already exist), then symlink the built `bin/tsforge.js` directly into Bun's global bin dir — skips `bun link --global` entirely, needs nothing but `bun install`, which already ran.

Both bugs are upstream Bun regressions, not ours — verified by reading Bun's own source (`PackageInstaller.rs`) and the linked issue/PR history.

## Test plan
- [x] `npm install -g @agjs/tsforge@0.53.0` to an isolated prefix — works, binary reports `tsforge 0.53.0`
- [x] Full `install.sh` run (auto mode, npm path) to an isolated `npm_config_prefix` — works end-to-end
- [x] Full `install.sh` run (`TSFORGE_INSTALL=git`) from a **completely fresh** `BUN_INSTALL` (no prior global state) — works end-to-end, symlink resolves and runs
- [x] Re-running the git path against an existing clone/existing global `package.json` is idempotent (doesn't clobber it)
- [x] `shellcheck scripts/install.sh` — clean
- [x] `diff scripts/install.sh apps/docs/public/install.sh` — identical (the CI check this repo already enforces)