### PR TITLE
chore: release 0.53.5

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@agjs/tsforge",
   "type": "module",
-  "version": "0.53.4",
+  "version": "0.53.5",
   "license": "MIT",
   "description": "TypeScript coding harness with a deterministic gate, stack-aware guardrails, and stream-level correction.",
   "repository": {


### PR DESCRIPTION
Version bump for the 100-turn review budget and the browserslist/postcss-selector-parser dependency fixes merged in #370.