### PR TITLE
fix(gate): monorepo-aware gating — stop phantom errors, janitor vandalism, and misattribution

### DIFF
--- a/0
+++ b/0
@@ -1,3 +1,0 @@
-[t] should not surface
-Error: should not surface
-    at <anonymous> (/agjs/code/tsforge/packages/core/tests/lib-trace.test.ts:37:22)

--- a/FALSE
+++ b/FALSE
@@ -1,3 +1,0 @@
-[t] should not surface
-Error: should not surface
-    at <anonymous> (/agjs/code/tsforge/packages/core/tests/lib-trace.test.ts:37:22)

--- a/Off
+++ b/Off
@@ -1,3 +1,0 @@
-[t] should not surface
-Error: should not surface
-    at <anonymous> (/agjs/code/tsforge/packages/core/tests/lib-trace.test.ts:37:22)

--- a/false
+++ b/false
@@ -1,3 +1,0 @@
-[t] should not surface
-Error: should not surface
-    at <anonymous> (/agjs/code/tsforge/packages/core/tests/lib-trace.test.ts:37:22)

--- a/no
+++ b/no
@@ -1,3 +1,0 @@
-[t] should not surface
-Error: should not surface
-    at <anonymous> (/agjs/code/tsforge/packages/core/tests/lib-trace.test.ts:37:22)

--- a/off
+++ b/off
@@ -1,3 +1,0 @@
-[t] should not surface
-Error: should not surface
-    at <anonymous> (/agjs/code/tsforge/packages/core/tests/lib-trace.test.ts:37:22)

--- a/packages/core/ARCHITECTURE.md
+++ b/packages/core/ARCHITECTURE.md
@@ -32,8 +32,8 @@ inventory, see the hand-drawn map on [Internals](/internals/).
 | `files` | Reading, creating, and hash-anchored editing of workspace files | core | 9 | 2k | 5 | 1 |
 | `policy` | Decides which actions are allowed in the current mode before they run | core | 5 | 2k | 5 | 3 |
 | `architecture` ⚠️ | Derives this map from source so the docs cannot drift from the code | optional | 8 | 1k | 0 | 0 |
-| `mcp` | Model Context Protocol client that exposes external servers as tools | optional | 8 | <1k | 2 | 1 |
 | `lsp` | TypeScript language service powering navigation and write-time diagnostics | optional | 3 | <1k | 5 | 0 |
+| `mcp` | Model Context Protocol client that exposes external servers as tools | optional | 8 | <1k | 2 | 1 |
 | `browser` | Headless Chromium oracle that render-checks a page as a gate stage | optional | 3 | <1k | 1 | 1 |
 | `infer-rules` | Scans a repo for its conventions and turns them into rule overrides | core | 7 | <1k | 5 | 2 |
 | `validate` | Runs the gate command and parses tool output into structured errors | core | 7 | <1k | 7 | 2 |

