### PR TITLE
chore: release 0.53.6

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@agjs/tsforge",
   "type": "module",
-  "version": "0.53.5",
+  "version": "0.53.6",
   "license": "MIT",
   "description": "TypeScript coding harness with a deterministic gate, stack-aware guardrails, and stream-level correction.",
   "repository": {


### PR DESCRIPTION
Bumps @agjs/tsforge to 0.53.6, picking up #372 (--log now works for `tsforge review`).