### PR TITLE
fix(eval): degeneration classifier no longer matches filenames in gate output

### DIFF
--- a/packages/core/src/eval/failure-class.ts
+++ b/packages/core/src/eval/failure-class.ts
@@ -207,7 +207,15 @@ function gatherSignals(
       (e) =>
         (e.kind === "edit" || e.kind === "tool") && REJECTED.test(e.message)
     ).length,
-    degenerated: events.some((e) => DEGENERATE.test(e.message)),
+    // `token` events are raw pass-through text (gate/tool output, streamed
+    // content) — never a harness-authored signal — so they're excluded here,
+    // same as the other kind-scoped signals below. Without this, a gate error
+    // that merely MENTIONS a path containing "degenerat" (e.g. a real TS2307
+    // on packages/core/tests/run-degenerated.test.ts) trips the regex and
+    // masks the actual cause with a false "degeneration" verdict.
+    degenerated: events.some(
+      (e) => e.kind !== "token" && DEGENERATE.test(e.message)
+    ),
     timedOut: events.some((e) => TIMED_OUT.test(e.message)),
     toolUseFailed: events.some((e) => TOOL_USE_FAILED.test(e.message)),
     tsErrors: rules.filter(

--- a/packages/core/tests/failure-class.test.ts
+++ b/packages/core/tests/failure-class.test.ts
@@ -168,6 +168,24 @@ describe("classifyRun", () => {
     ).toBe(FAILURE_CLASS.degeneration);
   });
 
+  test("a tsc error whose PATH merely mentions 'degenerat' does not false-positive as degeneration", () => {
+    // Real incident: packages/core/tests/run-degenerated.test.ts failed to
+    // resolve 'bun:test' (TS2307). The raw tsc text landed as a `token` event
+    // and its filename contains the substring "degenerat" — this must classify
+    // as hallucinated-import (the real cause), not degeneration.
+    const out = classifyRun([
+      ev("token", {
+        message:
+          "packages/core/tests/run-degenerated.test.ts(1,30): error TS2307: " +
+          "Cannot find module 'bun:test' or its corresponding type declarations.\n",
+      }),
+      ev("validated", { passed: false, rules: ["TS2307"] }),
+      STUCK,
+    ]);
+
+    expect(out.failureClass).toBe(FAILURE_CLASS.hallucinatedImport);
+  });
+
   test("malformed-tool-call / narrate-instead-of-build stops → tool-malformed", () => {
     expect(
       classifyRun([


### PR DESCRIPTION
## Summary
- The user hit a session that reported `failure class: degeneration` (stuck, 36 turns, never green) via `tsforge trace`. The actual repeating error was a genuine TS2307 — `Cannot find module 'bun:test'` in `packages/core/tests/run-degenerated.test.ts` — with no StreamGuard repetition-loop stop anywhere in the log.
- Root cause: `gatherSignals` in `failure-class.ts` scanned **every** event's raw `message` for `/repetition loop|degenerat/i`, including `token`-kind events (raw pass-through gate/tool output) — unlike the other signals, which are already scoped to specific event kinds. The tsc error text happens to contain the substring `"degenerat"` because of the test file's own name, so it tripped the regex and got classified as `degeneration` instead of `hallucinated-import` — masking the real cause and feeding the model the wrong `ATTRIBUTION_GUIDANCE` ("stop repeating" instead of "the missing module is an npm/type package, install it").
- Fix: exclude `token`-kind events from the `DEGENERATE` scan. Real terminal degeneration stops (`run.ts`, `session.ts`) always report as kind `"stuck"` or `"tool"`, never `"token"` — so this loses no real signal.

Note: the same trace's underlying gate failure (a monorepo root gated as one flattened project, missing per-package ambient types) turned out to already be fixed on `main` by #360, merged shortly before this session ran but not yet pulled locally. This PR is rebased on top of that — it's the one remaining, distinct bug from the same incident: `#360` never touched the `DEGENERATE` regex.

## Test plan
- [x] New regression test pins the exact repro: a `token`-kind TS2307 event whose message mentions `run-degenerated.test.ts` now classifies as `hallucinated-import`, not `degeneration`.
- [x] Confirmed red on the pre-fix code (`git stash` the fix, test fails with `Received: "degeneration"`), green after.
- [x] `bun run typecheck` — clean
- [x] `bun run lint` — clean
- [x] `bun test packages/core/tests/failure-class.test.ts packages/core/tests/gate-redetect.test.ts packages/core/tests/workspace-container-gate.test.ts packages/core/tests/gate-tsconfig-overlay.test.ts` — 77 pass, 0 fail (rebased on #360, no overlap/regressions with its own additions to these files)
- [x] Rebased onto current `main` (post #360, post 0.53.2) — mergeable, no conflicts