### PR TITLE
fix(review): wire --log into tsforge review

### DIFF
--- a/packages/core/ARCHITECTURE.md
+++ b/packages/core/ARCHITECTURE.md
@@ -94,20 +94,20 @@ Async functions returning an exit code, declared under the CLI — the commands.
 
 | Function | Declared |
 | --- | --- |
-| `agentsMode` | `cli.ts:368` |
-| `greenfieldMode` | `cli.ts:669` |
+| `agentsMode` | `cli.ts:382` |
+| `greenfieldMode` | `cli.ts:683` |
 | `harnessDiagnoseMode` | `cli/harness-diagnose-mode.ts:211` |
 | `harnessReviewMode` | `cli/harness-review-mode.ts:700` |
-| `main` | `cli.ts:785` |
-| `mapMode` | `cli.ts:504` |
-| `recipesMode` | `cli.ts:523` |
+| `main` | `cli.ts:799` |
+| `mapMode` | `cli.ts:518` |
+| `recipesMode` | `cli.ts:537` |
 | `repl` | `cli/repl.ts:1096` |
 | `reviewMode` | `cli.ts:201` |
 | `runOnce` | `cli.ts:103` |
 | `runTraceCommand` | `cli/repl-commands.ts:160` |
-| `scaffoldMode` | `cli.ts:751` |
-| `setupMode` | `cli.ts:512` |
-| `traceMode` | `cli.ts:574` |
+| `scaffoldMode` | `cli.ts:765` |
+| `setupMode` | `cli.ts:526` |
+| `traceMode` | `cli.ts:588` |
 
 ## Imports that leave `src/`
 

--- a/packages/core/src/cli.ts
+++ b/packages/core/src/cli.ts
@@ -49,7 +49,7 @@ import {
   modelForRun,
   envNumber,
 } from "./cli/model-setup";
