### PR TITLE
chore: release 0.53.4

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@agjs/tsforge",
   "type": "module",
-  "version": "0.53.3",
+  "version": "0.53.4",
   "license": "MIT",
   "description": "TypeScript coding harness with a deterministic gate, stack-aware guardrails, and stream-level correction.",
   "repository": {


### PR DESCRIPTION
Patch release for the base-ref-resolution fix (#367 / 1145e125): `tsforge review --base <branch>` was silently reporting zero changed files on a normal CI checkout (base branch only exists as `origin/<branch>`, not a local branch).