### PR TITLE
chore: release 0.53.7

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@agjs/tsforge",
   "type": "module",
-  "version": "0.53.6",
+  "version": "0.53.7",
   "license": "MIT",
   "description": "TypeScript coding harness with a deterministic gate, stack-aware guardrails, and stream-level correction.",
   "repository": {


### PR DESCRIPTION
Bumps @agjs/tsforge to 0.53.7, picking up #374 (review diffs against the merge-base, not the base ref's current tip).