-import { makeReporter, resolveLogPath } from "./cli/logging";
+import { makeReporter, resolveLogPath, withLedger } from "./cli/logging";
 import { resolveGate } from "./cli/gate-setup";
 import {
   loadTsforgeConfig,
@@ -224,6 +224,16 @@ async function reviewMode(args: ICliArgs): Promise<number> {
   // Configured reviewer model(s); empty ⇒ the primary model reviews.
   const reviewProviders = resolveReviewProviders(await loadModelsConfig());
 
+  // `--log` previously only worked for `runOnce`'s reporter (`makeReporter`,
+  // bound to the terminal render pipeline `review` doesn't use) — `review`
+  // accepted and silently ignored the flag. `withLedger` wraps review's own
+  // summary-tracker reporter instead, so the flag actually does something here.
+  const logFile = resolveLogPath("review", args.log);
+
+  if (logFile.length > 0) {
+    process.stdout.write(`  ↳ logging this run to ${logFile}\n`);
+  }
+
   const report = await review(makeProvider(entry), args.dir, {
     ...(args.base.length > 0 ? { base: args.base } : {}),
     staged: args.staged,
@@ -231,9 +241,13 @@ async function reviewMode(args: ICliArgs): Promise<number> {
     ...(reviewProviders.length > 0 ? { reviewProviders } : {}),
     log: (m) => process.stdout.write(`  ↳ ${m}\n`),
     concurrency,
-    // Each reviewer runs as a live agent; summarize the fan-out to the transcript.
-    onEvent: makeAgentSummaryTracker((line) =>
-      process.stdout.write(`  ↳ ${line}\n`)
+    // Each reviewer runs as a live agent; summarize the fan-out to the
+    // transcript, and (when --log is set) also append the raw event to the
+    // ledger.
+    onEvent: withLedger(
+      makeAgentSummaryTracker((line) => process.stdout.write(`  ↳ ${line}\n`)),
+      logFile,
+      "review"
     ),
   });
 

--- a/packages/core/src/cli/logging.ts
+++ b/packages/core/src/cli/logging.ts
@@ -75,30 +75,42 @@ const render: Reporter = (event) => {
   }
 };
 
-/** Reporter that renders to the terminal AND, when `--log <file>` is set, appends
- *  the full event stream as JSONL (one event per line, timestamped) for later
- *  evaluation — the durable record of what the agent did: its reasoning, every
- *  file it wrote, the gate verdicts, and the loops it got stuck in. Append-only
- *  (NOT overwritten like the session JSON), and unredacted — it's an opt-in local
- *  debug artifact. Logging failures never break the session. */
-export function makeReporter(
+/** Wraps any Reporter so that, when `--log <file>` is set, every event it
+ *  sees is ALSO appended as JSONL (one event per line, timestamped) — the
+ *  durable record of what the agent did: its reasoning, every file it
+ *  wrote, the gate verdicts, and the loops it got stuck in. Append-only
+ *  (NOT overwritten like the session JSON). Logging failures never break
+ *  the session. `logFile === ""` (logging off) returns `delegate` as-is. */
+export function withLedger(
+  delegate: Reporter,
   logFile: string,
   runId: string,
   sessionId?: string
 ): Reporter {
   if (logFile.length === 0) {
-    return render;
+    return delegate;
   }
 
   const ledger = new LedgerWriter(logFile, runId, sessionId);
 
   return (event) => {
-    render(event);
+    delegate(event);
 
     const { kind, agentId, ...rest } = event;
 
     ledger.record(ledgerTypeFor(event), { kind, ...rest }, agentId);
   };
+}
+
+/** `withLedger` bound to the CLI's own terminal reporter — what every
+ *  command used before `withLedger` existed to let others (e.g. `review`,
+ *  whose reporter isn't the terminal one) reuse the same ledger wiring. */
+export function makeReporter(
+  logFile: string,
+  runId: string,
+  sessionId?: string
+): Reporter {
+  return withLedger(render, logFile, runId, sessionId);
 }
 
 /** Resolve the run-log file when `--log` is set: an auto-named, timestamped JSONL

--- a/packages/core/tests/ledger.test.ts
+++ b/packages/core/tests/ledger.test.ts
@@ -9,7 +9,7 @@ import {
   type ILoopEvent,
   type LedgerEventType,
 } from "../src/loop";
-import { makeReporter } from "../src/cli/logging";
+import { makeReporter, withLedger } from "../src/cli/logging";
 import { parseEventLog } from "../src/eval";
 
 async function withLog<T>(
@@ -261,5 +261,38 @@ describe("agent attribution write→read round-trip", () => {
       expect(child?.totalTokens).toBe(42);
       expect(parent).toBeDefined();
     });
+  });
+
+  // `review`'s own reporter isn't the terminal one `makeReporter` wraps —
+  // this is what lets `--log` work there too (previously silently ignored:
+  // reviewMode accepted the flag but never wired up any ledger writer).
+  test("withLedger calls the delegate AND writes the ledger, for a non-terminal delegate", async () => {
+    await withLog(async (file, read) => {
+      const seenByDelegate: string[] = [];
+      const delegate = (event: ILoopEvent): void => {
+        seenByDelegate.push(event.kind);
+      };
+
+      const report = withLedger(delegate, file, "review");
+
+      report({ kind: "agent_spawned", task: "review", message: "review:reviewer-0" });
+
+      await new Promise<void>((resolve) => {
+        setImmediate(resolve);
+      });
+
+      expect(seenByDelegate).toEqual(["agent_spawned"]);
+
+      const [event] = await read();
+
+      expect(event?.type).toBe("agent_spawned");
+      expect(event?.runId).toBe("review");
+    });
+  });
+
+  test("withLedger returns the delegate unchanged when logFile is empty (logging off)", () => {
+    const delegate = (): void => undefined;
+
+    expect(withLedger(delegate, "", "review")).toBe(delegate);
   });
 });

--- a/packages/core/tests/ledger.test.ts
+++ b/packages/core/tests/ledger.test.ts
@@ -269,13 +269,18 @@ describe("agent attribution write→read round-trip", () => {
   test("withLedger calls the delegate AND writes the ledger, for a non-terminal delegate", async () => {
     await withLog(async (file, read) => {
       const seenByDelegate: string[] = [];
+
       const delegate = (event: ILoopEvent): void => {
         seenByDelegate.push(event.kind);
       };
 
       const report = withLedger(delegate, file, "review");
 
-      report({ kind: "agent_spawned", task: "review", message: "review:reviewer-0" });
+      report({
+        kind: "agent_spawned",
+        task: "review",
+        message: "review:reviewer-0",
+      });
 
       await new Promise<void>((resolve) => {
         setImmediate(resolve);


### PR DESCRIPTION
## Summary
- \`tsforge review --log\` announced a log path but silently wrote nothing — \`reviewMode()\` never composed a ledger writer onto its reporter, only the CLI's own terminal reporter (\`makeReporter\`) had one.
- Extracts a \`withLedger(delegate, logFile, runId, sessionId?)\` helper that composes a \`LedgerWriter\` onto ANY \`Reporter\`, and rebuilds \`makeReporter\` on top of it. \`reviewMode\` now uses \`withLedger\` directly.

## Test plan
- [x] \`bun test\` — 5884 pass, 15 skip, 0 fail
- [x] \`bun run typecheck\` — clean
- [x] Verified locally against a real repo: \`tsforge review --log\` now produces genuine structured JSONL (agent lifecycle, tool calls, model usage)