### PR TITLE
fix(plan-mode): a validated present_plan ends the send — approve lands at an idle prompt, not as mid-send steering

### DIFF
--- a/packages/core/src/loop/session.ts
+++ b/packages/core/src/loop/session.ts
@@ -3251,6 +3251,29 @@ export class Session {
       };
     }
 
+    // A present_plan proposal VALIDATED this turn (runOneToolCall set this): the plan
+    // card is rendered and awaiting the human, so END the send — real models otherwise
+    // keep exploring read-only and the human's "approve" typed meanwhile is peeled as
+    // mid-send steering instead of binding the plan. Unlike the ask_user pause this is
+    // a NORMAL end (no awaitingUser), so the next line routes through plan-approval
+    // detection (classifyReplRoute), not answer routing.
+    if (this.state.pendingPlanPause === true) {
+      this.state.pendingPlanPause = undefined;
+
+      return {
+        action: {
+          status: "responded",
+          turns: turn,
+        },
+        edited,
+        editsSinceCheck,
+        readonlyStreak: carry.readonlyStreak,
+        readonlyRecoveries: carry.readonlyRecoveries,
+        historyMetaStreak: carry.historyMetaStreak,
+        forceWriteNext: false,
+      };
+    }
+
     const hadHistoryMeta = turnHadHistoryMetaReject(
       this.ctx.messages,
       messagesStart

--- a/packages/core/src/loop/tools/index.ts
+++ b/packages/core/src/loop/tools/index.ts
@@ -6,6 +6,11 @@ export {
   askUserQuestion,
   shouldPauseForAskUser,
 } from "./ask-user-tool";
+export {
+  PRESENT_PLAN_SENTINEL,
+  presentPlanMessage,
+  shouldPauseForPresentPlan,
+} from "./present-plan-tool";
 export type {
   IToolContext,
   SpawnAgentFn,

--- a/packages/core/src/loop/tools/present-plan-tool.ts
+++ b/packages/core/src/loop/tools/present-plan-tool.ts
@@ -1,3 +1,4 @@
+import { TOOL_NAME } from "../../agent";
 import { countOpen } from "../worklist/checklist-store";
 import { advisePlanDecomposition } from "../worklist/plan-advice";
 import { planDocumentFromUnknown } from "../worklist/seed";
@@ -6,6 +7,37 @@ import { reject, type IToolContext } from "./tool-context";
 
 function isRecord(v: unknown): v is Record<string, unknown> {
   return typeof v === "object" && v !== null && !Array.isArray(v);
+}
+
+/** Prefix marking a SUCCESSFUL present_plan result the LOOP must treat as an execution
+ *  boundary: the proposal is validated and rendered, so nothing is left for the model
+ *  to do until the human approves or gives feedback — the send must END here. Without
+ *  it, real models keep exploring in the same send and the human's "approve" typed
+ *  meanwhile is swallowed as mid-send steering instead of binding the plan. Same
+ *  distinctive-marker pattern as ASK_USER_SENTINEL (stripped before the model sees the
+ *  result). Rejections return plain text so the model can revise in-send. */
+export const PRESENT_PLAN_SENTINEL = "<<<PRESENT_PLAN>>>";
+
+/** The clean model-facing message carried by a present_plan pause result (the result
+ *  itself if it is not one). */
+export function presentPlanMessage(result: string): string {
+  return result.startsWith(PRESENT_PLAN_SENTINEL)
+    ? result.slice(PRESENT_PLAN_SENTINEL.length)
+    : result;
+}
+
+/** True ONLY for a genuine present_plan pause: the CALL was `present_plan` AND its
+ *  result carries the sentinel. Gating on the call name (like shouldPauseForAskUser)
+ *  stops any other tool result that happens to start with the marker from forging an
+ *  end-of-send. */
+export function shouldPauseForPresentPlan(
+  callName: string,
+  result: string
+): boolean {
+  return (
+    callName === TOOL_NAME.presentPlan &&
+    result.startsWith(PRESENT_PLAN_SENTINEL)
+  );
 }
 
 /**
@@ -77,10 +109,11 @@ export function doPresentPlan(
     "then call present_plan again with the revised plan.";
 
   if (advice.length === 0) {
-    return base;
+    return PRESENT_PLAN_SENTINEL + base;
   }
 
   return (
+    PRESENT_PLAN_SENTINEL +
     `${base}\n\nDecomposition advice (optional revise via present_plan):\n` +
     advice.map((w) => `- ${w}`).join("\n")
   );

--- a/packages/core/src/loop/turn.ts
+++ b/packages/core/src/loop/turn.ts
@@ -76,6 +76,8 @@ import {
   executeTool,
   shouldPauseForAskUser,
   askUserQuestion,
+  shouldPauseForPresentPlan,
+  presentPlanMessage,
   type SpawnAgentFn,
   type IToolContext,
   type ICheckOutcome,
@@ -591,6 +593,12 @@ export interface ILoopState {
    *  drive loop ENDS the send (surfacing the question) so the human's next send is the
    *  reply. Cleared once consumed. Absent on autonomous runs (ask_user isn't offered). */
   pendingAskUser?: string;
+  /** Set when a present_plan proposal VALIDATED this turn: the plan is rendered and
+   *  awaiting the human, so the send ends here — real models otherwise keep exploring
+   *  and the human's "approve" typed meanwhile is swallowed as mid-send steering.
+   *  Unlike pendingAskUser this ends the send NORMALLY (no awaitingUser), so the next
+   *  line routes through plan-approval detection, not answer routing. */
+  pendingPlanPause?: boolean;
   /** WS-C: an ask_user pause ended a send that had ALSO edited a file. The `edited`
    *  accumulator is per-send, so the resume send would start `edited=false` and skip the
    *  gate — leaving that edit unvalidated. This flag re-seeds `edited` on the resume send
@@ -881,6 +889,22 @@ async function runOneToolCall(
     return false;
   }
 
+  // A VALIDATED present_plan is the same kind of boundary: the proposal is rendered
+  // and awaiting the human, so the send must end — feed the clean (sentinel-stripped)
+  // result back and stop. Gated on the CALL being present_plan so no other tool can
+  // forge an end-of-send. Rejected proposals return plain text and fall through, so
+  // the model revises in the same send.
+  if (shouldPauseForPresentPlan(call.name, result)) {
+    state.pendingPlanPause = true;
+    ctx.messages.push({
+      role: "tool",
+      content: presentPlanMessage(result),
+      toolCallId: callKey(call, index),
+    });
+
+    return false;
+  }
+
   let feedback = "";
   // F19 plugin drift is a HARD failure the guard deliberately rethrows — but
   // the tool has already executed by now, so the throw must not unwind before
@@ -1018,7 +1042,8 @@ export async function runToolCalls(
     // calls in the SAME model response (a `[ask_user, create]` batch must not write the
     // file before the human replies); STUB the rest (so no tool_call dangles → no 400)
     // and stop. The model re-issues them, with the answer in hand, on the next send.
-    if (state.pendingAskUser !== undefined) {
+    // A validated present_plan is the same boundary: the plan awaits the human.
+    if (state.pendingAskUser !== undefined || state.pendingPlanPause === true) {
       stubUnrunCalls(toolCalls, i, ctx);
       break;
     }

--- a/packages/core/tests/plan-mode.test.ts
+++ b/packages/core/tests/plan-mode.test.ts
@@ -162,6 +162,65 @@ test("plan mode advertises only read-only tools; toggling off restores writes", 
   });
 });
 
+// Live DeepSeek finding (trace 2026-08-27, follow-up to the #298 dead end): the
+// model presented a valid plan, then kept exploring in the SAME send (turn after
+// turn of read-only calls), and the human's "approve" typed meanwhile was peeled
+// as mid-send steering — never reaching plan-approval routing. A validated
+// present_plan is an execution boundary exactly like ask_user: the send must
+// end, siblings in the same batch must be stubbed, and the next line must
+// arrive at an idle prompt (where classifyReplRoute sees the approval).
+test("a validated present_plan ENDS the send — sibling calls stubbed, no further turns", async () => {
+  await withDir(async (dir) => {
+    let calls = 0;
+    const provider: IProvider = {
+      async complete() {
+        calls += 1;
+
+        // Batches present_plan WITH more exploration, then would keep going
+        // forever — only the harness boundary can end this send.
+        return {
+          content: "",
+          toolCalls: [
+            {
+              id: `p${String(calls)}`,
+              name: "present_plan",
+              arguments: { goal: "g", items: [{ title: "A" }] },
+            },
+            {
+              id: `r${String(calls)}`,
+              name: "run",
+              arguments: { command: "ls" },
+            },
+          ],
+        };
+      },
+    };
+    const session = await Session.create({
+      provider,
+      cwd: dir,
+      offerPresentPlan: true,
+    });
+
+    session.setPlanMode(true);
+    const result = await session.send("add a feature");
+
+    // ONE model call: the validated proposal ended the send.
+    expect(calls).toBe(1);
+    expect(result.status).toBe("responded");
+    // The proposal is pending approval, not silently dropped.
+    expect(session.getPendingPlan()).not.toBeNull();
+    // The sibling `run` in the same batch was stubbed, not executed — and every
+    // tool_call got a response (no dangling call → no API 400 on the next send).
+    const toolMsgs = session.messages
+      .filter((m) => m.role === "tool")
+      .map((m) => m.content);
+
+    expect(toolMsgs).toHaveLength(2);
+    expect(toolMsgs.join("\n")).toMatch(/not run|wait/i);
+    expect(toolMsgs.join("\n")).not.toContain("<<<PRESENT_PLAN>>>");
+  });
+});
+
 test("a fenced-snippet-heavy plan never trips the code-dump build nudge", async () => {
   await withDir(async (dir) => {
     let calls = 0;

--- a/packages/core/tests/present-plan-tool.test.ts
+++ b/packages/core/tests/present-plan-tool.test.ts
@@ -2,6 +2,9 @@ import { test, expect, describe } from "bun:test";
 import {
   doPresentPlan,
   presentPlanArgsToRaw,
+  presentPlanMessage,
+  shouldPauseForPresentPlan,
+  PRESENT_PLAN_SENTINEL,
 } from "../src/loop/tools/present-plan-tool";
 import type { IToolContext } from "../src/loop/tools/tool-context";
 import type { IPlanDocument } from "../src/loop/worklist/checklist.types";
@@ -105,5 +108,32 @@ describe("doPresentPlan", () => {
     );
 
     expect(presented[0]?.items[0]?.kind).toBe("create");
+  });
+});
+
+describe("present_plan pause sentinel", () => {
+  test("a VALID proposal carries the pause sentinel; the model-facing text is clean", () => {
+    // The send must END on a validated proposal — real models otherwise keep
+    // exploring and the human's "approve" is swallowed as mid-send steering.
+    const result = doPresentPlan({ goal: "g", items: [{ title: "A" }] }, ctx());
+
+    expect(result.startsWith(PRESENT_PLAN_SENTINEL)).toBe(true);
+    expect(shouldPauseForPresentPlan("present_plan", result)).toBe(true);
+    // The sentinel never reaches the model.
+    expect(presentPlanMessage(result)).not.toContain(PRESENT_PLAN_SENTINEL);
+    expect(presentPlanMessage(result)).toMatch(/presented/i);
+  });
+
+  test("a REJECTED proposal returns plain text — the model revises in the same send", () => {
+    const result = doPresentPlan({ goal: "x", items: [] }, ctx());
+
+    expect(result.startsWith(PRESENT_PLAN_SENTINEL)).toBe(false);
+    expect(shouldPauseForPresentPlan("present_plan", result)).toBe(false);
+  });
+
+  test("another tool cannot forge the boundary — gated on the call name", () => {
+    expect(
+      shouldPauseForPresentPlan("run", `${PRESENT_PLAN_SENTINEL}whatever`)
+    ).toBe(false);
   });
 });


### PR DESCRIPTION
## Context

Investigating stuck trace `2026-08-27-20-57-27` (fresh REPL, plan mode, 43 turns, 0 edits, stuck-killed) surfaced two coupled failures:

1. **present_plan was never advertised** — the #298 `interactive: false` hardcode had withdrawn the co-pilot tool surface. **Already fixed on main** (the `interactive` / `humanPresent` / `offerTaskTools` / `offerPresentPlan` config split, ~#347) while this was being investigated in parallel — this PR was rebuilt on top and no longer touches that.
2. **A validated present_plan didn't end the send.** Real models keep exploring read-only in the same send after presenting (the plan-mode note says stop and wait; models don't), and the human's "approve" typed meanwhile is peeled off as **mid-send steering** — it never reaches plan-approval routing, so the plan is never bound. Observed live: the DeepSeek run showed `↳ steering: approve` swallowed while the model kept issuing `ls`/`cat` turns after the PLAN card, with a later `run` still plan-mode-rejected.

## The fix

A validated `present_plan` becomes an execution boundary exactly like `ask_user`:

- `doPresentPlan` prefixes a **successful** result with `PRESENT_PLAN_SENTINEL`; rejections stay plain text so the model revises in-send.
- `turn.ts` intercepts it — gated on the **call name** (the `shouldPauseForAskUser` pattern) so no other tool can forge an end-of-send. Clean sentinel-stripped tool result, sibling calls in the same batch stubbed (no dangling tool_call → no API 400), `state.pendingPlanPause` set.
- `session.ts` ends the send on the flag as a **normal** `responded` — deliberately *not* `awaitingUser`, because while awaiting an ask_user answer the next line routes as the *answer* (a safety rule) and "approve" would be swallowed again. A normal end means the next line hits plan-approval detection at an idle prompt.

## Tests

- Sentinel units: valid proposal carries it, rejection doesn't, another tool can't forge it, the model never sees the marker.
- Loop test: a `[present_plan, run]` batch ends the send in **one model call**, the sibling is stubbed with a response, and the proposal is pending approval.

## Verification

- Full suite 5873 tests / 0 fail; typecheck, lint, prettier, `e2e:pty` all green on top of current main.
- Live pty run against the local DeepSeek-V4-Flash endpoint, fresh REPL, plan-mode default — all five checks pass: boots into plan mode → `present_plan` card rendered → **send ends at the card** → "approve" routed as **plan approval** (not steering) → plan bound, write unlocked, requested file created.

## Queued (out of scope)

- `--no-gate` session: `task_complete` is always rejected ("no gate wired"), so worklist tasks can never be closed there.
- Failure-class mislabel: a 0-edit, 0-gate-run stuck session is classified `build-fail`.
- Under the config-split design, a programmatic `Session` with plan mode on but `offerPresentPlan` unset still can't exit plan mode — the REPL always sets it, but a prompt↔offer consistency guard might be worth it.