--- a/packages/core/src/eval/failure-class.ts
+++ b/packages/core/src/eval/failure-class.ts
@@ -23,6 +23,13 @@ export const FAILURE_CLASS = {
   lintRule: "lint-rule",
   /** Imported a module that doesn't exist (TS2307 / "Cannot find module"). */
   hallucinatedImport: "hallucinated-import",
+  /** The typecheck ENVIRONMENT is missing the runtime's type definitions —
+   *  builtin modules (`bun:test`, `node:fs`) or runtime globals (`Bun`,
+   *  `process`) unresolvable. A gate/tsconfig misconfiguration, not model
+   *  error: telling the model to "install the package" sends it chasing
+   *  ghosts (observed: a Bun monorepo gated without bun-types → 708 errors,
+   *  attributed hallucinated-import, model stuck). */
+  missingRuntimeTypes: "missing-runtime-types",
   /** Output degenerated into a repetition loop (StreamGuard fired). */
   degeneration: "degeneration",
   /** A per-call/timeout backstop tripped. */
@@ -50,6 +57,9 @@ export interface IFailureSignals {
   tsErrors: number;
   lintErrors: number;
   missingModule: number;
+  /** Missing runtime type definitions: cannot-find-name-global codes (TS2580/
+   *  TS2591/TS2688/TS2868) + TS2307 on a `bun:`/`node:` BUILTIN specifier. */
+  envTypeErrors: number;
   browser: number;
   build: number;
 }
@@ -63,6 +73,14 @@ export interface IFailureSummary {
 
 const TS_CODE = /^TS\d+$/;
 const MISSING_MODULE = /cannot find module/i;
+// Runtime-global lookup failures: "Cannot find name 'Bun'/'process'…" — tsc's
+// install-@types hints (2580 node globals, 2591 process, 2688 missing types
+// file, 2868 Bun). These NEVER come from model-invented code in a repo that ran
+// before; they mean the GATE's tsconfig dropped the runtime's type definitions.
+const ENV_GLOBAL_CODES = new Set(["TS2580", "TS2591", "TS2688", "TS2868"]);
+// A TS2307 on a runtime BUILTIN specifier (`bun:test`, `node:fs`) is the same
+// environment signal — a model cannot hallucinate the runtime's own modules.
+const BUILTIN_MODULE = /cannot find module '(?:bun|node):/i;
 // The terminal degeneration stops say "repetition loop" (run.ts, session.ts) —
 // NOT "degenerate". Match both the user-facing phrase and the internal term.
 const DEGENERATE = /repetition loop|degenerat/i;
@@ -163,9 +181,20 @@ function gatherSignals(
   // Only fall back to the text scan when there are NO structured final rules to
   // classify from — i.e. it's a genuine fallback for unstructured logs, not a
   // veto over a decisive gate error.
+  //
+  // A TS2307 whose message names a runtime BUILTIN (`bun:test`, `node:fs`)
+  // counts as an environment error, not a hallucinated import — that split
+  // needs the per-error messages, so it only refines the finalErrors path;
+  // the rules-only fallback keeps every TS2307 under missingModule.
+  const builtin2307 = (finalErrors ?? []).filter(
+    (e) => e.rule === "TS2307" && BUILTIN_MODULE.test(e.message)
+  ).length;
   const missingModule =
-    rules.filter((r) => r === "TS2307").length +
+    rules.filter((r) => r === "TS2307").length -
+    builtin2307 +
     (rules.length === 0 && MISSING_MODULE.test(text) ? 1 : 0);
+  const envTypeErrors =
+    rules.filter((r) => ENV_GLOBAL_CODES.has(r)).length + builtin2307;
 
   return {
     repairs: events.filter((e) => e.kind === "repair").length,
@@ -181,9 +210,12 @@ function gatherSignals(
     degenerated: events.some((e) => DEGENERATE.test(e.message)),
     timedOut: events.some((e) => TIMED_OUT.test(e.message)),
     toolUseFailed: events.some((e) => TOOL_USE_FAILED.test(e.message)),
-    tsErrors: rules.filter((r) => TS_CODE.test(r) && r !== "TS2307").length,
+    tsErrors: rules.filter(
+      (r) => TS_CODE.test(r) && r !== "TS2307" && !ENV_GLOBAL_CODES.has(r)
+    ).length,
     lintErrors: rules.filter((r) => !TS_CODE.test(r)).length,
     missingModule,
+    envTypeErrors,
     browser: BROWSER.test(text) ? 1 : 0,
     build: BUILD.test(text) ? 1 : 0,
   };
@@ -273,6 +305,14 @@ export function classifyRun(
     return { failureClass: FAILURE_CLASS.degeneration, signals };
   }
 
+  // Environment errors outrank hallucinated-import: when the gate can't even
+  // resolve the runtime's own modules/globals, every other cannot-find-module
+  // in the same run is suspect (same broken resolution), and "install the
+  // package" guidance would send the model chasing ghosts.
+  if (signals.envTypeErrors > 0) {
+    return { failureClass: FAILURE_CLASS.missingRuntimeTypes, signals };
+  }
+
   if (signals.missingModule > 0) {
     return { failureClass: FAILURE_CLASS.hallucinatedImport, signals };
   }
@@ -313,6 +353,7 @@ function emptySignals(): IFailureSignals {
     tsErrors: 0,
     lintErrors: 0,
     missingModule: 0,
+    envTypeErrors: 0,
     browser: 0,
     build: 0,
   };
@@ -347,6 +388,12 @@ const ATTRIBUTION_GUIDANCE: Record<FailureClass, string> = {
     "if the missing module is an npm package, install it (and `@types/*` if it ships no types) " +
     "before more feature code; only create a local file when the import is a project-relative " +
     "path — do not invent packages",
+  [FAILURE_CLASS.missingRuntimeTypes]:
+    "the typecheck environment is missing the runtime's type definitions (Bun/Node globals or " +
+    "builtin modules) — a gate/tsconfig configuration problem, NOT missing npm packages. Do not " +
+    "install packages, create shim files, or edit code to work around unresolvable globals; if a " +
+    "tsconfig is in scope, ensure its `types` covers the runtime (e.g. `bun-types`/`@types/bun`, " +
+    "`@types/node`) — otherwise raise a hand",
   [FAILURE_CLASS.editReject]:
     "fix the path/scope of the write; do not retry the same rejected target",
   [FAILURE_CLASS.toolMalformed]:

--- a/packages/core/src/gate/tsconfig.ts
+++ b/packages/core/src/gate/tsconfig.ts
@@ -1,10 +1,15 @@
 import { join } from "node:path";
 import { TSC_BIN } from "./tool-paths";
 import { shellQuote } from "../lib/fs";
+import { isRecord } from "../lib/guards";
+import { listChildPackageRoots } from "./workspace-root";
 
 // The strict tsconfig tsforge brings to a greenfield project — strict + the
 // index-safety the local model is weakest at, with DOM + JSX libs so browser /
 // React code type-checks, and skipLibCheck so it never trips on dep .d.ts.
+// `__TYPES__` is replaced with a `"types"` line (or nothing) per project, so a
+// Bun package gets its runtime globals (`Bun`, `bun:test`) instead of hundreds
+// of phantom cannot-find-name errors.
 const STRICT_TSCONFIG = `{
   "compilerOptions": {
     "target": "ES2022",
@@ -12,7 +17,7 @@ const STRICT_TSCONFIG = `{
     "moduleResolution": "bundler",
     "lib": ["ES2022", "DOM", "DOM.Iterable"],
     "jsx": "react-jsx",
-    "strict": true,
+__TYPES__    "strict": true,
     "noUncheckedIndexedAccess": true,
     "noImplicitOverride": true,
     "noFallthroughCasesInSwitch": true,
@@ -68,6 +73,60 @@ const STRICT_TSCONFIG_OVERLAY = `{
   "exclude": ["../node_modules", "../dist", "../build", "../scratch", "../.tsforge"]
 }
 `;
+
+/** The greenfield strict tsconfig with the `__TYPES__` slot resolved for `cwd`:
+ *  a Bun package (bun lockfile / packageManager / engines.bun) gets a `"types"`
+ *  entry for whichever Bun type package is actually installed, so `Bun`,
+ *  `bun:test`, and `import.meta.dir` type-check; everything else gets no line. */
+export async function strictTsconfigFor(cwd: string): Promise<string> {
+  const types = (await usesBun(cwd)) ? await bunTypesPackage(cwd) : null;
+  const line = types === null ? "" : `    "types": ["${types}"],\n`;
+
+  return STRICT_TSCONFIG.replace("__TYPES__", line);
+}
+
+/** Bun runtime markers: a lockfile, or a bun packageManager/engines pin. */
+async function usesBun(cwd: string): Promise<boolean> {
+  if (
+    (await Bun.file(join(cwd, "bun.lock")).exists()) ||
+    (await Bun.file(join(cwd, "bun.lockb")).exists())
+  ) {
+    return true;
+  }
+
+  try {
+    const pkg: unknown = JSON.parse(
+      await Bun.file(join(cwd, "package.json")).text()
+    );
+
+    if (!isRecord(pkg)) {
+      return false;
+    }
+
+    return (
+      (typeof pkg.packageManager === "string" &&
+        pkg.packageManager.startsWith("bun@")) ||
+      (isRecord(pkg.engines) && "bun" in pkg.engines)
+    );
+  } catch {
+    return false;
+  }
+}
+
+/** The INSTALLED Bun type package's name (`@types/bun` or `bun-types`), or null
+ *  when neither resolves — a `"types"` entry naming an absent package trades the
+ *  phantom-global flood for a hard TS2688, so only ever point at a real one. */
+async function bunTypesPackage(cwd: string): Promise<string | null> {
+  for (const name of ["@types/bun", "bun-types"]) {
+    if (
+      await Bun.file(join(cwd, "node_modules", name, "package.json")).exists()
+    ) {
+      return name;
+    }
+  }
+
+  return null;
+}
 
 /** The gate overlay's home: tsforge's cache dir + the overlay filename. */
 const GATE_TSCONFIG_DIR = ".tsforge";
@@ -139,9 +198,17 @@ export async function tscPart(cwd: string): Promise<string | null> {
 
   // Greenfield: bring a strict tsconfig so tsc can gate — but only when this is
   // actually a TS project (has a package.json), so we never litter a random dir.
+  // A root with CHILD packages nested below it is never greenfield, whatever its
+  // own manifest looks like: a whole-tree strict tsconfig at a monorepo root
+  // sweeps every package under one config that owns none of their types/paths
+  // (observed: 708 phantom errors in a Bun monorepo, then quick-fix vandalism
+  // driven by those phantoms). Those roots gate per package or not at all.
   // Unlike the overlay, a greenfield tsconfig.json is a DURABLE project file.
-  if (await Bun.file(join(cwd, "package.json")).exists()) {
-    await Bun.write(join(cwd, PROJECT_TSCONFIG), STRICT_TSCONFIG);
+  if (
+    (await Bun.file(join(cwd, "package.json")).exists()) &&
+    listChildPackageRoots(cwd).length === 0
+  ) {
+    await Bun.write(join(cwd, PROJECT_TSCONFIG), await strictTsconfigFor(cwd));
     // The buildinfo lives in .tsforge/ (git-ignored), NOT next to the durable
     // tsconfig — so incremental never leaks a cache file into the user's tree.
     await ignoreGateArtifact(cwd);

--- a/packages/core/src/gate/workspace-root.ts
+++ b/packages/core/src/gate/workspace-root.ts
@@ -1,24 +1,96 @@
 import { join, resolve, relative, isAbsolute, basename } from "node:path";
-import { readdirSync, existsSync } from "node:fs";
+import { readdirSync, existsSync, readFileSync } from "node:fs";
+import { isRecord } from "../lib/guards";
+
+/** Manifest fields whose presence marks a package.json as a REAL package (its
+ *  own code + deps to gate) rather than a scripts-only monorepo root shell. */
+const DEP_FIELDS = [
+  "dependencies",
+  "devDependencies",
+  "peerDependencies",
+  "optionalDependencies",
+] as const;
+
+/** True when `cwd`'s package.json declares no dependencies of any kind — the
+ *  scripts-only shell manifest a monorepo root keeps for `engines`/`scripts`
+ *  (boringstack's shape). Unreadable/unparseable ⇒ NOT a shell (fail closed:
+ *  treat it as a real package rather than re-scoping the gate on bad JSON). */
+function isShellManifest(cwd: string): boolean {
+  let raw: string;
+
+  try {
+    raw = readFileSync(join(cwd, "package.json"), "utf8");
+  } catch {
+    return false;
+  }
+
+  try {
+    const pkg: unknown = JSON.parse(raw);
+
+    if (!isRecord(pkg)) {
+      return false;
+    }
+
+    return DEP_FIELDS.every((field) => {
+      const deps = pkg[field];
+
+      return (
+        deps === undefined || (isRecord(deps) && Object.keys(deps).length === 0)
+      );
+    });
+  } catch {
+    return false;
+  }
+}
 
 /**
- * A folder that contains other JS packages but is not itself a package
- * (no root package.json). Example: a multi-repo workspace root.
+ * A folder that contains other JS packages but is not itself a package to gate:
+ * either no root package.json at all (a multi-repo workspace bag), or a
+ * scripts-only shell manifest with the real packages nested below (a monorepo
+ * root like `apps/api` + `apps/ui`). Gating such a root as ONE package breaks
+ * everything downstream — a root tsconfig sweeping every .ts file across
+ * packages that own their types/paths yields hundreds of phantom errors (observed:
+ * a Bun monorepo red with 708 `bun:test`/`Bun`-not-found errors), so the
+ * per-package container gate must engage instead.
  */
 export function isWorkspaceContainer(cwd: string): boolean {
-  if (existsSync(join(cwd, "package.json"))) {
+  if (existsSync(join(cwd, "package.json")) && !isShellManifest(cwd)) {
     return false;
   }
 
   return listChildPackageRoots(cwd).length > 0;
 }
 
-/** Absolute paths of immediate child directories that have a package.json. */
+/** Package roots under `cwd`: immediate child directories with a package.json,
+ *  plus — for child directories WITHOUT one (grouping dirs like `apps/`,
+ *  `packages/`) — their immediate children that have one. Two levels covers the
+ *  conventional monorepo layouts; a dir that IS a package is never descended
+ *  into (its nested fixtures/examples belong to it, not the workspace). */
 export function listChildPackageRoots(cwd: string): string[] {
+  const out: string[] = [];
+
+  for (const child of childDirs(cwd)) {
+    if (existsSync(join(child, "package.json"))) {
+      out.push(child);
+      continue;
+    }
+
+    for (const grandchild of childDirs(child)) {
+      if (existsSync(join(grandchild, "package.json"))) {
+        out.push(grandchild);
+      }
+    }
+  }
+
+  return out.sort();
+}
+
+/** Absolute paths of `dir`'s child directories worth scanning for packages. */
+function childDirs(dir: string): string[] {
   let entries: { name: string; isDirectory: () => boolean }[];
 
   try {
-    entries = readdirSync(cwd, { withFileTypes: true, encoding: "utf8" });
+    entries = readdirSync(dir, { withFileTypes: true, encoding: "utf8" });
   } catch {
     return [];
   }
@@ -34,14 +106,10 @@ export function listChildPackageRoots(cwd: string): string[] {
       continue;
     }
 
-    const child = join(cwd, entry.name);
-
-    if (existsSync(join(child, "package.json"))) {
-      out.push(child);
-    }
+    out.push(join(dir, entry.name));
   }
 
-  return out.sort();
+  return out;
 }
 
 /** True when `abs` is `dir` itself or lives anywhere under it. */

--- a/packages/core/src/loop/turn.ts
+++ b/packages/core/src/loop/turn.ts
@@ -739,10 +739,17 @@ export interface ILoopState {
 }
 
 /** Build the in-process TS LanguageService if the project has a tsconfig. Guarded
- *  so a setup failure can't break the loop (the `tsc -p` gate stays authority). */
+ *  so a setup failure can't break the loop (the `tsc -p` gate stays authority).
+ *  Never at a workspace-container root: any tsconfig there governs NO package
+ *  (often litter from an old greenfield write), and a whole-monorepo program
+ *  with broken per-package resolution makes every LSP answer a phantom while
+ *  its synchronous typechecks stall the interactive event loop for minutes. */
 export async function buildTsService(cwd: string): Promise<TsService | null> {
   try {
-    if (await fileExists(cwd, "tsconfig.json")) {
+    if (
+      (await fileExists(cwd, "tsconfig.json")) &&
+      !isWorkspaceContainer(cwd)
+    ) {
       return new TsService(cwd);
     }
   } catch (err) {
@@ -1093,6 +1100,14 @@ function fixCountsFor(counts: Map<string, IFixCounts>, f: string): IFixCounts {
   return c;
 }
 
+/** Hand the event loop one macrotask turn so stdin/paint stay alive between
+ *  synchronous language-service chunks (the janitor runs in the TUI process). */
+function yieldToEventLoop(): Promise<void> {
+  return new Promise((resolve) => {
+    setImmediate(resolve);
+  });
+}
+
 /** TS quick-fixes + import hygiene over `files`; returns the total applied. */
 async function applyTsQuickFixes(
   ctx: ILoopCtx,
@@ -1109,6 +1124,11 @@ async function applyTsQuickFixes(
   for (const f of files) {
     try {
       if (await fileExists(cwd, f)) {
+        // The language-service passes below are synchronous CPU work on the
+        // interactive process's ONLY thread — without a yield per file, a
+        // multi-file janitor pass freezes the TUI (no paint, no input) for
+        // its whole duration.
+        await yieldToEventLoop();
         tsService.refresh(f);
         const quick = tsService.fixAll(f);
         // Dedupe/sort imports + drop unused ones the model left behind — free
@@ -1146,6 +1166,9 @@ async function applyIdiomRewrites(
   for (const f of files) {
     try {
       if (await fileExists(cwd, f)) {
+        // Same per-file yield as applyTsQuickFixes — ast-grep parses run on
+        // the TUI thread too.
+        await yieldToEventLoop();
         let idioms = await astGrepFix(join(cwd, f));
 
         // Backstop the write-time strip (covers files changed via rename/organize

--- a/packages/core/src/lsp/service.ts
+++ b/packages/core/src/lsp/service.ts
@@ -88,6 +88,46 @@ const SAFE_FIXES = new Set([
   "fixAddMissingConstraint",
 ]);
 
+/** Diagnostic codes that mean the PROGRAM'S ENVIRONMENT is broken — modules or
+ *  runtime globals unresolvable (2307 cannot-find-module, 2580/2591 node
+ *  globals, 2688 missing types file, 2868 Bun). Under such a program every
+ *  other diagnostic is suspect: imports look unused because their module didn't
+ *  resolve, code looks unreachable because a type collapsed — and the "safe"
+ *  auto-fixes become vandalism (observed: 872 phantom quick-fixes over a Bun
+ *  monorepo gated without bun-types). Auto-fixers must stand down per-file. */
+const ENV_BROKEN_DIAG_CODES = new Set([2307, 2580, 2591, 2688, 2868]);
+
+/** Infer format settings from the file's own text instead of TypeScript's
+ *  4-space default, so an auto-fix in a 2-space or tab-indented project doesn't
+ *  reformat every line it touches into a foreign style. The unit is the
+ *  smallest positive leading-space run (tabs win when any line starts with
+ *  one); an unindented or unreadable file keeps the defaults. */
+function formatSettingsFor(text: string | undefined): ts.FormatCodeSettings {
+  const settings = ts.getDefaultFormatCodeSettings("\n");
+
+  if (text === undefined) {
+    return settings;
+  }
+
+  let minSpaces = Number.POSITIVE_INFINITY;
+
+  for (const line of text.split("\n")) {
+    if (line.startsWith("\t")) {
+      return { ...settings, convertTabsToSpaces: false };
+    }
+
+    const indent = line.length - line.trimStart().length;
+
+    if (indent > 0 && line.trim().length > 0 && indent < minSpaces) {
+      minSpaces = indent;
+    }
+  }
+
+  return Number.isFinite(minSpaces) && minSpaces !== 4
+    ? { ...settings, indentSize: minSpaces, tabSize: minSpaces }
+    : settings;
+}
+
 /**
  * Thin wrapper over the TypeScript LanguageService — the engine behind tsserver,
  * run in-process. Gives semantic diagnostics, TypeScript's own quick-fixes,
@@ -176,7 +216,7 @@ export class TsService {
   quickFixes(file: string): ITsFix[] {
     const abs = this.toAbs(file);
     const prefs: ts.UserPreferences = {};
-    const fmt = ts.getDefaultFormatCodeSettings("\n");
+    const fmt = formatSettingsFor(ts.sys.readFile(abs));
     const fixes: ITsFix[] = [];
 
     for (const d of this.diagnostics(file)) {
@@ -221,9 +261,18 @@ export class TsService {
 
   private firstSafeFix(file: string): ts.CodeFixAction | undefined {
     const abs = this.toAbs(file);
-    const fmt = ts.getDefaultFormatCodeSettings("\n");
+    const diagnostics = this.diagnostics(file);
 
-    for (const d of this.diagnostics(file)) {
+    // Environment broken (unresolvable modules/globals) → no diagnostic in this
+    // file can be trusted; auto-fixing on phantoms deletes live code. Stand down
+    // and let the gate surface the real (config) problem instead.
+    if (diagnostics.some((d) => ENV_BROKEN_DIAG_CODES.has(d.code))) {
+      return undefined;
+    }
+
+    const fmt = formatSettingsFor(ts.sys.readFile(abs));
+
+    for (const d of diagnostics) {
       const actions = this.service.getCodeFixesAtPosition(
         abs,
         d.start,
@@ -700,11 +749,19 @@ export class TsService {
     return new Set([...edits.map((e) => e.fileName), fromAbs]).size;
   }
 
-  /** Organize imports (dedupe/sort/drop unused) for one file. Returns edits made. */
+  /** Organize imports (dedupe/sort/drop unused) for one file. Returns edits made.
+   *  Stands down when the file has environment-broken diagnostics — with modules
+   *  unresolvable, "unused" is a phantom judgment (see ENV_BROKEN_DIAG_CODES). */
   organizeImports(file: string): number {
+    const abs = this.toAbs(file);
+
+    if (this.diagnostics(file).some((d) => ENV_BROKEN_DIAG_CODES.has(d.code))) {
+      return 0;
+    }
+
     const changes = this.service.organizeImports(
-      { type: "file", fileName: this.toAbs(file) },
-      ts.getDefaultFormatCodeSettings("\n"),
+      { type: "file", fileName: abs },
+      formatSettingsFor(ts.sys.readFile(abs)),
       {}
     );
 

--- a/packages/core/tests/failure-class.test.ts
+++ b/packages/core/tests/failure-class.test.ts
@@ -372,3 +372,72 @@ describe("attributionLeadIn", () => {
     );
   });
 });
+
+describe("missing-runtime-types (environment errors, not model errors)", () => {
+  test("runtime-global codes (TS2868 Bun / TS2591 process) → missing-runtime-types, not type-error", () => {
+    const out = classifyRun([
+      ev("validated", {
+        passed: false,
+        rules: ["TS2868", "TS2868", "TS2591", "TS2339"],
+      }),
+      STUCK,
+    ]);
+
+    expect(out.failureClass).toBe(FAILURE_CLASS.missingRuntimeTypes);
+    expect(out.signals.envTypeErrors).toBe(3);
+  });
+
+  test("TS2307 on a bun:/node: BUILTIN counts as environment, and outranks hallucinated-import", () => {
+    const errors: ErrorSet = [
+      {
+        key: "a",
+        rule: "TS2307",
+        message:
+          "Cannot find module 'bun:test' or its corresponding type declarations.",
+      },
+      {
+        key: "b",
+        rule: "TS2307",
+        message:
+          "Cannot find module 'node:fs' or its corresponding type declarations.",
+      },
+      {
+        key: "c",
+        rule: "TS2307",
+        message:
+          "Cannot find module 'dotenv' or its corresponding type declarations.",
+      },
+    ];
+    const out = classifyRun([STUCK], errors);
+
+    // The two builtin failures prove the gate environment is broken — the
+    // 'dotenv' one is the same broken resolution, not a hallucination.
+    expect(out.failureClass).toBe(FAILURE_CLASS.missingRuntimeTypes);
+    expect(out.signals.envTypeErrors).toBe(2);
+    expect(out.signals.missingModule).toBe(1);
+  });
+
+  test("plain TS2307 on an npm-looking module with a healthy environment stays hallucinated-import", () => {
+    const errors: ErrorSet = [
+      {
+        key: "a",
+        rule: "TS2307",
+        message:
+          "Cannot find module 'left-padd' or its corresponding type declarations.",
+      },
+    ];
+    const out = classifyRun([STUCK], errors);
+
+    expect(out.failureClass).toBe(FAILURE_CLASS.hallucinatedImport);
+    expect(out.signals.envTypeErrors).toBe(0);
+  });
+
+  test("attribution lead-in forbids installing/shimming around missing runtime types", () => {
+    const lead = attributionLeadIn({
+      failureClass: FAILURE_CLASS.missingRuntimeTypes,
+    });
+
+    expect(lead).toContain("missing-runtime-types");
+    expect(lead).toContain("Do not install packages");
+  });
+});

--- a/packages/core/tests/gate-redetect.test.ts
+++ b/packages/core/tests/gate-redetect.test.ts
@@ -1008,9 +1008,13 @@ test("Session refuses the package→container downgrade when root package.json v
   };
 
   try {
-    // A root package.json + a child package: deleting the root later makes
-    // isWorkspaceContainer(dir) true.
-    await writeFile(join(dir, "package.json"), JSON.stringify({ name: "x" }));
+    // A root package.json WITH dependencies (a real package, not a scripts-only
+    // shell — shells with child packages are containers up front now) + a child
+    // package: deleting the root later makes isWorkspaceContainer(dir) true.
+    await writeFile(
+      join(dir, "package.json"),
+      JSON.stringify({ name: "x", dependencies: { "left-pad": "1.0.0" } })
+    );
     await mkdir(join(dir, "api"), { recursive: true });
     await writeFile(
       join(dir, "api", "package.json"),

--- a/packages/core/tests/gate-tsconfig-overlay.test.ts
+++ b/packages/core/tests/gate-tsconfig-overlay.test.ts
@@ -1,5 +1,6 @@
 import { test, expect, describe } from "bun:test";
-import { mkdtemp, rm, writeFile, readFile } from "node:fs/promises";
+import { mkdtemp, rm, writeFile, readFile, mkdir } from "node:fs/promises";
+import { existsSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { tscPart } from "../src/gate/tsconfig";
@@ -85,6 +86,95 @@ describe("gate tsconfig overlay — the strict floor holds against a loose proje
       // the gate claimed a strict floor it wasn't enforcing.
       expect(run.exitCode).not.toBe(0);
       expect(run.stdout + run.stderr).toContain("TS2322");
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+});
+
+describe("greenfield tsconfig — monorepo litter guard + Bun types", () => {
+  test("no root tsconfig is written when child packages exist (monorepo root)", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "tsforge-litter-"));
+
+    try {
+      // boringstack shape: scripts-only root manifest, packages under apps/.
+      await writeFile(
+        join(dir, "package.json"),
+        '{"name":"mono","private":true,"scripts":{"check":"true"}}'
+      );
+      await mkdir(join(dir, "apps", "api"), { recursive: true });
+      await writeFile(
+        join(dir, "apps", "api", "package.json"),
+        '{"name":"api"}'
+      );
+
+      const command = await tscPart(dir);
+
+      // Neither a gate command for the whole bag nor a littered tsconfig.json.
+      expect(command).toBeNull();
+      expect(existsSync(join(dir, "tsconfig.json"))).toBe(false);
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  test("greenfield Bun package gets the installed Bun types in its tsconfig", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "tsforge-buntypes-"));
+
+    try {
+      await writeFile(join(dir, "package.json"), '{"name":"svc"}');
+      await writeFile(join(dir, "bun.lock"), "{}");
+      await mkdir(join(dir, "node_modules", "@types", "bun"), {
+        recursive: true,
+      });
+      await writeFile(
+        join(dir, "node_modules", "@types", "bun", "package.json"),
+        '{"name":"@types/bun"}'
+      );
+
+      await tscPart(dir);
+
+      const written: unknown = JSON.parse(
+        await readFile(join(dir, "tsconfig.json"), "utf8")
+      );
+      const types =
+        typeof written === "object" &&
+        written !== null &&
+        "compilerOptions" in written
+          ? Reflect.get(
+              (written as { compilerOptions: object }).compilerOptions,
+              "types"
+            )
+          : undefined;
+
+      expect(types).toEqual(["@types/bun"]);
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  test("greenfield non-Bun package gets NO types entry; Bun without installed types too", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "tsforge-notypes-"));
+
+    try {
+      await writeFile(join(dir, "package.json"), '{"name":"svc"}');
+      await tscPart(dir);
+
+      const plain = await readFile(join(dir, "tsconfig.json"), "utf8");
+
+      expect(plain).not.toContain('"types"');
+      expect(plain).not.toContain("__TYPES__");
+
+      // Bun markers but no resolvable types package → still no entry (a types
+      // line naming an absent package is a hard TS2688).
+      await rm(join(dir, "tsconfig.json"));
+      await writeFile(join(dir, "bun.lock"), "{}");
+      await tscPart(dir);
+
+      const bun = await readFile(join(dir, "tsconfig.json"), "utf8");
+
+      expect(bun).not.toContain('"types"');
+      expect(bun).not.toContain("__TYPES__");
     } finally {
       await rm(dir, { recursive: true, force: true });
     }

--- a/packages/core/tests/lsp-service.test.ts
+++ b/packages/core/tests/lsp-service.test.ts
@@ -144,3 +144,57 @@ test("typeAt returns the type at a position", async () => {
     await rm(dir, { recursive: true, force: true });
   }
 });
+
+test("fixAll + organizeImports STAND DOWN when the file has environment-broken diagnostics", async () => {
+  // A module that can't resolve (broken env) + an import that would look
+  // "unused" + a would-be-unused local: under a broken program the janitor
+  // must not touch the file at all (observed vandalism: 872 phantom fixes in
+  // a Bun monorepo gated without bun-types).
+  const dir = await project({
+    "a.ts":
+      'import { helper } from "bun:test";\n' +
+      "const maybeUnused = 1;\n" +
+      "export const y = helper;\n" +
+      "void maybeUnused;\n",
+    "b.ts":
+      'import { readFileSync } from "not-a-real-module-xyz";\n' +
+      "const unused = 1;\n" +
+      "export const z = 2;\n",
+  });
+
+  try {
+    const svc = new TsService(dir);
+    const before = await Bun.file(join(dir, "b.ts")).text();
+
+    expect(svc.fixAll("b.ts")).toBe(0);
+    expect(svc.organizeImports("b.ts")).toBe(0);
+    expect(await Bun.file(join(dir, "b.ts")).text()).toBe(before);
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test("auto-fix formatting follows the file's own indent (2-space file stays 2-space)", async () => {
+  // A missing import fix in a 2-space file: TypeScript's DEFAULT format
+  // settings are 4-space, which reformatted touched import blocks into a
+  // foreign style across real repos.
+  const dir = await project({
+    "util.ts":
+      "export function twoSpaced(\n  a: number,\n  b: number\n): number {\n  return a + b;\n}\n",
+    "a.ts": "export const y = twoSpaced(\n  1,\n  2\n);\n",
+  });
+
+  try {
+    const svc = new TsService(dir);
+
+    svc.fixAll("a.ts");
+
+    const text = await Bun.file(join(dir, "a.ts")).text();
+
+    expect(text).toContain('import { twoSpaced } from "./util"');
+    // No line of the result uses a 4-space indent unit.
+    expect(text.split("\n").some((l) => l.startsWith("    "))).toBe(false);
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});

--- a/packages/core/tests/self-harness-mine.test.ts
+++ b/packages/core/tests/self-harness-mine.test.ts
@@ -85,6 +85,7 @@ describe("dominantSignal", () => {
       tsErrors: 0,
       lintErrors: 0,
       missingModule: 0,
+      envTypeErrors: 0,
       browser: 0,
       build: 0,
     };

--- a/packages/core/tests/workspace-container-gate.test.ts
+++ b/packages/core/tests/workspace-container-gate.test.ts
@@ -28,15 +28,86 @@ const stubTask: ITask = {
   files: ["**/*"],
 };
 
-test("isWorkspaceContainer: root package.json is never a container", async () => {
+test("isWorkspaceContainer: root package.json WITH deps is never a container", async () => {
   const dir = await tempDir();
 
   try {
-    await writeFile(join(dir, "package.json"), "{}");
+    await writeFile(
+      join(dir, "package.json"),
+      '{"dependencies":{"left-pad":"1.0.0"}}'
+    );
     await mkdir(join(dir, "packages"));
     await writeFile(join(dir, "packages", "package.json"), "{}");
 
     expect(isWorkspaceContainer(dir)).toBe(false);
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test("isWorkspaceContainer: scripts-only shell root over nested packages IS a container (boringstack shape)", async () => {
+  const dir = await tempDir();
+
+  try {
+    // Root manifest: scripts/engines only — no dependency fields at all.
+    await writeFile(
+      join(dir, "package.json"),
+      '{"name":"mono","private":true,"scripts":{"check":"true"},"engines":{"bun":"1.3.14"}}'
+    );
+    // Packages at depth 2 under a grouping dir, like apps/api + apps/ui.
+    await mkdir(join(dir, "apps", "api"), { recursive: true });
+    await mkdir(join(dir, "apps", "ui"), { recursive: true });
+    await writeFile(join(dir, "apps", "api", "package.json"), '{"name":"api"}');
+    await writeFile(join(dir, "apps", "ui", "package.json"), '{"name":"ui"}');
+
+    expect(isWorkspaceContainer(dir)).toBe(true);
+    expect(listChildPackageRoots(dir)).toEqual([
+      join(dir, "apps", "api"),
+      join(dir, "apps", "ui"),
+    ]);
+    // A tsconfig littered at the root by an old greenfield write must not
+    // change the verdict — detection keys on the manifest, not the litter.
+    await writeFile(join(dir, "tsconfig.json"), "{}");
+    expect(isWorkspaceContainer(dir)).toBe(true);
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test("isWorkspaceContainer: empty dep OBJECTS still count as a shell; bad JSON fails closed", async () => {
+  const dir = await tempDir();
+
+  try {
+    await mkdir(join(dir, "api"));
+    await writeFile(join(dir, "api", "package.json"), '{"name":"api"}');
+
+    await writeFile(
+      join(dir, "package.json"),
+      '{"name":"mono","dependencies":{},"devDependencies":{}}'
+    );
+    expect(isWorkspaceContainer(dir)).toBe(true);
+
+    // Unparseable root manifest → treat as a real package (never re-scope the
+    // gate on bad JSON).
+    await writeFile(join(dir, "package.json"), "{not json");
+    expect(isWorkspaceContainer(dir)).toBe(false);
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test("listChildPackageRoots: never descends INTO a package (nested fixtures stay its own)", async () => {
+  const dir = await tempDir();
+
+  try {
+    await mkdir(join(dir, "api", "examples", "demo"), { recursive: true });
+    await writeFile(join(dir, "api", "package.json"), '{"name":"api"}');
+    await writeFile(
+      join(dir, "api", "examples", "demo", "package.json"),
+      '{"name":"demo"}'
+    );
+
+    expect(listChildPackageRoots(dir)).toEqual([join(dir, "api")]);
   } finally {
     await rm(dir, { recursive: true, force: true });
   }

--- a/verbose
+++ b/verbose
@@ -1,3 +1,0 @@
-[t] boom
-Error: boom
-    at <anonymous> (/agjs/code/tsforge/packages/core/tests/lib-trace.test.ts:55:20)


### PR DESCRIPTION
## The repro

Asking a local model to bump dependencies in **boringstack** (a Bun monorepo: scripts-only root `package.json`, packages at `apps/api` / `apps/ui` / `apps/docs`) ended `stuck` with `failure class: hallucinated-import` after 52 turns. Trace: `2026-08-30-16-50-33-mtg1pnxp-mfyuof.jsonl`. The model's work was correct; the harness failed it four ways.

## Root causes

1. **Workspace detection missed the monorepo.** `isWorkspaceContainer` returned false because a root `package.json` — any at all — disqualified the dir, and discovery only scanned immediate children while the packages sit at depth 2 (`apps/*`). The per-package container gate never engaged.
2. **Greenfield logic littered a whole-tree strict tsconfig at the monorepo root** ("has package.json, no tsconfig" ⇒ greenfield). Every later gate typechecked all three apps under it — no `bun-types`, no per-app `paths`, resolution rooted where no app's node_modules live → **708 phantom errors** (`Cannot find module 'bun:test'`, `Cannot find name 'Bun'`, `Cannot find name 'process'`, …).
3. **The classifier blamed the model**: every TS2307 counts as `hallucinated-import`, so the inject told the model to *install* `bun:test`. Dead end by construction.
4. **The pre-gate janitor vandalized the repo, steered by the phantoms**: `tsFixAll: applied 872 TypeScript quick-fix(es)`, `auto-fixed 131 file(s)` — deleting "unused" imports (they only looked unused because resolution was broken) and reformatting 2-space code to TypeScript's default 4-space. And because the language service runs **synchronously on the TUI thread**, every one of those passes froze the UI — no paint, no input, no scrolling — for the duration.

## The fixes

- **`gate/workspace-root.ts`** — a dependency-less *shell* root manifest over child packages is a workspace container; discovery scans two levels and never descends into a package; unparseable manifest fails closed; a littered root tsconfig can't flip the verdict.
- **`gate/tsconfig.ts`** — greenfield never writes a root tsconfig when child packages exist; a genuine greenfield Bun package gets the *installed* Bun types (`@types/bun`/`bun-types`) in the generated config (never an entry naming an absent package — that trades the phantom flood for a hard TS2688).
- **`eval/failure-class.ts`** — new **`missing-runtime-types`** class: TS2580/2591/2688/2868 and TS2307 on `bun:`/`node:` builtins attribute to the environment, outrank `hallucinated-import`, and carry guidance that forbids installing/shimming around missing globals.
- **`lsp/service.ts`** — `fixAll`/`organizeImports` stand down on any file with environment-broken diagnostics; auto-fix formatting infers the file's own indent.
- **`loop/turn.ts`** — no `TsService` at a container root (whatever tsconfig sits there governs no package); per-file `setImmediate` yields in the janitor loops so the TUI keeps painting and reading input during passes.

Also deletes tracked test litter at the repo root (`0`, `FALSE`, `Off`, `false`, `no`, `off`, `verbose` — trace output written to filenames taken from `TSFORGE_TRACE` env values by `lib-trace.test.ts`; the test-isolation fix for that is a follow-up).

## Verification

- `bun test packages`: 5870 pass / 0 fail; typecheck, lint, format, rules/arch checks clean.
- Against the real repro (read-only + cache-namespace writes only): detection now reports the container with exactly `apps/api`, `apps/docs`, `apps/ui`; the per-package gate overlay typechecks **apps/api clean (708 phantoms → 0)** on the very tree the model produced, and surfaces 4 *real* strict-floor findings (TS1294) in apps/ui.

## Follow-ups (not in this PR)

- Move the language service off the main thread entirely (worker) — the per-file yields fix responsiveness for healthy programs, but a single huge file's pass is still a synchronous chunk.
- `lib-trace.test.ts` cwd isolation so it can't write trace files into the repo root again.
