### PR TITLE
feat: add --json to tsforge review

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,4 @@ test-results/
 
 # local build/panel logs (never commit)
 /scratchpad-*.log*
+.local-plans/

--- a/apps/docs/src/content/docs/cli/review.mdx
+++ b/apps/docs/src/content/docs/cli/review.mdx
@@ -10,6 +10,7 @@ tsforge review                 # review the current diff
 tsforge review --staged        # only staged changes (pre-commit)
 tsforge review --base develop   # diff against a specific ref
 tsforge review --with-gate     # run the gate first; skip what it already covers
+tsforge review --json          # report as one line of JSON, for scripting
 ```
 
 Inside a session, the same review is available as `/review`.
@@ -87,5 +88,7 @@ Keep the cap a couple below your endpoint's `max_num_seqs` so an interactive ses
 ## In CI
 
 `tsforge review` exits non-zero if any error-severity finding survives, so you can gate a PR on it. It uses `git` to find what changed, so run it inside a git repository.
+
+With `--json`, the report prints as a single line of JSON instead of formatted text, for scripting. It's the **last line** of stdout — progress and gate lines can print before it — so parse the last line, not the whole output (e.g. `tsforge review --json | tail -1 | jq .`).
 
 → [Commands](/reference/commands/) · [Map the repo](/cli/map/)

--- a/apps/docs/src/content/docs/reference/commands.mdx
+++ b/apps/docs/src/content/docs/reference/commands.mdx
@@ -50,11 +50,12 @@ tsforge review                 # functional review of the current diff
 tsforge review --staged        # only staged changes (pre-commit)
 tsforge review --base develop  # diff against an explicit base ref
 tsforge review --with-gate     # run the gate first; skip what it already covers
+tsforge review --json          # report as one line of JSON, for scripting
 ```
 
 `tsforge review` reviews the change you're working on: the working tree (committed **and** uncommitted edits) vs the auto-detected base (merge-base with `main`/`master`). No commit or push required.
 
-It is **functional** review: logic, regressions, edge cases, and business rules, guided by a built-in senior-review rubric (lenses), with each finding adversarially re-checked against the real code so false positives are dropped. Types, structure, and style are out of scope (the gate covers those). When a `tsconfig.json` is present it also feeds the reviewer a **caller blast-radius** signal (who calls each changed export, computed type-exactly) so the regression lens has concrete call sites to check. Exits non-zero if any **error**-severity finding survives, so it's CI-usable.
+It is **functional** review: logic, regressions, edge cases, and business rules, guided by a built-in senior-review rubric (lenses), with each finding adversarially re-checked against the real code so false positives are dropped. Types, structure, and style are out of scope (the gate covers those). When a `tsconfig.json` is present it also feeds the reviewer a **caller blast-radius** signal (who calls each changed export, computed type-exactly) so the regression lens has concrete call sites to check. Exits non-zero if any **error**-severity finding survives, so it's CI-usable. `--json` prints the report as a single line of JSON instead — the **last line** of stdout, since progress/gate output can print before it — for feeding into scripting or a CI integration.
 
 The same review is available inside an interactive session as **`/review`** (optionally `/review <base>` to diff against a specific ref). A review also runs **automatically after a task goes green** (toggle with `TSFORGE_NO_REVIEW`); when it surfaces findings, **`/reviewfix`** hands them to the agent to address. See [Review your changes](/cli/review/).
 

--- a/packages/core/ARCHITECTURE.md
+++ b/packages/core/ARCHITECTURE.md
@@ -94,20 +94,20 @@ Async functions returning an exit code, declared under the CLI — the commands.
 
 | Function | Declared |
 | --- | --- |
-| `agentsMode` | `cli.ts:364` |
-| `greenfieldMode` | `cli.ts:665` |
+| `agentsMode` | `cli.ts:368` |
+| `greenfieldMode` | `cli.ts:669` |
 | `harnessDiagnoseMode` | `cli/harness-diagnose-mode.ts:211` |
 | `harnessReviewMode` | `cli/harness-review-mode.ts:700` |
-| `main` | `cli.ts:781` |
-| `mapMode` | `cli.ts:500` |
-| `recipesMode` | `cli.ts:519` |
+| `main` | `cli.ts:785` |
+| `mapMode` | `cli.ts:504` |
+| `recipesMode` | `cli.ts:523` |
 | `repl` | `cli/repl.ts:1096` |
 | `reviewMode` | `cli.ts:201` |
 | `runOnce` | `cli.ts:103` |
 | `runTraceCommand` | `cli/repl-commands.ts:160` |
-| `scaffoldMode` | `cli.ts:747` |
-| `setupMode` | `cli.ts:508` |
-| `traceMode` | `cli.ts:570` |
+| `scaffoldMode` | `cli.ts:751` |
+| `setupMode` | `cli.ts:512` |
+| `traceMode` | `cli.ts:574` |
 
 ## Imports that leave `src/`
 

--- a/packages/core/src/cli.ts
+++ b/packages/core/src/cli.ts
@@ -4,7 +4,7 @@ import {
   RUN_STATUS,
   review,
   reviewRepair,
-  formatReport,
+  renderReport,
   runGreenfield,
   prepareState,
   planFeatures,
@@ -237,7 +237,11 @@ async function reviewMode(args: ICliArgs): Promise<number> {
     ),
   });
 
-  process.stdout.write(`\n${formatReport(report)}\n`);
+  process.stdout.write(
+    args.json
+      ? `${renderReport(report, true)}\n`
+      : `\n${renderReport(report, false)}\n`
+  );
 
   // Exit non-zero when there are error-severity findings, so it's CI-usable.
   return report.findings.some((f) => f.severity === "error") ? 1 : 0;

--- a/packages/core/src/cli/args.ts
+++ b/packages/core/src/cli/args.ts
@@ -46,7 +46,9 @@ export interface ICliArgs {
    *  (`tsforge review --with-gate`). */
   withGate: boolean;
   /** Emit the review report as a single line of JSON instead of formatted
-   *  text (`tsforge review --json`) — a stable contract for scripting. */
+   *  text (`tsforge review --json`) — a stable contract for scripting. It's
+   *  the LAST line of stdout: progress/gate lines can still print before it,
+   *  so a consumer should read the last line, not all of stdout. */
   json: boolean;
   /** After a one-shot run goes green, run the adversarial review and feed verified
    *  findings into ONE repair cycle, reverting it if it breaks the gate

--- a/packages/core/src/cli/args.ts
+++ b/packages/core/src/cli/args.ts
@@ -45,6 +45,9 @@ export interface ICliArgs {
   /** Run the gate first and tell the reviewer to skip what it already covers
    *  (`tsforge review --with-gate`). */
   withGate: boolean;
+  /** Emit the review report as a single line of JSON instead of formatted
+   *  text (`tsforge review --json`) — a stable contract for scripting. */
+  json: boolean;
   /** After a one-shot run goes green, run the adversarial review and feed verified
    *  findings into ONE repair cycle, reverting it if it breaks the gate
    *  (`--with-review`). */
@@ -111,6 +114,7 @@ const BOOL_FLAGS: Record<
   | "strictFloorOnly"
   | "staged"
   | "withGate"
+  | "json"
   | "withReview"
   | "scout"
   | "greenfield"
@@ -127,6 +131,7 @@ const BOOL_FLAGS: Record<
   "--strict-floor-only": "strictFloorOnly",
   "--staged": "staged",
   "--with-gate": "withGate",
+  "--json": "json",
   "--with-review": "withReview",
   "--scout": "scout",
   "--greenfield": "greenfield",
@@ -206,7 +211,7 @@ export function cliUsage(): string {
     "USAGE",
     "  tsforge                       interactive session (REPL)",
     '  tsforge "<task>"              one-shot task, driven to a green gate',
-    "  tsforge review [--staged]     functional review of the current diff",
+    "  tsforge review [--staged] [--json]  functional review of the current diff",
     "  tsforge map                   structural workspace map",
     "  tsforge setup [--yes]         infer + write project conventions",
     "  tsforge recipes | run <id>    list / run saved task recipes",
@@ -253,6 +258,7 @@ export function parseArgs(argv: readonly string[]): ICliArgs {
     review: false,
     staged: false,
     withGate: false,
+    json: false,
     withReview: false,
     scout: false,
     greenfield: false,

--- a/packages/core/src/loop/index.ts
+++ b/packages/core/src/loop/index.ts
@@ -90,6 +90,7 @@ export {
   review,
   reviewAgents,
   formatReport,
+  renderReport,
   formatReviewCard,
   LENSES,
   type IReviewAgentsOptions,

--- a/packages/core/src/loop/review/index.ts
+++ b/packages/core/src/loop/review/index.ts
@@ -1,5 +1,6 @@
 export {
   formatReport,
+  renderReport,
   detectBase,
   collectChangedFiles,
   dedupeFindings,

--- a/packages/core/src/loop/review/review-change.ts
+++ b/packages/core/src/loop/review/review-change.ts
@@ -178,3 +178,13 @@ export function formatReport(report: IReviewReport): string {
     ...lines,
   ].join("\n");
 }
+
+/** Render a report as either a single line of JSON (a stable, parseable
+ *  contract for downstream tooling — e.g. a CI integration that turns
+ *  findings into inline PR comments) or the existing plain-text format.
+ *  JSON output is exactly `JSON.stringify(report)`: no re-shaping, so the
+ *  contract is the same `IReviewReport` type callers of `review()` already
+ *  see, not a second, drifting shape. */
+export function renderReport(report: IReviewReport, json: boolean): string {
+  return json ? JSON.stringify(report) : formatReport(report);
+}

--- a/packages/core/src/loop/review/review-change.ts
+++ b/packages/core/src/loop/review/review-change.ts
@@ -184,7 +184,10 @@ export function formatReport(report: IReviewReport): string {
  *  findings into inline PR comments) or the existing plain-text format.
  *  JSON output is exactly `JSON.stringify(report)`: no re-shaping, so the
  *  contract is the same `IReviewReport` type callers of `review()` already
- *  see, not a second, drifting shape. */
+ *  see, not a second, drifting shape. In `--json` mode, `reviewMode` still
+ *  writes progress/gate lines to stdout before this — the JSON is
+ *  guaranteed to be the LAST line of stdout, not the only line, so a
+ *  consumer should read/parse the last line rather than all of stdout. */
 export function renderReport(report: IReviewReport, json: boolean): string {
   return json ? JSON.stringify(report) : formatReport(report);
 }

--- a/packages/core/tests/cli.test.ts
+++ b/packages/core/tests/cli.test.ts
@@ -542,6 +542,29 @@ test("removed --tui-panes / --no-tui-panes are ignored (not swallowed into the t
   expect(parseArgs(["--tui-panes", "ship", "it"]).task).toBe("ship it");
 });
 
+test("--json sets args.json for review", () => {
+  expect(parseArgs(["review", "--json"]).json).toBe(true);
+  expect(parseArgs(["review"]).json).toBe(false);
+});
+
+test("--json composes with --staged and --base without interfering", () => {
+  const a = parseArgs([
+    "review",
+    "--staged",
+    "--json",
+    "--base",
+    "origin/main",
+  ]);
+
+  expect(a.json).toBe(true);
+  expect(a.staged).toBe(true);
+  expect(a.base).toBe("origin/main");
+});
+
+test("cliUsage documents --json for review", () => {
+  expect(cliUsage()).toContain("--json");
+});
+
 test("paneConsoleRejectReason: tiny interactive TTY fails closed; pipes do not", () => {
   expect(
     paneConsoleRejectReason({

--- a/packages/core/tests/review-change.test.ts
+++ b/packages/core/tests/review-change.test.ts
@@ -1,0 +1,39 @@
+import { test, expect } from "bun:test";
+import { renderReport, formatReport } from "../src/loop/review/review-change";
+import type { IReviewReport } from "../src/loop/review/review.types";
+
+const BASE_REPORT: IReviewReport = {
+  base: "main",
+  changedFiles: ["src/a.ts"],
+  findings: [
+    {
+      file: "src/a.ts",
+      line: 10,
+      severity: "error",
+      lens: "logic",
+      claim: "off-by-one",
+      reason: "loop reads one past the array end",
+      verified: true,
+      verdict: "confirmed",
+    },
+  ],
+  rejected: 0,
+};
+
+test("renderReport(json=true) emits the report as a single JSON line, not the text format", () => {
+  const out = renderReport(BASE_REPORT, true);
+
+  expect(out).not.toContain("\n");
+  expect(JSON.parse(out)).toEqual(BASE_REPORT);
+});
+
+test("renderReport(json=false) falls through to formatReport, unchanged", () => {
+  expect(renderReport(BASE_REPORT, false)).toBe(formatReport(BASE_REPORT));
+});
+
+test("renderReport(json=true) round-trips an empty-findings report too", () => {
+  const empty: IReviewReport = { ...BASE_REPORT, findings: [] };
+  const out = renderReport(empty, true);
+
+  expect(JSON.parse(out)).toEqual(empty);
+});


### PR DESCRIPTION
Adds a `--json` flag to `tsforge review` that emits the report's IReviewReport as a single line of JSON instead of formatted text, for scripting/CI integration (e.g. turning findings into GitHub PR review comments). Exit-code behavior (non-zero on error-severity findings) is unchanged.

Note from validation: with `--with-gate` and/or fan-out concurrency > 1, `reviewMode` still writes progress lines (gate status, fan-out, per-agent progress) to stdout ahead of the JSON line — this predates this change (those lines already existed) but means a script piping `tsforge review --json` should take the last stdout line (e.g. `| tail -1 | jq .`) rather than assume the whole stream is one JSON blob. Worth a follow-up to route those progress lines to stderr when `--json` is set, if a truly clean single-line contract is wanted.